### PR TITLE
Objects.requireNonNull used in platform-core

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntake.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntake.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.components;
 
-import static com.swirlds.base.ArgumentUtils.throwArgNull;
 import static com.swirlds.logging.LogMarker.INTAKE_EVENT;
 import static com.swirlds.logging.LogMarker.STALE_EVENTS;
 import static com.swirlds.logging.LogMarker.SYNC;
@@ -37,6 +36,7 @@ import com.swirlds.platform.observers.EventObserverDispatcher;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -80,14 +80,14 @@ public class EventIntake {
             @NonNull final EventObserverDispatcher dispatcher,
             @NonNull final IntakeCycleStats stats,
             @NonNull final ShadowGraph shadowGraph) {
-        this.selfId = throwArgNull(selfId, "selfId");
-        this.eventLinker = throwArgNull(eventLinker, "eventLinker");
-        this.consensusSupplier = throwArgNull(consensusSupplier, "consensusSupplier");
+        this.selfId = Objects.requireNonNull(selfId, "selfId must not be null");
+        this.eventLinker = Objects.requireNonNull(eventLinker, "eventLinker must not be null");
+        this.consensusSupplier = Objects.requireNonNull(consensusSupplier, "consensusSupplier must not be null");
         this.consensusWrapper = new ConsensusWrapper(consensusSupplier);
-        this.addressBook = throwArgNull(addressBook, "addressBook");
-        this.dispatcher = throwArgNull(dispatcher, "dispatcher");
-        this.stats = throwArgNull(stats, "stats");
-        this.shadowGraph = throwArgNull(shadowGraph, "shadowGraph");
+        this.addressBook = Objects.requireNonNull(addressBook, "addressBook must not be null");
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+        this.stats = Objects.requireNonNull(stats, "stats must not be null");
+        this.shadowGraph = Objects.requireNonNull(shadowGraph, "shadowGraph must not be null");
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/AsyncPreconsensusEventWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/AsyncPreconsensusEventWriter.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.event.preconsensus;
 
-import static com.swirlds.base.ArgumentUtils.throwArgNull;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 
 import com.swirlds.common.context.PlatformContext;
@@ -28,6 +27,7 @@ import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.platform.internal.EventImpl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -107,9 +107,9 @@ public class AsyncPreconsensusEventWriter implements PreconsensusEventWriter {
             @NonNull final ThreadManager threadManager,
             @NonNull final PreconsensusEventWriter writer) {
 
-        throwArgNull(platformContext, "platformContext");
-        throwArgNull(threadManager, "threadManager");
-        this.writer = throwArgNull(writer, "writer");
+        Objects.requireNonNull(platformContext, "platformContext must not be null");
+        Objects.requireNonNull(threadManager, "threadManager must not be null");
+        this.writer = Objects.requireNonNull(writer, "writer must not be null");
 
         final PreconsensusEventStreamConfig config =
                 platformContext.getConfiguration().getConfigData(PreconsensusEventStreamConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/SyncPreconsensusEventWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/SyncPreconsensusEventWriter.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.event.preconsensus;
 
-import static com.swirlds.base.ArgumentUtils.throwArgNull;
 import static com.swirlds.common.units.DataUnit.UNIT_BYTES;
 import static com.swirlds.common.units.DataUnit.UNIT_MEGABYTES;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
@@ -33,6 +32,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -139,8 +139,8 @@ public class SyncPreconsensusEventWriter implements PreconsensusEventWriter, Sta
     public SyncPreconsensusEventWriter(
             @NonNull final PlatformContext platformContext, @NonNull final PreconsensusEventFileManager fileManager) {
 
-        throwArgNull(platformContext, "platformContext");
-        throwArgNull(fileManager, "fileManager");
+        Objects.requireNonNull(platformContext, "platformContext must not be null");
+        Objects.requireNonNull(fileManager, "fileManager must not be null");
 
         final PreconsensusEventStreamConfig config =
                 platformContext.getConfiguration().getConfigData(PreconsensusEventStreamConfig.class);
@@ -256,7 +256,7 @@ public class SyncPreconsensusEventWriter implements PreconsensusEventWriter, Sta
      */
     @Override
     public boolean isEventDurable(@NonNull final EventImpl event) {
-        throwArgNull(event, "event");
+        Objects.requireNonNull(event, "event must not be null");
         if (event.getStreamSequenceNumber() == EventImpl.STALE_EVENT_STREAM_SEQUENCE_NUMBER) {
             // Stale events are not written to disk.
             return false;
@@ -269,7 +269,7 @@ public class SyncPreconsensusEventWriter implements PreconsensusEventWriter, Sta
      */
     @Override
     public void waitUntilDurable(@NonNull final EventImpl event) throws InterruptedException {
-        throwArgNull(event, "event");
+        Objects.requireNonNull(event, "event must not be null");
         if (event.getStreamSequenceNumber() == EventImpl.STALE_EVENT_STREAM_SEQUENCE_NUMBER) {
             throw new IllegalStateException("Event is stale and will never be durable");
         }
@@ -282,8 +282,8 @@ public class SyncPreconsensusEventWriter implements PreconsensusEventWriter, Sta
     @Override
     public boolean waitUntilDurable(@NonNull final EventImpl event, @NonNull final Duration timeToWait)
             throws InterruptedException {
-        throwArgNull(event, "event");
-        throwArgNull(timeToWait, "timeToWait");
+        Objects.requireNonNull(event, "event must not be null");
+        Objects.requireNonNull(timeToWait, "timeToWait must not be null");
         if (event.getStreamSequenceNumber() == EventImpl.STALE_EVENT_STREAM_SEQUENCE_NUMBER) {
             throw new IllegalStateException("Event is stale and will never be durable");
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManagerImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManagerImpl.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.gossip;
 
-import com.swirlds.base.ArgumentUtils;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.system.EventCreationRule;
 import com.swirlds.common.system.EventCreationRuleResponse;
@@ -76,9 +75,10 @@ public class FallenBehindManagerImpl implements FallenBehindManager, EventCreati
         for (final int neighbor : neighbors) {
             allNeighbors.add(addressBook.getNodeId(neighbor));
         }
-        this.notifyPlatform = ArgumentUtils.throwArgNull(notifyPlatform, "notifyPlatform");
-        this.fallenBehindCallback = ArgumentUtils.throwArgNull(fallenBehindCallback, "fallenBehindCallback");
-        this.config = ArgumentUtils.throwArgNull(config, "config");
+        this.notifyPlatform = Objects.requireNonNull(notifyPlatform, "notifyPlatform must not be null");
+        this.fallenBehindCallback =
+                Objects.requireNonNull(fallenBehindCallback, "fallenBehindCallback must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
     }
 
     @Override

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ConsensusRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ConsensusRound.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.internal;
 
-import static com.swirlds.base.ArgumentUtils.throwArgNull;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 import com.swirlds.common.system.Round;
@@ -28,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -69,9 +69,9 @@ public class ConsensusRound implements Round {
             @NonNull final EventImpl keystoneEvent,
             @NonNull final GraphGenerations generations) {
 
-        throwArgNull(consensusEvents, "consensusEvents");
-        throwArgNull(keystoneEvent, "keystoneEvent");
-        throwArgNull(generations, "generations");
+        Objects.requireNonNull(consensusEvents, "consensusEvents must not be null");
+        Objects.requireNonNull(keystoneEvent, "keystoneEvent must not be null");
+        Objects.requireNonNull(generations, "generations must not be null");
 
         this.consensusEvents = Collections.unmodifiableList(consensusEvents);
         this.keystoneEvent = keystoneEvent;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerThrottle.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerThrottle.java
@@ -20,7 +20,6 @@ import static com.swirlds.logging.LogMarker.EXCEPTION;
 import static com.swirlds.logging.LogMarker.SOCKET_EXCEPTIONS;
 import static com.swirlds.logging.LogMarker.STARTUP;
 
-import com.swirlds.base.ArgumentUtils;
 import com.swirlds.common.StartupTime;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.system.NodeId;
@@ -32,6 +31,7 @@ import com.swirlds.platform.network.NetworkUtils;
 import com.swirlds.platform.system.SystemExitCode;
 import com.swirlds.platform.system.SystemExitUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -48,8 +48,8 @@ public class ReconnectLearnerThrottle {
     private int failedReconnectsInARow;
 
     public ReconnectLearnerThrottle(@NonNull final NodeId selfId, @NonNull final ReconnectConfig config) {
-        this.selfId = ArgumentUtils.throwArgNull(selfId, "selfId");
-        this.config = ArgumentUtils.throwArgNull(config, "config");
+        this.selfId = Objects.requireNonNull(selfId, "selfId must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
         this.failedReconnectsInARow = 0;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectProtocolResponder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectProtocolResponder.java
@@ -18,7 +18,6 @@ package com.swirlds.platform.reconnect;
 
 import static com.swirlds.logging.LogMarker.RECONNECT;
 
-import com.swirlds.base.ArgumentUtils;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.platform.components.state.query.LatestSignedStateProvider;
@@ -29,6 +28,7 @@ import com.swirlds.platform.network.unidirectional.NetworkProtocolResponder;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,13 +67,13 @@ public class ReconnectProtocolResponder implements NetworkProtocolResponder {
             @NonNull final ReconnectThrottle reconnectThrottle,
             @NonNull final FallenBehindManager fallenBehindManager,
             @NonNull final ReconnectMetrics stats) {
-        this.threadManager = ArgumentUtils.throwArgNull(threadManager, "threadManager");
+        this.threadManager = Objects.requireNonNull(threadManager, "threadManager must not be null");
         this.latestSignedStateProvider =
-                ArgumentUtils.throwArgNull(latestSignedStateProvider, "latestSignedStateProvider");
-        this.config = ArgumentUtils.throwArgNull(config, "config");
-        this.fallenBehindManager = ArgumentUtils.throwArgNull(fallenBehindManager, "fallenBehindManager");
-        this.reconnectThrottle = ArgumentUtils.throwArgNull(reconnectThrottle, "reconnectThrottle");
-        this.stats = ArgumentUtils.throwArgNull(stats, "stats");
+                Objects.requireNonNull(latestSignedStateProvider, "latestSignedStateProvider must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.fallenBehindManager = Objects.requireNonNull(fallenBehindManager, "fallenBehindManager must not be null");
+        this.reconnectThrottle = Objects.requireNonNull(reconnectThrottle, "reconnectThrottle must not be null");
+        this.stats = Objects.requireNonNull(stats, "stats must not be null");
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectThrottle.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectThrottle.java
@@ -18,7 +18,6 @@ package com.swirlds.platform.reconnect;
 
 import static com.swirlds.logging.LogMarker.RECONNECT;
 
-import com.swirlds.base.ArgumentUtils;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.system.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -26,6 +25,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,7 +59,7 @@ public class ReconnectThrottle {
     private Supplier<Instant> currentTime;
 
     public ReconnectThrottle(@NonNull final ReconnectConfig config) {
-        this.config = ArgumentUtils.throwArgNull(config, "config");
+        this.config = Objects.requireNonNull(config, "config must not be null");
         lastReconnectTime = new HashMap<>();
         reconnectingNode = null;
         currentTime = Instant::now;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectProtocol.java
@@ -18,7 +18,6 @@ package com.swirlds.platform.reconnect.emergency;
 
 import static com.swirlds.logging.LogMarker.RECONNECT;
 
-import com.swirlds.base.ArgumentUtils;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
 import com.swirlds.common.notification.listeners.ReconnectCompleteNotification;
@@ -35,6 +34,7 @@ import com.swirlds.platform.recovery.EmergencyRecoveryManager;
 import com.swirlds.platform.state.signed.SignedStateFinder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -97,7 +97,7 @@ public class EmergencyReconnectProtocol implements Protocol {
         this.reconnectSocketTimeout = reconnectSocketTimeout;
         this.reconnectMetrics = reconnectMetrics;
         this.reconnectController = reconnectController;
-        this.fallenBehindManager = ArgumentUtils.throwArgNull(fallenBehindManager, "fallenBehindManager");
+        this.fallenBehindManager = Objects.requireNonNull(fallenBehindManager, "fallenBehindManager must not be null");
     }
 
     @Override

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssHandler.java
@@ -16,8 +16,6 @@
 
 package com.swirlds.platform.state.iss;
 
-import static com.swirlds.base.ArgumentUtils.throwArgNull;
-
 import com.swirlds.base.time.Time;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.crypto.Hash;
@@ -75,16 +73,17 @@ public class IssHandler {
             @NonNull final FatalErrorConsumer fatalErrorConsumer,
             @NonNull final IssConsumer issConsumer) {
 
-        this.issConsumer = throwArgNull(issConsumer, "issConsumer");
-        this.haltRequestedConsumer = throwArgNull(haltRequestedConsumer, "haltRequestedConsumer");
-        this.fatalErrorConsumer = throwArgNull(fatalErrorConsumer, "fatalErrorConsumer");
+        this.issConsumer = Objects.requireNonNull(issConsumer, "issConsumer must not be null");
+        this.haltRequestedConsumer =
+                Objects.requireNonNull(haltRequestedConsumer, "haltRequestedConsumer must not be null");
+        this.fatalErrorConsumer = Objects.requireNonNull(fatalErrorConsumer, "fatalErrorConsumer must not be null");
         this.stateDumpRequestedDispatcher =
                 dispatchBuilder.getDispatcher(this, StateDumpRequestedTrigger.class)::dispatch;
 
-        this.stateConfig = throwArgNull(stateConfig, "stateConfig");
+        this.stateConfig = Objects.requireNonNull(stateConfig, "stateConfig must not be null");
         this.issDumpRateLimiter = new RateLimiter(time, Duration.ofSeconds(stateConfig.secondsBetweenISSDumps()));
 
-        this.selfId = throwArgNull(selfId, "selfId");
+        this.selfId = Objects.requireNonNull(selfId, "selfId must not be null");
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileManager.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.state.signed;
 
-import static com.swirlds.base.ArgumentUtils.throwArgNull;
 import static com.swirlds.common.io.utility.FileUtils.deleteDirectoryAndLog;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 import static com.swirlds.logging.LogMarker.STATE_TO_DISK;
@@ -127,15 +126,15 @@ public class SignedStateFileManager implements Startable {
             @NonNull final StateToDiskAttemptConsumer stateToDiskAttemptConsumer,
             @NonNull final MinimumGenerationNonAncientConsumer minimumGenerationNonAncientConsumer) {
 
-        this.metrics = throwArgNull(metrics, "metrics");
+        this.metrics = Objects.requireNonNull(metrics, "metrics must not be null");
         this.time = time;
         this.selfId = selfId;
         this.mainClassName = mainClassName;
         this.swirldName = swirldName;
         this.stateToDiskAttemptConsumer = stateToDiskAttemptConsumer;
         this.stateConfig = context.getConfiguration().getConfigData(StateConfig.class);
-        this.minimumGenerationNonAncientConsumer =
-                throwArgNull(minimumGenerationNonAncientConsumer, "minimumGenerationNonAncientConsumer");
+        this.minimumGenerationNonAncientConsumer = Objects.requireNonNull(
+                minimumGenerationNonAncientConsumer, "minimumGenerationNonAncientConsumer must not be null");
 
         final BasicConfig basicConfig = context.getConfiguration().getConfigData(BasicConfig.class);
 


### PR DESCRIPTION
`Objects.requireNonNull` used in platform-core instead of `throwArgNull`