### PR TITLE
TransactionGetFastRecord and CryptoGetStakers handlers

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryDispatcher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryDispatcher.java
@@ -32,7 +32,6 @@ import javax.inject.Singleton;
 public class QueryDispatcher {
 
     private static final String QUERY_NOT_SET = "Query not set";
-    private static final String GET_FAST_RECORD_IS_NOT_SUPPORTED = "TransactionGetFastRecord is not supported";
 
     private final QueryHandlers handlers;
 
@@ -79,6 +78,7 @@ public class QueryDispatcher {
             case NETWORK_GET_EXECUTION_TIME -> handlers.networkGetExecutionTimeHandler();
             case TRANSACTION_GET_RECEIPT -> handlers.networkTransactionGetReceiptHandler();
             case TRANSACTION_GET_RECORD -> handlers.networkTransactionGetRecordHandler();
+            case TRANSACTION_GET_FAST_RECORD -> handlers.networkTransactionGetFastRecordHandler();
 
             case SCHEDULE_GET_INFO -> handlers.scheduleGetInfoHandler();
 
@@ -87,8 +87,6 @@ public class QueryDispatcher {
             case TOKEN_GET_NFT_INFO -> handlers.tokenGetNftInfoHandler();
             case TOKEN_GET_NFT_INFOS -> handlers.tokenGetNftInfosHandler();
 
-            case TRANSACTION_GET_FAST_RECORD -> throw new UnsupportedOperationException(
-                    GET_FAST_RECORD_IS_NOT_SUPPORTED);
             case UNSET -> throw new UnsupportedOperationException(QUERY_NOT_SET);
         };
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryHandlers.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryHandlers.java
@@ -28,6 +28,7 @@ import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetAccountD
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetByKeyHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetExecutionTimeHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetVersionInfoHandler;
+import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetFastRecordHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetReceiptHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
 import com.hedera.node.app.service.schedule.impl.handlers.ScheduleGetInfoHandler;
@@ -65,6 +66,7 @@ public record QueryHandlers(
         @NonNull NetworkGetVersionInfoHandler networkGetVersionInfoHandler,
         @NonNull NetworkTransactionGetReceiptHandler networkTransactionGetReceiptHandler,
         @NonNull NetworkTransactionGetRecordHandler networkTransactionGetRecordHandler,
+        @NonNull NetworkTransactionGetFastRecordHandler networkTransactionGetFastRecordHandler,
         @NonNull ScheduleGetInfoHandler scheduleGetInfoHandler,
         @NonNull TokenGetInfoHandler tokenGetInfoHandler,
         @NonNull TokenGetAccountNftInfosHandler tokenGetAccountNftInfosHandler,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
@@ -89,6 +89,7 @@ public interface QueryWorkflowInjectionModule {
                 networkHandlers.networkGetVersionInfoHandler(),
                 networkHandlers.networkTransactionGetReceiptHandler(),
                 networkHandlers.networkTransactionGetRecordHandler(),
+                networkHandlers.networkTransactionGetFastRecordHandler(),
                 scheduleHandlers.scheduleGetInfoHandler(),
                 tokenHandlers.tokenGetInfoHandler(),
                 tokenHandlers.tokenGetAccountNftInfosHandler(),

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryDispatcherTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryDispatcherTest.java
@@ -41,6 +41,7 @@ import com.hedera.hapi.node.token.TokenGetNftInfoQuery;
 import com.hedera.hapi.node.token.TokenGetNftInfosQuery;
 import com.hedera.hapi.node.transaction.GetByKeyQuery;
 import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.TransactionGetFastRecordQuery;
 import com.hedera.hapi.node.transaction.TransactionGetReceiptQuery;
 import com.hedera.hapi.node.transaction.TransactionGetRecordQuery;
 import com.hedera.node.app.service.consensus.impl.handlers.ConsensusGetTopicInfoHandler;
@@ -55,6 +56,7 @@ import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetAccountD
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetByKeyHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetExecutionTimeHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetVersionInfoHandler;
+import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetFastRecordHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetReceiptHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
 import com.hedera.node.app.service.schedule.impl.handlers.ScheduleGetInfoHandler;
@@ -137,6 +139,9 @@ class QueryDispatcherTest {
     private NetworkTransactionGetReceiptHandler networkTransactionGetReceiptHandler;
 
     @Mock
+    private NetworkTransactionGetFastRecordHandler networkTransactionGetFastRecordHandler;
+
+    @Mock
     private NetworkTransactionGetRecordHandler networkTransactionGetRecordHandler;
 
     @Mock
@@ -180,6 +185,7 @@ class QueryDispatcherTest {
                 networkGetVersionInfoHandler,
                 networkTransactionGetReceiptHandler,
                 networkTransactionGetRecordHandler,
+                networkTransactionGetFastRecordHandler,
                 scheduleGetInfoHandler,
                 tokenGetInfoHandler,
                 tokenGetAccountNftInfosHandler,
@@ -361,6 +367,12 @@ class QueryDispatcherTest {
                                 .transactionGetRecord(
                                         TransactionGetRecordQuery.newBuilder().build())
                                 .build(),
-                        (Function<QueryHandlers, QueryHandler>) QueryHandlers::networkTransactionGetRecordHandler));
+                        (Function<QueryHandlers, QueryHandler>) QueryHandlers::networkTransactionGetRecordHandler),
+                Arguments.of(
+                        Query.newBuilder()
+                                .transactionGetFastRecord(TransactionGetFastRecordQuery.newBuilder()
+                                        .build())
+                                .build(),
+                        (Function<QueryHandlers, QueryHandler>) QueryHandlers::networkTransactionGetFastRecordHandler));
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
@@ -21,6 +21,7 @@ import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetAccountD
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetByKeyHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetExecutionTimeHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetVersionInfoHandler;
+import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetFastRecordHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetReceiptHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkUncheckedSubmitHandler;
@@ -45,6 +46,8 @@ public interface NetworkAdminServiceInjectionModule {
     NetworkTransactionGetReceiptHandler networkTransactionGetReceiptHandler();
 
     NetworkTransactionGetRecordHandler networkTransactionGetRecordHandler();
+
+    NetworkTransactionGetFastRecordHandler networkTransactionGetFastRecordHandler();
 
     NetworkUncheckedSubmitHandler networkUncheckedSubmitHandler();
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkAdminHandlers.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkAdminHandlers.java
@@ -42,6 +42,8 @@ public class NetworkAdminHandlers {
 
     private final NetworkTransactionGetRecordHandler networkTransactionGetRecordHandler;
 
+    private final NetworkTransactionGetFastRecordHandler networkTransactionGetFastRecordHandler;
+
     private final NetworkUncheckedSubmitHandler networkUncheckedSubmitHandler;
 
     /**
@@ -56,6 +58,7 @@ public class NetworkAdminHandlers {
             @NonNull final NetworkGetVersionInfoHandler networkGetVersionInfoHandler,
             @NonNull final NetworkTransactionGetReceiptHandler networkTransactionGetReceiptHandler,
             @NonNull final NetworkTransactionGetRecordHandler networkTransactionGetRecordHandler,
+            @NonNull final NetworkTransactionGetFastRecordHandler networkTransactionGetFastRecordHandler,
             @NonNull final NetworkUncheckedSubmitHandler networkUncheckedSubmitHandler) {
         this.freezeHandler = requireNonNull(freezeHandler, "freezeHandler must not be null");
         this.networkGetAccountDetailsHandler =
@@ -69,6 +72,8 @@ public class NetworkAdminHandlers {
                 networkTransactionGetReceiptHandler, "networkTransactionGetReceiptHandler must not be null");
         this.networkTransactionGetRecordHandler = requireNonNull(
                 networkTransactionGetRecordHandler, "networkTransactionGetRecordHandler must not be null");
+        this.networkTransactionGetFastRecordHandler = requireNonNull(
+                networkTransactionGetFastRecordHandler, "networkTransactionGetFastRecordHandler must not be null");
         this.networkUncheckedSubmitHandler =
                 requireNonNull(networkUncheckedSubmitHandler, "networkUncheckedSubmitHandler must not be null");
     }
@@ -108,5 +113,9 @@ public class NetworkAdminHandlers {
 
     public NetworkUncheckedSubmitHandler networkUncheckedSubmitHandler() {
         return networkUncheckedSubmitHandler;
+    }
+
+    public NetworkTransactionGetFastRecordHandler networkTransactionGetFastRecordHandler() {
+        return networkTransactionGetFastRecordHandler;
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetFastRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetFastRecordHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.token.impl.handlers;
+package com.hedera.node.app.service.networkadmin.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseHeader;
-import com.hedera.hapi.node.token.TokenGetNftInfosResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionGetFastRecordResponse;
 import com.hedera.node.app.spi.workflows.FreeQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -33,30 +32,29 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * This class contains all workflow-related functionality regarding {@link
- * HederaFunctionality#TOKEN_GET_NFT_INFOS}.
+ * This class contains all workflow-related functionality regarding TRANSACTION_GET_FAST_RECORD.
  * <p>
- * This token service call has been deprecated. Because protobufs promise backwards compatibility,
+ * This network service call is not supported. Because protobufs promise backwards compatibility,
  * we cannot remove it. However, it should not be used.
  */
 @Singleton
-public class TokenGetNftInfosHandler extends FreeQueryHandler {
+public class NetworkTransactionGetFastRecordHandler extends FreeQueryHandler {
     @Inject
-    public TokenGetNftInfosHandler() {
+    public NetworkTransactionGetFastRecordHandler() {
         // Exists for injection
     }
 
     @Override
     public QueryHeader extractHeader(@NonNull final Query query) {
         requireNonNull(query);
-        return query.tokenGetNftInfosOrThrow().header();
+        return query.transactionGetFastRecordOrThrow().header();
     }
 
     @Override
     public Response createEmptyResponse(@NonNull final ResponseHeader header) {
         requireNonNull(header);
-        final var response = TokenGetNftInfosResponse.newBuilder().header(requireNonNull(header));
-        return Response.newBuilder().tokenGetNftInfos(response).build();
+        final var response = TransactionGetFastRecordResponse.newBuilder().header(header);
+        return Response.newBuilder().transactionGetFastRecord(response).build();
     }
 
     @Override
@@ -67,7 +65,7 @@ public class TokenGetNftInfosHandler extends FreeQueryHandler {
 
     @Override
     public Response findResponse(@NonNull final QueryContext context, @NonNull final ResponseHeader header) {
-        // this code never runs, since validate fails every time
+        // this code should never be executed, as validate() should fail before we get here
         requireNonNull(context);
         requireNonNull(header);
         throw new UnsupportedOperationException(NOT_SUPPORTED.toString());

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetFastRecordHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetFastRecordHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.networkadmin.impl.test.handlers;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
+import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.hapi.node.base.QueryHeader;
+import com.hedera.hapi.node.base.ResponseHeader;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionGetFastRecordQuery;
+import com.hedera.hapi.node.transaction.TransactionGetFastRecordResponse;
+import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetFastRecordHandler;
+import com.hedera.node.app.spi.workflows.PreCheckException;
+import com.hedera.node.app.spi.workflows.QueryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NetworkTransactionGetFastRecordHandlerTest {
+    @Mock
+    private QueryContext context;
+
+    private NetworkTransactionGetFastRecordHandler subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new NetworkTransactionGetFastRecordHandler();
+    }
+
+    @Test
+    void extractsHeader() {
+        final var data = TransactionGetFastRecordQuery.newBuilder()
+                .header(QueryHeader.newBuilder().build())
+                .build();
+        final var query = Query.newBuilder().transactionGetFastRecord(data).build();
+        final var header = subject.extractHeader(query);
+        final var op = query.transactionGetFastRecordOrThrow();
+        assertThat(op.header()).isEqualTo(header);
+    }
+
+    @Test
+    void createsEmptyResponse() {
+        final var responseHeader = ResponseHeader.newBuilder().build();
+        final var response = subject.createEmptyResponse(responseHeader);
+        final var expectedResponse = Response.newBuilder()
+                .transactionGetFastRecord(
+                        TransactionGetFastRecordResponse.newBuilder().header(responseHeader))
+                .build();
+        assertThat(expectedResponse).isEqualTo(response);
+    }
+
+    @Test
+    void validateThrowsPreCheck() {
+        assertThatThrownBy(() -> subject.validate(context))
+                .isInstanceOf(PreCheckException.class)
+                .has(responseCode(NOT_SUPPORTED));
+    }
+
+    @Test
+    void findResponseThrowsUnsupported() {
+        final var responseHeader = ResponseHeader.newBuilder().build();
+        assertThatThrownBy(() -> subject.findResponse(context, responseHeader))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetStakersHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetStakersHandler.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.token.impl.handlers;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -58,13 +59,14 @@ public class CryptoGetStakersHandler extends FreeQueryHandler {
     @Override
     public void validate(@NonNull final QueryContext context) throws PreCheckException {
         requireNonNull(context);
-        throw new UnsupportedOperationException("Not implemented");
+        throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public Response findResponse(@NonNull final QueryContext context, @NonNull final ResponseHeader header) {
+        // this code never runs, since validate fails every time
         requireNonNull(context);
         requireNonNull(header);
-        throw new UnsupportedOperationException("Not implemented");
+        throw new UnsupportedOperationException(NOT_SUPPORTED.toString());
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetStakersHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetStakersHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token.impl.test.handlers;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
+import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.hapi.node.base.QueryHeader;
+import com.hedera.hapi.node.base.ResponseHeader;
+import com.hedera.hapi.node.token.CryptoGetStakersQuery;
+import com.hedera.hapi.node.token.CryptoGetStakersResponse;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.node.app.service.token.impl.handlers.CryptoGetStakersHandler;
+import com.hedera.node.app.spi.workflows.PreCheckException;
+import com.hedera.node.app.spi.workflows.QueryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CryptoGetStakersHandlerTest {
+    @Mock
+    private QueryContext context;
+
+    private CryptoGetStakersHandler subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new CryptoGetStakersHandler();
+    }
+
+    @Test
+    void extractsHeader() {
+        final var data = CryptoGetStakersQuery.newBuilder()
+                .header(QueryHeader.newBuilder().build())
+                .build();
+        final var query = Query.newBuilder().cryptoGetProxyStakers(data).build();
+        final var header = subject.extractHeader(query);
+        final var op = query.cryptoGetProxyStakersOrThrow();
+        assertThat(op.header()).isEqualTo(header);
+    }
+
+    @Test
+    void createsEmptyResponse() {
+        final var responseHeader = ResponseHeader.newBuilder().build();
+        final var response = subject.createEmptyResponse(responseHeader);
+        final var expectedResponse = Response.newBuilder()
+                .cryptoGetProxyStakers(CryptoGetStakersResponse.newBuilder().header(responseHeader))
+                .build();
+        assertThat(expectedResponse).isEqualTo(response);
+    }
+
+    @Test
+    void validateThrowsPreCheck() {
+        assertThatThrownBy(() -> subject.validate(context))
+                .isInstanceOf(PreCheckException.class)
+                .has(responseCode(NOT_SUPPORTED));
+    }
+
+    @Test
+    void findResponseThrowsUnsupported() {
+        final var responseHeader = ResponseHeader.newBuilder().build();
+        assertThatThrownBy(() -> subject.findResponse(context, responseHeader))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}


### PR DESCRIPTION
**Description**:
Implement handlers for TransactionGetFastRecord and CryptoGetStakers queries, which are unsupported.

**Related issue(s)**:

Fixes #7082 
Fixes #7081 

**Notes for reviewer**:
TransactionGetFastRecord was inadvertently left off of the list of queries for which stubs were created. Consequently, this PR contains modifications to a number of classes to hook it up. These modifications are not needed for CryptoGetStakers because the infrastructure for it was already set up.
