### PR TITLE
Documentation: same ordinal for config sources

### DIFF
--- a/platform-sdk/docs/base/configuration/configuration.md
+++ b/platform-sdk/docs/base/configuration/configuration.md
@@ -381,9 +381,8 @@ When creating a new config source it often makes sense to overwrite the default 
 method. The method returns an ordinal number that is used internally to sort all config sources. Here a config source
 with a higher ordinal number will overwrite properties of all config sources with a smaller ordinal number. The internal
 class `com.swirlds.config.impl.sources.ConfigSourceOrdinalConstants` provides constant ordinal numbers for all default
-implementations of config sources and can be used as a reference for custom ordinals.If 2 instances have the same ordinal
-number the instance that will be added later has the higher priority at the moment (might be changed in future - needs to 
-be discussed).
+implementations of config sources and can be used as a reference for custom ordinals. If 2 instances have the same ordinal
+number the api does not define what instance will have the higher priority.
 
 ### Adding custom converters to the configuration
 

--- a/platform-sdk/docs/base/configuration/configuration.md
+++ b/platform-sdk/docs/base/configuration/configuration.md
@@ -381,7 +381,9 @@ When creating a new config source it often makes sense to overwrite the default 
 method. The method returns an ordinal number that is used internally to sort all config sources. Here a config source
 with a higher ordinal number will overwrite properties of all config sources with a smaller ordinal number. The internal
 class `com.swirlds.config.impl.sources.ConfigSourceOrdinalConstants` provides constant ordinal numbers for all default
-implementations of config sources and can be used as a reference for custom ordinals.
+implementations of config sources and can be used as a reference for custom ordinals.If 2 instances have the same ordinal
+number the instance that will be added later has the higher priority at the moment (might be changed in future - needs to 
+be discussed).
 
 ### Adding custom converters to the configuration
 

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/source/ConfigSource.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/source/ConfigSource.java
@@ -57,7 +57,8 @@ public interface ConfigSource {
     /**
      * Returns the ordinal. The ordinal is used to define a priority order of all config sources while the config source
      * with the highest ordinal has the highest priority. A config source will overwrite values of properties that are
-     * already defined by a config source with a lower ordinal.
+     * already defined by a config source with a lower ordinal. If 2 instances have the same ordinal number the api does 
+     * not define what instance will have the higher priority.
      *
      * @return the ordinal
      */


### PR DESCRIPTION
Documentation: same ordinal for config sources