### PR TITLE
6941: Backport #6846 to 0.39

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -67,8 +67,8 @@ import org.apache.logging.log4j.Logger;
  * caches together. The {@link #merge()} method is provided to merge a cache with the one-prior cache.
  * These merges are non-destructive, meaning it is OK to continue to query against a cache that has been merged.
  * <p>
- * At some point, the cache should be flushed to disk. This is done by calling the {@link #dirtyLeaves(long, long,
- * boolean)} and {@link #dirtyHashes(long)} methods and sending them to the code responsible for flushing. The
+ * At some point, the cache should be flushed to disk. This is done by calling the {@link #dirtyLeavesForFlush(long,
+ * long)} and {@link #dirtyHashesForFlush(long)} methods and sending them to the code responsible for flushing. The
  * cache itself knows nothing about the data source or how to save data, it simply maintains a record of mutations
  * so that some other code can perform the flushing.
  * <p>
@@ -282,6 +282,12 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
     private ConcurrentArray<Mutation<Long, Hash>> dirtyHashes = new ConcurrentArray<>();
 
     /**
+     * Indicates if this virtual cache instance contains mutations from older cache versions
+     * as a result of cache merge operation.
+     */
+    private final AtomicBoolean mergedCopy = new AtomicBoolean(false);
+
+    /**
      * A shared lock that prevents two copies from being merged/released at the same time. For example,
      * one thread might be merging two caches while another thread is releasing the oldest copy. These
      * all happen completely in parallel, but we have some bookkeeping which should be done inside
@@ -470,11 +476,12 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
             // Merge my mutations into the previous (newer) cache's arrays.
             // This operation has a high probability of producing override mutations. That is, two mutations
             // for the same key/path but with different versions. Before returning to a caller a stream of
-            // dirty leaves or dirty internals, the stream must be sorted (which we had to do anyway) and
+            // dirty leaves or dirty hashes, the stream must be sorted (which we had to do anyway) and
             // deduplicated. But it makes for a _VERY FAST_ merge operation.
             p.dirtyLeaves.merge(dirtyLeaves);
             p.dirtyLeafPaths.merge(dirtyLeafPaths);
             p.dirtyHashes.merge(dirtyHashes);
+            p.mergedCopy.set(true);
 
             // Remove this cache from the chain and wire the prev and next caches together.
             // This will allow this cache to be garbage collected.
@@ -721,8 +728,49 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
     }
 
     /**
+     * Returns a stream of dirty leaves from this cache instance to hash this virtual map copy. The stream
+     * is sorted by paths.
+     *
+     * @param firstLeafPath
+     * 		The first leaf path to include to the stream
+     * @param lastLeafPath
+     *      The last leaf path to include to the stream
+     * @return
+     *      A stream of dirty leaves for hashing
+     */
+    public Stream<VirtualLeafRecord<K, V>> dirtyLeavesForHash(final long firstLeafPath, final long lastLeafPath) {
+        if (mergedCopy.get()) {
+            throw new IllegalStateException("Cannot get dirty leaves for hashing on a merged cache copy");
+        }
+        final Stream<VirtualLeafRecord<K, V>> result = dirtyLeaves(firstLeafPath, lastLeafPath, false);
+        return result.sorted(Comparator.comparingLong(VirtualLeafRecord::getPath));
+    }
+
+    /**
+     * Returns a stream of dirty leaves from this cache instance to flush this virtual map copy and all
+     * previous copies merged into this one to disk.
+     *
+     * @param firstLeafPath
+     * 		The first leaf path to include to the stream
+     * @param lastLeafPath
+     *      The last leaf path to include to the stream
+     * @return
+     *      A stream of dirty leaves for flushes
+     */
+    public Stream<VirtualLeafRecord<K, V>> dirtyLeavesForFlush(final long firstLeafPath, final long lastLeafPath) {
+        return dirtyLeaves(firstLeafPath, lastLeafPath, true);
+    }
+
+    /**
      * Gets a stream of dirty leaves <strong>from this cache instance</strong>. Deleted leaves are not included
      * in this stream.
+     *
+     * <p>
+     * This method is called for two purposes. First, to get dirty leaves to hash a single virtual map copy. The
+     * resulting stream is expected to be sorted. No duplicate entries are expected in this case, as within a
+     * single version there may not be duplicates. Second, to get dirty leaves to flush them to disk. In this
+     * case, the stream doesn't need to be sorted, but there may be duplicated entries from different versions.
+     *
      * <p>
      * This method may be called concurrently from multiple threads (although in practice, this should never happen).
      *
@@ -734,32 +782,32 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
      * 		The last leaf path to receive in the results. It is possible, through merging of multiple rounds,
      * 		for the data to have leaf data that is outside the expected range for the {@link VirtualMap} of
      * 		this cache. We need to provide the leaf boundaries to compensate for this.
-     * @param sorted
-     *      Indicates if the resulting stream should be sorted by path or not
+     * @param dedupe
+     *      Indicates if the duplicated entries should be removed from the stream
      * @return A non-null stream of dirty leaves. May be empty. Will not contain duplicate records
      * @throws MutabilityException
      * 		if called on a cache that still allows dirty leaves to be added
      */
-    public Stream<VirtualLeafRecord<K, V>> dirtyLeaves(
-            final long firstLeafPath, final long lastLeafPath, final boolean sorted) {
+    private Stream<VirtualLeafRecord<K, V>> dirtyLeaves(
+            final long firstLeafPath, final long lastLeafPath, final boolean dedupe) {
         if (!dirtyLeaves.isImmutable()) {
             throw new MutabilityException("Cannot call on a cache that is still mutable for dirty leaves");
         }
-        // Mark obsolete mutations to filter later
-        filterMutations(dirtyLeaves);
-        final Stream<VirtualLeafRecord<K, V>> result = dirtyLeaves.stream()
+        if (dedupe) {
+            // Mark obsolete mutations to filter later
+            filterMutations(dirtyLeaves);
+        }
+        return dirtyLeaves.stream()
                 .filter(mutation -> {
                     final long path = mutation.value.getPath();
                     return path >= firstLeafPath && path <= lastLeafPath;
                 })
-                .filter(mutation -> !mutation.isFiltered())
+                .filter(mutation -> {
+                    assert dedupe || !mutation.isFiltered();
+                    return !mutation.isFiltered();
+                })
                 .filter(mutation -> !mutation.isDeleted())
                 .map(mutation -> mutation.value);
-        if (sorted) {
-            return result.sorted(Comparator.comparingLong(VirtualLeafRecord::getPath));
-        } else {
-            return result;
-        }
     }
 
     /**
@@ -915,7 +963,7 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
     }
 
     /**
-     * Gets a stream of dirty internal records <strong>from this cache instance</strong>. Deleted records are
+     * Gets a stream of dirty hashes <strong>from this cache instance</strong>. Deleted hashes are
      * not included in this stream. Must be called <strong>after</strong> the cache has been sealed.
      * <p>
      * This method may be called concurrently from multiple threads (although in practice, this should never happen).
@@ -924,11 +972,11 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
      * 		The last leaf path at and above which no node results should be returned. It is possible,
      * 		through merging of multiple rounds, for the data to have data that is outside the expected range
      * 		for the {@link VirtualMap} of this cache. We need to provide the leaf boundaries to compensate for this.
-     * @return A non-null stream of dirty records. May be empty. Will not contain duplicate records.
+     * @return A non-null stream of dirty hashes. May be empty. Will not contain duplicate records.
      * @throws MutabilityException
      * 		if called on a non-sealed cache instance.
      */
-    public Stream<VirtualHashRecord> dirtyHashes(final long lastLeafPath) {
+    public Stream<VirtualHashRecord> dirtyHashesForFlush(final long lastLeafPath) {
         if (!dirtyHashes.isImmutable()) {
             throw new MutabilityException("Cannot get the dirty internal records for a non-sealed cache.");
         }
@@ -1137,11 +1185,13 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
                 // Hold a reference to this newest mutation in this cache
                 dirtyPaths.add(nextMutation);
             } else {
+                assert !nextMutation.isFiltered();
                 // This mutation already exists in this version. Simply update its value and deleted status.
                 nextMutation.value = value;
                 nextMutation.setDeleted(value == null);
             }
             if (previousMutation != null) {
+                assert !previousMutation.isFiltered();
                 previousMutation.next = nextMutation;
             } else {
                 mutation = nextMutation;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -1119,11 +1119,12 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
         try {
             // Get the leaves that were changed and sort them by path so that lower paths come first
             final Stream<VirtualLeafRecord<K, V>> dirtyLeaves =
-                    cacheToFlush.dirtyLeaves(stateToUse.getFirstLeafPath(), stateToUse.getLastLeafPath(), false);
+                    cacheToFlush.dirtyLeavesForFlush(stateToUse.getFirstLeafPath(), stateToUse.getLastLeafPath());
             // Get the deleted leaves
             final Stream<VirtualLeafRecord<K, V>> deletedLeaves = cacheToFlush.deletedLeaves();
             // Save the dirty hashes
-            final Stream<VirtualHashRecord> dirtyHashes = cacheToFlush.dirtyHashes(stateToUse.getLastLeafPath());
+            final Stream<VirtualHashRecord> dirtyHashes =
+                    cacheToFlush.dirtyHashesForFlush(stateToUse.getLastLeafPath());
             ds.saveRecords(
                     stateToUse.getFirstLeafPath(),
                     stateToUse.getLastLeafPath(),
@@ -1245,7 +1246,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
         };
         Hash virtualHash = hasher.hash(
                 records::findHash,
-                cache.dirtyLeaves(state.getFirstLeafPath(), state.getLastLeafPath(), true)
+                cache.dirtyLeavesForHash(state.getFirstLeafPath(), state.getLastLeafPath())
                         .iterator(),
                 state.getFirstLeafPath(),
                 state.getLastLeafPath(),

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
@@ -50,6 +50,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -588,7 +589,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
                 "value that was looked up should match original value");
 
         final List<VirtualLeafRecord<TestKey, TestValue>> dirtyLeaves =
-                cache1.dirtyLeaves(1, 1, true).toList();
+                cache1.dirtyLeavesForFlush(1, 1).toList();
         assertEquals(1, dirtyLeaves.size(), "incorrect number of dirty leaves");
         assertEquals(aardvarkLeaf1, dirtyLeaves.get(0), "there should be no dirty leaves");
     }
@@ -783,20 +784,25 @@ class VirtualNodeCacheTest extends VirtualTestBase {
 
         // Verify everything
         final AtomicInteger index = new AtomicInteger(0);
-        cache1.dirtyLeaves(totalMutationCount, totalMutationCount * 2, true).forEach(rec -> {
-            final int i = index.getAndIncrement();
-            assertEquals(totalMutationCount + i, rec.getPath(), "path should be one greater than mutation count");
-            assertEquals(new TestKey(i), rec.getKey(), "key should match expected");
-            if (i < nextMutationCount) {
-                assertEquals(
-                        new TestValue("OverriddenValue" + i), rec.getValue(), "value should have the expected data");
-            } else {
-                assertEquals(new TestValue("Value" + i), rec.getValue(), "value should have the expected data");
-            }
-        });
+        cache1.dirtyLeavesForFlush(totalMutationCount, totalMutationCount * 2)
+                .sorted(Comparator.comparingLong(VirtualLeafRecord::getPath))
+                .forEach(rec -> {
+                    final int i = index.getAndIncrement();
+                    assertEquals(
+                            totalMutationCount + i, rec.getPath(), "path should be one greater than mutation count");
+                    assertEquals(new TestKey(i), rec.getKey(), "key should match expected");
+                    if (i < nextMutationCount) {
+                        assertEquals(
+                                new TestValue("OverriddenValue" + i),
+                                rec.getValue(),
+                                "value should have the expected data");
+                    } else {
+                        assertEquals(new TestValue("Value" + i), rec.getValue(), "value should have the expected data");
+                    }
+                });
 
         index.set(0);
-        cache1.dirtyHashes(totalMutationCount * 2).forEach(rec -> {
+        cache1.dirtyHashesForFlush(totalMutationCount * 2).forEach(rec -> {
             final int i = index.getAndIncrement();
             assertEquals(i, rec.path(), "path should match index");
             if (i < nextMutationCount) { // mutated internal nodes
@@ -1145,7 +1151,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         //				"shouldn't be able to call method on immutable cache");
         assertThrows(
                 MutabilityException.class,
-                () -> cache0.dirtyHashes(right0.path()),
+                () -> cache0.dirtyHashesForFlush(right0.path()),
                 "shouldn't be able to call method on immutable cache");
     }
 
@@ -1448,7 +1454,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache0.putLeaf(appleLeaf0);
         assertThrows(
                 MutabilityException.class,
-                () -> cache0.dirtyLeaves(1, 1, true),
+                () -> cache0.dirtyLeavesForHash(1, 1),
                 "method shouldn't work on immutable cache");
     }
 
@@ -2022,7 +2028,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
 
         // End the round and create the next round
         nextRound();
-        validateDirtyLeaves(asList(bananaLeaf0, appleLeaf0, cherryLeaf0), cache0.dirtyLeaves(2, 4, true));
+        validateDirtyLeaves(asList(bananaLeaf0, appleLeaf0, cherryLeaf0), cache0.dirtyLeavesForHash(2, 4));
 
         // Add an internal node "left" at index 1 and then root at index 0
         final VirtualHashRecord leftInternal0 = leftInternal();
@@ -2042,7 +2048,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         // hashes are calculated and put to the cache. Here the cache doesn't contain hashes for dirty leaves
         // (bananaLeaf0, appleLeaf0, cherryLeaf0). Should dirtyHashes() include these leaf nodes? Currently
         // it doesn't
-        validateDirtyInternals(Set.of(rootInternal0, leftInternal0), cache0.dirtyHashes(4));
+        validateDirtyInternals(Set.of(rootInternal0, leftInternal0), cache0.dirtyHashesForFlush(4));
 
         // ROUND 1: Add D and E.
         final VirtualNodeCache<TestKey, TestValue> cache1 = cache;
@@ -2079,7 +2085,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
 
         // End the round and create the next round
         nextRound();
-        validateDirtyLeaves(asList(bananaLeaf1, dateLeaf1, appleLeaf1, eggplantLeaf1), cache1.dirtyLeaves(4, 8, true));
+        validateDirtyLeaves(asList(bananaLeaf1, dateLeaf1, appleLeaf1, eggplantLeaf1), cache1.dirtyLeavesForHash(4, 8));
 
         // Add an internal node "leftLeft" at index 3 and then "right" at index 2
         final VirtualHashRecord leftLeftInternal1 = leftLeftInternal();
@@ -2104,7 +2110,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
                         appleLeaf1,
                         eggplantLeaf1));
         validateDirtyInternals(
-                Set.of(rootInternal1, leftInternal1, rightInternal1, leftLeftInternal1), cache1.dirtyHashes(8));
+                Set.of(rootInternal1, leftInternal1, rightInternal1, leftLeftInternal1), cache1.dirtyHashesForFlush(8));
 
         // ROUND 2: Add F and G
         final VirtualNodeCache<TestKey, TestValue> cache2 = cache;
@@ -2144,7 +2150,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
 
         // End the round and create the next round
         nextRound();
-        validateDirtyLeaves(asList(cherryLeaf2, figLeaf2, bananaLeaf2, grapeLeaf2), cache2.dirtyLeaves(6, 12, true));
+        validateDirtyLeaves(asList(cherryLeaf2, figLeaf2, bananaLeaf2, grapeLeaf2), cache2.dirtyLeavesForHash(6, 12));
 
         // Add an internal node "rightLeft" at index 5 and then "leftRight" at index 4
         final VirtualHashRecord rightLeftInternal2 = rightLeftInternal();
@@ -2176,7 +2182,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
                         grapeLeaf2));
         validateDirtyInternals(
                 Set.of(rootInternal2, leftInternal2, rightInternal2, leftRightInternal2, rightLeftInternal2),
-                cache2.dirtyHashes(12));
+                cache2.dirtyHashesForFlush(12));
 
         // Now it is time to start mutating the tree. Some leaves will be removed and re-added, some
         // will be removed and replaced with a new value (same key).
@@ -2241,7 +2247,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         // End the round and create the next round
         nextRound();
         validateDirtyLeaves(
-                asList(dogLeaf3, grapeLeaf3, foxLeaf3, appleLeaf3, bananaLeaf3), cache3.dirtyLeaves(6, 12, true));
+                asList(dogLeaf3, grapeLeaf3, foxLeaf3, appleLeaf3, bananaLeaf3), cache3.dirtyLeavesForHash(6, 12));
 
         // We removed the internal node rightLeftInternal. We need to add it back in.
         final VirtualHashRecord rightLeftInternal3 = rightLeftInternal();
@@ -2265,7 +2271,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
                         leftLeftInternal3,
                         leftRightInternal3,
                         rightLeftInternal3),
-                cache3.dirtyHashes(12));
+                cache3.dirtyHashesForFlush(12));
 
         // At this point, we have built the tree successfully. Verify one more time that each version of
         // the cache still sees things the same way it did at the time the copy was made.
@@ -2470,7 +2476,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache.seal();
 
         final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache.dirtyLeaves(4, 8, true).toList();
+                cache.dirtyLeavesForHash(4, 8).toList();
         assertEquals(5, leaves.size(), "All leaves should be dirty");
         assertEquals(cherryLeaf(4), leaves.get(0), "Unexpected leaf");
         assertEquals(bananaLeaf(5), leaves.get(1), "Unexpected leaf");
@@ -2495,7 +2501,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache.seal();
 
         final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache.dirtyLeaves(3, 6, true).toList();
+                cache.dirtyLeavesForHash(3, 6).toList();
         assertEquals(4, leaves.size(), "Some leaves should be dirty");
         assertEquals(appleLeaf(3), leaves.get(0), "Unexpected leaf");
         assertEquals(cherryLeaf(4), leaves.get(1), "Unexpected leaf");
@@ -2539,7 +2545,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache.seal();
 
         final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache.dirtyLeaves(-1, -1, false).toList();
+                cache.dirtyLeavesForFlush(-1, -1).toList();
         assertEquals(0, leaves.size(), "All leaves should be missing");
     }
 
@@ -2569,7 +2575,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache.seal();
 
         final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache.dirtyLeaves(2, 4, true).toList();
+                cache.dirtyLeavesForHash(2, 4).toList();
         assertEquals(3, leaves.size(), "Should only have three leaves");
         assertEquals(bananaLeaf(2), leaves.get(0), "Unexpected leaf");
         assertEquals(appleLeaf(3), leaves.get(1), "Unexpected leaf");
@@ -2602,14 +2608,10 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache0.merge();
         cache1.merge();
 
-        final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache2.dirtyLeaves(4, 8, true).toList();
+        final Set<VirtualLeafRecord<TestKey, TestValue>> leaves =
+                cache2.dirtyLeavesForFlush(4, 8).collect(Collectors.toSet());
         assertEquals(5, leaves.size(), "All leaves should be dirty");
-        assertEquals(cherryLeaf(4), leaves.get(0), "Unexpected leaf");
-        assertEquals(bananaLeaf(5), leaves.get(1), "Unexpected leaf");
-        assertEquals(dateLeaf(6), leaves.get(2), "Unexpected leaf");
-        assertEquals(appleLeaf(7), leaves.get(3), "Unexpected leaf");
-        assertEquals(eggplantLeaf(8), leaves.get(4), "Unexpected leaf");
+        assertEquals(Set.of(cherryLeaf(4), bananaLeaf(5), dateLeaf(6), appleLeaf(7), eggplantLeaf(8)), leaves);
     }
 
     @Test
@@ -2645,13 +2647,10 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache0.merge();
         cache1.merge();
 
-        final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache2.dirtyLeaves(3, 6, true).toList();
+        final Set<VirtualLeafRecord<TestKey, TestValue>> leaves =
+                cache2.dirtyLeavesForFlush(3, 6).collect(Collectors.toSet());
         assertEquals(4, leaves.size(), "Some leaves should be dirty");
-        assertEquals(figLeaf(3), leaves.get(0), "Unexpected leaf");
-        assertEquals(eggplantLeaf(4), leaves.get(1), "Unexpected leaf");
-        assertEquals(dateLeaf(5), leaves.get(2), "Unexpected leaf");
-        assertEquals(grapeLeaf(6), leaves.get(3), "Unexpected leaf");
+        assertEquals(Set.of(figLeaf(3), eggplantLeaf(4), dateLeaf(5), grapeLeaf(6)), leaves);
     }
 
     @Test
@@ -2689,7 +2688,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache1.merge();
 
         final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
-                cache2.dirtyLeaves(-1, -1, true).toList();
+                cache2.dirtyLeavesForFlush(-1, -1).toList();
         assertEquals(0, leaves.size(), "All leaves should be deleted");
     }
 
@@ -2708,7 +2707,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache0.putHash(rightLeftInternal());
         cache0.seal();
 
-        final List<VirtualHashRecord> internals = cache0.dirtyHashes(12).toList();
+        final List<VirtualHashRecord> internals = cache0.dirtyHashesForFlush(12).toList();
         assertEquals(6, internals.size(), "All internals should be dirty");
         assertEquals(rootInternal(), internals.get(0), "Unexpected internal");
         assertEquals(leftInternal(), internals.get(1), "Unexpected internal");
@@ -2735,7 +2734,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache1.seal();
         cache0.merge();
 
-        final List<VirtualHashRecord> internals = cache1.dirtyHashes(12).toList();
+        final List<VirtualHashRecord> internals = cache1.dirtyHashesForFlush(12).toList();
         assertEquals(6, internals.size(), "All internals should be dirty");
         assertEquals(
                 Set.of(
@@ -2778,7 +2777,7 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache0.merge();
         cache1.merge();
 
-        final List<VirtualHashRecord> internals = cache2.dirtyHashes(12).toList();
+        final List<VirtualHashRecord> internals = cache2.dirtyHashesForFlush(12).toList();
         assertEquals(6, internals.size(), "All internals should be dirty");
         assertEquals(
                 Set.of(
@@ -2823,8 +2822,41 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         cache0.merge();
         cache1.merge();
 
-        final List<VirtualHashRecord> internals = cache2.dirtyHashes(-1).toList();
+        final List<VirtualHashRecord> internals = cache2.dirtyHashesForFlush(-1).toList();
         assertEquals(0, internals.size(), "No internals should be dirty");
+    }
+
+    @Test
+    @Tags({@Tag("VirtualMerkle"), @Tag("VirtualNodeCache"), @Tag("DirtyLeaves")})
+    @DisplayName("dirtyLeaves for hashing and flushes do not affect each other")
+    void dirtyLeaves_flushesAndHashing() {
+        final VirtualNodeCache<TestKey, TestValue> cache0 = new VirtualNodeCache<>();
+        cache0.putLeaf(appleLeaf(1));
+        cache0.putLeaf(bananaLeaf(2));
+
+        final VirtualNodeCache<TestKey, TestValue> cache1 = cache0.copy();
+        cache0.seal();
+        cache1.deleteLeaf(appleLeaf(1));
+        cache1.putLeaf(appleLeaf(3));
+        cache1.putLeaf(cherryLeaf(4));
+
+        // Hash version 0
+        final List<VirtualLeafRecord<TestKey, TestValue>> dirtyLeaves0H =
+                cache0.dirtyLeavesForHash(1, 2).toList();
+        assertEquals(List.of(appleLeaf(1), bananaLeaf(2)), dirtyLeaves0H);
+
+        cache1.copy();
+        cache1.seal();
+
+        // Hash version 1
+        final List<VirtualLeafRecord<TestKey, TestValue>> dirtyLeaves1 =
+                cache1.dirtyLeavesForHash(2, 4).toList();
+        assertEquals(List.of(appleLeaf(3), cherryLeaf(4)), dirtyLeaves1);
+
+        // Flush version 0
+        final Set<VirtualLeafRecord<TestKey, TestValue>> dirtyLeaves0F =
+                cache0.dirtyLeavesForFlush(1, 2).collect(Collectors.toSet());
+        assertEquals(Set.of(appleLeaf(1), bananaLeaf(2)), dirtyLeaves0F);
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Direct backport of #6865 to 0.39

Fixes: https://github.com/hashgraph/hedera-services/issues/6941
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
