### PR TITLE
6659: Exporting balances is not parallelized well when accountsOnDisk is enabled

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/VirtualMapLikeAdapter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/VirtualMapLikeAdapter.java
@@ -84,6 +84,20 @@ public final class VirtualMapLikeAdapter {
             }
 
             @Override
+            public void extractVirtualMapDataC(
+                    final ThreadManager threadManager,
+                    final InterruptableConsumer<Pair<K, V>> handler,
+                    final int threadCount)
+                    throws InterruptedException {
+                VirtualMapMigration.extractVirtualMapDataC(
+                        threadManager,
+                        real,
+                        pair -> handler.accept(
+                                Pair.of(pair.getKey().getKey(), pair.getValue().getValue())),
+                        threadCount);
+            }
+
+            @Override
             public void registerMetrics(final Metrics metrics) {
                 real.registerMetrics(metrics);
             }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/adapters/VirtualMapLike.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/adapters/VirtualMapLike.java
@@ -56,6 +56,9 @@ public interface VirtualMapLike<K extends VirtualKey, V extends VirtualValue> {
     void extractVirtualMapData(ThreadManager threadManager, InterruptableConsumer<Pair<K, V>> handler, int threadCount)
             throws InterruptedException;
 
+    void extractVirtualMapDataC(ThreadManager threadManager, InterruptableConsumer<Pair<K, V>> handler, int threadCount)
+            throws InterruptedException;
+
     static <K extends VirtualKey, V extends VirtualValue> VirtualMapLike<K, V> from(final VirtualMap<K, V> real) {
         return new VirtualMapLike<>() {
             @Override
@@ -70,6 +73,15 @@ public interface VirtualMapLike<K extends VirtualKey, V extends VirtualValue> {
                     final int threadCount)
                     throws InterruptedException {
                 VirtualMapMigration.extractVirtualMapData(threadManager, real, handler, threadCount);
+            }
+
+            @Override
+            public void extractVirtualMapDataC(
+                    final ThreadManager threadManager,
+                    final InterruptableConsumer<Pair<K, V>> handler,
+                    final int threadCount)
+                    throws InterruptedException {
+                VirtualMapMigration.extractVirtualMapDataC(threadManager, real, handler, threadCount);
             }
 
             @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
@@ -133,6 +133,23 @@ public class AccountStorageAdapter {
         }
     }
 
+    public void forEachParallel(final BiConsumer<EntityNum, HederaAccount> visitor) {
+        if (accountsOnDisk) {
+            try {
+                onDiskAccounts.extractVirtualMapDataC(
+                        getStaticThreadManager(),
+                        entry -> visitor.accept(entry.getKey().asEntityNum(), entry.getValue()),
+                        THREAD_COUNT);
+            } catch (final InterruptedException e) {
+                log.error("Interrupted while extracting VM data", e);
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        } else {
+            inMemoryAccounts.forEach(visitor);
+        }
+    }
+
     public boolean areOnDisk() {
         return accountsOnDisk;
     }


### PR DESCRIPTION
**Description**:
Improves performance of `SignedStateBalancesExporter` for token balances when `accounts.storeOnDisk` is enabled by avoiding serialization in `VirtualMapMigration.extractVirtualMapData()`.

**Related issue(s)**:

Fixes #6659
Relies on #7197
Requires #7264 for testing

**Notes for reviewer**:


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
