### PR TITLE
Update `BlockNoValidator` to expect genesis block `0`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/BlockNoValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/BlockNoValidator.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Assertions;
 public class BlockNoValidator implements RecordStreamValidator {
     @Override
     public void validateFiles(final List<RecordStreamFile> files) {
-        var precedingBlockNo = 0L;
+        var precedingBlockNo = -1L;
         for (final var file : files) {
             final var blockNo = file.getBlockNumber();
             Assertions.assertEquals(


### PR DESCRIPTION
**Description**:
 - `BlockNoValidator` should use `-1` as the "block number" preceding the genesis block.