### PR TITLE
fix: browser won't start in PROD mode

### DIFF
--- a/buildSrc/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -201,6 +201,10 @@ extraJavaModuleInfo {
         exportAllPackages()
         // no dependencies
     }
+    module("io.netty:netty-transport-native-epoll", "io.netty.transport.epoll") {
+        exportAllPackages()
+        // no dependencies
+    }
 
     knownModule("com.github.ben-manes.caffeine:caffeine", "com.github.benmanes.caffeine")
     knownModule("com.google.code.gson:gson", "com.google.gson")

--- a/buildSrc/src/main/kotlin/com/hedera/hashgraph/gradlebuild/rules/IoNettyNativeEpollMetadataRule.kt
+++ b/buildSrc/src/main/kotlin/com/hedera/hashgraph/gradlebuild/rules/IoNettyNativeEpollMetadataRule.kt
@@ -10,9 +10,10 @@ abstract class IoNettyNativeEpollMetadataRule : ComponentMetadataRule {
         val version = context.details.id.version
         context.details.allVariants {
             withFiles {
-                // Always pick 'linux-x86_64' by default
+                // Always pick 'linux-x86_64' and 'linux-aarch_64' by default
                 removeAllFiles()
                 addFile("$name-$version-linux-x86_64.jar")
+                addFile("$name-$version-linux-aarch_64.jar")
             }
         }
     }

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -292,8 +292,8 @@ module com.hedera.node.app.service.mono {
     requires com.swirlds.logging;
     requires com.swirlds.platform;
     requires io.netty.handler;
-    requires io.netty.transport.epoll;
     requires io.netty.transport;
+    requires io.netty.transport.epoll;
     requires org.apache.commons.collections4;
     requires org.apache.commons.io;
     requires org.bouncycastle.provider;

--- a/hedera-node/test-clients/src/itest/resources/network/config/node.properties
+++ b/hedera-node/test-clients/src/itest/resources/network/config/node.properties
@@ -1,2 +1,5 @@
 hedera.recordStream.logDir=network/itest/data/recordStreams
-netty.mode=TEST
+# NK(2023-06-02): Integration tests should now run netty with the PROD configuration
+#                 which is necessary to close the coverage gap discovered by issue #6908.
+#                 (https://github.com/hashgraph/hedera-services/issues/6908)
+netty.mode=PROD

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -134,7 +134,7 @@ dependencyResolutionManagement {
       val jacksonVersion = "2.13.3"
       val log4jVersion = "2.17.1"
       val mockitoVersion = "4.6.1"
-      val nettyVersion = "4.1.66.Final"
+      val nettyVersion = "4.1.77.Final"
       val swirldsVersion = "0.39.0-alpha.3"
       val systemStubsVersion = "2.0.2"
       val testContainersVersion = "1.17.2"


### PR DESCRIPTION
## Description

This pull request resolves the issue introduced by PR #6715  and reported in issue #6908 by @OlegMazurov and also by @tannerjfco via integration docker network deployment failures.

Additionally, this PR updates the `itest` suite to run netty in `PROD` mode and also adds support for `itest` with netty `PROD` on Apple M1 hardware. 

### Related Issues

- Closes #6908 