### PR TITLE
Update Release/0.39 branch hedera-protobufs tag

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -99,7 +99,7 @@ gitRepositories {
     // choose tag or branch of HAPI you would like to test with
     // this looks for a tag in hedera-protobufs repo
     // This version needs to match tha HAPI version below in versionCatalogs
-    tag.set("add-pbj-types-for-state")
+    tag.set("v0.39.0")
     // do not load project from repo
     autoInclude.set(false)
   }


### PR DESCRIPTION
**Description**: Update Release/0.39 branch hedera-protobufs tag to fix the compile errors:
Could not determine the dependencies of task ':hedera-node:test-clients:yahCliJar'.
> Could not resolve all dependencies for configuration ':hedera-node:test-clients:runtimeClasspath'.
   > Could not find com.hedera.hashgraph:hedera-protobuf-java-api:0.39.0.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #6889 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
