### PR TITLE
Restores mapping of "stand-in" `JContractIdKey` in hollow account finalization

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKey.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.legacy.core.jproto;
 
 import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.Key;
 
 /**
  * Maps to proto Key of type contractID.
@@ -92,5 +93,9 @@ public class JContractIDKey extends JKey {
     @Override
     public boolean isValid() {
         return !isEmpty();
+    }
+
+    protected Key convertJKeyEmpty() {
+        return Key.newBuilder().setContractID(getContractID()).build();
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
@@ -312,7 +312,9 @@ public abstract class JKey implements HederaKey {
         if (depth > MAX_KEY_DEPTH) {
             throw new InvalidKeyException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
         }
-        if (!(jkey.hasThresholdKey() || jkey.hasKeyList())) {
+        if (jkey.isEmpty()) {
+            return jkey.convertJKeyEmpty();
+        } else if (!(jkey.hasThresholdKey() || jkey.hasKeyList())) {
             return convertJKeyBasic(jkey);
         } else if (jkey.hasThresholdKey()) {
             List<JKey> jKeys = jkey.getThresholdKey().getKeys().getKeysList();
@@ -327,7 +329,7 @@ public abstract class JKey implements HederaKey {
                     .setThresholdKey(ThresholdKey.newBuilder().setKeys(keys).setThreshold(thd))
                     .build();
             return result;
-        } else {
+        } else if (jkey.hasKeyList()) {
             List<JKey> jKeys = jkey.getKeyList().getKeysList();
             List<Key> tkeys = new ArrayList<>();
             for (JKey aKey : jKeys) {
@@ -336,7 +338,18 @@ public abstract class JKey implements HederaKey {
             }
             KeyList keys = KeyList.newBuilder().addAllKeys(tkeys).build();
             return Key.newBuilder().setKeyList(keys).build();
+        } else {
+            return Key.newBuilder().build();
         }
+    }
+
+    /**
+     * Convert an empty JKey to an appropriate empty Key.
+     * Typically this just creates a new Key, but subclasses may override with specific behavior.
+     * @return An empty Key.
+     */
+    protected Key convertJKeyEmpty() {
+        return Key.newBuilder().build();
     }
 
     public static boolean equalUpToDecodability(JKey a, JKey b) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
@@ -312,7 +312,7 @@ public abstract class JKey implements HederaKey {
         if (depth > MAX_KEY_DEPTH) {
             throw new InvalidKeyException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
         }
-        if (!(jkey.hasThresholdKey() || jkey.hasKeyList() || jkey.isEmpty())) {
+        if (!(jkey.hasThresholdKey() || jkey.hasKeyList())) {
             return convertJKeyBasic(jkey);
         } else if (jkey.hasThresholdKey()) {
             List<JKey> jKeys = jkey.getThresholdKey().getKeys().getKeysList();
@@ -327,7 +327,7 @@ public abstract class JKey implements HederaKey {
                     .setThresholdKey(ThresholdKey.newBuilder().setKeys(keys).setThreshold(thd))
                     .build();
             return result;
-        } else if (jkey.hasKeyList()) {
+        } else {
             List<JKey> jKeys = jkey.getKeyList().getKeysList();
             List<Key> tkeys = new ArrayList<>();
             for (JKey aKey : jKeys) {
@@ -336,8 +336,6 @@ public abstract class JKey implements HederaKey {
             }
             KeyList keys = KeyList.newBuilder().addAllKeys(tkeys).build();
             return Key.newBuilder().setKeyList(keys).build();
-        } else {
-            return Key.newBuilder().build();
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyList.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyList.java
@@ -16,6 +16,8 @@
 
 package com.hedera.node.app.service.mono.legacy.core.jproto;
 
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -99,5 +101,9 @@ public class JKeyList extends JKey {
             }
         }
         return false;
+    }
+
+    protected Key convertJKeyEmpty() {
+        return Key.newBuilder().setKeyList(KeyList.newBuilder().build()).build();
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKeyTest.java
@@ -16,10 +16,12 @@
 
 package com.hedera.node.app.service.mono.legacy.core.jproto;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.hedera.node.app.service.mono.txns.contract.ContractCreateTransitionLogic;
 import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.Key;
+import java.security.InvalidKeyException;
 import org.junit.jupiter.api.Test;
 
 class JContractIDKeyTest {
@@ -45,5 +47,16 @@ class JContractIDKeyTest {
         assertFalse(subject.isForScheduledTxn());
         subject.setForScheduledTxn(true);
         assertTrue(subject.isForScheduledTxn());
+    }
+
+    @Test
+    void standinContractKeyConvertsPerUsual() throws InvalidKeyException {
+        final var expectedProtoKey = Key.newBuilder()
+                .setContractID(ContractID.newBuilder().setContractNum(0).build())
+                .build();
+
+        final var actualProtoKey = JKey.mapJKey(ContractCreateTransitionLogic.STANDIN_CONTRACT_ID_KEY);
+
+        assertEquals(expectedProtoKey, actualProtoKey);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -22,7 +22,8 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAdd
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.contractIdFromHexedMirrorAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.literalIdFromHexedMirrorAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.*;
+import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -22,8 +22,7 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAdd
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.contractIdFromHexedMirrorAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.literalIdFromHexedMirrorAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.*;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;


### PR DESCRIPTION
**Description**:
 - Restores previous behavior mapping an empty `JContractIdKey` to a `Key{contractID=0.0.0}` protobuf key.