### PR TITLE
Remove deprecated registerMonoAdapterSchemas

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/Service.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/Service.java
@@ -34,17 +34,6 @@ public interface Service {
     String getServiceName();
 
     /**
-     * Registers the schemas this service uses when running with {@code mono-service} adapters
-     * with the given {@link SchemaRegistry}. We can remove this method once we are no longer
-     * relying on EET's with {@code workflows.enabled} to validate behavior.
-     *
-     * @deprecated because this method is only used when running with {@code mono-service} adapters
-     * @param registry the registry to register the schemas with
-     * */
-    @Deprecated(forRemoval = true)
-    void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry);
-
-    /**
      * Registers the schemas this service really uses with the given {@link SchemaRegistry}.
      *
      * @param registry the registry to register the schemas with

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/RecordCache.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/RecordCache.java
@@ -70,6 +70,7 @@ public interface RecordCache {
      */
     @NonNull
     List<TransactionRecord> getRecords(@NonNull AccountID accountID);
+
     /**
      * Gets the "primary" receipt for the given {@link TransactionID}. A user may submit multiple transactions with the
      * same {@link TransactionID} to the network by submitting to multiple nodes. In that case, there will be multiple

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.spi.state;
+
+import com.swirlds.config.api.Configuration;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Provides the context for a migration of state from one {@link Schema} version to another.
+ */
+public interface MigrationContext {
+    /**
+     * Provides a reference to the previous {@link ReadableStates}. For example, if the previous state was version
+     * 1.2.3, then this method will return a {@link ReadableStates} that can be used to read the state of version 1.2.3.
+     * This state is strictly read-only. This is useful as it allows the migration code to refer to the previous state.
+     *
+     * @return A non-null reference to the previous states. For Genesis, this will be an empty {@link ReadableStates}.
+     */
+    @NonNull
+    ReadableStates previousStates();
+
+    /**
+     * Provides a references to the current working state. Initially, this state will be identical to that returned by
+     * {@link #previousStates()}, but as the migration progresses, this state will be updated to reflect the new values
+     * of the state. All new {@link Schema#statesToCreate()} will exist in this state.
+     *
+     * @return A non-null reference to the working state.
+     */
+    @NonNull
+    WritableStates newStates();
+
+    /**
+     * The {@link Configuration} for this migration. Any portion of this configuration which was based on state (such
+     * as, in our case, file 121) will be current as of the previous state. This configuration is read-only. Having this
+     * configuration is useful for migrations that should behavior differently based on configuration.
+     *
+     * @return The configuration to use.
+     */
+    @NonNull
+    Configuration configuration();
+}

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/Schema.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/Schema.java
@@ -78,17 +78,15 @@ public abstract class Schema implements Comparable<Schema> {
      * called with the {@link ReadableStates} of the previous version of the {@link Schema}. If
      * there was no previous version, then {@code previousStates} will be empty, but not null.
      *
-     * @param previousStates The {@link ReadableStates} of the previous {@link Schema} version
-     * @param newStates {@link WritableStates} for this schema.
+     * @param ctx {@link MigrationContext} for this schema migration
      */
-    public void migrate(@NonNull ReadableStates previousStates, @NonNull WritableStates newStates) {
-        Objects.requireNonNull(previousStates);
-        Objects.requireNonNull(newStates);
+    public void migrate(@NonNull final MigrationContext ctx) {
+        Objects.requireNonNull(ctx);
     }
 
     /**
      * The {@link Set} of state keys of all states that should be removed <b>AFTER</b> {@link
-     * #migrate(ReadableStates, WritableStates)}.
+     * #migrate(MigrationContext)}.
      *
      * @return the set of states to remove
      */

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SchemaTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SchemaTest.java
@@ -122,20 +122,11 @@ class SchemaTest extends StateTestBase {
     }
 
     @Test
-    @DisplayName("passing null previous states to migrate throws NPE")
-    void nullPreviousStatesThrows() {
-        final var schema1 = new TestSchema(1);
-        final var newStates = new MapWritableStates(Collections.emptyMap());
-        //noinspection DataFlowIssue
-        assertThatThrownBy(() -> schema1.migrate(null, newStates)).isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("passing null new states to migrate throws NPE")
+    @DisplayName("passing null context to migrate throws NPE")
     void nullNewStatesThrows() {
         final var schema1 = new TestSchema(1);
         final var prevStates = new MapWritableStates(Collections.emptyMap());
         //noinspection DataFlowIssue
-        assertThatThrownBy(() -> schema1.migrate(prevStates, null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> schema1.migrate(null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/TestSchema.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/TestSchema.java
@@ -17,9 +17,8 @@
 package com.hedera.node.app.spi.fixtures.state;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.node.app.spi.state.ReadableStates;
+import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
-import com.hedera.node.app.spi.state.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -48,8 +47,8 @@ public class TestSchema extends Schema {
     }
 
     @Override
-    public void migrate(@NonNull ReadableStates previousStates, @NonNull WritableStates newStates) {
-        super.migrate(previousStates, newStates);
+    public void migrate(@NonNull final MigrationContext ctx) {
+        super.migrate(ctx);
         if (onMigrate != null) {
             onMigrate.run();
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MigrationContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MigrationContextImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state.merkle;
+
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.node.app.spi.state.ReadableStates;
+import com.hedera.node.app.spi.state.WritableStates;
+import com.swirlds.config.api.Configuration;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An implementation of {@link MigrationContext}.
+ *
+ * @param previousStates The previous states.
+ * @param newStates The new states, preloaded with any new state definitions.
+ * @param configuration The configuration to use
+ */
+public record MigrationContextImpl(
+        @NonNull ReadableStates previousStates, @NonNull WritableStates newStates, @NonNull Configuration configuration)
+        implements MigrationContext {}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheService.java
@@ -45,12 +45,6 @@ public class RecordCacheService implements Service {
 
     /** {@inheritDoc} */
     @Override
-    public void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry) {
-        // No-op for now
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void registerSchemas(@NonNull SchemaRegistry registry) {
         // This is the genesis schema for this service, and simply creates the queue state that stores the
         // transaction records.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -18,22 +18,23 @@ package com.hedera.node.app.state.merkle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.SemanticVersionComparator;
 import com.hedera.node.app.spi.fixtures.state.TestSchema;
+import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import com.hedera.node.app.spi.state.ReadableSingletonState;
-import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.StateDefinition;
 import com.hedera.node.app.spi.state.WritableKVState;
 import com.hedera.node.app.spi.state.WritableSingletonState;
-import com.hedera.node.app.spi.state.WritableStates;
+import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,7 +42,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
@@ -52,14 +52,17 @@ import org.mockito.Mockito;
  */
 class MerkleSchemaRegistryTest extends MerkleTestBase {
     private MerkleSchemaRegistry schemaRegistry;
-    private @TempDir Path storageDir;
+    private Configuration config;
 
     @BeforeEach
     void setUp() {
         // We don't need a real registry, and the unit tests are much
         // faster if we use a mocked one
         registry = Mockito.mock(ConstructableRegistry.class);
-        schemaRegistry = new MerkleSchemaRegistry(registry, storageDir, FIRST_SERVICE);
+        schemaRegistry = new MerkleSchemaRegistry(registry, FIRST_SERVICE);
+        config = Mockito.mock(Configuration.class);
+        final var hederaConfig = Mockito.mock(HederaConfig.class);
+        lenient().when(config.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);
     }
 
     @Nested
@@ -69,22 +72,15 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("A null ConstructableRegistry throws")
         void nullRegistryThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> new MerkleSchemaRegistry(null, storageDir, FIRST_SERVICE))
+            assertThatThrownBy(() -> new MerkleSchemaRegistry(null, FIRST_SERVICE))
                     .isInstanceOf(NullPointerException.class);
-        }
-
-        @Test
-        @DisplayName("A null storageDir is OK")
-        void nullStorageDirOK() {
-            assertThat(new MerkleSchemaRegistry(registry, null, FIRST_SERVICE)).isNotNull();
         }
 
         @Test
         @DisplayName("A null serviceName throws")
         void nullServiceNameThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> new MerkleSchemaRegistry(registry, storageDir, null))
-                    .isInstanceOf(NullPointerException.class);
+            assertThatThrownBy(() -> new MerkleSchemaRegistry(registry, null)).isInstanceOf(NullPointerException.class);
         }
     }
 
@@ -109,7 +105,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
             // Then on migrateFromV9ToV10, it is called
             migrateFromV9ToV10();
-            Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any(), Mockito.any());
+            Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any());
         }
 
         @Test
@@ -124,7 +120,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
             // Then on migrateFromV9ToV10, it is called only once
             migrateFromV9ToV10();
-            Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any(), Mockito.any());
+            Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any());
         }
 
         @Test
@@ -140,8 +136,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
             // Then on migrateFromV9ToV10, the last one registered wins
             migrateFromV9ToV10();
-            Mockito.verify(schema1, Mockito.times(0)).migrate(Mockito.any(), Mockito.any());
-            Mockito.verify(schema2, Mockito.times(1)).migrate(Mockito.any(), Mockito.any());
+            Mockito.verify(schema1, Mockito.times(0)).migrate(Mockito.any());
+            Mockito.verify(schema2, Mockito.times(1)).migrate(Mockito.any());
         }
 
         /** Utility method that migrates from version 9 to 10 */
@@ -150,7 +146,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     new MerkleHederaState(
                             (tree, state) -> {}, (e, m, s) -> {}, (state, platform, dualState, trigger, version) -> {}),
                     version(9, 0, 0),
-                    version(10, 0, 0));
+                    version(10, 0, 0),
+                    config);
         }
     }
 
@@ -175,7 +172,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a null hederaState throws NPE")
         void nullMerkleThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(null, versions[0], versions[1]))
+            assertThatThrownBy(() -> schemaRegistry.migrate(null, versions[0], versions[1], config))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -183,7 +180,15 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a null currentVersion throws NPE")
         void nullCurrentVersionThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], null))
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], null, config))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Calling migrate with a null config throws NPE")
+        void nullConfigVersionThrows() {
+            //noinspection ConstantConditions
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[1], null))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -191,7 +196,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a currentVersion < previousVersion throws IAE")
         void currentVersionLessThanPreviousVersionThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[5], versions[4]))
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[5], versions[4], config))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -203,10 +208,10 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
             // When it is registered twice and migrate is called
             schemaRegistry.register(schema);
-            schemaRegistry.migrate(merkleTree, versions[1], versions[1]);
+            schemaRegistry.migrate(merkleTree, versions[1], versions[1], config);
 
             // Then nothing happens
-            Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any(), Mockito.any());
+            Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
         }
 
         @ParameterizedTest(name = "From ({0}, {1}]")
@@ -242,22 +247,22 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
             }
 
             // When we migrate
-            schemaRegistry.migrate(merkleTree, versions[firstVersion], versions[lastVersion]);
+            schemaRegistry.migrate(merkleTree, versions[firstVersion], versions[lastVersion], config);
 
             // Then each schema less than or equal to firstVersion are not called
             for (int i = 1; i <= firstVersion; i++) {
-                Mockito.verify(schemas[i], Mockito.times(0)).migrate(Mockito.any(), Mockito.any());
+                Mockito.verify(schemas[i], Mockito.times(0)).migrate(Mockito.any());
             }
 
             // And each schema greater than firstVersion and less than or equal to lastVersion are
             // called
             for (int i = firstVersion + 1; i <= lastVersion; i++) {
-                Mockito.verify(schemas[i], Mockito.times(1)).migrate(Mockito.any(), Mockito.any());
+                Mockito.verify(schemas[i], Mockito.times(1)).migrate(Mockito.any());
             }
 
             // And each schema greater than lastVersion are not called
             for (int i = lastVersion + 1; i < versions.length; i++) {
-                Mockito.verify(schemas[i], Mockito.times(0)).migrate(Mockito.any(), Mockito.any());
+                Mockito.verify(schemas[i], Mockito.times(0)).migrate(Mockito.any());
             }
 
             // And each called schema was called in order
@@ -286,7 +291,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
             schemaRegistry.register(schemaV6);
 
             // When we migrate from v0 to v7
-            schemaRegistry.migrate(merkleTree, null, versions[7]);
+            schemaRegistry.migrate(merkleTree, null, versions[7], config);
 
             // Then each of v1, v4, and v6 are called
             assertThat(called).hasSize(3);
@@ -313,10 +318,12 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     }
 
                     @Override
-                    public void migrate(@NonNull ReadableStates previousStates, @NonNull WritableStates newStates) {
-                        assertThat(previousStates.isEmpty()).isTrue();
-                        assertThat(newStates.size()).isEqualTo(1);
-                        final WritableKVState<String, String> fruit = newStates.get(FRUIT_STATE_KEY);
+                    public void migrate(@NonNull final MigrationContext ctx) {
+                        assertThat(ctx).isNotNull();
+                        assertThat(ctx.previousStates().isEmpty()).isTrue();
+                        assertThat(ctx.newStates().size()).isEqualTo(1);
+                        final WritableKVState<String, String> fruit =
+                                ctx.newStates().get(FRUIT_STATE_KEY);
                         fruit.put(A_KEY, APPLE);
                         fruit.put(B_KEY, BANANA);
                         fruit.put(C_KEY, CHERRY);
@@ -336,7 +343,11 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     }
 
                     @Override
-                    public void migrate(@NonNull ReadableStates previousStates, @NonNull WritableStates newStates) {
+                    public void migrate(@NonNull final MigrationContext ctx) {
+                        assertThat(ctx).isNotNull();
+                        final var previousStates = ctx.previousStates();
+                        final var newStates = ctx.newStates();
+
                         // First check that the previous states only includes what was there before,
                         // and nothing new
                         assertThat(previousStates.isEmpty()).isFalse();
@@ -389,7 +400,11 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     }
 
                     @Override
-                    public void migrate(@NonNull ReadableStates previousStates, @NonNull WritableStates newStates) {
+                    public void migrate(@NonNull MigrationContext ctx) {
+                        assertThat(ctx).isNotNull();
+                        final var previousStates = ctx.previousStates();
+                        final var newStates = ctx.newStates();
+
                         // Verify that everything in v2 is still here
                         assertThat(previousStates.stateKeys())
                                 .containsExactlyInAnyOrder(FRUIT_STATE_KEY, ANIMAL_STATE_KEY, COUNTRY_STATE_KEY);
@@ -432,7 +447,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
                 // When we migrate
                 schemaRegistry.register(schemaV1);
-                schemaRegistry.migrate(merkleTree, versions[0], versions[1]);
+                schemaRegistry.migrate(merkleTree, versions[0], versions[1], config);
 
                 // Then we see that the values for A, B, and C are available
                 final var readableStates = merkleTree.createReadableStates(FIRST_SERVICE);
@@ -451,7 +466,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                 // When we migrate
                 schemaRegistry.register(schemaV1);
                 schemaRegistry.register(schemaV2);
-                schemaRegistry.migrate(merkleTree, versions[0], versions[2]);
+                schemaRegistry.migrate(merkleTree, versions[0], versions[2], config);
 
                 // We should see the v2 state (the delta from v2 after applied atop v1)
                 final var readableStates = merkleTree.createReadableStates(FIRST_SERVICE);
@@ -481,7 +496,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                 schemaRegistry.register(schemaV1);
                 schemaRegistry.register(schemaV2);
                 schemaRegistry.register(schemaV3);
-                schemaRegistry.migrate(merkleTree, versions[0], versions[3]);
+                schemaRegistry.migrate(merkleTree, versions[0], versions[3], config);
 
                 // We should see the v3 state (the delta from v3 after applied atop v2 and v1)
                 final var readableStates = merkleTree.createReadableStates(FIRST_SERVICE);
@@ -516,7 +531,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                 schemaRegistry.register(schemaV2);
 
                 // We should see that the migration failed
-                assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[2]))
+                assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[2], config))
                         .isInstanceOf(RuntimeException.class)
                         .hasMessage("Bad");
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -33,6 +33,7 @@ import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.constructable.RuntimeConstructable;
+import com.swirlds.common.io.utility.TemporaryFileBuilder;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -41,7 +42,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 class SerializationTest extends MerkleTestBase {
@@ -49,10 +49,10 @@ class SerializationTest extends MerkleTestBase {
     private Configuration config;
 
     @BeforeEach
-    void setUp(@TempDir final Path tempDir) {
+    void setUp() throws IOException {
         setupConstructableRegistry();
 
-        this.dir = tempDir;
+        this.dir = TemporaryFileBuilder.buildTemporaryDirectory();
         this.config = Mockito.mock(Configuration.class);
         final var hederaConfig = Mockito.mock(HederaConfig.class);
         lenient().when(config.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -17,34 +17,45 @@
 package com.hedera.node.app.state.merkle;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 
 import com.hedera.node.app.spi.fixtures.state.TestSchema;
+import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import com.hedera.node.app.spi.state.ReadableQueueState;
 import com.hedera.node.app.spi.state.ReadableSingletonState;
-import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.StateDefinition;
 import com.hedera.node.app.spi.state.WritableKVState;
 import com.hedera.node.app.spi.state.WritableQueueState;
 import com.hedera.node.app.spi.state.WritableSingletonState;
-import com.hedera.node.app.spi.state.WritableStates;
+import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.constructable.RuntimeConstructable;
-import com.swirlds.common.io.utility.TemporaryFileBuilder;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 class SerializationTest extends MerkleTestBase {
+    private Path dir;
+    private Configuration config;
 
     @BeforeEach
-    void setUp() {
+    void setUp(@TempDir final Path tempDir) {
         setupConstructableRegistry();
+
+        this.dir = tempDir;
+        this.config = Mockito.mock(Configuration.class);
+        final var hederaConfig = Mockito.mock(HederaConfig.class);
+        lenient().when(config.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);
     }
 
     Schema createV1Schema() {
@@ -61,7 +72,8 @@ class SerializationTest extends MerkleTestBase {
             }
 
             @Override
-            public void migrate(@NonNull ReadableStates previousStates, @NonNull WritableStates newStates) {
+            public void migrate(@NonNull final MigrationContext ctx) {
+                final var newStates = ctx.newStates();
                 final WritableKVState<String, String> fruit = newStates.get(FRUIT_STATE_KEY);
                 fruit.put(A_KEY, APPLE);
                 fruit.put(B_KEY, BANANA);
@@ -103,32 +115,31 @@ class SerializationTest extends MerkleTestBase {
     void simpleReadAndWrite() throws IOException, ConstructableRegistryException {
         // Given a merkle tree with some fruit and animals and country
         final var v1 = version(1, 0, 0);
-        final var dir = TemporaryFileBuilder.buildTemporaryDirectory();
         final var originalTree = new MerkleHederaState(
                 (tree, state) -> {}, (evt, meta, provider) -> {}, (state, platform, dual, trigger, version) -> {});
-        final var originalRegistry = new MerkleSchemaRegistry(registry, dir, FIRST_SERVICE);
+        final var originalRegistry = new MerkleSchemaRegistry(registry, FIRST_SERVICE);
         final var schemaV1 = createV1Schema();
         originalRegistry.register(schemaV1);
-        originalRegistry.migrate(originalTree, null, v1);
+        originalRegistry.migrate(originalTree, null, v1, config);
 
         // When we serialize it to bytes and deserialize it back into a tree
         originalTree.copy(); // make a fast copy because we can only write to disk an immutable copy
         CRYPTO.digestTreeSync(originalTree);
         final var serializedBytes = writeTree(originalTree, dir);
-        final var newRegistry = new MerkleSchemaRegistry(registry, dir, FIRST_SERVICE);
+        final var newRegistry = new MerkleSchemaRegistry(registry, FIRST_SERVICE);
         newRegistry.register(schemaV1);
 
         // Register the MerkleHederaState so, when found in serialized bytes, it will register with
         // our migration callback, etc. (normally done by the Hedera main method)
         final Supplier<RuntimeConstructable> constructor = () -> new MerkleHederaState(
-                (tree, state) -> newRegistry.migrate((MerkleHederaState) state, v1, v1),
+                (tree, state) -> newRegistry.migrate((MerkleHederaState) state, v1, v1, config),
                 (event, meta, provider) -> {},
                 (state, platform, dualState, trigger, version) -> {});
         final var pair = new ClassConstructorPair(MerkleHederaState.class, constructor);
         registry.registerConstructable(pair);
 
         final MerkleHederaState loadedTree = parseTree(serializedBytes, dir);
-        newRegistry.migrate(loadedTree, schemaV1.getVersion(), schemaV1.getVersion());
+        newRegistry.migrate(loadedTree, schemaV1.getVersion(), schemaV1.getVersion(), config);
         loadedTree.migrate(1);
 
         // Then, we should be able to see all our original states again

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/adapters/MerkleMapLikeAdapterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/adapters/MerkleMapLikeAdapterTest.java
@@ -194,7 +194,7 @@ class MerkleMapLikeAdapterTest {
         final var tokenService = new TokenServiceImpl();
         final ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
 
-        tokenService.registerMonoAdapterSchemas(schemaRegistry);
+        tokenService.registerSchemas(schemaRegistry);
 
         verify(schemaRegistry).register(schemaCaptor.capture());
         final var schema = schemaCaptor.getValue();

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -21,8 +21,14 @@ import com.hedera.node.app.spi.fixtures.state.ListWritableQueueState;
 import com.hedera.node.app.spi.fixtures.state.MapReadableKVState;
 import com.hedera.node.app.spi.fixtures.state.MapWritableKVState;
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
+import com.hedera.node.app.spi.state.EmptyReadableStates;
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
+import com.hedera.node.app.spi.state.WritableStates;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -59,9 +65,27 @@ public class FakeSchemaRegistry implements SchemaRegistry {
             }
 
             // Run the migration which will populate the writable states
+            final var previousStates = new EmptyReadableStates();
             final var writableStates = new MapWritableStates(dataSources);
-            // TODO Fix this
-            //            schema.migrate(writableStates);
+            schema.migrate(new MigrationContext() {
+                @NonNull
+                @Override
+                public ReadableStates previousStates() {
+                    return previousStates;
+                }
+
+                @NonNull
+                @Override
+                public WritableStates newStates() {
+                    return writableStates;
+                }
+
+                @NonNull
+                @Override
+                public Configuration configuration() {
+                    return ConfigurationBuilder.create().build();
+                }
+            });
 
             // Now commit them all
             for (final var s : writables.values()) {

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -21,7 +21,6 @@ import com.hedera.node.app.spi.fixtures.state.ListWritableQueueState;
 import com.hedera.node.app.spi.fixtures.state.MapReadableKVState;
 import com.hedera.node.app.spi.fixtures.state.MapWritableKVState;
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
-import com.hedera.node.app.spi.state.EmptyReadableStates;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -61,7 +60,8 @@ public class FakeSchemaRegistry implements SchemaRegistry {
 
             // Run the migration which will populate the writable states
             final var writableStates = new MapWritableStates(dataSources);
-            schema.migrate(new EmptyReadableStates(), writableStates);
+            // TODO Fix this
+            //            schema.migrate(writableStates);
 
             // Now commit them all
             for (final var s : writables.values()) {

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/BytesConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/BytesConverter.java
@@ -32,11 +32,9 @@ public class BytesConverter implements ConfigConverter<Bytes> {
     public Bytes convert(@NonNull String value) throws IllegalArgumentException, NullPointerException {
         if (value == null) {
             throw new NullPointerException("BytesConverter cannot convert null value");
-        } else if (!value.startsWith("0x")) {
-            throw new IllegalArgumentException("Invalid format. Value must start with '0x': " + value);
         } else {
             try {
-                final var hex = value.substring(2);
+                final var hex = value.startsWith("0x") ? value.substring(2) : value;
                 final var bytes = unhex(hex);
                 return Bytes.wrap(bytes);
             } catch (final Exception e) {

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BootstrapConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BootstrapConfig.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.config.data;
 
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 
@@ -26,7 +27,7 @@ public record BootstrapConfig(
         @ConfigProperty(
                         value = "genesisPublicKey",
                         defaultValue = "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92")
-                String genesisPublicKey,
+                Bytes genesisPublicKey,
         @ConfigProperty(value = "hapiPermissions.path", defaultValue = "data/config/api-permission.properties")
                 String hapiPermissionsPath,
         @ConfigProperty(value = "networkProperties.path", defaultValue = "data/config/application.properties")

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/BytesConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/BytesConverterTest.java
@@ -54,6 +54,7 @@ class BytesConverterTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
+                "",
                 "0x",
                 "0xaa",
                 "0x1234",
@@ -72,7 +73,7 @@ class BytesConverterTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", " ", "  ", "1", "123", "abc", "0xu", "0x1", "0x123", "0x12345"})
+    @ValueSource(strings = {" ", "  ", "1", "123", "abc", "0xu", "0x1", "0x123", "0x12345", " 0xaa", "0xaa "})
     void testInvalidValue(final String value) {
         // given
         final BytesConverter bytesConverter = new BytesConverter();

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
@@ -39,11 +39,6 @@ public final class ConsensusServiceImpl implements ConsensusService {
     public static final String TOPICS_KEY = "TOPICS";
 
     @Override
-    public void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry) {
-        registerSchemas(registry);
-    }
-
-    @Override
     public void registerSchemas(@NonNull SchemaRegistry registry) {
         registry.register(consensusSchema());
     }

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceImpl.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceImpl.java
@@ -16,45 +16,17 @@
 
 package com.hedera.node.app.service.file.impl;
 
-import com.hedera.hapi.node.base.FileID;
-import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.hapi.node.state.file.File;
 import com.hedera.node.app.service.file.FileService;
-import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.service.file.impl.schemas.GenesisSchema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
-import com.hedera.node.app.spi.state.StateDefinition;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Set;
 
 /** Standard implementation of the {@link FileService} {@link com.hedera.node.app.spi.Service}. */
 public final class FileServiceImpl implements FileService {
-    private static final long MAX_BLOBS = 50_000_000L;
-    private static final SemanticVersion CURRENT_VERSION =
-            SemanticVersion.newBuilder().minor(34).build();
     public static final String BLOBS_KEY = "FILES";
 
     @Override
-    public void registerMonoAdapterSchemas(@NonNull final SchemaRegistry registry) {
-        registerSchemas(registry);
-    }
-
-    @Override
     public void registerSchemas(@NonNull final SchemaRegistry registry) {
-        registry.register(fileServiceSchema());
-    }
-
-    private Schema fileServiceSchema() {
-        return new Schema(CURRENT_VERSION) {
-            @NonNull
-            @Override
-            public Set<StateDefinition> statesToCreate() {
-                return Set.of(filesDef());
-            }
-        };
-    }
-
-    @NonNull
-    private static StateDefinition<FileID, File> filesDef() {
-        return StateDefinition.onDisk(BLOBS_KEY, FileID.PROTOBUF, File.PROTOBUF, Math.toIntExact(MAX_BLOBS));
+        registry.register(new GenesisSchema());
     }
 }

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.file.impl.schemas;
+
+import static com.hedera.hapi.node.base.HederaFunctionality.fromString;
+import static com.hedera.node.app.service.file.impl.FileServiceImpl.BLOBS_KEY;
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.hapi.node.base.CurrentAndNextFeeSchedule;
+import com.hedera.hapi.node.base.FeeComponents;
+import com.hedera.hapi.node.base.FeeData;
+import com.hedera.hapi.node.base.FeeSchedule;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.KeyList;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.SubType;
+import com.hedera.hapi.node.base.TimestampSeconds;
+import com.hedera.hapi.node.base.TransactionFeeSchedule;
+import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.transaction.ExchangeRate;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.spi.state.StateDefinition;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.node.config.data.BootstrapConfig;
+import com.hedera.node.config.data.FilesConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The initial schema definition for the file service.
+ */
+public class GenesisSchema extends Schema {
+    private static final Logger logger = LogManager.getLogger(GenesisSchema.class);
+    private static final SemanticVersion GENESIS_VERSION = SemanticVersion.DEFAULT;
+    /**
+     * A hint to the database system of the maximum number of files we will store. This MUST NOT BE CHANGED. If it is
+     * changed, then the database has to be rebuilt.
+     */
+    private static final int MAX_FILES_HINT = 50_000_000;
+
+    /** Create a new instance */
+    public GenesisSchema() {
+        super(GENESIS_VERSION);
+    }
+
+    @NonNull
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Set<StateDefinition> statesToCreate() {
+        return Set.of(StateDefinition.onDisk(BLOBS_KEY, FileID.PROTOBUF, File.PROTOBUF, MAX_FILES_HINT));
+    }
+
+    @Override
+    public void migrate(@NonNull final MigrationContext ctx) {
+        logger.debug("Migrating genesis state");
+        final var bootstrapConfig = ctx.configuration().getConfigData(BootstrapConfig.class);
+        final var filesConfig = ctx.configuration().getConfigData(FilesConfig.class);
+        final WritableKVState<FileID, File> files = ctx.newStates().get(BLOBS_KEY);
+        createGenesisAddressBook(bootstrapConfig, filesConfig, files);
+        createGenesisNodeDetails(bootstrapConfig, filesConfig, files);
+        createGenesisFeeSchedule(bootstrapConfig, filesConfig, files);
+        createGenesisExchangeRate(bootstrapConfig, filesConfig, files);
+        createGenesisNetworkProperties(bootstrapConfig, filesConfig, files);
+        createGenesisHapiPermissions(bootstrapConfig, filesConfig, files);
+        createGenesisThrottleDefinitions(bootstrapConfig, filesConfig, files);
+        createGenesisSoftwareUpdateZip(bootstrapConfig, filesConfig, files);
+    }
+
+    // ================================================================================================================
+    // Creates and loads the Address Book into state
+
+    private void createGenesisAddressBook(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis address book file");
+        // TBD Implement this method
+    }
+
+    // ================================================================================================================
+    // Creates and loads the Node Details into state
+
+    private void createGenesisNodeDetails(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis node details file");
+        // TBD Implement this method
+    }
+
+    // ================================================================================================================
+    // Creates and loads the initial Fee Schedule into state
+
+    private void createGenesisFeeSchedule(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis fee schedule file");
+        final var resourceName = bootstrapConfig.feeSchedulesJsonResource();
+        try (final var in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
+            final var feeScheduleJsonBytes = requireNonNull(in).readAllBytes();
+            final var feeSchedule = parseFeeSchedules(feeScheduleJsonBytes);
+            final var fileNum = filesConfig.feeSchedules();
+            final var fileId = FileID.newBuilder().fileNum(fileNum).build();
+            final var masterKey =
+                    Key.newBuilder().ed25519(bootstrapConfig.genesisPublicKey()).build();
+            files.put(
+                    fileId,
+                    File.newBuilder()
+                            .contents(CurrentAndNextFeeSchedule.PROTOBUF.toBytes(feeSchedule))
+                            .fileNumber(fileNum)
+                            .keys(KeyList.newBuilder().keys(masterKey))
+                            .expirationTime(bootstrapConfig.systemEntityExpiry())
+                            .build());
+        } catch (IOException | NullPointerException e) {
+            throw new IllegalArgumentException(
+                    "Fee schedule (" + resourceName + ") " + "could not be found in the class path", e);
+        }
+    }
+
+    private static CurrentAndNextFeeSchedule parseFeeSchedules(@NonNull final byte[] feeScheduleJsonBytes) {
+        try {
+            final var json = new ObjectMapper();
+            final var rootNode = json.readTree(feeScheduleJsonBytes);
+            final var builder = CurrentAndNextFeeSchedule.newBuilder();
+            final var schedules = rootNode.elements();
+            while (schedules.hasNext()) {
+                final var scheduleContainerNode = schedules.next();
+                if (scheduleContainerNode.has("currentFeeSchedule")) {
+                    final var currentFeeSchedule = parseFeeSchedule(scheduleContainerNode.get("currentFeeSchedule"));
+                    builder.currentFeeSchedule(currentFeeSchedule);
+                } else if (scheduleContainerNode.has("nextFeeSchedule")) {
+                    final var nextFeeSchedule = parseFeeSchedule(scheduleContainerNode.get("nextFeeSchedule"));
+                    builder.nextFeeSchedule(nextFeeSchedule);
+                } else {
+                    logger.warn("Unexpected node encountered while parsing fee schedule: {}", scheduleContainerNode);
+                }
+            }
+
+            return builder.build();
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Unable to parse fee schedule file", e);
+        }
+    }
+
+    private static FeeSchedule parseFeeSchedule(@NonNull final JsonNode scheduleNode) {
+        final var builder = FeeSchedule.newBuilder();
+        final var transactionFeeSchedules = new ArrayList<TransactionFeeSchedule>();
+        final var transactionFeeScheduleIterator = scheduleNode.elements();
+        while (transactionFeeScheduleIterator.hasNext()) {
+            final var childNode = transactionFeeScheduleIterator.next();
+            if (childNode.has("transactionFeeSchedule")) {
+                final var transactionFeeScheduleNode = childNode.get("transactionFeeSchedule");
+                final var feesContainer = transactionFeeScheduleNode.get("fees");
+                final var feeDataList = new ArrayList<FeeData>();
+                feesContainer.elements().forEachRemaining(feeNode -> feeDataList.add(parseFeeData(feeNode)));
+                transactionFeeSchedules.add(TransactionFeeSchedule.newBuilder()
+                        .hederaFunctionality(fromString(transactionFeeScheduleNode
+                                .get("hederaFunctionality")
+                                .asText()))
+                        .fees(feeDataList)
+                        .build());
+            } else if (childNode.has("expiryTime")) {
+                final var expiryTime = childNode.get("expiryTime").asLong();
+                builder.expiryTime(TimestampSeconds.newBuilder().seconds(expiryTime));
+            } else {
+                logger.warn("Unexpected node encountered while parsing fee schedule: {}", childNode);
+            }
+        }
+
+        return builder.transactionFeeSchedule(transactionFeeSchedules).build();
+    }
+
+    private static FeeData parseFeeData(@NonNull final JsonNode feeNode) {
+        return FeeData.newBuilder()
+                .subType(SubType.fromString(feeNode.get("subType").asText()))
+                .nodedata(parseFeeComponents(feeNode.get("nodedata")))
+                .networkdata(parseFeeComponents(feeNode.get("networkdata")))
+                .servicedata(parseFeeComponents(feeNode.get("servicedata")))
+                .build();
+    }
+
+    private static FeeComponents parseFeeComponents(@NonNull final JsonNode componentNode) {
+        return FeeComponents.newBuilder()
+                .constant(componentNode.get("constant").asLong())
+                .bpt(componentNode.get("bpt").asLong())
+                .vpt(componentNode.get("vpt").asLong())
+                .rbh(componentNode.get("rbh").asLong())
+                .sbh(componentNode.get("sbh").asLong())
+                .gas(componentNode.get("gas").asLong())
+                .bpr(componentNode.get("bpr").asLong())
+                .sbpr(componentNode.get("sbpr").asLong())
+                .min(componentNode.get("min").asLong())
+                .max(componentNode.get("max").asLong())
+                .build();
+    }
+
+    // ================================================================================================================
+    // Creates and loads the initial Exchange Rate into state
+
+    private void createGenesisExchangeRate(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis exchange rate file");
+        // See HfsSystemFilesManager#defaultRates. This does the same thing.
+        final var exchangeRateSet = ExchangeRateSet.newBuilder()
+                .currentRate(ExchangeRate.newBuilder()
+                        .centEquiv(bootstrapConfig.ratesCurrentCentEquiv())
+                        .hbarEquiv(bootstrapConfig.ratesCurrentHbarEquiv())
+                        .expirationTime(TimestampSeconds.newBuilder().seconds(bootstrapConfig.ratesCurrentExpiry()))
+                        .build())
+                .nextRate(ExchangeRate.newBuilder()
+                        .centEquiv(bootstrapConfig.ratesNextCentEquiv())
+                        .hbarEquiv(bootstrapConfig.ratesNextHbarEquiv())
+                        .expirationTime(TimestampSeconds.newBuilder().seconds(bootstrapConfig.ratesNextExpiry()))
+                        .build())
+                .build();
+
+        final var fileNum = filesConfig.exchangeRates();
+        final var fileId = FileID.newBuilder().fileNum(fileNum).build();
+        final var masterKey =
+                Key.newBuilder().ed25519(bootstrapConfig.genesisPublicKey()).build();
+        files.put(
+                fileId,
+                File.newBuilder()
+                        .contents(ExchangeRateSet.PROTOBUF.toBytes(exchangeRateSet))
+                        .fileNumber(fileNum)
+                        .keys(KeyList.newBuilder().keys(masterKey))
+                        .expirationTime(bootstrapConfig.systemEntityExpiry())
+                        .build());
+    }
+
+    // ================================================================================================================
+    // Creates and loads the network properties into state
+
+    private void createGenesisNetworkProperties(
+            @NonNull final BootstrapConfig v,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis network properties file");
+        // TBD Implement this method
+    }
+
+    // ================================================================================================================
+    // Creates and loads the HAPI Permissions into state
+
+    private void createGenesisHapiPermissions(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis HAPI permissions file");
+        // TBD Implement this method
+    }
+
+    // ================================================================================================================
+    // Creates and loads the Throttle definitions into state
+
+    private void createGenesisThrottleDefinitions(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis throttle definitions file");
+        // TBD Implement this method
+    }
+
+    // ================================================================================================================
+    // Creates and loads the software update file into state (may be empty? NOT SURE)
+
+    private void createGenesisSoftwareUpdateZip(
+            @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final FilesConfig filesConfig,
+            @NonNull final WritableKVState<FileID, File> files) {
+        logger.debug("Creating genesis software update zip file");
+        // TBD Implement this method
+    }
+}

--- a/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module com.hedera.node.app.service.file.impl {
     requires com.swirlds.config;
     requires org.apache.commons.lang3;
     requires org.apache.logging.log4j;
+    requires com.fasterxml.jackson.databind;
 
     provides com.hedera.node.app.service.file.FileService with
             FileServiceImpl;

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileServiceImplTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileServiceImplTest.java
@@ -39,7 +39,7 @@ class FileServiceImplTest {
     void registersExpectedSchema() {
         ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
 
-        subject().registerMonoAdapterSchemas(registry);
+        subject().registerSchemas(registry);
 
         verify(registry).register(schemaCaptor.capture());
 

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module com.hedera.node.app.service.mono {
     exports com.hedera.node.app.service.mono.state.submerkle to
             com.hedera.node.app.service.mono.test.fixtures,
             com.hedera.node.app,
+            com.hedera.node.app.service.network.admin.impl,
             com.hedera.node.app.service.schedule.impl,
             com.hedera.node.app.service.schedule.impl.test,
             com.hedera.node.app.service.token.impl,

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/FreezeServiceImpl.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/FreezeServiceImpl.java
@@ -17,8 +17,10 @@
 package com.hedera.node.app.service.networkadmin.impl;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.node.app.service.mono.state.merkle.MerkleSpecialFiles;
 import com.hedera.node.app.service.networkadmin.FreezeService;
 import com.hedera.node.app.service.networkadmin.impl.codec.MonoSpecialFilesAdapterCodec;
+import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
@@ -36,7 +38,7 @@ public final class FreezeServiceImpl implements FreezeService {
             SemanticVersion.newBuilder().minor(34).build();
 
     @Override
-    public void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry) {
+    public void registerSchemas(@NonNull SchemaRegistry registry) {
         registry.register(networkAdminSchema());
     }
 
@@ -47,6 +49,12 @@ public final class FreezeServiceImpl implements FreezeService {
             @SuppressWarnings("rawtypes")
             public Set<StateDefinition> statesToCreate() {
                 return Set.of(StateDefinition.singleton(UPGRADE_FILES_KEY, new MonoSpecialFilesAdapterCodec()));
+            }
+
+            @Override
+            public void migrate(@NonNull MigrationContext ctx) {
+                final var upgradeFilesState = ctx.newStates().getSingleton(UPGRADE_FILES_KEY);
+                upgradeFilesState.put(new MerkleSpecialFiles());
             }
         };
     }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/ReadableRunningHashLeafStoreImpl.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/ReadableRunningHashLeafStoreImpl.java
@@ -23,6 +23,7 @@ import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.networkadmin.ReadableRunningHashLeafStore;
 import com.hedera.node.app.spi.state.ReadableSingletonState;
 import com.hedera.node.app.spi.state.ReadableStates;
+import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.RunningHash;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -50,5 +51,11 @@ public class ReadableRunningHashLeafStoreImpl implements ReadableRunningHashLeaf
     @NonNull
     public RunningHash getNMinusThreeRunningHash() {
         return requireNonNull(runningHashState.get()).getNMinus3RunningHash();
+    }
+
+    @NonNull
+    @Override
+    public Hash getRunningHash() {
+        return requireNonNull(runningHashState.get()).getRunningHash().getHash();
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module com.hedera.node.app.service.network.admin.impl {
     requires transitive com.hedera.node.app.service.mono;
     requires transitive com.hedera.node.app.service.network.admin;
     requires transitive com.hedera.node.app.spi;
+    requires transitive com.hedera.node.config;
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.common;

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/module-info.java
@@ -15,7 +15,6 @@ module com.hedera.node.app.service.network.admin.impl {
     requires com.github.spotbugs.annotations;
     requires org.apache.logging.log4j;
     requires com.hedera.node.app.service.token;
-    requires com.hedera.node.config;
     requires com.google.common;
 
     provides com.hedera.node.app.service.networkadmin.FreezeService with

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
@@ -54,7 +54,7 @@ class FreezeServiceImplTest {
         final var subject = new FreezeServiceImpl();
         ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
 
-        subject.registerMonoAdapterSchemas(registry);
+        subject.registerSchemas(registry);
         verify(registry).register(schemaCaptor.capture());
         final var schema = schemaCaptor.getValue();
 

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/NetworkServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/NetworkServiceImplTest.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.service.networkadmin.impl.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.node.app.service.networkadmin.NetworkService;
 import com.hedera.node.app.service.networkadmin.impl.NetworkServiceImpl;
@@ -51,21 +50,12 @@ class NetworkServiceImplTest {
     }
 
     @Test
-    void doesNotYetHaveModularizedSchema() {
-        final NetworkService subject = new NetworkServiceImpl();
-
-        subject.registerSchemas(registry);
-
-        verifyNoInteractions(registry);
-    }
-
-    @Test
     void registersExpectedSchemaForMonoAdapter() {
         ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
 
         final var subject = new NetworkServiceImpl();
 
-        subject.registerMonoAdapterSchemas(registry);
+        subject.registerSchemas(registry);
         verify(registry).register(schemaCaptor.capture());
 
         final var schema = schemaCaptor.getValue();

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/NetworkServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/NetworkServiceImplTest.java
@@ -50,7 +50,7 @@ class NetworkServiceImplTest {
     }
 
     @Test
-    void registersExpectedSchemaForMonoAdapter() {
+    void registersExpectedSchema() {
         ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
 
         final var subject = new NetworkServiceImpl();

--- a/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/ReadableRunningHashLeafStore.java
+++ b/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/ReadableRunningHashLeafStore.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.networkadmin;
 
+import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.RunningHash;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -29,4 +30,11 @@ public interface ReadableRunningHashLeafStore {
      */
     @NonNull
     RunningHash getNMinusThreeRunningHash();
+
+    /**
+     * Get the current running hash from running hash leaf.
+     * @return the current running hash
+     */
+    @NonNull
+    Hash getRunningHash();
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.schedule.impl;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.service.mono.state.codec.MonoMapCodecAdapter;
+import com.hedera.node.app.service.mono.state.merkle.MerkleScheduledTransactionsState;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKey;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKeySerializer;
 import com.hedera.node.app.service.mono.state.virtual.schedule.ScheduleEqualityVirtualKey;
@@ -29,6 +30,7 @@ import com.hedera.node.app.service.mono.state.virtual.temporal.SecondSinceEpocVi
 import com.hedera.node.app.service.mono.state.virtual.temporal.SecondSinceEpocVirtualKeySerializer;
 import com.hedera.node.app.service.schedule.ScheduleService;
 import com.hedera.node.app.service.schedule.impl.serdes.MonoSchedulingStateAdapterCodec;
+import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
@@ -48,7 +50,7 @@ public final class ScheduleServiceImpl implements ScheduleService {
     public static final String SCHEDULES_BY_EQUALITY_KEY = "SCHEDULES_BY_EQUALITY";
 
     @Override
-    public void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry) {
+    public void registerSchemas(@NonNull SchemaRegistry registry) {
         registry.register(scheduleSchema());
     }
 
@@ -63,6 +65,13 @@ public final class ScheduleServiceImpl implements ScheduleService {
                         schedulesByIdDef(),
                         schedulesByExpirySec(),
                         schedulesByEquality());
+            }
+
+            @Override
+            public void migrate(@NonNull MigrationContext ctx) {
+                // Prepopulate the ScheduleServices state with default values for genesis
+                final var s = ctx.newStates().getSingleton(SCHEDULING_STATE_KEY);
+                s.put(new MerkleScheduledTransactionsState()); // never scheduled
             }
         };
     }

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/ScheduleServiceImplTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/ScheduleServiceImplTest.java
@@ -53,7 +53,7 @@ class ScheduleServiceImplTest {
 
         final var subject = ScheduleService.getInstance();
 
-        subject.registerMonoAdapterSchemas(registry);
+        subject.registerSchemas(registry);
         verify(registry).register(schemaCaptor.capture());
 
         final var schema = schemaCaptor.getValue();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
@@ -39,7 +39,7 @@ public final class ContractServiceImpl implements ContractService {
     public static final String BYTECODE_KEY = "BYTECODE";
 
     @Override
-    public void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry) {
+    public void registerSchemas(@NonNull SchemaRegistry registry) {
         registry.register(contractSchema());
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
@@ -55,7 +55,7 @@ class ContractServiceImplTest {
 
         final var subject = ContractService.getInstance();
 
-        subject.registerMonoAdapterSchemas(registry);
+        subject.registerSchemas(registry);
         verify(registry).register(schemaCaptor.capture());
 
         final var schema = schemaCaptor.getValue();

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/UtilServiceImpl.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/UtilServiceImpl.java
@@ -17,13 +17,6 @@
 package com.hedera.node.app.service.util.impl;
 
 import com.hedera.node.app.service.util.UtilService;
-import com.hedera.node.app.spi.state.SchemaRegistry;
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 /** Standard implementation of the {@link UtilService} {@link com.hedera.node.app.spi.Service}. */
-public final class UtilServiceImpl implements UtilService {
-    @Override
-    public void registerMonoAdapterSchemas(@NonNull SchemaRegistry registry) {
-        // No-op
-    }
-}
+public final class UtilServiceImpl implements UtilService {}


### PR DESCRIPTION
Closes #6971 

From this PR forward, the modular services are responsible for setting up their own state, starting with a Genesis Schema (0.0.0). This Genesis schema will prepopulate the state for the service as appropriate. We will have a separate migration code for migrating from mainnet state into the modular state. This migration could be as simple or as complex as needed, based on the needs of the service. That mono->modular migration will be done in a separate PR. For now, each service author should focus on getting the genesis state right and passing all e2e tests.