### PR TITLE
7006: Old virtual map copies aren't released during to disk migration

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDisk.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDisk.java
@@ -84,6 +84,7 @@ public class MapMigrationToDisk {
                     onDiskAccounts.get().put(new EntityNumVirtualKey(num.longValue()), onDiskAccount);
                     if (insertionsSoFar.incrementAndGet() % insertionsPerCopy == 0) {
                         final var onDiskAccountsCopy = onDiskAccounts.get().copy();
+                        onDiskAccounts.get().release();
                         onDiskAccounts.set(onDiskAccountsCopy);
                     }
                 }),
@@ -111,6 +112,7 @@ public class MapMigrationToDisk {
                     onDiskRels.get().put(EntityNumVirtualKey.fromPair(numPair), onDiskRel);
                     if (insertionsSoFar.incrementAndGet() % insertionsPerCopy == 0) {
                         final var onDiskRelCopy = onDiskRels.get().copy();
+                        onDiskRels.get().release();
                         onDiskRels.set(onDiskRelCopy);
                     }
                 }),


### PR DESCRIPTION
Backport to 0.39

Fixes: https://github.com/hashgraph/hedera-services/issues/7006
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>