### PR TITLE
Partial fixes for #6984

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -274,8 +274,6 @@ module com.hedera.node.app.service.mono {
     requires transitive com.swirlds.virtualmap;
     requires transitive dagger;
     requires transitive headlong;
-    requires transitive grpc.stub;
-    requires transitive io.grpc;
     requires transitive io.helidon.grpc.core;
     requires transitive io.helidon.grpc.server;
     requires transitive javax.inject;
@@ -292,8 +290,6 @@ module com.hedera.node.app.service.mono {
     requires com.swirlds.base;
     requires com.swirlds.logging;
     requires com.swirlds.platform;
-    requires io.netty.handler;
-    requires io.netty.transport;
     requires org.apache.commons.collections4;
     requires org.apache.commons.io;
     requires org.bouncycastle.provider;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/HgcaaLogValidator.java
@@ -54,6 +54,9 @@ public class HgcaaLogValidator {
 
         private static final List<List<String>> PROBLEM_PATTERNS_TO_IGNORE = List.of(
                 List.of("active throttles, but", "Not performing a reset!"),
+                List.of(
+                        "Could not start Helidon gRPC with TLS support on port",
+                        "Resource on path: /opt/hedera/services/hedera.crt does not exist"),
                 List.of("Specified TLS cert 'hedera.crt' doesn't exist!"),
                 List.of("Could not start Netty with TLS support on port 50212"),
                 List.of("CryptoTransfer throughput congestion has no throttle buckets"),


### PR DESCRIPTION
Small commit to fix the failing integration tests
 * Added two "problem patterns" to HgcaaLogValidator so that log validation is correct with current code.
 * Removed unnecessary module requires from mono-service leftover from shift to helidon-grpc
