### PR TITLE
Removed terrible `throws Throwable` from some test scenario code, replaced with correct exceptions

### DIFF
--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleSignScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleSignScenarios.java
@@ -20,16 +20,22 @@ import static com.hedera.test.factories.txns.CryptoTransferFactory.newSignedCryp
 import static com.hedera.test.factories.txns.ScheduleSignFactory.newSignedScheduleSign;
 import static com.hedera.test.factories.txns.TinyBarsFromTo.tinyBarsFromTo;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 import com.hedera.node.app.service.mono.utils.accessors.SignedTxnAccessor;
 import com.hedera.test.factories.txns.ScheduleUtils;
 import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum ScheduleSignScenarios implements TxnHandlingScenario {
     SCHEDULE_SIGN_MISSING_SCHEDULE {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
                     newSignedScheduleSign().signing(UNKNOWN_SCHEDULE).get());
         }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SignedTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SignedTxnFactory.java
@@ -23,6 +23,7 @@ import static java.util.Collections.EMPTY_LIST;
 import static java.util.stream.Collectors.toList;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.hapi.utils.fee.FeeBuilder;
 import com.hedera.test.factories.keys.KeyFactory;
 import com.hedera.test.factories.keys.KeyTree;
@@ -34,6 +35,9 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +82,8 @@ public abstract class SignedTxnFactory<T extends SignedTxnFactory<T>> {
 
     protected abstract void customizeTxn(TransactionBody.Builder txn);
 
-    public Transaction get() throws Throwable {
+    public Transaction get()
+            throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException, InvalidKeyException {
         final Transaction provisional = signed(signableTxn(customFee.orElse(0L)));
         return customFee.isPresent() ? provisional : signed(signableTxn(feeFor(provisional, payerKt.numLeaves())));
     }
@@ -91,7 +96,8 @@ public abstract class SignedTxnFactory<T extends SignedTxnFactory<T>> {
                 .setBodyBytes(ByteString.copyFrom(txn.build().toByteArray()));
     }
 
-    private Transaction signed(final Transaction.Builder txnWithSigs) throws Throwable {
+    private Transaction signed(final Transaction.Builder txnWithSigs)
+            throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException, InvalidKeyException {
         final List<KeyTree> signers = allKts();
         return sigFactory.signWithSigMap(txnWithSigs, signers, keyFactory);
     }


### PR DESCRIPTION
Small change to remove a few of the `throws Throwable` clauses that cause everything in the test fixtures to declare Throwable rather than specific exceptions or, at least, the much narrower Exception.

Precursor to Schedule Handler work for #5518