### PR TITLE
6887: Cannot snapshot to disk after MerkleMap to VirtualMap migration…

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -96,6 +96,7 @@ import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.fcqueue.FCQueue;
 import com.swirlds.jasperdb.VirtualDataSourceJasperDB;
 import com.swirlds.merkle.map.MerkleMap;
+import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.gui.SwirldsGui;
 import com.swirlds.platform.state.DualStateImpl;
 import com.swirlds.virtualmap.VirtualKey;
@@ -147,6 +148,17 @@ public class ServicesState extends PartialNaryMerkleInternal
     public ServicesState() {
         // RuntimeConstructable
         bootstrapProperties = null;
+        // This is a workaround to support multiple nodes running in a single process for testing
+        // purposes. When a node is restored from a saved state, all virtual maps are restored to
+        // the default MerkleDb instance. There is no way yet to provide node config to MerkleDb,
+        // it's a singleton. It leads to nodes to overwrite each other's data. To work it around,
+        // let's reset the default MerkleDb path. It has to be done before the state is loaded
+        // from disk, so I'm putting this code right into the constructor
+        final boolean enabledJasperdbToMerkleDb =
+                getBootstrapProperties().getBooleanProperty(PropertyNames.VIRTUALDATASOURCE_JASPERDB_TO_MERKLEDB);
+        if (enabledJasperdbToMerkleDb) {
+            MerkleDb.setDefaultPath(null);
+        }
     }
 
     @VisibleForTesting

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactory.java
@@ -89,7 +89,8 @@ public class VirtualMapFactory {
             this.storageDir = storageDir;
         } else {
             try {
-                this.storageDir = TemporaryFileBuilder.buildTemporaryDirectory(USE_MERKLE_DB ? "merkledb" : "jasperdb");
+                // Let MerkleDb manage its paths
+                this.storageDir = USE_MERKLE_DB ? null : TemporaryFileBuilder.buildTemporaryDirectory("jasperdb");
             } catch (final IOException z) {
                 throw new UncheckedIOException(z);
             }


### PR DESCRIPTION
Fix for #6887. Fix summary: when MerkleDb is used, don't specify database paths explicitly in services code, but let MerkleDb manage it internally by using "null" as the storage path. The second part of the fix is support for running multiple nodes in a single process for testing purposes. This is done by resetting MerkleDb default paths at node startup (before a saved state is loaded).

Testing:

* jasperdb -> merkledb -> merkledb + data on disk
* jasperdb -> merkledb + data on disk
* merkledb -> merkledb + data on disk

Fixes: https://github.com/hashgraph/hedera-services/issues/6887
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>