### PR TITLE
Change `JKey` methods to throw `InvalidKeyException` and add `equals` and `hashCode`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/AdaptedMonoProcessLogic.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/AdaptedMonoProcessLogic.java
@@ -38,13 +38,13 @@ import com.swirlds.common.system.SoftwareVersion;
 import com.swirlds.common.system.transaction.ConsensusTransaction;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 
 @Singleton
 public class AdaptedMonoProcessLogic implements ProcessLogic {
@@ -120,7 +120,7 @@ public class AdaptedMonoProcessLogic implements ProcessLogic {
     private JKey mapToJKey(@NonNull final Key key) {
         try {
             return JKey.mapKey(key);
-        } catch (DecoderException e) {
+        } catch (InvalidKeyException e) {
             throw new IllegalArgumentException("Unable to map key", e);
         }
     }

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/codec/FileServiceStateTranslator.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/codec/FileServiceStateTranslator.java
@@ -27,7 +27,7 @@ import com.hedera.node.app.service.mono.pbj.PbjConverter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.apache.commons.codec.DecoderException;
+import java.security.InvalidKeyException;
 
 /**
  * The class is used to convert a {@link com.hedera.node.app.service.mono.files.HFileMeta} content and metadata  to a {@link File} and vice versa during the migration process
@@ -82,7 +82,7 @@ public class FileServiceStateTranslator {
      */
     @NonNull
     public static FileMetadataAndContent pbjToState(
-            @NonNull FileID fileID, @NonNull ReadableFileStoreImpl readableFileStore) throws DecoderException {
+            @NonNull FileID fileID, @NonNull ReadableFileStoreImpl readableFileStore) throws InvalidKeyException {
         requireNonNull(fileID);
         requireNonNull(readableFileStore);
         final var optionalFile = readableFileStore.getFileLeaf(fileID);
@@ -95,7 +95,7 @@ public class FileServiceStateTranslator {
      * @return File and metadata pair object
      */
     @NonNull
-    public static FileMetadataAndContent pbjToState(@NonNull File file) throws DecoderException {
+    public static FileMetadataAndContent pbjToState(@NonNull File file) throws InvalidKeyException {
         requireNonNull(file);
         var keys = (file.hasKeys())
                 ? com.hedera.node.app.service.mono.legacy.core.jproto.JKey.convertKey(

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
@@ -28,7 +28,7 @@ import com.hedera.node.app.service.file.impl.codec.FileServiceStateTranslator.Fi
 import com.hedera.node.app.service.file.impl.test.FileTestBase;
 import com.hedera.node.app.service.mono.files.HFileMeta;
 import com.hedera.node.app.service.mono.utils.MiscUtils;
-import org.apache.commons.codec.DecoderException;
+import java.security.InvalidKeyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +45,7 @@ public class FileServiceStateTranslatorTest extends FileTestBase {
     void setUp() {}
 
     @Test
-    void createFileMetadataAndContentFromFile() throws DecoderException {
+    void createFileMetadataAndContentFromFile() throws InvalidKeyException {
         final var existingFile = readableStore.getFileMetadata(fileId);
         assertFalse(existingFile.deleted());
 
@@ -69,7 +69,7 @@ public class FileServiceStateTranslatorTest extends FileTestBase {
     }
 
     @Test
-    void createFileMetadataAndContentFromFileWithEmptyKeysAndMemo() throws DecoderException {
+    void createFileMetadataAndContentFromFileWithEmptyKeysAndMemo() throws InvalidKeyException {
         final var existingFile = readableStore.getFileMetadata(fileId);
         assertFalse(existingFile.deleted());
 
@@ -101,7 +101,7 @@ public class FileServiceStateTranslatorTest extends FileTestBase {
     }
 
     @Test
-    void createFileMetadataAndContentFromFileWithEmptyConentForDeletedFile() throws DecoderException {
+    void createFileMetadataAndContentFromFileWithEmptyConentForDeletedFile() throws InvalidKeyException {
 
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoContent);
 
@@ -125,7 +125,7 @@ public class FileServiceStateTranslatorTest extends FileTestBase {
     }
 
     @Test
-    void createFileMetadataAndContentFromReadableFileStore() throws DecoderException {
+    void createFileMetadataAndContentFromReadableFileStore() throws InvalidKeyException {
         final var existingFile = readableStore.getFileMetadata(fileId);
         assertFalse(existingFile.deleted());
 
@@ -200,7 +200,7 @@ public class FileServiceStateTranslatorTest extends FileTestBase {
         assertEquals(createFile(), convertedFile);
     }
 
-    private FileMetadataAndContent getExpectedMonoFileMetaAndContent() throws DecoderException {
+    private FileMetadataAndContent getExpectedMonoFileMetaAndContent() throws InvalidKeyException {
         var keys = com.hedera.node.app.service.mono.legacy.core.jproto.JKey.convertKey(
                 Key.newBuilder().keyList(file.keys()).build(), 1);
         com.hedera.node.app.service.mono.files.HFileMeta hFileMeta =
@@ -214,7 +214,7 @@ public class FileServiceStateTranslatorTest extends FileTestBase {
         return new FileMetadataAndContent(file.contents().toByteArray(), hFileMeta);
     }
 
-    private FileMetadataAndContent getExpectedMonoFileMetaAndContentEmptyContent() throws DecoderException {
+    private FileMetadataAndContent getExpectedMonoFileMetaAndContentEmptyContent() throws InvalidKeyException {
         var keys = com.hedera.node.app.service.mono.legacy.core.jproto.JKey.convertKey(
                 Key.newBuilder().keyList(file.keys()).build(), 1);
         com.hedera.node.app.service.mono.files.HFileMeta hFileMeta =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/Utils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/Utils.java
@@ -22,9 +22,9 @@ import static java.util.stream.Collectors.toSet;
 import com.hedera.node.app.spi.key.HederaKey;
 import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.InvalidKeyException;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.codec.DecoderException;
 
 // This class should not exist. Right now we have code that needs to map from a JKey to a
 // HederaKey, but that should be an implementation detail handled somewhere in the token
@@ -45,7 +45,7 @@ public class Utils {
                 return Optional.empty();
             }
             return Optional.of(fcKey);
-        } catch (DecoderException ignore) {
+        } catch (InvalidKeyException ignore) {
             return Optional.empty();
         }
     }
@@ -61,10 +61,11 @@ public class Utils {
                 return Optional.empty();
             }
             return Optional.of(fcKey);
-        } catch (DecoderException ignore) {
+        } catch (InvalidKeyException ignore) {
             return Optional.empty();
         }
     }
+
     /**
      * Converts a set of {@link com.hedera.hapi.node.base.Key} to a set of {@link HederaKey}
      *

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateTopicResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateTopicResourceUsage.java
@@ -31,9 +31,9 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.InvalidKeyException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -86,7 +86,7 @@ public class UpdateTopicResourceUsage implements TxnResourceUsageEstimator {
                         merkleTopic.hasAutoRenewAccountId(),
                         expiry,
                         txnBody.getConsensusUpdateTopic());
-            } catch (final DecoderException illegal) {
+            } catch (final InvalidKeyException illegal) {
                 log.warn("Usage estimation unexpectedly failed for {}!", txnBody, illegal);
                 throw new InvalidTxBodyException(illegal);
             }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManager.java
@@ -37,6 +37,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.InvalidKeyException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -45,7 +46,6 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.datatypes.Address;
@@ -183,7 +183,7 @@ public class AliasManager extends HederaEvmContractAliases implements ContractAl
                             numEOAliases.incrementAndGet();
                         }
                     } catch (final InvalidProtocolBufferException
-                            | DecoderException
+                            | InvalidKeyException
                             | IllegalArgumentException ignore) {
                         // any expected exception means no eth mapping
                     }
@@ -259,7 +259,7 @@ public class AliasManager extends HederaEvmContractAliases implements ContractAl
             final Key key = Key.parseFrom(alias);
             final JKey jKey = JKey.mapKey(key);
             return tryAddressRecovery(jKey, ADDRESS_RECOVERY_FN);
-        } catch (InvalidProtocolBufferException | DecoderException | IllegalArgumentException ignore) {
+        } catch (InvalidProtocolBufferException | InvalidKeyException | IllegalArgumentException ignore) {
             // any expected exception means no eth mapping
             return null;
         }
@@ -274,7 +274,7 @@ public class AliasManager extends HederaEvmContractAliases implements ContractAl
             final Key key = Key.parseFrom(ret);
             final JKey jKey = JKey.mapKey(key);
             return tryAddressRecovery(jKey, ADDRESS_RECOVERY_FN);
-        } catch (InvalidProtocolBufferException | DecoderException | IllegalArgumentException ignore) {
+        } catch (InvalidProtocolBufferException | InvalidKeyException | IllegalArgumentException ignore) {
             // any expected exception means no eth mapping
             return null;
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
@@ -16,8 +16,6 @@
 
 package com.hedera.node.app.service.mono.legacy.core.jproto;
 
-import static java.util.Collections.emptyList;
-
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.node.app.spi.key.HederaKey;
@@ -29,10 +27,11 @@ import com.swirlds.common.io.streams.SerializableDataInputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.commons.codec.DecoderException;
 
 /** Maps to proto Key. */
 public abstract class JKey implements HederaKey {
@@ -59,9 +58,9 @@ public abstract class JKey implements HederaKey {
      *
      * @param key the proto Key to be converted
      * @return the generated JKey instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type
      */
-    public static JKey mapKey(Key key) throws DecoderException {
+    public static JKey mapKey(Key key) throws InvalidKeyException {
         return convertKey(key, 1);
     }
 
@@ -70,9 +69,8 @@ public abstract class JKey implements HederaKey {
      *
      * @param key the proto Key to be converted
      * @return the generated JKey instance
-     * @throws DecoderException on an inconvertible given key
      */
-    public static JKey mapKey(@NonNull final com.hedera.hapi.node.base.Key key) throws DecoderException {
+    public static JKey mapKey(@NonNull final com.hedera.hapi.node.base.Key key) throws InvalidKeyException {
         return convertKey(key, 1);
     }
 
@@ -83,11 +81,11 @@ public abstract class JKey implements HederaKey {
      * @param key the current proto Key to be converted
      * @param depth current level that is to be verified. The first level has a value of 1.
      * @return the converted JKey instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type or exceeds the allowable depth of nesting.
      */
-    public static JKey convertKey(Key key, int depth) throws DecoderException {
+    public static JKey convertKey(Key key, int depth) throws InvalidKeyException {
         if (depth > MAX_KEY_DEPTH) {
-            throw new DecoderException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
+            throw new InvalidKeyException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
         }
 
         if (!(key.hasThresholdKey() || key.hasKeyList())) {
@@ -120,12 +118,12 @@ public abstract class JKey implements HederaKey {
      * @param key the current proto Key to be converted
      * @param depth current level that is to be verified. The first level has a value of 1.
      * @return the converted JKey instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type or exceeds the allowable depth of nesting.
      */
     public static JKey convertKey(@NonNull final com.hedera.hapi.node.base.Key key, final int depth)
-            throws DecoderException {
+            throws InvalidKeyException {
         if (depth > MAX_KEY_DEPTH) {
-            throw new DecoderException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
+            throw new InvalidKeyException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
         }
 
         if (!(key.hasThresholdKey() || key.hasKeyList())) {
@@ -134,7 +132,7 @@ public abstract class JKey implements HederaKey {
 
         if (key.hasThresholdKey()) {
             final var thresholdKey = key.thresholdKeyOrThrow();
-            List<com.hedera.hapi.node.base.Key> tKeys = thresholdKey.keys().keysOrElse(emptyList());
+            List<com.hedera.hapi.node.base.Key> tKeys = thresholdKey.keys().keysOrElse(Collections.emptyList());
             List<JKey> jkeys = new ArrayList<>();
             for (var aKey : tKeys) {
                 JKey res = convertKey(aKey, depth + 1);
@@ -160,9 +158,9 @@ public abstract class JKey implements HederaKey {
      *
      * @param key proto Key to be converted
      * @return the converted JKey instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type
      */
-    private static JKey convertBasic(Key key) throws DecoderException {
+    private static JKey convertBasic(Key key) throws InvalidKeyException {
         JKey rv;
         if (!key.getEd25519().isEmpty()) {
             byte[] pubKeyBytes = key.getEd25519().toByteArray();
@@ -185,7 +183,7 @@ public abstract class JKey implements HederaKey {
         } else if (!key.getDelegatableContractId().getEvmAddress().isEmpty()) {
             rv = new JDelegatableContractAliasKey(key.getDelegatableContractId());
         } else {
-            throw new DecoderException("Key type not implemented: key=" + key);
+            throw new InvalidKeyException("Key type not implemented: key=" + key);
         }
 
         return rv;
@@ -196,9 +194,9 @@ public abstract class JKey implements HederaKey {
      *
      * @param key proto Key to be converted
      * @return the converted JKey instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type
      */
-    private static JKey convertBasic(final com.hedera.hapi.node.base.Key key) throws DecoderException {
+    private static JKey convertBasic(final com.hedera.hapi.node.base.Key key) throws InvalidKeyException {
         final var oneOf = key.key();
         return switch (oneOf.kind()) {
             case ED25519 -> {
@@ -229,7 +227,7 @@ public abstract class JKey implements HederaKey {
                             .build();
                     yield new JContractIDKey(proto);
                 } else {
-                    throw new DecoderException("Unable to decode contract key=" + key);
+                    throw new InvalidKeyException("Unable to decode contract key=" + key);
                 }
             }
             case DELEGATABLE_CONTRACT_ID -> {
@@ -244,10 +242,10 @@ public abstract class JKey implements HederaKey {
                             .build();
                     yield new JDelegatableContractIDKey(proto);
                 } else {
-                    throw new DecoderException("Unable to decode contract key=" + key);
+                    throw new InvalidKeyException("Unable to decode contract key=" + key);
                 }
             }
-            default -> throw new DecoderException("Key type not implemented: key=" + key);
+            default -> throw new InvalidKeyException("Key type not implemented: key=" + key);
         };
     }
 
@@ -256,9 +254,9 @@ public abstract class JKey implements HederaKey {
      *
      * @param jkey JKey object to be converted
      * @return the converted proto Key instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type
      */
-    static Key convertJKeyBasic(JKey jkey) throws DecoderException {
+    static Key convertJKeyBasic(JKey jkey) throws InvalidKeyException {
         Key rv;
         if (jkey.hasEd25519Key()) {
             rv = Key.newBuilder()
@@ -294,9 +292,11 @@ public abstract class JKey implements HederaKey {
                             jkey.getDelegatableContractAliasKey().getContractID())
                     .build();
         } else {
-            throw new DecoderException("Key type not implemented: key=" + jkey);
+            // Warning: Do Not allow anything that calls toString, equals, or hashCode on JKey here.
+            //          Object.toString calls hashCode, and equals and hashCode both call this method
+            //          so you would create an infinite recursion.
+            throw new InvalidKeyException("Key type not implemented.");
         }
-
         return rv;
     }
 
@@ -306,14 +306,13 @@ public abstract class JKey implements HederaKey {
      * @param jkey the current JKey to be converted
      * @param depth current level that is to be verified. The first level has a value of 1.
      * @return the converted proto Key instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type or exceeds the allowable depth of nesting.
      */
-    public static Key convertJKey(JKey jkey, int depth) throws DecoderException {
+    public static Key convertJKey(JKey jkey, int depth) throws InvalidKeyException {
         if (depth > MAX_KEY_DEPTH) {
-            throw new DecoderException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
+            throw new InvalidKeyException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
         }
-
-        if (!(jkey.hasThresholdKey() || jkey.hasKeyList())) {
+        if (!(jkey.hasThresholdKey() || jkey.hasKeyList() || jkey.isEmpty())) {
             return convertJKeyBasic(jkey);
         } else if (jkey.hasThresholdKey()) {
             List<JKey> jKeys = jkey.getThresholdKey().getKeys().getKeysList();
@@ -327,8 +326,8 @@ public abstract class JKey implements HederaKey {
             Key result = Key.newBuilder()
                     .setThresholdKey(ThresholdKey.newBuilder().setKeys(keys).setThreshold(thd))
                     .build();
-            return (result);
-        } else {
+            return result;
+        } else if (jkey.hasKeyList()) {
             List<JKey> jKeys = jkey.getKeyList().getKeysList();
             List<Key> tkeys = new ArrayList<>();
             for (JKey aKey : jKeys) {
@@ -336,8 +335,9 @@ public abstract class JKey implements HederaKey {
                 tkeys.add(res);
             }
             KeyList keys = KeyList.newBuilder().addAllKeys(tkeys).build();
-            Key result = Key.newBuilder().setKeyList(keys).build();
-            return (result);
+            return Key.newBuilder().setKeyList(keys).build();
+        } else {
+            return Key.newBuilder().build();
         }
     }
 
@@ -355,14 +355,38 @@ public abstract class JKey implements HederaKey {
         return Objects.equals(aKey, bKey);
     }
 
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        try {
+            return Objects.equals(mapJKey(this), mapJKey((JKey) other));
+        } catch (InvalidKeyException ignore) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        try {
+            return Objects.hashCode(mapJKey(this));
+        } catch (InvalidKeyException ignore) {
+            return Integer.MIN_VALUE;
+        }
+    }
+
     /**
      * Maps a JKey instance to a proto Key instance.
      *
      * @param jkey the JKey to be converted
      * @return the converted proto Key instance
-     * @throws DecoderException on an inconvertible given key
+     * @throws InvalidKeyException If the key is not a valid key type
      */
-    public static Key mapJKey(JKey jkey) throws DecoderException {
+    public static Key mapJKey(JKey jkey) throws InvalidKeyException {
         return convertJKey(jkey, 1);
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
@@ -55,9 +55,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.security.InvalidKeyException;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.codec.DecoderException;
 
 public final class PbjConverter {
     public static @NonNull AccountID toPbj(@NonNull com.hederahashgraph.api.proto.java.AccountID accountID) {
@@ -1284,7 +1284,7 @@ public final class PbjConverter {
         requireNonNull(jKey);
         try {
             return toPbj(JKey.mapJKey(jKey));
-        } catch (DecoderException e) {
+        } catch (InvalidKeyException e) {
             throw new RuntimeException(e);
         }
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapper.java
@@ -30,9 +30,9 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.RoyaltyFee;
 import com.hederahashgraph.api.proto.java.TokenID;
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.codec.DecoderException;
 
 public class TokenCreateWrapper {
     private final boolean isFungible;
@@ -153,7 +153,7 @@ public class TokenCreateWrapper {
         this.royaltyFees = royaltyFees;
     }
 
-    public void setAllInheritedKeysTo(final JKey senderKey) throws DecoderException {
+    public void setAllInheritedKeysTo(final JKey senderKey) throws InvalidKeyException {
         for (final var tokenKey : tokenKeys) {
             if (tokenKey.key().isShouldInheritAccountKeySet()) {
                 tokenKey.key().setInheritedKey(JKey.mapJKey(senderKey));

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenCreatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenCreatePrecompile.java
@@ -90,6 +90,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,7 +98,6 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import javax.inject.Provider;
-import org.apache.commons.codec.DecoderException;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -346,7 +346,7 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
         verifySolidityInput();
         try {
             replaceInheritedProperties();
-        } catch (final DecoderException e) {
+        } catch (final InvalidKeyException e) {
             throw new InvalidTransactionException(FAIL_INVALID);
         }
         transactionBody = syntheticTxnFactory.createTokenCreate(tokenCreateOp);
@@ -493,11 +493,11 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
         }
     }
 
-    private void replaceInheritedKeysWithSenderKey(final AccountID parentId) throws DecoderException {
+    private void replaceInheritedKeysWithSenderKey(final AccountID parentId) throws InvalidKeyException {
         tokenCreateOp.setAllInheritedKeysTo((JKey) ledgers.accounts().get(parentId, AccountProperty.KEY));
     }
 
-    private void replaceInheritedProperties() throws DecoderException {
+    private void replaceInheritedProperties() throws InvalidKeyException {
         final var parentId = EntityIdUtils.accountIdFromEvmAddress(senderAddress);
         var parentAutoRenewId = (EntityId) ledgers.accounts().get(parentId, AUTO_RENEW_ACCOUNT_ID);
         if (parentAutoRenewId == null) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicUpdateTransitionLogic.java
@@ -45,12 +45,12 @@ import com.hederahashgraph.api.proto.java.ConsensusUpdateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.security.InvalidKeyException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -253,7 +253,7 @@ public class TopicUpdateTransitionLogic implements TransitionLogic {
             if (op.hasSubmitKey() && !applyNewSubmitKey(op)) {
                 return false;
             }
-        } catch (DecoderException e) {
+        } catch (InvalidKeyException e) {
             log.error("Decoder exception updating topic {}. ", topicId, e);
             transactionContext.setStatus(BAD_ENCODING);
             return false;
@@ -261,7 +261,7 @@ public class TopicUpdateTransitionLogic implements TransitionLogic {
         return true;
     }
 
-    private boolean applyNewSubmitKey(final ConsensusUpdateTopicTransactionBody op) throws DecoderException {
+    private boolean applyNewSubmitKey(final ConsensusUpdateTopicTransactionBody op) throws InvalidKeyException {
         var newSubmitKey = op.getSubmitKey();
         if (!validator.hasGoodEncoding(newSubmitKey)) {
             transactionContext.setStatus(BAD_ENCODING);
@@ -273,7 +273,7 @@ public class TopicUpdateTransitionLogic implements TransitionLogic {
 
     private boolean applyNewAdminKey(
             final ConsensusUpdateTopicTransactionBody op, final TopicID topicId, final MerkleTopic topic)
-            throws DecoderException {
+            throws InvalidKeyException {
         var newAdminKey = op.getAdminKey();
         if (!validator.hasGoodEncoding(newAdminKey)) {
             log.error(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -53,13 +53,13 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.security.InvalidKeyException;
 import java.util.EnumSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -231,7 +231,7 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
                 if (!fcKey.isValid()) {
                     return INVALID_ADMIN_KEY;
                 }
-            } catch (DecoderException e) {
+            } catch (InvalidKeyException e) {
                 return BAD_ENCODING;
             }
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogic.java
@@ -46,13 +46,13 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.security.InvalidKeyException;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -159,7 +159,7 @@ public class FileUpdateTransitionLogic implements TransitionLogic {
     }
 
     static void mapToStatus(final IllegalArgumentException iae, final TransactionContext txnCtx) {
-        if (iae.getCause() instanceof DecoderException) {
+        if (iae.getCause() instanceof InvalidKeyException) {
             txnCtx.setStatus(BAD_ENCODING);
             return;
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidator.java
@@ -52,11 +52,11 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransferList;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.StringUtils;
 import org.bouncycastle.util.Arrays;
 
@@ -127,7 +127,7 @@ public class ContextOptionValidator implements OptionValidator {
         try {
             mapKey(key);
             return true;
-        } catch (final DecoderException ignore) {
+        } catch (final InvalidKeyException ignore) {
             return false;
         }
     }
@@ -162,7 +162,7 @@ public class ContextOptionValidator implements OptionValidator {
     public JKey attemptDecodeOrThrow(final Key k) {
         try {
             return JKey.mapKey(k);
-        } catch (final DecoderException e) {
+        } catch (final InvalidKeyException e) {
             throw new InvalidTransactionException(ResponseCodeEnum.BAD_ENCODING);
         }
     }
@@ -222,7 +222,7 @@ public class ContextOptionValidator implements OptionValidator {
     public JKey attemptToDecodeOrThrow(final Key key, final ResponseCodeEnum code) {
         try {
             return JKey.mapKey(key);
-        } catch (final DecoderException e) {
+        } catch (final InvalidKeyException e) {
             throw new InvalidTransactionException(code);
         }
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/PureValidation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/PureValidation.java
@@ -38,9 +38,9 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Optional;
-import org.apache.commons.codec.DecoderException;
 
 public final class PureValidation {
     private PureValidation() {
@@ -124,7 +124,7 @@ public final class PureValidation {
                 return failure;
             }
             return OK;
-        } catch (DecoderException ignore) {
+        } catch (InvalidKeyException ignore) {
             return failure;
         }
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
@@ -198,6 +198,7 @@ import com.swirlds.fcqueue.FCQueue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -215,7 +216,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.apache.commons.codec.DecoderException;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -453,7 +453,7 @@ public final class MiscUtils {
     public static JKey asFcKeyUnchecked(final Key key) {
         try {
             return JKey.mapKey(key);
-        } catch (final DecoderException impermissible) {
+        } catch (final InvalidKeyException impermissible) {
             throw new IllegalArgumentException("Key " + key + " should have been decode-able!", impermissible);
         }
     }
@@ -465,7 +465,7 @@ public final class MiscUtils {
                 return Optional.empty();
             }
             return Optional.of(fcKey);
-        } catch (final DecoderException ignore) {
+        } catch (final InvalidKeyException ignore) {
             return Optional.empty();
         }
     }
@@ -600,7 +600,7 @@ public final class MiscUtils {
         }
         try {
             return mapJKey(k).toString();
-        } catch (final DecoderException ignore) {
+        } catch (final InvalidKeyException ignore) {
             return "<N/A>";
         }
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
@@ -132,6 +132,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.merkle.map.MerkleMap;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -139,7 +140,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.codec.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
@@ -364,7 +364,7 @@ class StateViewTest {
         subject.contractBytecode = bytecode;
     }
 
-    private void setUpToken(final MerkleToken token) throws DecoderException {
+    private void setUpToken(final MerkleToken token) throws InvalidKeyException {
         token.setMemo(tokenMemo);
         token.setAdminKey(TxnHandlingScenario.TOKEN_ADMIN_KT.asJKey());
         token.setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asJKey());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/FeeCalcUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/FeeCalcUtilsTest.java
@@ -41,6 +41,7 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.swirlds.merkle.map.MerkleMap;
+import java.security.InvalidKeyException;
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.Optional;
@@ -102,7 +103,7 @@ public class FeeCalcUtilsTest {
     }
 
     @Test
-    void returnsFileExpiryIfAvail() throws Exception {
+    void returnsFileExpiryIfAvail() throws InvalidKeyException {
         final var view = mock(StateView.class);
         final var fid = IdUtils.asFile("1.2.3");
         final var wacl = JKey.mapKey(Key.newBuilder()

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateMerkleTopicResourceUsageTest.java
@@ -55,8 +55,8 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.common.utility.CommonUtils;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.InvalidKeyException;
 import java.util.Optional;
-import org.apache.commons.codec.DecoderException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,7 +115,7 @@ class UpdateMerkleTopicResourceUsageTest extends TopicResourceUsageTestBase {
     }
 
     @Test
-    void getFeeThrowsExceptionForBadKeys() throws DecoderException, IllegalArgumentException {
+    void getFeeThrowsExceptionForBadKeys() throws InvalidKeyException, IllegalArgumentException {
         final var txnBody = makeTransactionBody(
                 topicId,
                 defaultMemo,
@@ -128,7 +128,7 @@ class UpdateMerkleTopicResourceUsageTest extends TopicResourceUsageTestBase {
                 new MerkleTopic(defaultMemo, adminKey, submitKey, 0, new EntityId(0, 1, 2), new RichInstant(36_000, 0));
         given(topics.get(EntityNum.fromTopicId(topicId))).willReturn(merkleTopic);
         final var mockedJkey = mockStatic(JKey.class);
-        mockedJkey.when(() -> JKey.mapJKey(any())).thenThrow(new DecoderException());
+        mockedJkey.when(() -> JKey.mapJKey(any())).thenThrow(new InvalidKeyException());
 
         assertThrows(InvalidTxBodyException.class, () -> subject.usageGiven(txnBody, sigValueObj, view));
         assertThat(
@@ -138,7 +138,7 @@ class UpdateMerkleTopicResourceUsageTest extends TopicResourceUsageTestBase {
     }
 
     @Test
-    void updateToMissingTopic() throws DecoderException, InvalidTxBodyException {
+    void updateToMissingTopic() throws InvalidKeyException, InvalidTxBodyException {
         final var txBody = makeTransactionBody(
                 topicId,
                 defaultMemo,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManagerTest.java
@@ -44,10 +44,10 @@ import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.merkle.map.MerkleMap;
+import java.security.InvalidKeyException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiConsumer;
-import org.apache.commons.codec.DecoderException;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
@@ -113,7 +113,7 @@ class AliasManagerTest {
     }
 
     @Test
-    void canLinkAndUnlinkEthereumAddresses() throws InvalidProtocolBufferException, DecoderException {
+    void canLinkAndUnlinkEthereumAddresses() throws InvalidProtocolBufferException, InvalidKeyException {
         final Key key = Key.parseFrom(ECDSA_PUBLIC_KEY);
         final JKey jKey = JKey.mapKey(key);
         final boolean added = subject.maybeLinkEvmAddress(jKey, num);
@@ -125,7 +125,7 @@ class AliasManagerTest {
     }
 
     @Test
-    void publicKeyCouldNotBeParsed() throws InvalidProtocolBufferException, DecoderException {
+    void publicKeyCouldNotBeParsed() throws InvalidProtocolBufferException, InvalidKeyException {
         Key key = Key.parseFrom(ECDSA_PUBLIC_KEY);
         JKey jKey = JKey.mapKey(key);
         subject.maybeLinkEvmAddress(jKey, num);
@@ -145,7 +145,7 @@ class AliasManagerTest {
     }
 
     @Test
-    void skipsUnrecoverableEthereumAddresses() throws InvalidProtocolBufferException, DecoderException {
+    void skipsUnrecoverableEthereumAddresses() throws InvalidProtocolBufferException, InvalidKeyException {
         final Key key = Key.parseFrom(ECDSA_PUBLIC_KEY);
         final JKey jKey = JKey.mapKey(key);
         final boolean added = subject.maybeLinkEvmAddress(jKey, num, any -> null);
@@ -158,7 +158,7 @@ class AliasManagerTest {
     }
 
     @Test
-    void wontLinkOrUnlinked25519Key() throws DecoderException {
+    void wontLinkOrUnlinked25519Key() throws InvalidKeyException {
         final var keyData = ByteString.copyFrom("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes());
         final Key key = Key.newBuilder().setEd25519(keyData).build();
         final JKey jKey = JKey.mapKey(key);
@@ -205,7 +205,7 @@ class AliasManagerTest {
 
     @Test
     void lookupIdByECDSAKeyAliasShouldReturnNumFromEVMAddressAliasMap()
-            throws InvalidProtocolBufferException, DecoderException {
+            throws InvalidProtocolBufferException, InvalidKeyException {
         subject.link(ByteString.copyFrom(ECDSA_PUBLIC_KEY_ADDRESS), num);
         assertEquals(num, subject.lookupIdBy(ByteString.copyFrom(ECDSA_PUBLIC_KEY)));
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/AccountPropertyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/AccountPropertyTest.java
@@ -69,6 +69,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
@@ -108,7 +109,7 @@ class AccountPropertyTest {
 
     @Test
     @SuppressWarnings("java:S5961")
-    void gettersAndSettersWork() throws Exception {
+    void gettersAndSettersWork() throws NegativeAccountBalanceException, InvalidKeyException {
         final boolean origIsDeleted = false;
         final boolean origIsReceiverSigReq = false;
         final boolean origIsContract = false;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyListTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyListTest.java
@@ -28,6 +28,7 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -73,7 +74,7 @@ class JKeyListTest {
     }
 
     @Test
-    void invalidJKeyListTest() throws Exception {
+    void invalidJKeyListTest() throws InvalidKeyException {
         Key validED25519Key = Key.newBuilder()
                 .setEd25519(TxnUtils.randomUtf8ByteString(JEd25519Key.ED25519_BYTE_LENGTH))
                 .build();
@@ -111,7 +112,7 @@ class JKeyListTest {
     }
 
     @Test
-    void validJKeyListTest() throws Exception {
+    void validJKeyListTest() throws InvalidKeyException {
         Key validED25519Key = Key.newBuilder()
                 .setEd25519(TxnUtils.randomUtf8ByteString(JEd25519Key.ED25519_BYTE_LENGTH))
                 .build();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeySerializerTest.java
@@ -39,6 +39,7 @@ import com.swirlds.common.utility.CommonUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,7 +48,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
 import net.i2p.crypto.eddsa.KeyPairGenerator;
-import org.apache.commons.codec.DecoderException;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 
@@ -438,7 +438,7 @@ class JKeySerializerTest {
     }
 
     @Test
-    void jKeyProtoSerDes() throws IOException, DecoderException {
+    void jKeyProtoSerDes() throws IOException, InvalidKeyException {
         final Map<String, PrivateKey> pubKey2privKeyMap = new HashMap<>();
         Key protoKey;
         JKey jkey = null;
@@ -470,7 +470,7 @@ class JKeySerializerTest {
     }
 
     @Test
-    void jKeyECDSASecp256k1KeySerDes() throws Exception {
+    void jKeyECDSASecp256k1KeySerDes() throws InvalidKeyException {
         final Map<String, PrivateKey> pubKey2privKeyMap = new HashMap<>();
         Key protoKey;
         protoKey = genSingleECDSASecp256k1Key(pubKey2privKeyMap);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyTest.java
@@ -34,9 +34,9 @@ import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hedera.test.utils.TxnUtils;
 import com.hederahashgraph.api.proto.java.Key;
+import java.security.InvalidKeyException;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.Test;
 
 class JKeyTest {
@@ -64,7 +64,7 @@ class JKeyTest {
 
         // expect:
         assertThrows(
-                DecoderException.class,
+                InvalidKeyException.class,
                 () -> JKey.convertKey(keyTooDeep, 1),
                 "Exceeding max expansion depth of " + JKey.MAX_KEY_DEPTH);
     }
@@ -76,7 +76,7 @@ class JKeyTest {
 
         // expect:
         assertThrows(
-                DecoderException.class,
+                InvalidKeyException.class,
                 () -> JKey.convertJKey(jKeyTooDeep, 1),
                 "Exceeding max expansion depth of " + JKey.MAX_KEY_DEPTH);
     }
@@ -108,7 +108,7 @@ class JKeyTest {
     }
 
     @Test
-    void canMapDelegateToGrpc() throws DecoderException {
+    void canMapDelegateToGrpc() throws InvalidKeyException {
         final var id = IdUtils.asContract("1.2.3");
         final var expected = Key.newBuilder().setDelegatableContractId(id).build();
 
@@ -119,7 +119,7 @@ class JKeyTest {
     }
 
     @Test
-    void canMapDelegateFromGrpc() throws DecoderException {
+    void canMapDelegateFromGrpc() throws InvalidKeyException {
         final var id = IdUtils.asContract("1.2.3");
         final var input = Key.newBuilder().setDelegatableContractId(id).build();
 
@@ -133,7 +133,7 @@ class JKeyTest {
     void rejectsEmptyKey() {
         // expect:
         assertThrows(
-                DecoderException.class,
+                InvalidKeyException.class,
                 () -> JKey.convertJKeyBasic(new JKey() {
                     @Override
                     public boolean isEmpty() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JThresholdKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JThresholdKeyTest.java
@@ -25,6 +25,7 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
+import java.security.InvalidKeyException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -60,12 +61,12 @@ class JThresholdKeyTest {
                 .build();
     }
 
-    private JKey jThresholdKey(final KeyList keyList, final int threshold) throws Exception {
+    private JKey jThresholdKey(final KeyList keyList, final int threshold) throws InvalidKeyException {
         return JKey.convertKey(thresholdKey(keyList, threshold), 1);
     }
 
     @Test
-    void JThresholdKeyWithVariousThresholdTest() throws Exception {
+    void JThresholdKeyWithVariousThresholdTest() throws InvalidKeyException {
         final Key validContractIDKey = Key.newBuilder()
                 .setContractID(ContractID.newBuilder().setContractNum(1L).build())
                 .build();
@@ -83,7 +84,7 @@ class JThresholdKeyTest {
     }
 
     @Test
-    void invalidJThresholdKeyTest() throws Exception {
+    void invalidJThresholdKeyTest() throws InvalidKeyException {
         final Key validED25519Key = Key.newBuilder()
                 .setEd25519(TxnUtils.randomUtf8ByteString(JEd25519Key.ED25519_BYTE_LENGTH))
                 .build();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/serialization/JKeyAdditionalTypeSupportTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/serialization/JKeyAdditionalTypeSupportTest.java
@@ -31,26 +31,27 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import java.io.ByteArrayInputStream;
-import org.apache.commons.codec.DecoderException;
+import java.io.IOException;
+import java.security.InvalidKeyException;
 import org.junit.jupiter.api.Test;
 
 class JKeyAdditionalTypeSupportTest {
     @Test
-    void serializingJContractIDKeyTest() throws Exception {
+    void serializingJContractIDKeyTest() throws IOException, InvalidKeyException {
         final var cid = ContractID.newBuilder().setShardNum(0).setRealmNum(0).setContractNum(1001);
         final var key = Key.newBuilder().setContractID(cid).build();
         commonAssertions(key);
     }
 
     @Test
-    void serializingJRSA_3072KeyTest() throws Exception {
+    void serializingJRSA_3072KeyTest() throws IOException, InvalidKeyException {
         final var keyBytes = TxnUtils.randomUtf8ByteString(3072 / 8);
         final var key = Key.newBuilder().setRSA3072(keyBytes).build();
         commonAssertions(key);
     }
 
     @Test
-    void canMapAndUnmapContractAliasKeys() throws DecoderException {
+    void canMapAndUnmapContractAliasKeys() throws InvalidKeyException {
         final byte[] mockAddr = unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb");
         final var input = ContractID.newBuilder()
                 .setEvmAddress(ByteString.copyFrom(mockAddr))
@@ -65,7 +66,7 @@ class JKeyAdditionalTypeSupportTest {
     }
 
     @Test
-    void canMapAndUnmapContractDelegateAliasKeys() throws DecoderException {
+    void canMapAndUnmapContractDelegateAliasKeys() throws InvalidKeyException {
         final byte[] mockAddr = unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb");
         final var input = ContractID.newBuilder()
                 .setEvmAddress(ByteString.copyFrom(mockAddr))
@@ -79,7 +80,7 @@ class JKeyAdditionalTypeSupportTest {
         assertTrue(JKey.equalUpToDecodability(subject, reconstructed));
     }
 
-    private void commonAssertions(final Key key) throws Exception {
+    private void commonAssertions(final Key key) throws InvalidKeyException, IOException {
         final var jKey = JKey.mapKey(key);
 
         final var ser = JKeySerializer.serialize(jKey);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -53,10 +53,10 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,7 +87,7 @@ class BackedSystemAccountsCreatorTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void setup() throws DecoderException, NegativeAccountBalanceException, IllegalArgumentException {
+    void setup() throws InvalidKeyException, NegativeAccountBalanceException, IllegalArgumentException {
         genesisKey = JKey.mapKey(Key.newBuilder()
                 .setKeyList(KeyList.newBuilder().addKeys(MiscUtils.asKeyUnchecked(pretendKey)))
                 .build());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BlocklistAccountCreatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BlocklistAccountCreatorTest.java
@@ -49,8 +49,8 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
+import java.security.InvalidKeyException;
 import java.util.function.Supplier;
-import org.apache.commons.codec.DecoderException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,7 +91,7 @@ class BlocklistAccountCreatorTest {
     private BlocklistAccountCreator subject;
 
     @BeforeEach
-    void setUp() throws DecoderException {
+    void setUp() throws InvalidKeyException {
         ids = new EntityIdSource() {
             long nextId = FIRST_UNUSED_ID;
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManagerTest.java
@@ -83,13 +83,13 @@ import com.swirlds.common.utility.CommonUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.InvalidKeyException;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import org.apache.commons.codec.DecoderException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -160,7 +160,7 @@ class HfsSystemFilesManagerTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void setup() throws DecoderException {
+    void setup() throws InvalidKeyException {
         final var keyBytes = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes();
         masterKey = new JEd25519Key(keyBytes);
         expectedInfo = new HFileMeta(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManagerTest.java
@@ -77,11 +77,11 @@ import com.swirlds.common.merkle.utility.MerkleLong;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.merkle.tree.MerkleBinaryTree;
 import com.swirlds.merkle.tree.MerkleTreeInternalNode;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.commons.codec.DecoderException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -130,7 +130,7 @@ class MigrationRecordsManagerTest {
             genesisKey = JKey.mapKey(Key.newBuilder()
                     .setKeyList(KeyList.newBuilder().addKeys(MiscUtils.asKeyUnchecked(systemAccountKey)))
                     .build());
-        } catch (DecoderException e) {
+        } catch (InvalidKeyException e) {
             throw new RuntimeException(e);
         }
     }
@@ -323,7 +323,7 @@ class MigrationRecordsManagerTest {
     }
 
     @Test
-    void streamsBlocklistedAccountWhenFeatureFlagIsEnabled() throws DecoderException {
+    void streamsBlocklistedAccountWhenFeatureFlagIsEnabled() throws InvalidKeyException {
         final var bodyCaptor = forClass(TransactionBody.Builder.class);
         given(consensusTimeTracker.unlimitedPreceding()).willReturn(true);
         given(bootstrapProperties.getBooleanProperty(PropertyNames.ACCOUNTS_BLOCKLIST_ENABLED))
@@ -592,7 +592,7 @@ class MigrationRecordsManagerTest {
         given(systemAccountsCreator.getSystemAccountsCreated()).willReturn(systemAccounts);
     }
 
-    private void givenBlocklistedAccountsCreated() throws DecoderException {
+    private void givenBlocklistedAccountsCreated() throws InvalidKeyException {
         blocklistedAccounts.addAll(List.of(
                 blockedAccount(ByteString.copyFromUtf8(EVM_ADDRESS_1), MEMO_1),
                 blockedAccount(ByteString.copyFromUtf8(EVM_ADDRESS_2), MEMO_2)));
@@ -601,7 +601,7 @@ class MigrationRecordsManagerTest {
         given(blocklistAccountCreator.getBlockedAccountsCreated()).willReturn(blocklistedAccounts);
     }
 
-    private HederaAccount blockedAccount(ByteString evmAddress, String memo) throws DecoderException {
+    private HederaAccount blockedAccount(ByteString evmAddress, String memo) throws InvalidKeyException {
         return new HederaAccountCustomizer()
                 .isReceiverSigRequired(true)
                 .isDeclinedReward(true)

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccessTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccessTest.java
@@ -79,12 +79,12 @@ import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import org.apache.commons.codec.DecoderException;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
@@ -360,7 +360,7 @@ class StaticEntityAccessTest {
     }
 
     @Test
-    void getKeys() throws DecoderException {
+    void getKeys() throws InvalidKeyException {
         token.setAdminKey(TxnHandlingScenario.TOKEN_ADMIN_KT.asJKey());
         token.setKycKey(TxnHandlingScenario.TOKEN_KYC_KT.asJKey());
         token.setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asJKey());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgersTest.java
@@ -104,12 +104,12 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenInfo;
 import com.hederahashgraph.api.proto.java.TokenNftInfo;
 import com.swirlds.fchashmap.FCHashMap;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.codec.DecoderException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -656,7 +656,7 @@ class WorldLedgersTest {
     }
 
     @Test
-    void nonStaticKeyInfoWorks() throws DecoderException {
+    void nonStaticKeyInfoWorks() throws InvalidKeyException {
         given(tokensLedger.get(fungibleToken, TokenProperty.ADMIN_KEY))
                 .willReturn(TxnHandlingScenario.TOKEN_ADMIN_KT.asJKey());
         given(tokensLedger.get(fungibleToken, TokenProperty.FREEZE_KEY))
@@ -1017,7 +1017,7 @@ class WorldLedgersTest {
         assertEquals(FUNGIBLE_COMMON, tokenAccessor.typeOf(fungibleTokenAddress));
     }
 
-    private void setUpToken(final MerkleToken token) throws DecoderException {
+    private void setUpToken(final MerkleToken token) throws InvalidKeyException {
         token.setMemo(tokenMemo);
         token.setPauseKey(TxnHandlingScenario.TOKEN_PAUSE_KT.asJKey());
         token.setDeleted(true);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -105,10 +105,10 @@ import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransferList;
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.codec.DecoderException;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
@@ -462,7 +462,7 @@ class SyntheticTxnFactoryTest {
     }
 
     @Test
-    void createsExpectedCryptoCreateWithECKeyAlias() throws DecoderException {
+    void createsExpectedCryptoCreateWithECKeyAlias() throws InvalidKeyException {
         final var balance = 10L;
         final var key = KeyFactory.getDefaultInstance().newEcdsaSecp256k1();
         final var alias = key.toByteString();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapperTest.java
@@ -36,9 +36,9 @@ import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
+import java.security.InvalidKeyException;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.codec.DecoderException;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +50,7 @@ class TokenCreateWrapperTest {
     private final ContractID contractID = EntityIdUtils.contractIdFromEvmAddress(contractAddress);
 
     @Test
-    void setInheritedKeysToSpecificKeyWorksAsExpected() throws DecoderException {
+    void setInheritedKeysToSpecificKeyWorksAsExpected() throws InvalidKeyException {
         // given
         final var key = new JContractIDKey(contractID);
         final var wrapper = createTokenCreateWrapperWithKeys(List.of(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/AutoCreationLogicTest.java
@@ -73,11 +73,11 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.NftTransfer;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.codec.DecoderException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.BeforeEach;
@@ -216,7 +216,7 @@ class AutoCreationLogicTest {
     }
 
     @Test
-    void happyPathECKeyAliasWithHbarChangeWorks() throws InvalidProtocolBufferException, DecoderException {
+    void happyPathECKeyAliasWithHbarChangeWorks() throws InvalidProtocolBufferException, InvalidKeyException {
         givenCollaborators(mockBuilder, AUTO_MEMO);
         final var key = Key.parseFrom(ecdsaKeyBytes);
         final var pretendAddress = keyAliasToEVMAddress(ecKeyAlias);
@@ -253,7 +253,7 @@ class AutoCreationLogicTest {
     }
 
     @Test
-    void hollowAccountWithHbarChangeWorks() throws InvalidProtocolBufferException, DecoderException {
+    void hollowAccountWithHbarChangeWorks() throws InvalidProtocolBufferException, InvalidKeyException {
         final var jKey = JKey.mapKey(Key.parseFrom(ecdsaKeyBytes));
         final var evmAddressAlias =
                 ByteString.copyFrom(EthSigsUtils.recoverAddressFromPubKey(jKey.getECDSASecp256k1Key()));
@@ -291,7 +291,7 @@ class AutoCreationLogicTest {
     }
 
     @Test
-    void hollowAccountWithFtChangeWorks() throws InvalidProtocolBufferException, DecoderException {
+    void hollowAccountWithFtChangeWorks() throws InvalidProtocolBufferException, InvalidKeyException {
         final var jKey = JKey.mapKey(Key.parseFrom(ecdsaKeyBytes));
         final var evmAddressAlias =
                 ByteString.copyFrom(EthSigsUtils.recoverAddressFromPubKey(jKey.getECDSASecp256k1Key()));
@@ -327,7 +327,7 @@ class AutoCreationLogicTest {
     }
 
     @Test
-    void hollowAccountWithNFTChangeWorks() throws InvalidProtocolBufferException, DecoderException {
+    void hollowAccountWithNFTChangeWorks() throws InvalidProtocolBufferException, InvalidKeyException {
         final var jKey = JKey.mapKey(Key.parseFrom(ecdsaKeyBytes));
         final var evmAddressAlias =
                 ByteString.copyFrom(EthSigsUtils.recoverAddressFromPubKey(jKey.getECDSASecp256k1Key()));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -95,8 +95,8 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.merkle.map.MerkleMap;
+import java.security.InvalidKeyException;
 import java.time.Instant;
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -565,7 +565,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void acceptsECKeyWhenECKeyAndExtractedEVMAddressAreNotUnique() throws DecoderException {
+    void acceptsECKeyWhenECKeyAndExtractedEVMAddressAreNotUnique() throws InvalidKeyException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
         final var opBuilder = CryptoCreateTransactionBody.newBuilder().setKey(ECDSA_KEY);
@@ -726,7 +726,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void followsHappyPathECKeyAndEVMAddressAlias() throws DecoderException {
+    void followsHappyPathECKeyAndEVMAddressAlias() throws InvalidKeyException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
         final var opBuilder = CryptoCreateTransactionBody.newBuilder()
                 .setMemo(MEMO)
@@ -769,7 +769,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void followsHappyPathECKey() throws DecoderException {
+    void followsHappyPathECKey() throws InvalidKeyException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
         final var opBuilder = CryptoCreateTransactionBody.newBuilder().setKey(ECDSA_KEY);
@@ -809,7 +809,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void followsHappyPathECKeyWithBothFlagsAreEnabled() throws DecoderException {
+    void followsHappyPathECKeyWithBothFlagsAreEnabled() throws InvalidKeyException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
         final var opBuilder = CryptoCreateTransactionBody.newBuilder().setKey(ECDSA_KEY);
@@ -849,7 +849,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void followsHappyPathECKeyAndCreateWithAliasAndLazyCreateDisabled() throws DecoderException {
+    void followsHappyPathECKeyAndCreateWithAliasAndLazyCreateDisabled() throws InvalidKeyException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
         final var opBuilder = CryptoCreateTransactionBody.newBuilder().setKey(ECDSA_KEY);
@@ -888,7 +888,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void followsHappyPathEDKey() throws DecoderException {
+    void followsHappyPathEDKey() throws InvalidKeyException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
         final var opBuilder = CryptoCreateTransactionBody.newBuilder().setKey(aPrimitiveEDKey);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogicTest.java
@@ -67,10 +67,10 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.EnumSet;
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -425,7 +425,7 @@ class FileUpdateTransitionLogicTest {
     void transitionCatchesBadlyEncodedKey() {
         givenTxnCtxUpdating(EnumSet.of(UpdateTarget.KEY));
         // and:
-        willThrow(new IllegalArgumentException(new DecoderException()))
+        willThrow(new IllegalArgumentException(new InvalidKeyException()))
                 .given(hfs)
                 .setattr(argThat(nonSysFileTarget::equals), any());
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/MiscUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/MiscUtilsTest.java
@@ -212,6 +212,7 @@ import com.swirlds.merkle.map.MerkleMap;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -220,7 +221,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -736,7 +736,7 @@ class MiscUtilsTest {
     }
 
     @Test
-    void describesCorrectly() throws DecoderException {
+    void describesCorrectly() throws InvalidKeyException {
         assertEquals("<N/A>", describe(null));
 
         final var key = Key.newBuilder()

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/accounts/MerkleAccountFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/accounts/MerkleAccountFactory.java
@@ -29,6 +29,7 @@ import com.hedera.test.factories.keys.KeyTree;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenID;
+import java.security.InvalidKeyException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -192,11 +193,11 @@ public class MerkleAccountFactory {
         return this;
     }
 
-    public MerkleAccountFactory accountKeys(final KeyTree kt) throws Exception {
+    public MerkleAccountFactory accountKeys(final KeyTree kt) throws InvalidKeyException {
         return accountKeys(kt.asKey(keyFactory));
     }
 
-    public MerkleAccountFactory accountKeys(final Key k) throws Exception {
+    public MerkleAccountFactory accountKeys(final Key k) throws InvalidKeyException {
         return accountKeys(JKey.mapKey(k));
     }
 

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTree.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTree.java
@@ -20,9 +20,9 @@ import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.pbj.PbjConverter;
 import com.hedera.node.app.service.mono.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.Key;
+import java.security.InvalidKeyException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import org.apache.commons.codec.DecoderException;
 
 public class KeyTree {
     private final KeyTreeNode root;
@@ -52,7 +52,7 @@ public class KeyTree {
         root.traverse(shouldVisit, visitor);
     }
 
-    public JKey asJKey() throws DecoderException {
+    public JKey asJKey() throws InvalidKeyException {
         return JKey.mapKey(asKey());
     }
 

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/BadPayerScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/BadPayerScenarios.java
@@ -16,15 +16,21 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.CryptoCreateFactory.newSignedCryptoCreate;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.CryptoCreateFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum BadPayerScenarios implements TxnHandlingScenario {
     INVALID_PAYER_ID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedCryptoCreate().payer(MISSING_ACCOUNT_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(CryptoCreateFactory.newSignedCryptoCreate()
+                    .payer(MISSING_ACCOUNT_ID)
+                    .get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusCreateTopicScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusCreateTopicScenarios.java
@@ -24,12 +24,12 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum ConsensusCreateTopicScenarios implements TxnHandlingScenario {
     CONSENSUS_CREATE_TOPIC_NO_ADDITIONAL_KEYS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusCreateTopic().get());
         }
     },
     CONSENSUS_CREATE_TOPIC_ADMIN_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusCreateTopic()
                     .adminKey(SIMPLE_TOPIC_ADMIN_KEY)
                     .nonPayerKts(SIMPLE_TOPIC_ADMIN_KEY)
@@ -37,7 +37,7 @@ public enum ConsensusCreateTopicScenarios implements TxnHandlingScenario {
         }
     },
     CONSENSUS_CREATE_TOPIC_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusCreateTopic()
                     .adminKey(SIMPLE_TOPIC_ADMIN_KEY)
                     .autoRenewAccountId(MISC_ACCOUNT_ID)
@@ -47,7 +47,7 @@ public enum ConsensusCreateTopicScenarios implements TxnHandlingScenario {
     },
 
     CONSENSUS_CREATE_TOPIC_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusCreateTopic()
                     .adminKey(SIMPLE_TOPIC_ADMIN_KEY)
                     .autoRenewAccountId(DEFAULT_PAYER_ID)
@@ -56,7 +56,7 @@ public enum ConsensusCreateTopicScenarios implements TxnHandlingScenario {
         }
     },
     CONSENSUS_CREATE_TOPIC_MISSING_AUTORENEW_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusCreateTopic()
                     .autoRenewAccountId(MISSING_ACCOUNT_ID)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusDeleteTopicScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusDeleteTopicScenarios.java
@@ -16,21 +16,28 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.ConsensusDeleteTopicFactory.newSignedConsensusDeleteTopic;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.ConsensusDeleteTopicFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum ConsensusDeleteTopicScenarios implements TxnHandlingScenario {
     CONSENSUS_DELETE_TOPIC_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedConsensusDeleteTopic(EXISTING_TOPIC_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ConsensusDeleteTopicFactory.newSignedConsensusDeleteTopic(EXISTING_TOPIC_ID)
+                    .get());
         }
     },
     CONSENSUS_DELETE_TOPIC_MISSING_TOPIC_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedConsensusDeleteTopic(MISSING_TOPIC_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ConsensusDeleteTopicFactory.newSignedConsensusDeleteTopic(MISSING_TOPIC_ID)
+                    .get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusSubmitMessageScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusSubmitMessageScenarios.java
@@ -16,21 +16,30 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.ConsensusSubmitMessageFactory.newSignedConsensusSubmitMessage;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.ConsensusSubmitMessageFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum ConsensusSubmitMessageScenarios implements TxnHandlingScenario {
     CONSENSUS_SUBMIT_MESSAGE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
-                    newSignedConsensusSubmitMessage(EXISTING_TOPIC_ID).get());
+                    ConsensusSubmitMessageFactory.newSignedConsensusSubmitMessage(EXISTING_TOPIC_ID)
+                            .get());
         }
     },
     CONSENSUS_SUBMIT_MESSAGE_MISSING_TOPIC_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
-                    newSignedConsensusSubmitMessage(MISSING_TOPIC_ID).get());
+                    ConsensusSubmitMessageFactory.newSignedConsensusSubmitMessage(MISSING_TOPIC_ID)
+                            .get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusUpdateTopicScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusUpdateTopicScenarios.java
@@ -17,33 +17,33 @@
 package com.hedera.test.factories.scenarios;
 
 import static com.hedera.test.factories.txns.ConsensusUpdateTopicFactory.newSignedConsensusUpdateTopic;
-import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.SignedTxnFactory;
 import java.time.Instant;
 
 public enum ConsensusUpdateTopicScenarios implements TxnHandlingScenario {
     CONSENSUS_UPDATE_TOPIC_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID).get());
         }
     },
     CONSENSUS_UPDATE_TOPIC_MISSING_TOPIC_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedConsensusUpdateTopic(MISSING_TOPIC_ID).get());
         }
     },
     CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID)
                     .adminKey(UPDATE_TOPIC_ADMIN_KT)
                     .get());
         }
     },
     CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID)
                     .adminKey(UPDATE_TOPIC_ADMIN_KT)
                     .autoRenewAccountId(MISC_ACCOUNT_ID)
@@ -51,15 +51,15 @@ public enum ConsensusUpdateTopicScenarios implements TxnHandlingScenario {
         }
     },
     CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID)
                     .adminKey(UPDATE_TOPIC_ADMIN_KT)
-                    .autoRenewAccountId(DEFAULT_PAYER_ID)
+                    .autoRenewAccountId(SignedTxnFactory.DEFAULT_PAYER_ID)
                     .get());
         }
     },
     CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_CUSTOM_PAYER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID)
                     .adminKey(UPDATE_TOPIC_ADMIN_KT)
                     .autoRenewAccountId(CUSTOM_PAYER_ACCOUNT_ID)
@@ -67,14 +67,14 @@ public enum ConsensusUpdateTopicScenarios implements TxnHandlingScenario {
         }
     },
     CONSENSUS_UPDATE_TOPIC_MISSING_AUTORENEW_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID)
                     .autoRenewAccountId(MISSING_ACCOUNT_ID)
                     .get());
         }
     },
     CONSENSUS_UPDATE_TOPIC_EXPIRY_ONLY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID)
                     .expirationTime(Instant.ofEpochSecond(1578331832))
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractCreateScenarios.java
@@ -16,32 +16,46 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.ContractCreateFactory.newSignedContractCreate;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.ContractCreateFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum ContractCreateScenarios implements TxnHandlingScenario {
     CONTRACT_CREATE_WITH_ADMIN_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedContractCreate().useAdminKey(true).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ContractCreateFactory.newSignedContractCreate()
+                    .useAdminKey(true)
+                    .get());
         }
     },
     CONTRACT_CREATE_NO_ADMIN_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedContractCreate().useAdminKey(false).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ContractCreateFactory.newSignedContractCreate()
+                    .useAdminKey(false)
+                    .get());
         }
     },
     CONTRACT_CREATE_DEPRECATED_CID_ADMIN_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedContractCreate().useDeprecatedAdminKey(true).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ContractCreateFactory.newSignedContractCreate()
+                    .useDeprecatedAdminKey(true)
+                    .get());
         }
     },
     CONTRACT_CREATE_WITH_AUTO_RENEW_ACCOUNT {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedContractCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ContractCreateFactory.newSignedContractCreate()
                     .useAdminKey(false)
                     .useAutoRenewAccount(true)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractDeleteScenarios.java
@@ -16,42 +16,41 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.ContractDeleteFactory.newSignedContractDelete;
-
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.ContractDeleteFactory;
 
 public enum ContractDeleteScenarios implements TxnHandlingScenario {
     CONTRACT_DELETE_XFER_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedContractDelete(MISC_CONTRACT_ID)
+        public PlatformTxnAccessor platformTxn() throws Exception {
+            return PlatformTxnAccessor.from(ContractDeleteFactory.newSignedContractDelete(MISC_CONTRACT_ID)
                     .withBeneficiary(RECEIVER_SIG)
                     .get());
         }
     },
     CONTRACT_DELETE_IMMUTABLE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedContractDelete(IMMUTABLE_CONTRACT_ID)
+        public PlatformTxnAccessor platformTxn() throws Exception {
+            return PlatformTxnAccessor.from(ContractDeleteFactory.newSignedContractDelete(IMMUTABLE_CONTRACT_ID)
                     .withBeneficiary(RECEIVER_SIG)
                     .get());
         }
     },
     CONTRACT_DELETE_XFER_CONTRACT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedContractDelete(MISC_CONTRACT_ID)
+        public PlatformTxnAccessor platformTxn() throws Exception {
+            return PlatformTxnAccessor.from(ContractDeleteFactory.newSignedContractDelete(MISC_CONTRACT_ID)
                     .withBeneficiary(MISC_RECIEVER_SIG_CONTRACT)
                     .get());
         }
     },
     CONTRACT_DELETE_MISSING_ACCOUNT_BENEFICIARY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedContractDelete(MISC_CONTRACT_ID)
+        public PlatformTxnAccessor platformTxn() throws Exception {
+            return PlatformTxnAccessor.from(ContractDeleteFactory.newSignedContractDelete(MISC_CONTRACT_ID)
                     .withBeneficiary(MISSING_ACCOUNT)
                     .get());
         }
     },
     CONTRACT_DELETE_MISSING_CONTRACT_BENEFICIARY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedContractDelete(MISC_CONTRACT_ID)
+        public PlatformTxnAccessor platformTxn() throws Exception {
+            return PlatformTxnAccessor.from(ContractDeleteFactory.newSignedContractDelete(MISC_CONTRACT_ID)
                     .withBeneficiary(MISSING_CONTRACT)
                     .get());
         }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractUpdateScenarios.java
@@ -22,14 +22,14 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum ContractUpdateScenarios implements TxnHandlingScenario {
     CONTRACT_UPDATE_EXPIRATION_ONLY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newExpiration(DEFAULT_EXPIRY)
                     .get());
         }
     },
     CONTRACT_UPDATE_EXPIRATION_PLUS_NEW_ADMIN_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newAdminKt(SIMPLE_NEW_ADMIN_KT)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -37,7 +37,7 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_EXPIRATION_PLUS_NEW_DEPRECATED_CID_ADMIN_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newDeprecatedAdminKey(true)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -45,7 +45,7 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_EXPIRATION_PLUS_NEW_PROXY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newProxyAccount(MISC_ACCOUNT_ID)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -53,7 +53,7 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_EXPIRATION_PLUS_NEW_AUTORENEW_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newAutoRenewPeriod(DEFAULT_PERIOD)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -61,7 +61,7 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_EXPIRATION_PLUS_NEW_FILE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newFile(MISC_FILE_ID)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -69,7 +69,7 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_EXPIRATION_PLUS_NEW_MEMO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newMemo(DEFAULT_MEMO)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -77,14 +77,14 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_WITH_NEW_ADMIN_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newAdminKt(SIMPLE_NEW_ADMIN_KT)
                     .get());
         }
     },
     CONTRACT_UPDATE_NEW_AUTO_RENEW_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newAutoRenewAccount(MISC_ACCOUNT_ID)
                     .newExpiration(DEFAULT_EXPIRY)
@@ -92,7 +92,7 @@ public enum ContractUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CONTRACT_UPDATE_INVALID_AUTO_RENEW_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedContractUpdate(MISC_CONTRACT_ID)
                     .newAutoRenewAccount(MISSING_ACCOUNT_ID)
                     .newExpiration(DEFAULT_EXPIRY)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoAllowanceScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoAllowanceScenarios.java
@@ -23,7 +23,7 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
     CRYPTO_APPROVE_ALLOWANCE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceList)
                     .withNftAllowances(nftAllowanceList)
@@ -33,7 +33,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_ALLOWANCE_SELF_OWNER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoSelfOwnerAllowanceList)
                     .withNftAllowances(nftSelfOwnerAllowanceList)
@@ -43,7 +43,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_ALLOWANCE_USING_DELEGATING_SPENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceList)
                     .withNftAllowances(delegatingNftAllowanceList)
@@ -53,7 +53,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_TOKEN_ALLOWANCE_MISSING_OWNER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceList)
                     .withNftAllowances(nftAllowanceList)
@@ -62,7 +62,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_CRYPTO_ALLOWANCE_MISSING_OWNER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceMissingOwnerList)
                     .withNftAllowances(nftAllowanceList)
@@ -71,7 +71,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_NFT_ALLOWANCE_MISSING_OWNER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceList)
                     .withNftAllowances(nftAllowanceMissingOwnerList)
@@ -80,7 +80,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_NFT_ALLOWANCE_MISSING_DELEGATING_SPENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceList)
                     .withNftAllowances(delegatingNftAllowanceMissingOwnerList)
@@ -89,7 +89,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_APPROVE_ALLOWANCE_NO_OWNER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedApproveAllowance()
                     .withCryptoAllowances(cryptoAllowanceNoOwnerList)
                     .withNftAllowances(nftAllowanceList)
@@ -99,7 +99,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_DELETE_ALLOWANCE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedDeleteAllowance()
                     .withNftAllowances(nftDeleteAllowanceList)
                     .nonPayerKts(OWNER_ACCOUNT_KT)
@@ -107,7 +107,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_DELETE_ALLOWANCE_SELF_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedDeleteAllowance()
                     .withNftAllowances(nftDeleteAllowanceListSelf)
                     .nonPayerKts(OWNER_ACCOUNT_KT)
@@ -115,7 +115,7 @@ public enum CryptoAllowanceScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_DELETE_NFT_ALLOWANCE_MISSING_OWNER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedDeleteAllowance()
                     .withNftAllowances(nftDeleteAllowanceMissingOwnerList)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoCreateScenarios.java
@@ -27,13 +27,13 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum CryptoCreateScenarios implements TxnHandlingScenario {
     CRYPTO_CREATE_NO_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoCreate().receiverSigRequired(false).get());
         }
     },
     CRYPTO_CREATE_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(true)
                     .nonPayerKts(DEFAULT_ACCOUNT_KT)
@@ -41,7 +41,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_RECEIVER_SIG_ED_ADMIN_KEY_EVM_ADDRESS_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(true)
                     .alias(ByteStringUtils.wrapUnsafely(recoverAddressFromPubKey(
@@ -51,7 +51,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_NO_RECEIVER_SIG_ED_ADMIN_KEY_EVM_ADDRESS_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(false)
                     .alias(ByteStringUtils.wrapUnsafely(recoverAddressFromPubKey(
@@ -61,7 +61,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_RECEIVER_SIG_ECDSA_ADMIN_KEY_DIFFERENT_EVM_ADDRESS_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(true)
                     .accountKt(ECDSA_KT)
@@ -72,7 +72,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_NO_RECEIVER_SIG_ECDSA_ADMIN_KEY_DIFFERENT_EVM_ADDRESS_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(false)
                     .accountKt(ECDSA_KT)
@@ -83,7 +83,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_RECEIVER_SIG_ECDSA_ADMIN_KEY_EVM_ADDRESS_ALIAS_FROM_SAME_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(true)
                     .accountKt(ECDSA_KT)
@@ -94,7 +94,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_NO_RECEIVER_SIG_ECDSA_ADMIN_KEY_EVM_ADDRESS_ALIAS_FROM_SAME_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .receiverSigRequired(false)
                     .accountKt(ECDSA_KT)
@@ -105,7 +105,7 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_CREATE_COMPLEX_PAYER_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoCreate()
                     .payer(COMPLEX_KEY_ACCOUNT_ID)
                     .payerKt(COMPLEX_KEY_ACCOUNT_KT)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoDeleteScenarios.java
@@ -23,55 +23,55 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum CryptoDeleteScenarios implements TxnHandlingScenario {
     CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoDelete(DEFAULT_PAYER_ID, NO_RECEIVER_SIG_ID).get());
         }
     },
     CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_CUSTOM_PAYER_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoDelete(CUSTOM_PAYER_ACCOUNT_ID, NO_RECEIVER_SIG_ID)
                     .get());
         }
     },
     CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoDelete(MISC_ACCOUNT_ID, NO_RECEIVER_SIG_ID).get());
         }
     },
     CRYPTO_DELETE_TARGET_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoDelete(MISC_ACCOUNT_ID, RECEIVER_SIG_ID).get());
         }
     },
     CRYPTO_DELETE_TARGET_RECEIVER_SIG_RECEIVER_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoDelete(MISC_ACCOUNT_ID, DEFAULT_PAYER_ID).get());
         }
     },
     CRYPTO_DELETE_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoDelete(DEFAULT_PAYER_ID, RECEIVER_SIG_ID).get());
         }
     },
     CRYPTO_DELETE_TARGET_RECEIVER_SIG_CUSTOM_PAYER_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoDelete(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID)
                     .get());
         }
     },
     CRYPTO_DELETE_MISSING_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoDelete(MISC_ACCOUNT_ID, MISSING_ACCOUNT_ID).get());
         }
     },
     CRYPTO_DELETE_MISSING_TARGET {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoDelete(MISSING_ACCOUNT_ID, NO_RECEIVER_SIG_ID)
                     .get());
         }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
@@ -35,7 +35,7 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 public enum CryptoTransferScenarios implements TxnHandlingScenario {
     CRYPTO_TRANSFER_TOKEN_RECEIVER_IS_MISSING_ALIAS_SCENARIO {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjusting(DEFAULT_PAYER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
                     .adjustingAlias(CURRENTLY_UNUSED_ALIAS, KNOWN_TOKEN_NO_SPECIAL_KEYS, +1_000)
@@ -43,7 +43,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_RECEIVER_IS_MISSING_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromAccountToAlias(FIRST_TOKEN_SENDER_ID, CURRENTLY_UNUSED_ALIAS, 1_000L))
@@ -52,14 +52,14 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(ROYALTY_TOKEN_NFT, NO_RECEIVER_SIG, MISC_ACCOUNT)
                     .get());
         }
     },
     CRYPTO_TRANSFER_SENDER_IS_MISSING_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromAliasToAlias(CURRENTLY_UNUSED_ALIAS, NO_RECEIVER_SIG_ALIAS, 1_000L))
@@ -67,7 +67,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_NO_RECEIVER_SIG_USING_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromAccountToAlias(DEFAULT_PAYER_ID, NO_RECEIVER_SIG_ALIAS, 1_000L))
@@ -75,7 +75,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_TO_IMMUTABLE_RECEIVER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromTo(FIRST_TOKEN_SENDER_ID, STAKING_FUND_ID, 1_000L))
@@ -83,7 +83,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_TOKEN_TO_IMMUTABLE_RECEIVER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .adjusting(DEFAULT_PAYER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
@@ -92,7 +92,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_NFT_FROM_MISSING_SENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .changingOwner(
@@ -103,7 +103,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_NFT_TO_MISSING_RECEIVER_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .changingOwner(
@@ -114,7 +114,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_NFT_FROM_IMMUTABLE_SENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .changingOwner(
@@ -125,7 +125,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_NFT_TO_IMMUTABLE_RECEIVER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER, STAKING_FUND)
@@ -133,7 +133,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_FROM_IMMUTABLE_SENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromTo(STAKING_FUND_ID, NO_RECEIVER_SIG_ID, 1_000L))
@@ -141,7 +141,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_NO_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, NO_RECEIVER_SIG_ID, 1_000L))
@@ -149,7 +149,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_CUSTOM_PAYER_SENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, NO_RECEIVER_SIG_ID, 1_000L))
@@ -157,7 +157,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_RECEIVER_SIG_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(RECEIVER_SIG_KT)
                     .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
@@ -165,7 +165,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_RECEIVER_SIG_USING_ALIAS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(RECEIVER_SIG_KT)
                     .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
@@ -173,7 +173,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_TRANSFER_MISSING_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(RECEIVER_SIG_KT)
                     .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, MISSING_ACCOUNT_ID, 1_000L))
@@ -181,7 +181,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     VALID_QUERY_PAYMENT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(MISC_ACCOUNT_KT, RECEIVER_SIG_KT)
                     .transfers(
@@ -191,7 +191,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     QUERY_PAYMENT_MISSING_SIGS_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(MISC_ACCOUNT_KT)
                     .transfers(
@@ -201,7 +201,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
         }
     },
     QUERY_PAYMENT_INVALID_SENDER_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(MISC_ACCOUNT_KT)
                     .transfers(
@@ -212,7 +212,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_EXTANT_SENDERS {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjusting(DEFAULT_PAYER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
                     .adjusting(SECOND_TOKEN_SENDER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
@@ -223,7 +223,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_MOVING_HBARS_WITH_EXTANT_SENDER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjustingHbars(FIRST_TOKEN_SENDER, -2_000)
                     .adjustingHbars(TOKEN_RECEIVER, +2_000)
@@ -233,7 +233,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_MOVING_HBARS_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjustingHbars(FIRST_TOKEN_SENDER, -2_000)
                     .adjustingHbars(RECEIVER_SIG, +2_000)
@@ -243,7 +243,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjusting(FIRST_TOKEN_SENDER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
                     .adjusting(SECOND_TOKEN_SENDER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
@@ -254,7 +254,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_MISSING_SENDERS {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjusting(FIRST_TOKEN_SENDER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
                     .adjusting(MISSING_ACCOUNT, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
@@ -265,7 +265,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER, TOKEN_RECEIVER)
                     .get());
@@ -273,7 +273,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_USING_ALIAS {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER_ALIAS, TOKEN_RECEIVER)
                     .get());
@@ -281,7 +281,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_RECEIVER_SIG_REQ {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER, RECEIVER_SIG)
                     .changingOwner(ROYALTY_TOKEN_NFT, SECOND_TOKEN_SENDER, DEFAULT_PAYER)
@@ -290,7 +290,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER, NO_RECEIVER_SIG)
                     .get());
@@ -298,7 +298,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_BUT_ROYALTY_FEE_WITH_FALLBACK_TRIGGERED {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .adjustingHbars(FIRST_TOKEN_SENDER, -1)
                     .adjustingHbars(DEFAULT_PAYER, +1)
@@ -308,7 +308,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_TRIGGERED_BUT_SENDER_IS_TREASURY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(ROYALTY_TOKEN_NFT, MISC_ACCOUNT, NO_RECEIVER_SIG)
                     .get());
@@ -316,7 +316,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_AND_FALLBACK_NOT_TRIGGERED_DUE_TO_HBAR {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(ROYALTY_TOKEN_NFT, FIRST_TOKEN_SENDER, NO_RECEIVER_SIG)
                     .adjustingHbars(FIRST_TOKEN_SENDER, +1_000)
@@ -325,7 +325,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_AND_FALLBACK_NOT_TRIGGERED_DUE_TO_FT {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(ROYALTY_TOKEN_NFT, FIRST_TOKEN_SENDER, NO_RECEIVER_SIG)
                     .adjusting(FIRST_TOKEN_SENDER, KNOWN_TOKEN_IMMUTABLE, +1_000)
@@ -334,7 +334,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_AND_MISSING_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(MISSING_TOKEN_NFT, FIRST_TOKEN_SENDER, NO_RECEIVER_SIG)
                     .adjusting(FIRST_TOKEN_SENDER, KNOWN_TOKEN_IMMUTABLE, +1_000)
@@ -343,7 +343,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_MISSING_SENDER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(KNOWN_TOKEN_NFT, MISSING_ACCOUNT, TOKEN_RECEIVER)
                     .get());
@@ -351,7 +351,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_MISSING_RECEIVER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER, MISSING_ACCOUNT)
                     .get());
@@ -359,7 +359,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     CRYPTO_TRANSFER_ALLOWANCE_SPENDER_SCENARIO {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .nonPayerKts(DEFAULT_PAYER_KT)
                     .transfers(approvedTinyBarsFromTo(OWNER_ACCOUNT_ID, NO_RECEIVER_SIG_ID, 1_000L))
@@ -368,7 +368,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     TOKEN_TRANSFER_ALLOWANCE_SPENDER_SCENARIO {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .approvedAdjusting(OWNER_ACCOUNT, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
                     .adjusting(TOKEN_RECEIVER, KNOWN_TOKEN_NO_SPECIAL_KEYS, +1_000)
@@ -377,7 +377,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
     },
     NFT_TRANSFER_ALLOWANCE_SPENDER_SCENARIO {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoTransfer()
                     .approvedChangingOwner(KNOWN_TOKEN_NFT, OWNER_ACCOUNT, TOKEN_RECEIVER)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
@@ -26,44 +26,44 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum CryptoUpdateScenarios implements TxnHandlingScenario {
     CRYPTO_UPDATE_NO_NEW_KEY_SELF_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoUpdate(DEFAULT_PAYER_ID).get());
         }
     },
     CRYPTO_UPDATE_NO_NEW_KEY_CUSTOM_PAYER_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoUpdate(CUSTOM_PAYER_ACCOUNT_ID).get());
         }
     },
     CRYPTO_UPDATE_NO_NEW_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoUpdate(MISC_ACCOUNT_ID).get());
         }
     },
     CRYPTO_UPDATE_IMMUTABLE_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoUpdate(STAKING_FUND_ID).get());
         }
     },
     CRYPTO_UPDATE_MISSING_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoUpdate(MISSING_ACCOUNT_ID).get());
         }
     },
     CRYPTO_UPDATE_COMPLEX_KEY_ACCOUNT_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(COMPLEX_KEY_ACCOUNT_ID)
                     .nonPayerKts(COMPLEX_KEY_ACCOUNT_KT)
                     .get());
         }
     },
     CRYPTO_UPDATE_COMPLEX_KEY_ACCOUNT_ADD_NEW_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(COMPLEX_KEY_ACCOUNT_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)
                     .nonPayerKts(COMPLEX_KEY_ACCOUNT_KT, NEW_ACCOUNT_KT)
@@ -71,41 +71,41 @@ public enum CryptoUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_UPDATE_WITH_NEW_KEY_SELF_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(DEFAULT_PAYER_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)
                     .get());
         }
     },
     CRYPTO_UPDATE_WITH_NEW_KEY_CUSTOM_PAYER_PAID_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(CUSTOM_PAYER_ACCOUNT_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)
                     .get());
         }
     },
     CRYPTO_UPDATE_WITH_NEW_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(MISC_ACCOUNT_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)
                     .get());
         }
     },
     CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NEW_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(SYS_ACCOUNT_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)
                     .get());
         }
     },
     CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NO_NEW_KEY_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedCryptoUpdate(SYS_ACCOUNT_ID).get());
         }
     },
     CRYPTO_UPDATE_SYS_ACCOUNT_WITH_PRIVILEGED_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(SYS_ACCOUNT_ID)
                     .payer(MASTER_PAYER_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)
@@ -113,14 +113,14 @@ public enum CryptoUpdateScenarios implements TxnHandlingScenario {
         }
     },
     CRYPTO_UPDATE_TREASURY_ACCOUNT_WITH_TREASURY_AND_NO_NEW_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(TREASURY_PAYER_ID)
                     .payer(TREASURY_PAYER_ID)
                     .get());
         }
     },
     CRYPTO_UPDATE_TREASURY_ACCOUNT_WITH_TREASURY_AND_NEW_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedCryptoUpdate(TREASURY_PAYER_ID)
                     .payer(TREASURY_PAYER_ID)
                     .newAccountKt(NEW_ACCOUNT_KT)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileAppendScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileAppendScenarios.java
@@ -24,36 +24,36 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum FileAppendScenarios implements TxnHandlingScenario {
     VANILLA_FILE_APPEND_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileAppend(MISC_FILE_ID).get());
         }
     },
     SYSTEM_FILE_APPEND_WITH_PRIVILEGD_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedFileAppend(SYS_FILE_ID).payer(MASTER_PAYER_ID).get());
         }
     },
     TREASURY_SYS_FILE_APPEND_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedFileAppend(SYS_FILE_ID).payer(TREASURY_PAYER_ID).get());
         }
     },
     MASTER_SYS_FILE_APPEND_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedFileAppend(SYS_FILE_ID).payer(MASTER_PAYER_ID).get());
         }
     },
     IMMUTABLE_FILE_APPEND_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedFileAppend(IMMUTABLE_FILE_ID).get());
         }
     },
     FILE_APPEND_MISSING_TARGET_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileAppend(MISSING_FILE_ID).get());
         }
     }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
@@ -16,14 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.FileCreateFactory.newSignedFileCreate;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.FileCreateFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum FileCreateScenarios implements TxnHandlingScenario {
     VANILLA_FILE_CREATE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedFileCreate().get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(
+                    FileCreateFactory.newSignedFileCreate().get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileDeleteScenarios.java
@@ -16,25 +16,36 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.FileDeleteFactory.newSignedFileDelete;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.FileDeleteFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum FileDeleteScenarios implements TxnHandlingScenario {
     VANILLA_FILE_DELETE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedFileDelete(MISC_FILE_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(
+                    FileDeleteFactory.newSignedFileDelete(MISC_FILE_ID).get());
         }
     },
     IMMUTABLE_FILE_DELETE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
-                    newSignedFileDelete(IMMUTABLE_FILE_ID).get());
+                    FileDeleteFactory.newSignedFileDelete(IMMUTABLE_FILE_ID).get());
         }
     },
     MISSING_FILE_DELETE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedFileDelete(MISSING_FILE_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(
+                    FileDeleteFactory.newSignedFileDelete(MISSING_FILE_ID).get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileUpdateScenarios.java
@@ -24,12 +24,12 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum FileUpdateScenarios implements TxnHandlingScenario {
     VANILLA_FILE_UPDATE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileUpdate(MISC_FILE_ID).get());
         }
     },
     TREASURY_SYS_FILE_UPDATE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileUpdate(SYS_FILE_ID)
                     .payer(TREASURY_PAYER_ID)
                     .newWaclKt(SIMPLE_NEW_WACL_KT)
@@ -37,13 +37,13 @@ public enum FileUpdateScenarios implements TxnHandlingScenario {
         }
     },
     TREASURY_SYS_FILE_UPDATE_SCENARIO_NO_NEW_KEY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedFileUpdate(SYS_FILE_ID).payer(TREASURY_PAYER_ID).get());
         }
     },
     MASTER_SYS_FILE_UPDATE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileUpdate(SYS_FILE_ID)
                     .payer(MASTER_PAYER_ID)
                     .newWaclKt(SIMPLE_NEW_WACL_KT)
@@ -51,13 +51,13 @@ public enum FileUpdateScenarios implements TxnHandlingScenario {
         }
     },
     IMMUTABLE_FILE_UPDATE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedFileUpdate(IMMUTABLE_FILE_ID).get());
         }
     },
     FILE_UPDATE_NEW_WACL_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileUpdate(MISC_FILE_ID)
                     .payer(TREASURY_PAYER_ID)
                     .newWaclKt(SIMPLE_NEW_WACL_KT)
@@ -65,7 +65,7 @@ public enum FileUpdateScenarios implements TxnHandlingScenario {
         }
     },
     FILE_UPDATE_MISSING_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedFileUpdate(MISSING_FILE_ID)
                     .payer(TREASURY_PAYER_ID)
                     .newWaclKt(SIMPLE_NEW_WACL_KT)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleCreateScenarios.java
@@ -16,184 +16,220 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.CryptoTransferFactory.newSignedCryptoTransfer;
-import static com.hedera.test.factories.txns.CryptoUpdateFactory.newSignedCryptoUpdate;
-import static com.hedera.test.factories.txns.ScheduleCreateFactory.newSignedScheduleCreate;
-import static com.hedera.test.factories.txns.ScheduleSignFactory.newSignedScheduleSign;
-import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
-import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
-import static com.hedera.test.factories.txns.SignedTxnFactory.MASTER_PAYER_ID;
-import static com.hedera.test.factories.txns.SignedTxnFactory.TREASURY_PAYER_ID;
-import static com.hedera.test.factories.txns.TinyBarsFromTo.tinyBarsFromTo;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.CryptoTransferFactory;
+import com.hedera.test.factories.txns.CryptoUpdateFactory;
+import com.hedera.test.factories.txns.ScheduleCreateFactory;
+import com.hedera.test.factories.txns.ScheduleSignFactory;
+import com.hedera.test.factories.txns.SignedTxnFactory;
+import com.hedera.test.factories.txns.TinyBarsFromTo;
 import com.hedera.test.utils.IdUtils;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum ScheduleCreateScenarios implements TxnHandlingScenario {
     SCHEDULE_CREATE_NESTED_SCHEDULE_SIGN {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .missingAdmin()
-                    .creating(newSignedScheduleSign()
+                    .creating(ScheduleSignFactory.newSignedScheduleSign()
                             .signing(KNOWN_SCHEDULE_IMMUTABLE)
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_NONSENSE {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedScheduleCreate().schedulingNonsense().get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .schedulingNonsense()
+                    .get());
         }
     },
     SCHEDULE_CREATE_XFER_NO_ADMIN {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .missingAdmin()
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_INVALID_XFER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .missingAdmin()
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISSING_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISSING_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .creating(newSignedCryptoTransfer()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .designatingPayer(DILIGENT_SIGNING_PAYER)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER_AS_SELF {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .designatingPayer(DEFAULT_PAYER)
-                    .creating(newSignedCryptoTransfer()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .designatingPayer(SignedTxnFactory.DEFAULT_PAYER)
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER_AS_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .designatingPayer(CUSTOM_PAYER_ACCOUNT)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_SENDER_AND_PAYER_AS_SELF {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .designatingPayer(DEFAULT_PAYER)
-                    .creating(newSignedCryptoTransfer()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .designatingPayer(SignedTxnFactory.DEFAULT_PAYER)
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(
+                                    SignedTxnFactory.DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_SENDER_AS_SELF_AND_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .designatingPayer(DILIGENT_SIGNING_PAYER)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(
+                                    SignedTxnFactory.DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_SENDER_AS_CUSTOM_PAYER_AND_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .designatingPayer(DILIGENT_SIGNING_PAYER)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_SENDER_AND_PAYER_AS_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .designatingPayer(CUSTOM_PAYER_ACCOUNT)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_SELF_SENDER_AND_PAYER_AS_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .designatingPayer(CUSTOM_PAYER_ACCOUNT)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(
+                                    SignedTxnFactory.DEFAULT_PAYER_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_ADMIN_CUSTOM_PAYER_SENDER_AND_PAYER_AS_SELF {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .designatingPayer(DEFAULT_PAYER)
-                    .creating(newSignedCryptoTransfer()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .designatingPayer(SignedTxnFactory.DEFAULT_PAYER)
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(CUSTOM_PAYER_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_XFER_WITH_MISSING_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
                     .missingAdmin()
                     .designatingPayer(MISSING_ACCOUNT)
-                    .creating(newSignedCryptoTransfer()
+                    .creating(CryptoTransferFactory.newSignedCryptoTransfer()
                             .skipPayerSig()
-                            .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+                            .transfers(TinyBarsFromTo.tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
                             .get())
                     .get());
         }
     },
     SCHEDULE_CREATE_TREASURY_UPDATE_WITH_TREASURY_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .designatingPayer(IdUtils.asAccount(TREASURY_PAYER_ID))
-                    .creating(newSignedCryptoUpdate(TREASURY_PAYER_ID)
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .designatingPayer(IdUtils.asAccount(SignedTxnFactory.TREASURY_PAYER_ID))
+                    .creating(CryptoUpdateFactory.newSignedCryptoUpdate(SignedTxnFactory.TREASURY_PAYER_ID)
                             .skipPayerSig()
                             .newAccountKt(NEW_ACCOUNT_KT)
                             .get())
@@ -201,10 +237,12 @@ public enum ScheduleCreateScenarios implements TxnHandlingScenario {
         }
     },
     SCHEDULE_CREATE_SYS_ACCOUNT_UPDATE_WITH_PRIVILEGED_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .designatingPayer(IdUtils.asAccount(MASTER_PAYER_ID))
-                    .creating(newSignedCryptoUpdate(SYS_ACCOUNT_ID)
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .designatingPayer(IdUtils.asAccount(SignedTxnFactory.MASTER_PAYER_ID))
+                    .creating(CryptoUpdateFactory.newSignedCryptoUpdate(SYS_ACCOUNT_ID)
                             .skipPayerSig()
                             .newAccountKt(NEW_ACCOUNT_KT)
                             .get())
@@ -212,11 +250,13 @@ public enum ScheduleCreateScenarios implements TxnHandlingScenario {
         }
     },
     SCHEDULE_CREATE_SYS_ACCOUNT_UPDATE_WITH_PRIVILEGED_CUSTOM_PAYER_AND_REGULAR_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleCreate()
-                    .payer(MASTER_PAYER_ID)
-                    .designatingPayer(IdUtils.asAccount(MASTER_PAYER_ID))
-                    .creating(newSignedCryptoUpdate(SYS_ACCOUNT_ID)
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleCreateFactory.newSignedScheduleCreate()
+                    .payer(SignedTxnFactory.MASTER_PAYER_ID)
+                    .designatingPayer(IdUtils.asAccount(SignedTxnFactory.MASTER_PAYER_ID))
+                    .creating(CryptoUpdateFactory.newSignedCryptoUpdate(SYS_ACCOUNT_ID)
                             .skipPayerSig()
                             .newAccountKt(NEW_ACCOUNT_KT)
                             .get())

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleDeleteScenarios.java
@@ -16,31 +16,42 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.ScheduleDeleteFactory.newSignedScheduleDelete;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.ScheduleDeleteFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum ScheduleDeleteScenarios implements TxnHandlingScenario {
     SCHEDULE_DELETE_WITH_KNOWN_SCHEDULE {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedScheduleDelete()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleDeleteFactory.newSignedScheduleDelete()
                     .deleting(KNOWN_SCHEDULE_WITH_ADMIN)
                     .get());
         }
     },
     SCHEDULE_DELETE_WITH_MISSING_SCHEDULE {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedScheduleDelete().deleting(UNKNOWN_SCHEDULE).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleDeleteFactory.newSignedScheduleDelete()
+                    .deleting(UNKNOWN_SCHEDULE)
+                    .get());
         }
     },
     SCHEDULE_DELETE_WITH_MISSING_SCHEDULE_ADMIN_KEY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedScheduleDelete().deleting(KNOWN_SCHEDULE_IMMUTABLE).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(ScheduleDeleteFactory.newSignedScheduleDelete()
+                    .deleting(KNOWN_SCHEDULE_IMMUTABLE)
+                    .get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleSignScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleSignScenarios.java
@@ -42,13 +42,17 @@ public enum ScheduleSignScenarios implements TxnHandlingScenario {
     },
     SCHEDULE_SIGN_KNOWN_SCHEDULE {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
                     newSignedScheduleSign().signing(KNOWN_SCHEDULE_WITH_ADMIN).get());
         }
 
         @Override
-        public byte[] extantSchedulingBodyBytes() throws Throwable {
+        public byte[] extantSchedulingBodyBytes()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var accessor = SignedTxnAccessor.from(newSignedCryptoTransfer()
                     .sansTxnId()
                     .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1))
@@ -64,14 +68,18 @@ public enum ScheduleSignScenarios implements TxnHandlingScenario {
     },
     SCHEDULE_SIGN_KNOWN_SCHEDULE_WITH_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedScheduleSign()
                     .signing(KNOWN_SCHEDULE_WITH_EXPLICIT_PAYER)
                     .get());
         }
 
         @Override
-        public byte[] extantSchedulingBodyBytes() throws Throwable {
+        public byte[] extantSchedulingBodyBytes()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var accessor = SignedTxnAccessor.from(newSignedCryptoTransfer()
                     .sansTxnId()
                     .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1))
@@ -87,14 +95,18 @@ public enum ScheduleSignScenarios implements TxnHandlingScenario {
     },
     SCHEDULE_SIGN_KNOWN_SCHEDULE_WITH_PAYER_SELF {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedScheduleSign()
                     .signing(KNOWN_SCHEDULE_WITH_EXPLICIT_PAYER_SELF)
                     .get());
         }
 
         @Override
-        public byte[] extantSchedulingBodyBytes() throws Throwable {
+        public byte[] extantSchedulingBodyBytes()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var accessor = SignedTxnAccessor.from(newSignedCryptoTransfer()
                     .sansTxnId()
                     .transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1))
@@ -110,7 +122,9 @@ public enum ScheduleSignScenarios implements TxnHandlingScenario {
     },
     SCHEDULE_SIGN_KNOWN_SCHEDULE_WITH_NOW_INVALID_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedScheduleSign()
                     .signing(KNOWN_SCHEDULE_WITH_NOW_INVALID_PAYER)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemDeleteScenarios.java
@@ -16,22 +16,30 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.SystemDeleteFactory.newSignedSystemDelete;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 import com.hedera.test.factories.sigs.SigMapGenerator;
+import com.hedera.test.factories.txns.SystemDeleteFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import java.util.Set;
 
 public enum SystemDeleteScenarios implements TxnHandlingScenario {
     SYSTEM_DELETE_FILE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedSystemDelete().file(MISC_FILE_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(SystemDeleteFactory.newSignedSystemDelete()
+                    .file(MISC_FILE_ID)
+                    .get());
         }
     },
     FULL_PAYER_SIGS_VIA_MAP_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedSystemDelete()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(SystemDeleteFactory.newSignedSystemDelete()
                     .payer(DILIGENT_SIGNING_PAYER_ID)
                     .payerKt(DILIGENT_SIGNING_PAYER_KT)
                     .nonPayerKts(MISC_FILE_WACL_KT)
@@ -40,8 +48,10 @@ public enum SystemDeleteScenarios implements TxnHandlingScenario {
         }
     },
     MISSING_PAYER_SIGS_VIA_MAP_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedSystemDelete()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(SystemDeleteFactory.newSignedSystemDelete()
                     .payer(TOKEN_TREASURY_ID)
                     .payerKt(TOKEN_TREASURY_KT)
                     .nonPayerKts(MISC_FILE_WACL_KT)
@@ -50,11 +60,13 @@ public enum SystemDeleteScenarios implements TxnHandlingScenario {
         }
     },
     INVALID_PAYER_SIGS_VIA_MAP_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             SigMapGenerator buggySigMapGen = SigMapGenerator.withUniquePrefixes();
             buggySigMapGen.setInvalidEntries(Set.of(1));
 
-            return PlatformTxnAccessor.from(newSignedSystemDelete()
+            return PlatformTxnAccessor.from(SystemDeleteFactory.newSignedSystemDelete()
                     .fee(1_234L)
                     .sigMapGen(buggySigMapGen)
                     .payer(DILIGENT_SIGNING_PAYER_ID)
@@ -65,10 +77,12 @@ public enum SystemDeleteScenarios implements TxnHandlingScenario {
         }
     },
     AMBIGUOUS_SIG_MAP_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             SigMapGenerator ambigSigMapGen = SigMapGenerator.withAmbiguousPrefixes();
 
-            return PlatformTxnAccessor.from(newSignedSystemDelete()
+            return PlatformTxnAccessor.from(SystemDeleteFactory.newSignedSystemDelete()
                     .fee(1_234L)
                     .keyFactory(overlapFactory)
                     .sigMapGen(ambigSigMapGen)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemUndeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemUndeleteScenarios.java
@@ -16,15 +16,21 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.SystemUndeleteFactory.newSignedSystemUndelete;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.SystemUndeleteFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum SystemUndeleteScenarios implements TxnHandlingScenario {
     SYSTEM_UNDELETE_FILE_SCENARIO {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedSystemUndelete().file(MISC_FILE_ID).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(SystemUndeleteFactory.newSignedSystemUndelete()
+                    .file(MISC_FILE_ID)
+                    .get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenAssociateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenAssociateScenarios.java
@@ -16,17 +16,21 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
-import static com.hedera.test.factories.txns.SignedTxnFactory.STAKING_FUND;
-import static com.hedera.test.factories.txns.TokenAssociateFactory.newSignedTokenAssociate;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.SignedTxnFactory;
+import com.hedera.test.factories.txns.TokenAssociateFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenAssociateScenarios implements TxnHandlingScenario {
     TOKEN_ASSOCIATE_WITH_KNOWN_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenAssociate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenAssociateFactory.newSignedTokenAssociate()
                     .targeting(MISC_ACCOUNT)
                     .associating(KNOWN_TOKEN_WITH_KYC)
                     .associating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
@@ -36,9 +40,11 @@ public enum TokenAssociateScenarios implements TxnHandlingScenario {
     },
     TOKEN_ASSOCIATE_WITH_SELF_PAID_KNOWN_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenAssociate()
-                    .targeting(DEFAULT_PAYER)
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenAssociateFactory.newSignedTokenAssociate()
+                    .targeting(SignedTxnFactory.DEFAULT_PAYER)
                     .associating(KNOWN_TOKEN_WITH_KYC)
                     .associating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .get());
@@ -46,8 +52,10 @@ public enum TokenAssociateScenarios implements TxnHandlingScenario {
     },
     TOKEN_ASSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenAssociate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenAssociateFactory.newSignedTokenAssociate()
                     .targeting(CUSTOM_PAYER_ACCOUNT)
                     .associating(KNOWN_TOKEN_WITH_KYC)
                     .associating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
@@ -56,17 +64,21 @@ public enum TokenAssociateScenarios implements TxnHandlingScenario {
     },
     TOKEN_ASSOCIATE_WITH_IMMUTABLE_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenAssociate()
-                    .targeting(STAKING_FUND)
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenAssociateFactory.newSignedTokenAssociate()
+                    .targeting(SignedTxnFactory.STAKING_FUND)
                     .associating(KNOWN_TOKEN_WITH_KYC)
                     .get());
         }
     },
     TOKEN_ASSOCIATE_WITH_MISSING_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenAssociate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenAssociateFactory.newSignedTokenAssociate()
                     .targeting(MISSING_ACCOUNT)
                     .associating(KNOWN_TOKEN_WITH_KYC)
                     .associating(KNOWN_TOKEN_NO_SPECIAL_KEYS)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenBurnScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenBurnScenarios.java
@@ -18,12 +18,18 @@ package com.hedera.test.factories.scenarios;
 
 import static com.hedera.test.factories.txns.TokenBurnFactory.newSignedTokenBurn;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenBurnScenarios implements TxnHandlingScenario {
     BURN_WITH_SUPPLY_KEYED_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedTokenBurn()
                     .burning(KNOWN_TOKEN_WITH_SUPPLY)
                     .nonPayerKts(TOKEN_SUPPLY_KT)
@@ -32,14 +38,18 @@ public enum TokenBurnScenarios implements TxnHandlingScenario {
     },
     BURN_WITH_MISSING_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
                     newSignedTokenBurn().burning(MISSING_TOKEN).get());
         }
     },
     BURN_FOR_TOKEN_WITHOUT_SUPPLY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
                     newSignedTokenBurn().burning(KNOWN_TOKEN_NO_SPECIAL_KEYS).get());
         }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
@@ -29,13 +29,13 @@ import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 
 public enum TokenCreateScenarios implements TxnHandlingScenario {
     TOKEN_CREATE_WITH_ADMIN_ONLY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedTokenCreate().nonPayerKts(TOKEN_ADMIN_KT).get());
         }
     },
     TOKEN_CREATE_WITH_ADMIN_AND_FREEZE {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .frozen()
                     .nonPayerKts(TOKEN_ADMIN_KT, TOKEN_FREEZE_KT)
@@ -43,13 +43,13 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_MISSING_ADMIN {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(
                     newSignedTokenCreate().missingAdmin().get());
         }
     },
     TOKEN_CREATE_WITH_AUTO_RENEW {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .autoRenew(MISC_ACCOUNT)
@@ -57,7 +57,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_AUTO_RENEW_AS_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .autoRenew(DEFAULT_PAYER)
@@ -65,7 +65,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_AUTO_RENEW_AS_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .autoRenew(CUSTOM_PAYER_ACCOUNT)
@@ -73,7 +73,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_MISSING_AUTO_RENEW {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .autoRenew(MISSING_ACCOUNT)
@@ -81,7 +81,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -90,7 +90,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_INVALID_COLLECTOR {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromNum(666666L);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -99,7 +99,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ_BUT_USING_WILDCARD_DENOM {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -108,7 +108,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ_USING_WILDCARD_DENOM {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -117,7 +117,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -126,7 +126,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(DEFAULT_PAYER);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -135,7 +135,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -144,7 +144,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_NO_SIG_REQ_NO_FALLBACK {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -153,7 +153,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_SIG_REQ_NO_FALLBACK {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -162,7 +162,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_FALLBACK_NO_WILDCARD_BUT_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -171,7 +171,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_FALLBACK_WILDCARD_AND_NO_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -180,7 +180,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_ROYALTY_FEE_NO_FALLBACK_AND_NO_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -189,7 +189,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_DENOMINATION_AND_NO_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -198,7 +198,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_NO_DENOM_AND_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -207,7 +207,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_FIXED_FEE_NO_DENOM_AND_NO_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -216,7 +216,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_FALLBACK_WILDCARD_AND_SIG_REQ {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -225,7 +225,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_MISSING_COLLECTOR {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             final var collector = EntityId.fromGrpcAccountId(MISSING_ACCOUNT);
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
@@ -234,7 +234,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_MISSING_TREASURY {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .treasury(MISSING_ACCOUNT)
@@ -242,7 +242,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_TREASURY_AS_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .treasury(DEFAULT_PAYER)
@@ -250,7 +250,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
         }
     },
     TOKEN_CREATE_WITH_TREASURY_AS_CUSTOM_PAYER {
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn() throws Exception {
             return PlatformTxnAccessor.from(newSignedTokenCreate()
                     .missingAdmin()
                     .treasury(CUSTOM_PAYER_ACCOUNT)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDeleteScenarios.java
@@ -16,30 +16,42 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenDeleteFactory.newSignedTokenDelete;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenDeleteFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenDeleteScenarios implements TxnHandlingScenario {
     DELETE_WITH_KNOWN_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenDelete().deleting(KNOWN_TOKEN_NO_SPECIAL_KEYS).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDeleteFactory.newSignedTokenDelete()
+                    .deleting(KNOWN_TOKEN_NO_SPECIAL_KEYS)
+                    .get());
         }
     },
     DELETE_WITH_MISSING_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenDelete().deleting(MISSING_TOKEN).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDeleteFactory.newSignedTokenDelete()
+                    .deleting(MISSING_TOKEN)
+                    .get());
         }
     },
     DELETE_WITH_MISSING_TOKEN_ADMIN_KEY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenDelete().deleting(KNOWN_TOKEN_IMMUTABLE).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDeleteFactory.newSignedTokenDelete()
+                    .deleting(KNOWN_TOKEN_IMMUTABLE)
+                    .get());
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDissociateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDissociateScenarios.java
@@ -16,16 +16,21 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
-import static com.hedera.test.factories.txns.TokenDissociateFactory.newSignedTokenDissociate;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.SignedTxnFactory;
+import com.hedera.test.factories.txns.TokenDissociateFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenDissociateScenarios implements TxnHandlingScenario {
     TOKEN_DISSOCIATE_WITH_KNOWN_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenDissociate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDissociateFactory.newSignedTokenDissociate()
                     .targeting(MISC_ACCOUNT)
                     .dissociating(KNOWN_TOKEN_WITH_KYC)
                     .dissociating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
@@ -35,9 +40,11 @@ public enum TokenDissociateScenarios implements TxnHandlingScenario {
     },
     TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenDissociate()
-                    .targeting(DEFAULT_PAYER)
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDissociateFactory.newSignedTokenDissociate()
+                    .targeting(SignedTxnFactory.DEFAULT_PAYER)
                     .dissociating(KNOWN_TOKEN_WITH_KYC)
                     .dissociating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .get());
@@ -45,8 +52,10 @@ public enum TokenDissociateScenarios implements TxnHandlingScenario {
     },
     TOKEN_DISSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenDissociate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDissociateFactory.newSignedTokenDissociate()
                     .targeting(CUSTOM_PAYER_ACCOUNT)
                     .dissociating(KNOWN_TOKEN_WITH_KYC)
                     .dissociating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
@@ -55,8 +64,10 @@ public enum TokenDissociateScenarios implements TxnHandlingScenario {
     },
     TOKEN_DISSOCIATE_WITH_MISSING_TARGET {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenDissociate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenDissociateFactory.newSignedTokenDissociate()
                     .targeting(MISSING_ACCOUNT)
                     .dissociating(KNOWN_TOKEN_WITH_KYC)
                     .dissociating(KNOWN_TOKEN_NO_SPECIAL_KEYS)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFeeScheduleUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFeeScheduleUpdateScenarios.java
@@ -20,13 +20,19 @@ import static com.hedera.node.app.service.mono.state.submerkle.EntityId.MISSING_
 import static com.hedera.node.app.service.mono.state.submerkle.FcCustomFee.fixedFee;
 import static com.hedera.test.factories.txns.TokenFeeScheduleUpdateFactory.newSignedTokenFeeScheduleUpdate;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     UPDATE_TOKEN_FEE_SCHEDULE_BUT_TOKEN_DOESNT_EXIST {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .updating(MISSING_TOKEN)
                     .withCustom(fixedFee(1, null, MISSING_ENTITY_ID, false))
@@ -35,7 +41,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_NO_FEE_SCHEDULE_KEY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .withCustom(fixedFee(1, null, MISSING_ENTITY_ID, false))
@@ -44,7 +52,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_NO_FEE_COLLECTOR_SIG_REQ {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var feeCollectorSigReq = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .updating(KNOWN_TOKEN_WITH_FEE_SCHEDULE_KEY)
@@ -54,7 +64,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_NO_FEE_COLLECTOR_NO_SIG_REQ {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var feeCollectorNoSigReq = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .updating(KNOWN_TOKEN_WITH_FEE_SCHEDULE_KEY)
@@ -64,7 +76,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var feeCollectorNoSigReq = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
             final var feeCollectorWithSigReq = EntityId.fromGrpcAccountId(RECEIVER_SIG);
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
@@ -76,7 +90,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .payer(RECEIVER_SIG_ID)
                     .payerKt(RECEIVER_SIG_KT)
@@ -87,7 +103,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_NO_SIG_REQ_AND_AS_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .payer(NO_RECEIVER_SIG_ID)
                     .payerKt(NO_RECEIVER_SIG_KT)
@@ -98,7 +116,9 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_MISSING_FEE_COLLECTOR {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             final var missingFeeCollector = EntityId.fromGrpcAccountId(MISSING_ACCOUNT);
             return PlatformTxnAccessor.from(newSignedTokenFeeScheduleUpdate()
                     .updating(KNOWN_TOKEN_WITH_FEE_SCHEDULE_KEY)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFreezeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFreezeScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenFreezeFactory.newSignedTokenFreeze;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenFreezeFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenFreezeScenarios implements TxnHandlingScenario {
     VALID_FREEZE_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenFreeze()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenFreezeFactory.newSignedTokenFreeze()
                     .freezing(KNOWN_TOKEN_WITH_FREEZE)
                     .withAccount(OWNER_ACCOUNT)
                     .nonPayerKts(TOKEN_FREEZE_KT)
@@ -33,8 +38,10 @@ public enum TokenFreezeScenarios implements TxnHandlingScenario {
     },
     FREEZE_WITH_NO_KEYS {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenFreeze()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenFreezeFactory.newSignedTokenFreeze()
                     .freezing(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .withAccount(OWNER_ACCOUNT)
                     .nonPayerKts(TOKEN_ADMIN_KT)

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycGrantScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycGrantScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenGrantKycFactory.newSignedTokenGrantKyc;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenGrantKycFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenKycGrantScenarios implements TxnHandlingScenario {
     VALID_GRANT_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenGrantKyc()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenGrantKycFactory.newSignedTokenGrantKyc()
                     .granting(KNOWN_TOKEN_WITH_KYC, MISC_ACCOUNT)
                     .nonPayerKts(TOKEN_KYC_KT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycRevokeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycRevokeScenarios.java
@@ -16,16 +16,21 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenCreateFactory.newSignedTokenCreate;
-import static com.hedera.test.factories.txns.TokenRevokeKycFactory.newSignedTokenRevokeKyc;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenCreateFactory;
+import com.hedera.test.factories.txns.TokenRevokeKycFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenKycRevokeScenarios implements TxnHandlingScenario {
     VALID_REVOKE_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenRevokeKyc()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenRevokeKycFactory.newSignedTokenRevokeKyc()
                     .revoking(KNOWN_TOKEN_WITH_KYC, MISC_ACCOUNT)
                     .nonPayerKts(TOKEN_KYC_KT)
                     .get());
@@ -33,15 +38,19 @@ public enum TokenKycRevokeScenarios implements TxnHandlingScenario {
     },
     REVOKE_WITH_MISSING_TXN_BODY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
-                    newSignedTokenCreate().missingAdmin().get());
+                    TokenCreateFactory.newSignedTokenCreate().missingAdmin().get());
         }
     },
     REVOKE_WITH_INVALID_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenRevokeKyc()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenRevokeKycFactory.newSignedTokenRevokeKyc()
                     .revoking(MISSING_TOKEN, MISC_ACCOUNT)
                     .nonPayerKts(TOKEN_KYC_KT)
                     .get());
@@ -49,8 +58,10 @@ public enum TokenKycRevokeScenarios implements TxnHandlingScenario {
     },
     REVOKE_FOR_TOKEN_WITHOUT_KYC {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenRevokeKyc()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenRevokeKycFactory.newSignedTokenRevokeKyc()
                     .revoking(KNOWN_TOKEN_WITH_FREEZE, MISC_ACCOUNT)
                     .nonPayerKts(TOKEN_KYC_KT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenMintScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenMintScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenMintFactory.newSignedTokenMint;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenMintFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenMintScenarios implements TxnHandlingScenario {
     MINT_WITH_SUPPLY_KEYED_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenMint()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenMintFactory.newSignedTokenMint()
                     .minting(KNOWN_TOKEN_WITH_SUPPLY)
                     .nonPayerKts(TOKEN_SUPPLY_KT)
                     .get());
@@ -32,16 +37,21 @@ public enum TokenMintScenarios implements TxnHandlingScenario {
     },
     MINT_WITH_MISSING_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
             return PlatformTxnAccessor.from(
-                    newSignedTokenMint().minting(MISSING_TOKEN).get());
+                    TokenMintFactory.newSignedTokenMint().minting(MISSING_TOKEN).get());
         }
     },
     MINT_FOR_TOKEN_WITHOUT_SUPPLY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenMint().minting(KNOWN_TOKEN_NO_SPECIAL_KEYS).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenMintFactory.newSignedTokenMint()
+                    .minting(KNOWN_TOKEN_NO_SPECIAL_KEYS)
+                    .get());
         }
     },
 }

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenPauseScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenPauseScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenPauseFactory.newSignedTokenPause;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenPauseFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenPauseScenarios implements TxnHandlingScenario {
     VALID_PAUSE_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenPause()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenPauseFactory.newSignedTokenPause()
                     .pausing(KNOWN_TOKEN_WITH_PAUSE)
                     .nonPayerKts(TOKEN_PAUSE_KT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnfreezeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnfreezeScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenUnfreezeFactory.newSignedTokenUnfreeze;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenUnfreezeFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenUnfreezeScenarios implements TxnHandlingScenario {
     VALID_UNFREEZE_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUnfreeze()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUnfreezeFactory.newSignedTokenUnfreeze()
                     .unfreezing(KNOWN_TOKEN_WITH_FREEZE)
                     .withAccount(OWNER_ACCOUNT)
                     .nonPayerKts(TOKEN_FREEZE_KT)
@@ -33,8 +38,10 @@ public enum TokenUnfreezeScenarios implements TxnHandlingScenario {
     },
     UNFREEZE_WITH_MISSING_FREEZE_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUnfreeze()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUnfreezeFactory.newSignedTokenUnfreeze()
                     .withAccount(OWNER_ACCOUNT)
                     .unfreezing(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .get());
@@ -42,8 +49,10 @@ public enum TokenUnfreezeScenarios implements TxnHandlingScenario {
     },
     UNFREEZE_WITH_INVALID_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUnfreeze()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUnfreezeFactory.newSignedTokenUnfreeze()
                     .unfreezing(MISSING_TOKEN)
                     .withAccount(OWNER_ACCOUNT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnpauseScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnpauseScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenUnpauseFactory.newSignedTokenUnpause;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenUnpauseFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenUnpauseScenarios implements TxnHandlingScenario {
     VALID_UNPAUSE_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUnpause()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUnpauseFactory.newSignedTokenUnpause()
                     .unPausing(KNOWN_TOKEN_WITH_PAUSE)
                     .nonPayerKts(TOKEN_PAUSE_KT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUpdateScenarios.java
@@ -16,23 +16,31 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
-import static com.hedera.test.factories.txns.TokenUpdateFactory.newSignedTokenUpdate;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.SignedTxnFactory;
+import com.hedera.test.factories.txns.TokenUpdateFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenUpdateScenarios implements TxnHandlingScenario {
     UPDATE_WITH_NO_KEYS_AFFECTED {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenUpdate().updating(KNOWN_TOKEN_NO_SPECIAL_KEYS).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
+                    .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
+                    .get());
         }
     },
     UPDATE_REPLACING_TREASURY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newTreasury(TOKEN_TREASURY)
                     .get());
@@ -40,17 +48,21 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_REPLACING_TREASURY_AS_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
-                    .newTreasury(DEFAULT_PAYER)
+                    .newTreasury(SignedTxnFactory.DEFAULT_PAYER)
                     .get());
         }
     },
     UPDATE_REPLACING_TREASURY_AS_CUSTOM_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newTreasury(CUSTOM_PAYER_ACCOUNT)
                     .get());
@@ -58,8 +70,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_REPLACING_WITH_MISSING_TREASURY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newTreasury(MISSING_ACCOUNT)
                     .get());
@@ -67,8 +81,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_REPLACING_ADMIN_KEY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newAdmin(TOKEN_REPLACE_KT)
                     .get());
@@ -76,8 +92,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_WITH_SUPPLY_KEYED_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_WITH_SUPPLY)
                     .replacingSupply()
                     .get());
@@ -85,8 +103,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_WITH_KYC_KEYED_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_WITH_KYC)
                     .replacingKyc()
                     .get());
@@ -94,8 +114,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_WITH_FREEZE_KEYED_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_WITH_FREEZE)
                     .replacingFreeze()
                     .get());
@@ -103,8 +125,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_WITH_WIPE_KEYED_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_WITH_WIPE)
                     .replacingWipe()
                     .get());
@@ -112,8 +136,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_WITH_MISSING_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(MISSING_TOKEN)
                     .newAutoRenew(MISC_ACCOUNT)
                     .get());
@@ -121,15 +147,20 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     UPDATE_WITH_MISSING_TOKEN_ADMIN_KEY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenUpdate().updating(KNOWN_TOKEN_IMMUTABLE).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
+                    .updating(KNOWN_TOKEN_IMMUTABLE)
+                    .get());
         }
     },
     TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newAutoRenew(MISC_ACCOUNT)
                     .get());
@@ -137,17 +168,21 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT_AS_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
-                    .newAutoRenew(DEFAULT_PAYER)
+                    .newAutoRenew(SignedTxnFactory.DEFAULT_PAYER)
                     .get());
         }
     },
     TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT_AS_CUSTOM_PAYER {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newAutoRenew(CUSTOM_PAYER_ACCOUNT)
                     .get());
@@ -155,8 +190,10 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
     },
     TOKEN_UPDATE_WITH_MISSING_AUTO_RENEW_ACCOUNT {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenUpdate()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenUpdateFactory.newSignedTokenUpdate()
                     .updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
                     .newAutoRenew(MISSING_ACCOUNT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenWipeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenWipeScenarios.java
@@ -16,15 +16,20 @@
 
 package com.hedera.test.factories.scenarios;
 
-import static com.hedera.test.factories.txns.TokenWipeFactory.newSignedTokenWipe;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
+import com.hedera.test.factories.txns.TokenWipeFactory;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 
 public enum TokenWipeScenarios implements TxnHandlingScenario {
     VALID_WIPE_WITH_EXTANT_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenWipe()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenWipeFactory.newSignedTokenWipe()
                     .wiping(KNOWN_TOKEN_WITH_WIPE, MISC_ACCOUNT)
                     .nonPayerKts(TOKEN_WIPE_KT)
                     .get());
@@ -32,15 +37,20 @@ public enum TokenWipeScenarios implements TxnHandlingScenario {
     },
     WIPE_WITH_MISSING_TOKEN {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(
-                    newSignedTokenWipe().wiping(MISSING_TOKEN, MISC_ACCOUNT).get());
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenWipeFactory.newSignedTokenWipe()
+                    .wiping(MISSING_TOKEN, MISC_ACCOUNT)
+                    .get());
         }
     },
     WIPE_FOR_TOKEN_WITHOUT_KEY {
         @Override
-        public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(newSignedTokenWipe()
+        public PlatformTxnAccessor platformTxn()
+                throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException,
+                        InvalidKeyException {
+            return PlatformTxnAccessor.from(TokenWipeFactory.newSignedTokenWipe()
                     .wiping(KNOWN_TOKEN_NO_SPECIAL_KEYS, MISC_ACCOUNT)
                     .nonPayerKts(TOKEN_KYC_KT)
                     .get());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
@@ -40,13 +40,14 @@ import static com.hedera.test.utils.IdUtils.asSchedule;
 import static com.hedera.test.utils.IdUtils.asToken;
 import static com.hedera.test.utils.IdUtils.asTopic;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.quality.Strictness.LENIENT;
 
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.node.app.service.mono.files.HFileMeta;
 import com.hedera.node.app.service.mono.files.HederaFs;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
@@ -83,14 +84,16 @@ import com.hederahashgraph.api.proto.java.TokenAllowance;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.swirlds.merkle.map.MerkleMap;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import java.time.Instant;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.apache.commons.codec.DecoderException;
 
 public interface TxnHandlingScenario {
-    PlatformTxnAccessor platformTxn() throws Throwable;
+    PlatformTxnAccessor platformTxn() throws Exception;
 
     default com.hedera.hapi.node.transaction.TransactionBody pbjTxnBody() {
         try {
@@ -250,7 +253,7 @@ public interface TxnHandlingScenario {
         }
     }
 
-    default HederaFs hfs() throws Exception {
+    default HederaFs hfs() throws InvalidKeyException {
         HederaFs hfs = mock(HederaFs.class);
         given(hfs.exists(MISC_FILE)).willReturn(true);
         given(hfs.exists(SYS_FILE)).willReturn(true);
@@ -267,7 +270,7 @@ public interface TxnHandlingScenario {
         return topics;
     }
 
-    private static HFileMeta convert(final FileGetInfoResponse.FileInfo fi) throws DecoderException {
+    private static HFileMeta convert(final FileGetInfoResponse.FileInfo fi) throws InvalidKeyException {
         return new HFileMeta(
                 fi.getDeleted(),
                 JKey.mapKey(Key.newBuilder().setKeyList(fi.getKeys()).build()),
@@ -388,7 +391,8 @@ public interface TxnHandlingScenario {
         return tokenStore;
     }
 
-    default byte[] extantSchedulingBodyBytes() throws Throwable {
+    default byte[] extantSchedulingBodyBytes()
+            throws InvalidProtocolBufferException, SignatureException, NoSuchAlgorithmException, InvalidKeyException {
         return scheduleCreateTxnWith(
                         Key.getDefaultInstance(),
                         "",

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/topics/TopicFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/topics/TopicFactory.java
@@ -23,6 +23,7 @@ import com.hedera.node.app.service.mono.state.submerkle.RichInstant;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import java.security.InvalidKeyException;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -55,7 +56,7 @@ public class TopicFactory {
     private JKey uncheckedMap(Key k) {
         try {
             return JKey.mapKey(k);
-        } catch (Exception ignore) {
+        } catch (InvalidKeyException ignore) {
         }
         throw new AssertionError("Valid key failed to map!");
     }

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleDeleteHandlerParityTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleDeleteHandlerParityTest.java
@@ -96,11 +96,11 @@ import com.hedera.test.factories.keys.KeyTree;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hedera.test.utils.TestFixturesKeyLookup;
+import java.security.InvalidKeyException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -192,7 +192,7 @@ class AdapterUtils {
     }
 
     public static ReadableScheduleStore mockSchedule(Long schedId, KeyTree key, TransactionBody txnBody)
-            throws DecoderException {
+            throws InvalidKeyException {
         final ScheduleID scheduleID =
                 ScheduleID.newBuilder().scheduleNum(schedId).build();
         given(schedule.hasAdminKey()).willReturn(key == null ? false : true);

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleDeleteHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleDeleteHandlerTest.java
@@ -37,9 +37,9 @@ import com.hedera.node.app.service.schedule.impl.handlers.ScheduleDeleteHandler;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.state.ReadableKVStateBase;
 import com.hedera.node.app.spi.workflows.PreCheckException;
+import java.security.InvalidKeyException;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -69,7 +69,7 @@ class ScheduleDeleteHandlerTest extends ScheduleHandlerTestBase {
     }
 
     @Test
-    void scheduleDeleteHappyPath() throws DecoderException, PreCheckException {
+    void scheduleDeleteHappyPath() throws InvalidKeyException, PreCheckException, InvalidKeyException {
         final var txn = scheduleDeleteTransaction();
         scheduledTxn = givenSetupForScheduleDelete(txn);
         BDDMockito.given(schedule.hasAdminKey()).willReturn(true);


### PR DESCRIPTION
Issue #7133 
 * Removed `DecoderException` from JKey and all other code that uses `JKey`
    * Almost all of the uses are in test code, surprisingly little non-test code uses JKey
 * Removed all other uses of `DecoderException` from the codebase

Issue #7137
 * Added `equals` and `hashCode` to `JKey`. * Note that this implementation is not efficient, but is a good bridge to the PBJ Key object that replaces JKey soon.
    * One remaining use is in platform-sdk in `CommonUtils` line 232.
        * A call to apache commons `Hex.decodeHex` is wrapped in a try/catch that catches the `DecoderException`
