### PR TITLE
Fix Event Flow Unit Tests

### DIFF
--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/EventFlowTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/EventFlowTests.java
@@ -20,6 +20,7 @@ import static com.swirlds.common.test.AssertionUtils.assertEventuallyEquals;
 import static com.swirlds.common.test.AssertionUtils.assertEventuallyTrue;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static com.swirlds.test.framework.ResourceLoader.loadLog4jContext;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -257,6 +258,8 @@ class EventFlowTests {
         // Extract the transactions from other events
         final HashSet<Transaction> otherConsensusTransactions =
                 extractTransactions((id) -> !Objects.equals(id, selfId), consensusRounds);
+
+        assertDoesNotThrow(wrapper::waitUntilAllRoundsAreHandled);
 
         final TransactionTracker consensusState =
                 (TransactionTracker) swirldStateManager.getConsensusState().getSwirldState();
@@ -599,7 +602,7 @@ class EventFlowTests {
         final State state = getInitialState(swirldState, initialState, addressBook);
 
         systemTransactionTracker = new SystemTransactionTracker();
-        signedStateTracker = new ArrayBlockingQueue<>(100);
+        signedStateTracker = new ArrayBlockingQueue<>(1000);
 
         final PreConsensusSystemTransactionManager preConsensusSystemTransactionManager =
                 new PreConsensusSystemTransactionManagerFactory()
@@ -706,7 +709,7 @@ class EventFlowTests {
         assertEventuallyEquals(
                 expected.size(),
                 actual::size,
-                Duration.ofSeconds(4),
+                Duration.ofSeconds(2),
                 String.format(
                         "%s contains a different number of transactions. Expected: %s, actual: %s",
                         desc, expected.size(), actual.size()));

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/EventFlowWrapper.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/EventFlowWrapper.java
@@ -97,6 +97,10 @@ public class EventFlowWrapper {
         return selfTransactions;
     }
 
+    public void waitUntilAllRoundsAreHandled() throws InterruptedException {
+        consensusRoundHandler.waitUntilNotBusy();
+    }
+
     public HashSet<ConsensusTransactionImpl> applyPreConsensusEvents(
             final int numTransactions, final EventEmitter<?> eventEmitter) {
         return applyPreConsensusEvents(numTransactions, (indexedEvent) -> true, eventEmitter);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/SwirldStateFlowTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/SwirldStateFlowTests.java
@@ -61,7 +61,6 @@ public class SwirldStateFlowTests extends EventFlowTests {
      */
     @ParameterizedTest
     @MethodSource({"preConsParams"})
-    @Tag(TestQualifierTags.TIME_CONSUMING)
     @DisplayName("All transactions sent to preHandle")
     void testPreHandle(final Long seed, final int numNodes, final int numTransactions) {
         testPreHandle(
@@ -77,7 +76,6 @@ public class SwirldStateFlowTests extends EventFlowTests {
      */
     @ParameterizedTest
     @MethodSource("postConsHandleParams")
-    @Tag(TestQualifierTags.TIME_CONSUMING)
     @DisplayName("Transactions handled post-consensus")
     void testPostConsensusHandle(final Long seed, final int numNodes, final int numEvents) {
         testPostConsensusHandle(seed, numNodes, numEvents, origSwirldState);
@@ -89,7 +87,6 @@ public class SwirldStateFlowTests extends EventFlowTests {
      */
     @ParameterizedTest
     @MethodSource("postConsHandleParams")
-    @Tag(TestQualifierTags.TIME_CONSUMING)
     @DisplayName("Next epoch copied to epoch")
     void testPostConsensusHandleEpochUpdate(final Long seed, final int numNodes, final int numEvents) {
         testPostConsensusHandleEpochUpdate(seed, numNodes, numEvents, origSwirldState);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/SwirldStateFlowTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/eventflow/SwirldStateFlowTests.java
@@ -18,14 +18,12 @@ package com.swirlds.platform.test.eventflow;
 
 import com.swirlds.common.system.SwirldState;
 import com.swirlds.platform.state.SwirldStateManagerImpl;
-import com.swirlds.test.framework.TestQualifierTags;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
**Description**:
Remove the `TIME_CONSUMING` tag prevents important event flow tests from running and get them passing again.

**Related issue(s)**:

Fixes #7230 

**Notes for reviewer**:
None

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
