### PR TITLE
Automatically assert `FastCopyable` copies have stable serialization

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccount.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccount.java
@@ -110,6 +110,11 @@ public class OnDiskAccount implements VirtualValue, HederaAccount {
         this.hbarAllowances = that.hbarAllowances;
         this.fungibleAllowances = that.fungibleAllowances;
         this.nftOperatorApprovals = that.nftOperatorApprovals;
+        this.firstStorageKeyNonZeroBytes = that.firstStorageKeyNonZeroBytes;
+        if (that.firstStorageKey != null) {
+            this.firstStorageKey = new int[that.firstStorageKey.length];
+            System.arraycopy(that.firstStorageKey, 0, this.firstStorageKey, 0, that.firstStorageKey.length);
+        }
         System.arraycopy(that.ints, 0, this.ints, 0, IntValues.COUNT);
         System.arraycopy(that.longs, 0, this.longs, 0, LongValues.COUNT);
     }


### PR DESCRIPTION
**Description**:
 - Updates `SelfSerializableDataTest` to automatically assert that `FastCopyable` serializations don't change under `copy()`.
 - Includes `OnDiskAccount.copy()` fix from [here](https://github.com/hashgraph/hedera-services/pull/7134) (fails without it as expected).