### PR TITLE
Make all TokenService validators not depend on `ConfigProvider`

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.spi.info;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.swirlds.common.system.address.AddressBook;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Summarizes useful information about the nodes in the {@link AddressBook} from the Platform. In
@@ -41,5 +42,20 @@ public interface NodeInfo {
      * @throws IllegalArgumentException if the book did not contain the id, or was missing an
      *     account for the id
      */
+    @NonNull
     AccountID accountOf(long nodeId);
+
+    /**
+     * Returns if the given node id is valid and the address book contains the id.
+     * @param nodeId the id of interest
+     * @return true if the given node id is valid. False otherwise.
+     */
+    default boolean isValidId(long nodeId) {
+        try {
+            accountOf(nodeId);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -38,6 +38,7 @@ import com.hedera.node.app.service.token.CryptoSignatureWaivers;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
+import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.app.spi.validation.EntityType;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -60,13 +61,17 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
 
     private final CryptoSignatureWaivers waivers;
     private StakingValidator stakingValidator;
+    private NodeInfo nodeInfo;
 
     @Inject
     public CryptoUpdateHandler(
-            @NonNull final CryptoSignatureWaivers waivers, @NonNull final StakingValidator stakingValidator) {
+            @NonNull final CryptoSignatureWaivers waivers,
+            @NonNull final StakingValidator stakingValidator,
+            @NonNull final NodeInfo nodeInfo) {
         this.waivers = requireNonNull(waivers, "The supplied argument 'waivers' must not be null");
         this.stakingValidator =
                 requireNonNull(stakingValidator, "The supplied argument 'stakingValidator' must not be null");
+        this.nodeInfo = requireNonNull(nodeInfo, "The supplied argument 'nodeInfo' must not be null");
     }
 
     @Override
@@ -265,6 +270,8 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
                 op.stakedId().kind().name(),
                 op.stakedAccountId(),
                 op.stakedNodeId(),
-                accountStore);
+                accountStore,
+                context,
+                nodeInfo);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -142,7 +142,8 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
     private void validateSemantics(final HandleContext context) {
         requireNonNull(context);
         final var op = context.body().tokenMintOrThrow();
-        validator.validateMint(op.amount(), op.metadata());
+        final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
+        validator.validateMint(op.amount(), op.metadata(), tokensConfig);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
@@ -29,7 +29,6 @@ import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.NftAllowance;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableNftStore;
-import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.HederaConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -38,25 +37,11 @@ import java.util.List;
 import javax.inject.Inject;
 
 public class AllowanceValidator {
-    final ConfigProvider configProvider;
 
     @Inject
-    public AllowanceValidator(final ConfigProvider configProvider) {
-        this.configProvider = configProvider;
-    }
+    public AllowanceValidator() {}
 
-    /**
-     * Check if the allowance feature is enabled
-     *
-     * @return true if the feature is enabled in {@link HederaConfig}
-     */
-    public boolean isEnabled() {
-        final var hederaConfig = configProvider.getConfiguration().getConfigData(HederaConfig.class);
-        return hederaConfig.allowancesIsEnabled();
-    }
-
-    protected void validateTotalAllowancesPerTxn(final int totalAllowances) {
-        final var hederaConfig = configProvider.getConfiguration().getConfigData(HederaConfig.class);
+    protected void validateTotalAllowancesPerTxn(final int totalAllowances, @NonNull final HederaConfig hederaConfig) {
         validateFalse(
                 exceedsTxnLimit(totalAllowances, hederaConfig.allowancesMaxTransactionLimit()),
                 MAX_ALLOWANCES_EXCEEDED);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/StakingValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/StakingValidator.java
@@ -23,9 +23,9 @@ import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.node.app.service.mono.context.NodeInfo;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.app.spi.info.NodeInfo;
+import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.data.StakingConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -37,31 +37,29 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class StakingValidator {
-    private NodeInfo nodeInfo;
-    private ConfigProvider configProvider;
-
     @Inject
-    public StakingValidator(NodeInfo nodeInfo, ConfigProvider configProvider) {
-        this.nodeInfo = nodeInfo;
-        this.configProvider = configProvider;
-    }
+    public StakingValidator() {}
 
     /**
      * Validates staked id if present
+     *
      * @param hasDeclineRewardChange if the transaction body has decline reward field to be updated
-     * @param stakedIdKind staked id kind (account or node)
-     * @param stakedAccountIdInOp staked account id
-     * @param stakedNodeIdInOp staked node id
-     * @param accountStore readable account store
+     * @param stakedIdKind           staked id kind (account or node)
+     * @param stakedAccountIdInOp    staked account id
+     * @param stakedNodeIdInOp       staked node id
+     * @param accountStore           readable account store
+     * @param context
      */
     public void validateStakedId(
             @NonNull final boolean hasDeclineRewardChange,
             @NonNull final String stakedIdKind,
             @Nullable final AccountID stakedAccountIdInOp,
             @Nullable final Long stakedNodeIdInOp,
-            @NonNull ReadableAccountStore accountStore) {
+            @NonNull ReadableAccountStore accountStore,
+            @NonNull final HandleContext context,
+            @NonNull final NodeInfo nodeInfo) {
         final var hasStakingId = stakedAccountIdInOp != null || stakedNodeIdInOp != null;
-        final var stakingConfig = configProvider.getConfiguration().getConfigData(StakingConfig.class);
+        final var stakingConfig = context.configuration().getConfigData(StakingConfig.class);
         // If staking is not enabled, then can't update staked id
         validateFalse(!stakingConfig.isEnabled() && (hasStakingId || hasDeclineRewardChange), STAKING_NOT_ENABLED);
 
@@ -75,7 +73,7 @@ public class StakingValidator {
         if (stakedIdKind.equals("STAKED_ACCOUNT_ID")) {
             validateTrue(accountStore.getAccountById(requireNonNull(stakedAccountIdInOp)) != null, INVALID_STAKING_ID);
         } else if (stakedIdKind.equals("STAKED_NODE_ID")) {
-            validateTrue(nodeInfo.isValidId((requireNonNull(stakedNodeIdInOp).longValue())), INVALID_STAKING_ID);
+            validateTrue(nodeInfo.isValidId((requireNonNull(stakedNodeIdInOp))), INVALID_STAKING_ID);
         }
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAttributesValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAttributesValidator.java
@@ -35,7 +35,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.TokensConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -49,21 +48,17 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class TokenAttributesValidator {
-    private final ConfigProvider configProvider;
     public static final Key IMMUTABILITY_SENTINEL_KEY =
             Key.newBuilder().keyList(KeyList.DEFAULT).build();
 
     @Inject
-    public TokenAttributesValidator(@NonNull final ConfigProvider configProvider) {
-        this.configProvider = configProvider;
-    }
+    public TokenAttributesValidator() {}
 
     /**
      * Validates the token symbol, if it is exists and is not empty or not too long.
      * @param symbol the token symbol to validate
      */
-    public void validateTokenSymbol(@Nullable final String symbol) {
-        final var tokensConfig = configProvider.getConfiguration().getConfigData(TokensConfig.class);
+    public void validateTokenSymbol(@Nullable final String symbol, @NonNull final TokensConfig tokensConfig) {
         tokenStringCheck(symbol, tokensConfig.maxSymbolUtf8Bytes(), MISSING_TOKEN_SYMBOL, TOKEN_SYMBOL_TOO_LONG);
     }
 
@@ -71,8 +66,7 @@ public class TokenAttributesValidator {
      * Validates the token name, if it is exists and is not empty or not too long.
      * @param name the token name to validate
      */
-    public void validateTokenName(@Nullable final String name) {
-        final var tokensConfig = configProvider.getConfiguration().getConfigData(TokensConfig.class);
+    public void validateTokenName(@Nullable final String name, @NonNull final TokensConfig tokensConfig) {
         tokenStringCheck(name, tokensConfig.maxTokenNameUtf8Bytes(), MISSING_TOKEN_NAME, TOKEN_NAME_TOO_LONG);
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenCreateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenCreateValidator.java
@@ -119,8 +119,8 @@ public class TokenCreateValidator {
         }
 
         context.attributeValidator().validateMemo(op.memo());
-        tokenAttributesValidator.validateTokenSymbol(op.symbol());
-        tokenAttributesValidator.validateTokenName(op.name());
+        tokenAttributesValidator.validateTokenSymbol(op.symbol(), config);
+        tokenAttributesValidator.validateTokenName(op.name(), config);
 
         tokenAttributesValidator.checkKeys(
                 op.hasAdminKey(), op.adminKey(),

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
@@ -34,7 +34,6 @@ import com.hedera.hapi.node.token.CryptoApproveAllowanceTransactionBody;
 import com.hedera.hapi.node.token.NftAllowance;
 import com.hedera.hapi.node.token.TokenAllowance;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.config.VersionedConfigImpl;
 import com.hedera.node.app.service.token.impl.*;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.handlers.CryptoApproveAllowanceHandler;
@@ -44,7 +43,6 @@ import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,9 +55,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
     @Mock(strictness = Strictness.LENIENT)
-    private ConfigProvider configProvider;
-
-    @Mock(strictness = Strictness.LENIENT)
     private HandleContext handleContext;
 
     private CryptoApproveAllowanceHandler subject;
@@ -68,8 +63,8 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
     public void setUp() {
         super.setUp();
         refreshWritableStores();
-        final var validator = new ApproveAllowanceValidator(configProvider);
-        givenStoresAndConfig(configProvider, handleContext);
+        final var validator = new ApproveAllowanceValidator();
+        givenStoresAndConfig(handleContext);
 
         subject = new CryptoApproveAllowanceHandler(validator);
     }
@@ -344,7 +339,6 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
         configuration = new HederaTestConfigBuilder()
                 .withValue("hedera.allowances.maxAccountLimit", 2)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
         given(handleContext.configuration()).willReturn(configuration);
 
         final var txn = cryptoApproveAllowanceTransaction(

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
@@ -38,7 +38,6 @@ import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.config.ConfigProvider;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,9 +48,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
     @Mock(strictness = LENIENT)
-    private ConfigProvider configProvider;
-
-    @Mock(strictness = LENIENT)
     private HandleContext handleContext;
 
     private CryptoDeleteAllowanceHandler subject;
@@ -59,13 +55,12 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
     @BeforeEach
     public void setUp() {
         super.setUp();
-        final var deleteAllowanceValidator = new DeleteAllowanceValidator(configProvider);
+        final var deleteAllowanceValidator = new DeleteAllowanceValidator();
         subject = new CryptoDeleteAllowanceHandler(deleteAllowanceValidator);
         refreshWritableStores();
-        givenStoresAndConfig(configProvider, handleContext);
+        givenStoresAndConfig(handleContext);
 
         given(handleContext.configuration()).willReturn(configuration);
-        given(configProvider.getConfiguration()).willReturn(versionedConfig);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -54,7 +54,6 @@ import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.config.VersionedConfigImpl;
 import com.hedera.node.app.service.mono.config.HederaNumbers;
-import com.hedera.node.app.service.mono.context.NodeInfo;
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.context.properties.PropertySource;
 import com.hedera.node.app.service.token.impl.CryptoSignatureWaiversImpl;
@@ -64,6 +63,7 @@ import com.hedera.node.app.service.token.impl.handlers.CryptoUpdateHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
+import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -116,7 +116,6 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
     private final long updateAccountNum = 32132L;
     private final AccountID updateAccountId =
             AccountID.newBuilder().accountNum(updateAccountNum).build();
-    private final Key opKey = B_COMPLEX_KEY;
 
     private Account updateAccount;
     private Configuration configuration;
@@ -135,8 +134,8 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         attributeValidator = new StandardizedAttributeValidator(consensusSecondNow, compositeProps, dynamicProperties);
         expiryValidator = new StandardizedExpiryValidator(
                 System.out::println, attributeValidator, consensusSecondNow, hederaNumbers, configProvider);
-        stakingValidator = new StakingValidator(nodeInfo, configProvider);
-        subject = new CryptoUpdateHandler(waivers, stakingValidator);
+        stakingValidator = new StakingValidator();
+        subject = new CryptoUpdateHandler(waivers, stakingValidator, nodeInfo);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -331,8 +331,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         final var config = new HederaTestConfigBuilder()
                 .withValue("staking.isEnabled", false)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1));
-
+        given(handleContext.configuration()).willReturn(config);
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(STAKING_NOT_ENABLED));
@@ -347,7 +346,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         final var config = new HederaTestConfigBuilder()
                 .withValue("staking.isEnabled", false)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1));
+        given(handleContext.configuration()).willReturn(config);
 
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -44,7 +44,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -75,10 +74,10 @@ import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.config.ConfigProvider;
-import com.hedera.node.config.VersionedConfiguration;
-import com.hedera.node.config.data.TokensConfig;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.config.api.Configuration;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,10 +88,18 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
     private static final AccountID ACCOUNT_4680 = BaseCryptoHandler.asAccount(4680);
     private static final AccountID TREASURY_ACCOUNT_9876 = BaseCryptoHandler.asAccount(9876);
     private static final TokenID TOKEN_531 = BaseTokenHandler.asToken(531);
-    private final ConfigProvider configProvider = mock(ConfigProvider.class);
-
-    private final TokenSupplyChangeOpsValidator validator = new TokenSupplyChangeOpsValidator(configProvider);
+    private final TokenSupplyChangeOpsValidator validator = new TokenSupplyChangeOpsValidator();
     private final TokenAccountWipeHandler subject = new TokenAccountWipeHandler(validator);
+
+    private Configuration configuration;
+
+    @BeforeEach
+    public void setUp() {
+        configuration = new HederaTestConfigBuilder()
+                .withValue("tokens.nfts.areEnabled", true)
+                .withValue("tokens.nfts.maxBatchSizeWipe", 100)
+                .getOrCreateConfig();
+    }
 
     @Nested
     class PureChecks {
@@ -222,7 +229,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void invalidFungibleAmount() {
-            mockConfig();
+
             final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, -1);
             final var context = mockContext(txn);
 
@@ -233,7 +240,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void accountDoesntExist() {
-            mockConfig();
+
             // Both stores are intentionally empty
             writableAccountStore = newWritableStoreWithAccounts();
             writableTokenStore = newWritableStoreWithTokens();
@@ -247,8 +254,10 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void fungibleAmountExceedsBatchSize() {
-            final var maxBatchSize = 5;
-            mockConfig(maxBatchSize, true);
+            configuration = new HederaTestConfigBuilder()
+                    .withValue("tokens.nfts.areEnabled", true)
+                    .withValue("tokens.nfts.maxBatchSizeWipe", 5)
+                    .getOrCreateConfig();
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -258,7 +267,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                             .accountNumber(TREASURY_ACCOUNT_9876.accountNumOrThrow())
                             .build());
             writableTokenStore = newWritableStoreWithTokens();
-            final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, maxBatchSize + 1);
+            final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, 6);
             final var context = mockContext(txn);
 
             assertThatThrownBy(() -> subject.handle(context))
@@ -268,7 +277,10 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void nftAmountExceedsBatchSize() {
-            mockConfig(2, true);
+            configuration = new HederaTestConfigBuilder()
+                    .withValue("tokens.nfts.areEnabled", true)
+                    .withValue("tokens.nfts.maxBatchSizeWipe", 2)
+                    .getOrCreateConfig();
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -288,7 +300,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void tokenIdNotFound() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -308,7 +320,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void tokenIsDeleted() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -331,7 +343,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void tokenIsPaused() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -354,7 +366,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void tokenDoesntHaveWipeKey() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -379,7 +391,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void accountRelDoesntExist() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -401,7 +413,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void givenAccountIsTreasury() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -422,7 +434,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void fungibleAmountNegatesSupply() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -449,7 +461,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void fungibleAmountNegatesBalance() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -478,7 +490,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void fungibleAmountBurnedWithLeftoverAccountBalance() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -515,7 +527,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void fungibleAmountBurnedWithNoLeftoverAccountBalance() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -552,7 +564,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void nftSerialNumDoesntExist() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -576,7 +588,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void nftNotOwnedByAccount() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -606,7 +618,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void numNftSerialsNegatesSupply() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -633,7 +645,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void nftSerialNumsIsEmpty() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -661,7 +673,6 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
         void nftSerialsWipedWithLeftoverNftSerials() {
             // i.e. leftover NFT serials remaining with the owning account
 
-            mockConfig();
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -740,7 +751,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
         @Test
         void nftSerialsWipedWithNoLeftoverNftSerials() {
-            mockConfig();
+
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -821,7 +832,6 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
         void duplicateNftSerials() {
             // This is a success case, and should be identical to the case without no duplicates above
 
-            mockConfig();
             mockOkExpiryValidator();
             writableAccountStore = newWritableStoreWithAccounts(
                     Account.newBuilder()
@@ -946,25 +956,11 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
             given(context.writableStore(WritableTokenStore.class)).willReturn(writableTokenStore);
             given(context.writableStore(WritableTokenRelationStore.class)).willReturn(writableTokenRelStore);
             given(context.writableStore(WritableNftStore.class)).willReturn(writableNftStore);
+            given(context.configuration()).willReturn(configuration);
 
             given(context.expiryValidator()).willReturn(validator);
 
             return context;
-        }
-
-        private void mockConfig() {
-            mockConfig(100, true);
-        }
-
-        private void mockConfig(final int maxBatchSize, final boolean nftsEnabled) {
-            final var mockTokensConfig = mock(TokensConfig.class);
-            lenient().when(mockTokensConfig.nftsAreEnabled()).thenReturn(nftsEnabled);
-            lenient().when(mockTokensConfig.nftsMaxBatchSizeWipe()).thenReturn(maxBatchSize);
-
-            final var mockConfig = mock(VersionedConfiguration.class);
-            lenient().when(mockConfig.getConfigData(TokensConfig.class)).thenReturn(mockTokensConfig);
-
-            given(configProvider.getConfiguration()).willReturn(mockConfig);
         }
     }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -95,6 +95,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
     @BeforeEach
     public void setUp() {
+        super.setUp();
         configuration = new HederaTestConfigBuilder()
                 .withValue("tokens.nfts.areEnabled", true)
                 .withValue("tokens.nfts.maxBatchSizeWipe", 100)

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
@@ -91,7 +91,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
     private static final TokenID TOKEN_123 = BaseTokenHandler.asToken(123);
 
     private final ConfigProvider configProvider = mock(ConfigProvider.class);
-    private TokenSupplyChangeOpsValidator validator = new TokenSupplyChangeOpsValidator(configProvider);
+    private TokenSupplyChangeOpsValidator validator = new TokenSupplyChangeOpsValidator();
     private final TokenBurnHandler subject = new TokenBurnHandler(validator);
 
     @Nested
@@ -315,7 +315,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
         @Test
         void fungibleAmountExceedsBatchSize() {
             mockConfig(1, true);
-            validator = new TokenSupplyChangeOpsValidator(configProvider);
+            validator = new TokenSupplyChangeOpsValidator();
 
             final var txn = newBurnTxn(TOKEN_123, 2);
             final var context = mockContext(txn);
@@ -477,7 +477,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
         @Test
         void nftsGivenButNotEnabled() {
             mockConfig(100, false);
-            validator = new TokenSupplyChangeOpsValidator(configProvider);
+            validator = new TokenSupplyChangeOpsValidator();
 
             final var txn = newBurnTxn(TOKEN_123, 0, 1L);
             final var context = mockContext(txn);
@@ -490,7 +490,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
         @Test
         void nftSerialCountExceedsBatchSize() {
             mockConfig(1, true);
-            validator = new TokenSupplyChangeOpsValidator(configProvider);
+            validator = new TokenSupplyChangeOpsValidator();
 
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L);
             final var context = mockContext(txn);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandleParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandleParityTest.java
@@ -70,18 +70,13 @@ import com.hedera.node.app.service.token.impl.validators.TokenAttributesValidato
 import com.hedera.node.app.service.token.impl.validators.TokenCreateValidator;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TokenCreateHandleParityTest {
-    @Mock
-    private ConfigProvider configProvider;
-
     private ReadableAccountStore accountStore;
     private TokenCreateHandler subject;
     private CustomFeesValidator customFeesValidator;
@@ -90,7 +85,7 @@ class TokenCreateHandleParityTest {
 
     @BeforeEach
     void setUp() {
-        tokenFieldsValidator = new TokenAttributesValidator(configProvider);
+        tokenFieldsValidator = new TokenAttributesValidator();
         customFeesValidator = new CustomFeesValidator();
         tokenCreateValidator = new TokenCreateValidator(tokenFieldsValidator);
         accountStore = SigReqAdapterUtils.wellKnownAccountStoreAt();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
@@ -127,11 +127,11 @@ class TokenCreateHandlerTest extends CryptoTokenHandlerTestBase {
         super.setUp();
         refreshWritableStores();
         recordBuilder = new SingleTransactionRecordBuilder(consensusInstant);
-        tokenFieldsValidator = new TokenAttributesValidator(configProvider);
+        tokenFieldsValidator = new TokenAttributesValidator();
         customFeesValidator = new CustomFeesValidator();
         tokenCreateValidator = new TokenCreateValidator(tokenFieldsValidator);
         subject = new TokenCreateHandler(customFeesValidator, tokenCreateValidator);
-        givenStoresAndConfig(configProvider, handleContext);
+        givenStoresAndConfig(handleContext);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
@@ -33,24 +33,19 @@ import com.hedera.node.app.service.token.impl.test.handlers.util.ParityTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TokenMintHandlerParityTest extends ParityTestBase {
-    @Mock
-    private ConfigProvider configProvider;
-
     private TokenSupplyChangeOpsValidator validator;
     private TokenMintHandler subject;
 
     @BeforeEach
     void setup() {
-        validator = new TokenSupplyChangeOpsValidator(configProvider);
+        validator = new TokenSupplyChangeOpsValidator();
         subject = new TokenMintHandler(validator);
     }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
@@ -27,7 +27,6 @@ import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.token.TokenMintTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.config.VersionedConfigImpl;
 import com.hedera.node.app.records.SingleTransactionRecordBuilder;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenMintHandler;
@@ -38,7 +37,6 @@ import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
@@ -48,9 +46,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
-    @Mock(strictness = Mock.Strictness.LENIENT)
-    private ConfigProvider configProvider;
-
     @Mock(strictness = Mock.Strictness.LENIENT)
     private HandleContext handleContext;
 
@@ -64,8 +59,8 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
     public void setUp() {
         super.setUp();
         refreshWritableStores();
-        givenStoresAndConfig(configProvider, handleContext);
-        subject = new TokenMintHandler(new TokenSupplyChangeOpsValidator(configProvider));
+        givenStoresAndConfig(handleContext);
+        subject = new TokenMintHandler(new TokenSupplyChangeOpsValidator());
         recordBuilder = new SingleTransactionRecordBuilder(consensusNow);
     }
 
@@ -75,7 +70,6 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         configuration = new HederaTestConfigBuilder()
                 .withValue("tokens.nfts.areEnabled", false)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
         given(handleContext.configuration()).willReturn(configuration);
 
         assertThatThrownBy(() -> subject.handle(handleContext))
@@ -184,7 +178,6 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         configuration = new HederaTestConfigBuilder()
                 .withValue("tokens.nfts.maxMetadataBytes", 1)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
         given(handleContext.configuration()).willReturn(configuration);
 
         assertThatThrownBy(() -> subject.handle(handleContext))
@@ -199,7 +192,6 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         configuration = new HederaTestConfigBuilder()
                 .withValue("tokens.nfts.maxBatchSizeMint", 1)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
         given(handleContext.configuration()).willReturn(configuration);
 
         assertThatThrownBy(() -> subject.handle(handleContext))
@@ -214,7 +206,6 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         configuration = new HederaTestConfigBuilder()
                 .withValue("tokens.nfts.maxAllowedMints", 1)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
         given(handleContext.configuration()).willReturn(configuration);
 
         assertThatThrownBy(() -> subject.handle(handleContext))

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
@@ -67,7 +67,6 @@ import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.WritableStates;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
-import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.CommonUtils;
@@ -677,9 +676,8 @@ public class CryptoTokenHandlerTestBase extends StateBuilderUtil {
                 .build();
     }
 
-    protected void givenStoresAndConfig(final ConfigProvider configProvider, final HandleContext handleContext) {
+    protected void givenStoresAndConfig(final HandleContext handleContext) {
         configuration = new HederaTestConfigBuilder().getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
         given(handleContext.configuration()).willReturn(configuration);
         given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
         given(handleContext.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/AllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/AllowanceValidatorTest.java
@@ -26,27 +26,20 @@ import static org.mockito.BDDMockito.given;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.NftAllowance;
-import com.hedera.node.app.config.VersionedConfigImpl;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.AllowanceValidator;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.config.ConfigProvider;
-import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AllowanceValidatorTest extends CryptoTokenHandlerTestBase {
     private AllowanceValidator subject;
-
-    @Mock
-    private ConfigProvider configProvider;
 
     @BeforeEach
     public void setUp() {
@@ -59,7 +52,7 @@ class AllowanceValidatorTest extends CryptoTokenHandlerTestBase {
         given(readableStates.<AccountID, Account>get(ACCOUNTS)).willReturn(readableAccounts);
         readableAccountStore = new ReadableAccountStoreImpl(readableStates);
 
-        subject = new AllowanceValidator(configProvider);
+        subject = new AllowanceValidator();
     }
 
     @Test
@@ -82,21 +75,6 @@ class AllowanceValidatorTest extends CryptoTokenHandlerTestBase {
         list.add(Nftid);
         list.add(Nftid2);
         assertThat(aggregateApproveNftAllowances(list)).isEqualTo(4);
-    }
-
-    @Test
-    void checksFlagIfEnabled() {
-        final var trueConfig = new HederaTestConfigBuilder()
-                .withValue("hedera.allowances.isEnabled", true)
-                .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(trueConfig, 1));
-        assertThat(subject.isEnabled()).isTrue();
-
-        final var falseConfig = new HederaTestConfigBuilder()
-                .withValue("hedera.allowances.isEnabled", false)
-                .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(falseConfig, 1));
-        assertThat(subject.isEnabled()).isFalse();
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
@@ -30,12 +30,10 @@ import com.hedera.hapi.node.token.CryptoApproveAllowanceTransactionBody;
 import com.hedera.hapi.node.token.NftAllowance;
 import com.hedera.hapi.node.token.TokenAllowance;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.config.VersionedConfigImpl;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.ApproveAllowanceValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,16 +44,13 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
     private ApproveAllowanceValidator subject;
 
     @Mock(strictness = LENIENT)
-    private ConfigProvider configProvider;
-
-    @Mock(strictness = LENIENT)
     private HandleContext handleContext;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        givenStoresAndConfig(configProvider, handleContext);
-        subject = new ApproveAllowanceValidator(configProvider);
+        givenStoresAndConfig(handleContext);
+        subject = new ApproveAllowanceValidator();
     }
 
     @Test
@@ -65,8 +60,7 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
         final var configuration = new HederaTestConfigBuilder()
                 .withValue("hedera.allowances.isEnabled", false)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
-
+        given(handleContext.configuration()).willReturn(configuration);
         assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(NOT_SUPPORTED));
@@ -80,8 +74,6 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
         final var configuration = new HederaTestConfigBuilder()
                 .withValue("hedera.allowances.maxTransactionLimit", 1)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
-
         assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(MAX_ALLOWANCES_EXCEEDED));
@@ -344,7 +336,7 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
                         .serialNumbers(List.of(1L, 2L, 3L))
                         .build()));
 
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
+        given(handleContext.configuration()).willReturn(configuration);
         assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(INVALID_TOKEN_NFT_SERIAL_NUMBER));
@@ -364,7 +356,7 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
                         .serialNumbers(List.of(1L, 2L, -3L))
                         .build()));
 
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
+        given(handleContext.configuration()).willReturn(configuration);
         assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(INVALID_TOKEN_NFT_SERIAL_NUMBER));
@@ -384,7 +376,7 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
                         .serialNumbers(List.of(1L, 2L, 2L, 1L))
                         .build()));
 
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
+        given(handleContext.configuration()).willReturn(configuration);
         assertThatNoException().isThrownBy(() -> subject.validate(handleContext, account, readableAccountStore));
     }
 
@@ -396,8 +388,7 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
         final var configuration = new HederaTestConfigBuilder()
                 .withValue("hedera.allowances.maxTransactionLimit", 1)
                 .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(configuration, 1));
-
+        given(handleContext.configuration()).willReturn(configuration);
         assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(MAX_ALLOWANCES_EXCEEDED));

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
@@ -74,6 +74,7 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
         final var configuration = new HederaTestConfigBuilder()
                 .withValue("hedera.allowances.maxTransactionLimit", 1)
                 .getOrCreateConfig();
+        given(handleContext.configuration()).willReturn(configuration);
         assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(MAX_ALLOWANCES_EXCEEDED));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -17,6 +17,7 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
@@ -638,7 +639,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
     }
 
     private HapiSpec wipeHappyPath() {
-        return defaultHapiSpec("WipeHappyPath")
+        return onlyDefaultHapiSpec("WipeHappyPath")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(WIPE_KEY),
@@ -654,13 +655,15 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                                 .treasury(TOKEN_TREASURY)
                                 .wipeKey(WIPE_KEY),
                         tokenAssociate(ACCOUNT, NFT),
+                        getTokenInfo(NFT).logged(),
                         mintToken(NFT, List.of(ByteString.copyFromUtf8("memo"), ByteString.copyFromUtf8(MEMO_2))),
+                        getTokenInfo(NFT).logged(),
                         cryptoTransfer(movingUnique(NFT, 2L).between(TOKEN_TREASURY, ACCOUNT)))
                 .when(wipeTokenAccount(NFT, ACCOUNT, List.of(2L)).via(WIPE_TXN))
                 .then(
                         getAccountInfo(ACCOUNT).hasOwnedNfts(0),
                         getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
-                        getTokenInfo(NFT).hasTotalSupply(1),
+                        getTokenInfo(NFT).hasTotalSupply(1).logged(),
                         getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID),
                         getTokenNftInfo(NFT, 1).hasSerialNum(1),
                         wipeTokenAccount(NFT, ACCOUNT, List.of(1L)).hasKnownStatus(ACCOUNT_DOES_NOT_OWN_WIPED_NFT));


### PR DESCRIPTION
Make all TokenService validators not depend on `ConfigProvider`