### PR TITLE
Move utility functions dealing with resource paths (for BDD suites) to their own class

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ResourceLocator.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ResourceLocator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.hapi.utils;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class ResourceLocator {
+
+    public static final String RESOURCE_PATH_SEGMENT = "src/main/resource";
+    public static final String TEST_CLIENTS_PREFIX = "hedera-node" + File.separator + "test-clients" + File.separator;
+
+    public static Path relocatedIfNotPresentInWorkingDir(final Path p) {
+        return relocatedIfNotPresentInWorkingDir(p.toFile()).toPath();
+    }
+
+    public static File relocatedIfNotPresentInWorkingDir(final File f) {
+        return relocatedIfNotPresentWithCurrentPathPrefix(f, RESOURCE_PATH_SEGMENT, TEST_CLIENTS_PREFIX);
+    }
+
+    public static File relocatedIfNotPresentWithCurrentPathPrefix(
+            final File f, final String firstSegmentToRelocate, final String newPathPrefix) {
+        if (!f.exists()) {
+            final var absPath = f.getAbsolutePath();
+            final var idx = absPath.indexOf(firstSegmentToRelocate);
+            if (idx == -1) {
+                return f;
+            }
+            final var relocatedPath = newPathPrefix + absPath.substring(idx);
+            return new File(relocatedPath);
+        } else {
+            return f;
+        }
+    }
+}

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Ed25519Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Ed25519Utils.java
@@ -16,8 +16,9 @@
 
 package com.hedera.node.app.hapi.utils.keys;
 
+import static com.hedera.node.app.hapi.utils.ResourceLocator.relocatedIfNotPresentInWorkingDir;
+
 import java.io.*;
-import java.nio.file.Path;
 import java.security.*;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
@@ -40,8 +41,6 @@ public final class Ed25519Utils {
     private static final Provider BC_PROVIDER = new BouncyCastleProvider();
     private static final Provider ED_PROVIDER = new EdDSASecurityProvider();
 
-    private static final String RESOURCE_PATH_SEGMENT = "src/main/resource";
-    public static final String TEST_CLIENTS_PREFIX = "hedera-node" + File.separator + "test-clients" + File.separator;
     public static final EdDSANamedCurveSpec ED25519_PARAMS =
             EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     private static final DrbgParameters.Instantiation DRBG_INSTANTIATION =
@@ -70,14 +69,6 @@ public final class Ed25519Utils {
         } catch (final IOException | OperatorCreationException | PKCSException e) {
             throw new IllegalArgumentException(e);
         }
-    }
-
-    public static Path relocatedIfNotPresentInWorkingDir(final Path p) {
-        return relocatedIfNotPresentInWorkingDir(p.toFile()).toPath();
-    }
-
-    public static File relocatedIfNotPresentInWorkingDir(final File f) {
-        return relocatedIfNotPresentWithCurrentPathPrefix(f, RESOURCE_PATH_SEGMENT, TEST_CLIENTS_PREFIX);
     }
 
     public static void writeKeyTo(final byte[] seed, final String pemLoc, final String passphrase) {
@@ -111,21 +102,6 @@ public final class Ed25519Utils {
     public static KeyPair keyPairFrom(final EdDSAPrivateKey privateKey) {
         final var publicKey = new EdDSAPublicKey(new EdDSAPublicKeySpec(privateKey.getAbyte(), ED25519_PARAMS));
         return new KeyPair(publicKey, privateKey);
-    }
-
-    public static File relocatedIfNotPresentWithCurrentPathPrefix(
-            final File f, final String firstSegmentToRelocate, final String newPathPrefix) {
-        if (!f.exists()) {
-            final var absPath = f.getAbsolutePath();
-            final var idx = absPath.indexOf(firstSegmentToRelocate);
-            if (idx == -1) {
-                return f;
-            }
-            final var relocatedPath = newPathPrefix + absPath.substring(idx);
-            return new File(relocatedPath);
-        } else {
-            return f;
-        }
     }
 
     private Ed25519Utils() {

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ResourceLocatorTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ResourceLocatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.hapi.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+class ResourceLocatorTest {
+
+    @Test
+    void doesNotRelocateIfSegmentMissing() {
+        final var missingLoc = "test/resources/vectors/genesis.pem";
+
+        final var relocated = ResourceLocator.relocatedIfNotPresentWithCurrentPathPrefix(
+                new File(missingLoc), "NOPE", "src" + File.separator);
+
+        assertEquals(missingLoc, relocated.getPath());
+    }
+
+    @Test
+    void triesToRelocateObviouslyMissingPath() {
+        final var notPresent = Paths.get("nowhere/src/main/resources/nothing.txt");
+
+        final var expected = Paths.get("hedera-node/test-clients/src/main/resources/nothing.txt");
+
+        final var actual = ResourceLocator.relocatedIfNotPresentInWorkingDir(notPresent);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/keys/Ed25519UtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/keys/Ed25519UtilsTest.java
@@ -16,16 +16,14 @@
 
 package com.hedera.node.app.hapi.utils.keys;
 
-import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.relocatedIfNotPresentInWorkingDir;
-import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.relocatedIfNotPresentWithCurrentPathPrefix;
 import static com.swirlds.common.utility.CommonUtils.hex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.node.app.hapi.utils.ResourceLocator;
 import com.swirlds.common.utility.CommonUtils;
 import java.io.File;
-import java.nio.file.Paths;
 import java.security.KeyPair;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import org.junit.jupiter.api.Test;
@@ -56,31 +54,10 @@ class Ed25519UtilsTest {
     void canRelocateFromWhenFileIsMissing() {
         final var missingLoc = "test/resources/vectors/genesis.pem";
 
-        final var relocated =
-                relocatedIfNotPresentWithCurrentPathPrefix(new File(missingLoc), "test", "src" + File.separator);
+        final var relocated = ResourceLocator.relocatedIfNotPresentWithCurrentPathPrefix(
+                new File(missingLoc), "test", "src" + File.separator);
 
         assertEquals("src/test/resources/vectors/genesis.pem", relocated.getPath());
-    }
-
-    @Test
-    void doesNotRelocateIfSegmentMissing() {
-        final var missingLoc = "test/resources/vectors/genesis.pem";
-
-        final var relocated =
-                relocatedIfNotPresentWithCurrentPathPrefix(new File(missingLoc), "NOPE", "src" + File.separator);
-
-        assertEquals(missingLoc, relocated.getPath());
-    }
-
-    @Test
-    void triesToRelocateObviouslyMissingPath() {
-        final var notPresent = Paths.get("nowhere/src/main/resources/nothing.txt");
-
-        final var expected = Paths.get("hedera-node/test-clients/src/main/resources/nothing.txt");
-
-        final var actual = relocatedIfNotPresentInWorkingDir(notPresent);
-
-        assertEquals(expected, actual);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamAccess.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamAccess.java
@@ -21,9 +21,8 @@ import static com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStrea
 import static com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils.parseRecordFileConsensusTime;
 import static com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils.parseSidecarFileConsensusTimeAndSequenceNo;
 import static com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils.readMaybeCompressedRecordStreamFile;
-import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.TEST_CLIENTS_PREFIX;
-import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.relocatedIfNotPresentWithCurrentPathPrefix;
 
+import com.hedera.node.app.hapi.utils.ResourceLocator;
 import com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils;
 import com.hedera.services.stream.proto.RecordStreamFile;
 import com.hedera.services.stream.proto.SidecarFile;
@@ -88,7 +87,8 @@ public enum RecordStreamAccess {
         if (!validatingListeners.containsKey(loc)) {
             // In most cases should let us run HapiSpec#main() from both the root and test-clients/
             // directories
-            var fAtLoc = relocatedIfNotPresentWithCurrentPathPrefix(new File(loc), "..", TEST_CLIENTS_PREFIX);
+            var fAtLoc = ResourceLocator.relocatedIfNotPresentWithCurrentPathPrefix(
+                    new File(loc), "..", ResourceLocator.TEST_CLIENTS_PREFIX);
             if (!fAtLoc.exists()) {
                 throw new IllegalArgumentException("No such record stream file location: " + fAtLoc.getAbsolutePath());
             }
@@ -106,7 +106,8 @@ public enum RecordStreamAccess {
      * @throws IOException if there is an error reading the files
      */
     public Data readStreamDataFrom(String loc, final String relativeSidecarLoc) throws IOException {
-        final var fAtLoc = relocatedIfNotPresentWithCurrentPathPrefix(new File(loc), "..", TEST_CLIENTS_PREFIX);
+        final var fAtLoc = ResourceLocator.relocatedIfNotPresentWithCurrentPathPrefix(
+                new File(loc), "..", ResourceLocator.TEST_CLIENTS_PREFIX);
         loc = fAtLoc.getAbsolutePath();
         final var recordFiles = orderedRecordFilesFrom(loc, f -> true);
         final var sidecarLoc = loc + File.separator + relativeSidecarLoc;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
@@ -16,7 +16,7 @@
 
 package com.hedera.services.bdd.suites.contract;
 
-import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.relocatedIfNotPresentInWorkingDir;
+import static com.hedera.node.app.hapi.utils.ResourceLocator.relocatedIfNotPresentInWorkingDir;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
@@ -26,7 +26,6 @@ import static com.swirlds.common.utility.CommonUtils.hex;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static java.lang.System.arraycopy;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
@@ -309,7 +308,9 @@ public class Utils {
                 numExpectedChildren++;
                 childOfInterest++;
             }
-            assertEquals(numExpectedChildren, response.getChildTransactionRecordsCount(), "Wrong # of children");
+            if (numExpectedChildren != response.getChildTransactionRecordsCount())
+                throw new IllegalStateException("Wrong # of children, have %d expectedd %d"
+                        .formatted(response.getChildTransactionRecordsCount(), numExpectedChildren));
             final var create2Record = response.getChildTransactionRecords(childOfInterest);
             final var create2Address =
                     create2Record.getContractCreateResult().getEvmAddress().getValue();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
@@ -16,7 +16,6 @@
 
 package com.hedera.services.bdd.suites.regression;
 
-import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.relocatedIfNotPresentInWorkingDir;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
@@ -37,6 +36,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.records.RecordCreationSuite.STAKING_FEES_NODE_REWARD_PERCENTAGE;
 import static com.hedera.services.bdd.suites.records.RecordCreationSuite.STAKING_FEES_STAKING_REWARD_PERCENTAGE;
 
+import com.hedera.node.app.hapi.utils.ResourceLocator;
 import com.hedera.node.app.hapi.utils.fee.FeeObject;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
@@ -80,8 +80,8 @@ public class TargetNetworkPrep extends HapiSuite {
         final AtomicReference<FeeObject> feeObs = new AtomicReference<>();
         try {
             final var defaultPermissionsLoc = "src/main/resource/api-permission.properties";
-            final var stylized121 =
-                    Files.readString(relocatedIfNotPresentInWorkingDir(Paths.get(defaultPermissionsLoc)));
+            final var stylized121 = Files.readString(
+                    ResourceLocator.relocatedIfNotPresentInWorkingDir(Paths.get(defaultPermissionsLoc)));
             final var serde = StandardSerdes.SYS_FILE_SERDES.get(122L);
 
             return defaultHapiSpec("ensureSystemStateAsExpectedWithSystemDefaultFiles")


### PR DESCRIPTION
**Description**:

There are utility functions, used by the BDD suites, for finding (and adjusting) resource paths, that have been living in `hapi.utils.keys.Ed25519Utils.java`.  They clearly don't belong there.

I moved them to a separate class, `ResourceLocator`, still in `hapi-utils`.  Perhaps they should actually be in a different module?

**Related issue(s)**:

Fixes #6916
See also #6814

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
