### PR TITLE
Fix `HederaTestConfigBuilder` usage

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomChainIdOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomChainIdOperationTest.java
@@ -57,7 +57,7 @@ class CustomChainIdOperationTest {
 
     @Test
     void usesContractsConfigFromContext() {
-        final var config = new HederaTestConfigBuilder().getOrCreateConfig();
+        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
         given(messageFrame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);
         given(messageFrame.getRemainingGas()).willReturn(Long.MAX_VALUE);
         final var contractsConfig = config.getConfigData(ContractsConfig.class);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v030/Version030FeatureFlagsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v030/Version030FeatureFlagsTest.java
@@ -37,14 +37,14 @@ class Version030FeatureFlagsTest {
 
     @Test
     void everythingIsDisabled() {
-        final var config = new HederaTestConfigBuilder().getOrCreateConfig();
+        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
         given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);
         assertFalse(subject.isImplicitCreationEnabled(frame));
     }
 
     @Test
     void create2FeatureFlagWorks() {
-        final var config = new HederaTestConfigBuilder()
+        final var config = HederaTestConfigBuilder.create()
                 .withValue("contracts.allowCreate2", false)
                 .getOrCreateConfig();
         given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v034/Version034FeatureFlagsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v034/Version034FeatureFlagsTest.java
@@ -38,14 +38,14 @@ class Version034FeatureFlagsTest {
 
     @Test
     void implicitCreationEnabledIfLazyAndAutoCreationBothEnabled() {
-        final var config = new HederaTestConfigBuilder().getOrCreateConfig();
+        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
         given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);
         assertTrue(subject.isImplicitCreationEnabled(frame));
     }
 
     @Test
     void implicitCreationNotEnabledIfLazyCreationNotEnabled() {
-        final var config = new HederaTestConfigBuilder()
+        final var config = HederaTestConfigBuilder.create()
                 .withValue("lazyCreation.enabled", false)
                 .getOrCreateConfig();
         given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);
@@ -54,7 +54,7 @@ class Version034FeatureFlagsTest {
 
     @Test
     void implicitCreationNotEnabledIfAutoCreationNotEnabled() {
-        final var config = new HederaTestConfigBuilder()
+        final var config = HederaTestConfigBuilder.create()
                 .withValue("autoCreation.enabled", false)
                 .getOrCreateConfig();
         given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);


### PR DESCRIPTION
**Description**:
 - Updates unit tests to use `create()` instead of constructor on `HederaTestConfigBuilder`. 😞 