### PR TITLE
Add stats for platform_degraded and platform_healthyNetworkFraction_fraction to Network Status dashboard

### DIFF
--- a/hedera-node/infrastructure/dashboards/network-details-prom.json
+++ b/hedera-node/infrastructure/dashboards/network-details-prom.json
@@ -327,7 +327,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "platform_healthyNetworkFraction_fraction{environment=\"$Network\", type=\"max\"}",
+          "expr": "platform_healthyNetworkFraction_fraction{environment=\"$Network\", type=\"mean\"}",
           "legendFormat": "node{{node_id}}",
           "range": true,
           "refId": "A"

--- a/hedera-node/infrastructure/dashboards/network-details-prom.json
+++ b/hedera-node/infrastructure/dashboards/network-details-prom.json
@@ -125,7 +125,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
       "targets": [
         {
           "datasource": {
@@ -153,6 +153,188 @@
         }
       ],
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "NO"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "YES"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "platform_degraded{node=~\".*\", environment=\"$Network\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "node{{node}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Degraded?",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "node(.*)",
+            "renamePattern": "Node $1"
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "editorMode": "code",
+          "expr": "platform_healthyNetworkFraction_fraction{environment=\"$Network\", type=\"max\"}",
+          "legendFormat": "node{{node_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "healthyNetworkFraction",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -216,7 +398,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 8
       },
       "id": 37,
       "options": {
@@ -257,7 +439,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 16
       },
       "id": 26,
       "panels": [],
@@ -284,6 +466,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "decimals": 3,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -321,7 +504,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
       "targets": [
         {
           "datasource": {

--- a/hedera-node/infrastructure/dashboards/network-details-prom.json
+++ b/hedera-node/infrastructure/dashboards/network-details-prom.json
@@ -251,38 +251,38 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
+            "drawStyle": "points",
+            "lineInterpolation": "linear",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "lineWidth": 1,
             "fillOpacity": 0,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "spanNulls": false,
+            "showPoints": "auto",
             "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
             },
             "thresholdsStyle": {
               "mode": "off"
             }
+          },
+          "color": {
+            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -297,7 +297,11 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "decimals": 2,
+          "max": 1.2,
+          "min": 0,
+          "unit": "none"
         },
         "overrides": []
       },
@@ -309,15 +313,15 @@
       },
       "id": 41,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
         "tooltip": {
           "mode": "single",
           "sort": "none"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
         }
       },
       "targets": [


### PR DESCRIPTION
This PR adds stats for platform_degraded and platform_healthyNetworkFraction_fraction to the network status dashboard. These stats were added to the platform in 0.39.x. 

The following screenshot shows the top of the network status dashboard with degraded + healthNetworkFraction stats added.

![Screenshot 2023-06-02 at 15 45 52](https://github.com/hashgraph/hedera-services/assets/294617/36f1710e-d747-4eee-ac72-4a15c791aba3)

