### PR TITLE
Change nft owner and spender identifier from long to AccountID

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
@@ -396,10 +396,15 @@ public class CryptoApproveAllowanceHandler implements TransactionHandler {
             final var nft = uniqueTokenStore.get(tokenId, serialNum);
             final var token = tokenStore.get(tokenId);
 
-            validateTrue(isValidOwner(nft, owner.accountNumber(), token), SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
-            final var copy = nft.copyBuilder()
-                    .spenderNumber(spenderId.accountNumOrThrow())
+            // FUTURE: owner will be updated to use an AccountID instead of a long account number
+            // Issue #7243
+            AccountID accountOwner = AccountID.newBuilder()
+                    .accountNum(owner.accountNumber())
+                    .realmNum(0)
+                    .shardNum(0)
                     .build();
+            validateTrue(isValidOwner(nft, accountOwner, token), SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
+            final var copy = nft.copyBuilder().spenderId(spenderId).build();
             uniqueTokenStore.put(copy);
         }
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteAllowanceHandler.java
@@ -97,7 +97,8 @@ public class CryptoDeleteAllowanceHandler implements TransactionHandler {
     }
 
     /**
-     * Deletes allowance for the given nft serials. Clears spender on the provided nft serials if the owner owns the serials.
+     * Deletes allowance for the given nft serials.
+     * Clears spender on the provided nft serials if the owner owns the serials.
      * If owner is not specified payer is considered as the owner.
      * If the owner doesn't own these serials throws an exception.
      * @param context handle context
@@ -152,10 +153,18 @@ public class CryptoDeleteAllowanceHandler implements TransactionHandler {
 
                 validateTrue(nft != null, INVALID_NFT_ID);
                 // Check if owner owns the nft
-                validateTrue(isValidOwner(nft, owner.accountNumber(), token), SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
+                // FUTURE: owner will be updated to use an AccountID instead of a long account number
+                // Issue #7243
+                AccountID accountOwner = AccountID.newBuilder()
+                        .accountNum(owner.accountNumber())
+                        .realmNum(0)
+                        .shardNum(0)
+                        .build();
+                validateTrue(isValidOwner(nft, accountOwner, token), SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
 
                 // Clear spender on the nft
-                final var copy = nft.copyBuilder().spenderNumber(0L).build();
+                // sets account number to AccountIDProtoCodec.ACCOUNT_UNSET
+                final var copy = nft.copyBuilder().spenderId(AccountID.DEFAULT).build();
                 nftStore.put(copy);
             }
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -56,6 +56,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -153,8 +154,8 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
                 final var nft = nftStore.get(tokenId, nftSerial);
                 validateTrue(nft != null, INVALID_NFT_ID);
 
-                final var nftOwner = nft.ownerNumber();
-                validateTrue(nftOwner == accountId.accountNum(), ACCOUNT_DOES_NOT_OWN_WIPED_NFT);
+                final var nftOwner = nft.ownerId();
+                validateTrue(Objects.equals(nftOwner, accountId), ACCOUNT_DOES_NOT_OWN_WIPED_NFT);
             }
 
             // Check that the new token balance will not be negative

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
@@ -24,6 +24,7 @@ import static com.hedera.node.app.service.token.impl.validators.TokenSupplyChang
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
@@ -121,7 +122,7 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
                 final var nft = nftStore.get(tokenId, nftSerial);
                 validateTrue(nft != null, INVALID_NFT_ID);
 
-                final var nftOwner = nft.ownerNumber();
+                final var nftOwner = nft.ownerId();
                 validateTrue(treasuryOwnsNft(nftOwner), TREASURY_MUST_OWN_BURNED_NFT);
             }
 
@@ -167,8 +168,8 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
         return new ValidationResult(token, treasuryRel);
     }
 
-    private boolean treasuryOwnsNft(final long ownerNum) {
-        return ownerNum == 0;
+    private boolean treasuryOwnsNft(final AccountID ownerID) {
+        return ownerID == null;
     }
 
     private record ValidationResult(@NonNull Token token, @NonNull TokenRelation tokenTreasuryRel) {}

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfoHandler.java
@@ -25,7 +25,6 @@ import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalseP
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseHeader;
@@ -134,10 +133,10 @@ public class TokenGetNftInfoHandler extends PaidQueryHandler {
             final var info = TokenNftInfo.newBuilder()
                     .ledgerId(config.id())
                     .nftID(nftId)
-                    .accountID(AccountID.newBuilder().accountNum(nft.ownerNumber()))
+                    .accountID(nft.ownerId())
                     .creationTime(nft.mintTime())
                     .metadata(nft.metadata())
-                    .spenderId(AccountID.newBuilder().accountNum(nft.spenderNumber()))
+                    .spenderId(nft.spenderId())
                     .build();
             return Optional.of(info);
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -234,7 +234,7 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
                         .tokenTypeNumber(tokenId.tokenNum())
                         .serialNumber(currentSerialNumber)
                         .build())
-                .ownerNumber(0L)
+                // ownerID is null to indicate owned by treasury
                 .mintTime(Timestamp.newBuilder()
                         .seconds(consensusTime.getEpochSecond())
                         .nanos(consensusTime.getNano())

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
@@ -20,6 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.*;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TokenID;
@@ -106,13 +107,20 @@ public class AllowanceValidator {
      * as an invalid owner and returns false.
      *
      * @param nft given nft
-     * @param ownerNum owner given in allowance
+     * @param ownerID owner given in allowance
      * @param token token for which nft belongs to
      * @return whether the owner is valid
      */
-    public static boolean isValidOwner(final Nft nft, final long ownerNum, final Token token) {
-        final var listedOwner = nft.ownerNumber();
-        return listedOwner == 0 ? ownerNum == token.treasuryAccountNumber() : listedOwner == ownerNum;
+    public static boolean isValidOwner(
+            @NonNull final Nft nft, @NonNull final AccountID ownerID, @NonNull final Token token) {
+        requireNonNull(nft);
+        requireNonNull(ownerID);
+        requireNonNull(token);
+        if (nft.hasOwnerId()) {
+            return nft.ownerId().equals(ownerID);
+        } else {
+            return ownerID.accountNum() == token.treasuryAccountNumber();
+        }
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableNftStoreTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableNftStoreTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.common.UniqueTokenId;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.node.app.service.token.impl.WritableNftStore;
@@ -116,10 +117,11 @@ class WritableNftStoreTest extends CryptoTokenHandlerTestBase {
         // Set up the NFT state with an existing NFT
         final var nftToRemove =
                 UniqueTokenId.newBuilder().tokenTypeNumber(1).serialNumber(1).build();
+        final var ownerId = AccountID.newBuilder().accountNum(12345).build();
         writableNftState = emptyWritableNftStateBuilder()
                 .value(
                         nftToRemove,
-                        Nft.newBuilder().id(nftToRemove).ownerNumber(12345).build())
+                        Nft.newBuilder().id(nftToRemove).ownerId(ownerId).build())
                 .build();
         assertTrue(writableNftState.contains(nftToRemove));
         given(writableStates.<UniqueTokenId, Nft>get(NFTS)).willReturn(writableNftState);
@@ -137,10 +139,11 @@ class WritableNftStoreTest extends CryptoTokenHandlerTestBase {
         // Set up the NFT state with an existing NFT
         final var nftToRemove =
                 UniqueTokenId.newBuilder().tokenTypeNumber(1).serialNumber(1).build();
+        final var ownerId = AccountID.newBuilder().accountNum(12345).build();
         writableNftState = emptyWritableNftStateBuilder()
                 .value(
                         nftToRemove,
-                        Nft.newBuilder().id(nftToRemove).ownerNumber(12345).build())
+                        Nft.newBuilder().id(nftToRemove).ownerId(ownerId).build())
                 .build();
         assertTrue(writableNftState.contains(nftToRemove));
         given(writableStates.<UniqueTokenId, Nft>get(NFTS)).willReturn(writableNftState);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
@@ -156,10 +156,10 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
 
         assertThat(writableNftStore.get(uniqueTokenIdSl1)).isNotNull();
         assertThat(writableNftStore.get(uniqueTokenIdSl2)).isNotNull();
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isNull();
 
         subject.handle(handleContext);
 
@@ -180,10 +180,10 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
 
         assertThat(writableNftStore.get(uniqueTokenIdSl1)).isNotNull();
         assertThat(writableNftStore.get(uniqueTokenIdSl2)).isNotNull();
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
     }
 
     @Test
@@ -209,10 +209,10 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
 
         assertThat(writableNftStore.get(uniqueTokenIdSl1)).isNotNull();
         assertThat(writableNftStore.get(uniqueTokenIdSl2)).isNotNull();
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isNull();
 
         subject.handle(handleContext);
 
@@ -233,10 +233,10 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
 
         assertThat(writableNftStore.get(uniqueTokenIdSl1)).isNotNull();
         assertThat(writableNftStore.get(uniqueTokenIdSl2)).isNotNull();
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
     }
 
     @Test
@@ -251,20 +251,20 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
         final var existingOwner = writableAccountStore.getAccountById(ownerId);
         assertThat(existingOwner.approveForAllNftAllowances()).hasSize(1);
 
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isNull();
 
         subject.handle(handleContext);
 
         final var modifiedOwner = writableAccountStore.getAccountById(ownerId);
 
         assertThat(modifiedOwner.approveForAllNftAllowances()).isEmpty();
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
     }
 
     @Test
@@ -293,12 +293,8 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
         // change the state to have the payer as owner for NFTs for a passing test.
         // If not it fails since those NFTs are not owned by the payer.
         writableNftState = emptyWritableNftStateBuilder()
-                .value(
-                        uniqueTokenIdSl1,
-                        nftSl1.copyBuilder().ownerNumber(accountNum).build())
-                .value(
-                        uniqueTokenIdSl2,
-                        nftSl2.copyBuilder().ownerNumber(accountNum).build())
+                .value(uniqueTokenIdSl1, nftSl1.copyBuilder().ownerId(payerId).build())
+                .value(uniqueTokenIdSl2, nftSl2.copyBuilder().ownerId(payerId).build())
                 .build();
         given(writableStates.<UniqueTokenId, Nft>get(NFTS)).willReturn(writableNftState);
         writableNftStore = new WritableNftStore(writableStates);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
@@ -85,52 +85,52 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void happyPathDeletesAllowances() {
-        writableNftStore.put(
-                nftSl1.copyBuilder().spenderNumber(spenderId.accountNum()).build());
-        writableNftStore.put(
-                nftSl2.copyBuilder().spenderNumber(spenderId.accountNum()).build());
+        writableNftStore.put(nftSl1.copyBuilder().spenderId(spenderId).build());
+        writableNftStore.put(nftSl2.copyBuilder().spenderId(spenderId).build());
 
         final var txn = cryptoDeleteAllowanceTransaction(payerId);
         given(handleContext.body()).willReturn(txn);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
 
         subject.handle(handleContext);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId().accountNum())
+                .isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId().accountNum())
+                .isNull();
     }
 
     @Test
     void canDeleteAllowancesOnTreasury() {
-        writableNftStore.put(
-                nftSl1.copyBuilder().spenderNumber(spenderId.accountNum()).build());
-        writableNftStore.put(
-                nftSl2.copyBuilder().spenderNumber(spenderId.accountNum()).build());
+        writableNftStore.put(nftSl1.copyBuilder().spenderId(spenderId).build());
+        writableNftStore.put(nftSl2.copyBuilder().spenderId(spenderId).build());
 
         final var txn = cryptoDeleteAllowanceTransaction(payerId);
         given(handleContext.body()).willReturn(txn);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
 
         subject.handle(handleContext);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId().accountNum())
+                .isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId().accountNum())
+                .isNull();
     }
 
     @Test
@@ -161,27 +161,27 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
     void failsDeleteAllowancesOnInvalidTreasury() {
         writableTokenStore.put(
                 nonFungibleToken.copyBuilder().treasuryAccountNumber(200L).build());
-        writableNftStore.put(
-                nftSl1.copyBuilder().spenderNumber(spenderId.accountNum()).build());
-        writableNftStore.put(
-                nftSl2.copyBuilder().spenderNumber(spenderId.accountNum()).build());
+        writableNftStore.put(nftSl1.copyBuilder().spenderId(spenderId).build());
+        writableNftStore.put(nftSl2.copyBuilder().spenderId(spenderId).build());
 
         final var txn = cryptoDeleteAllowanceTransaction(payerId);
         given(handleContext.body()).willReturn(txn);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
 
         subject.handle(handleContext);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId().accountNum())
+                .isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId().accountNum())
+                .isNull();
     }
 
     @Test
@@ -192,27 +192,27 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
                 .serialNumbers(List.of(1L, 2L))
                 .build();
 
-        writableNftStore.put(
-                nftSl1.copyBuilder().ownerNumber(ownerId.accountNum()).build());
-        writableNftStore.put(
-                nftSl2.copyBuilder().ownerNumber(ownerId.accountNum()).build());
+        writableNftStore.put(nftSl1.copyBuilder().ownerId(ownerId).build());
+        writableNftStore.put(nftSl2.copyBuilder().ownerId(ownerId).build());
 
         final var txn = txnWithAllowance(payerId, nftAllowance);
         given(handleContext.body()).willReturn(txn);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(0);
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(0);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isNull();
 
         subject.handle(handleContext);
         // No error thrown and no changes to state
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(0);
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(0);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId().accountNum())
+                .isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId().accountNum())
+                .isNull();
     }
 
     @Test
@@ -222,19 +222,17 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
                 .serialNumbers(List.of(1L, 2L))
                 .build();
 
-        writableNftStore.put(
-                nftSl1.copyBuilder().spenderNumber(spenderId.accountNum()).build());
-        writableNftStore.put(
-                nftSl2.copyBuilder().spenderNumber(spenderId.accountNum()).build());
+        writableNftStore.put(nftSl1.copyBuilder().spenderId(spenderId).build());
+        writableNftStore.put(nftSl2.copyBuilder().spenderId(spenderId).build());
 
         final var txn = txnWithAllowance(payerId, nftAllowance);
         given(handleContext.body()).willReturn(txn);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(ownerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(ownerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
 
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
@@ -248,31 +246,29 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
                 .serialNumbers(List.of(1L, 2L))
                 .build();
 
-        writableNftStore.put(nftSl1.copyBuilder()
-                .ownerNumber(payerId.accountNum())
-                .spenderNumber(spenderId.accountNum())
-                .build());
-        writableNftStore.put(nftSl2.copyBuilder()
-                .ownerNumber(payerId.accountNum())
-                .spenderNumber(spenderId.accountNum())
-                .build());
+        writableNftStore.put(
+                nftSl1.copyBuilder().ownerId(payerId).spenderId(spenderId).build());
+        writableNftStore.put(
+                nftSl2.copyBuilder().ownerId(payerId).spenderId(spenderId).build());
 
         final var txn = txnWithAllowance(payerId, nftAllowance);
         given(handleContext.body()).willReturn(txn);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(payerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(payerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isEqualTo(spenderId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isEqualTo(spenderId.accountNum());
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(payerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(payerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId()).isEqualTo(spenderId);
 
         subject.handle(handleContext);
 
         assertThat(ownerAccount.approveForAllNftAllowances()).hasSize(1);
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerNumber()).isEqualTo(payerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerNumber()).isEqualTo(payerId.accountNum());
-        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderNumber()).isZero();
-        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderNumber()).isZero();
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).ownerId()).isEqualTo(payerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).ownerId()).isEqualTo(payerId);
+        assertThat(writableNftStore.get(uniqueTokenIdSl1).spenderId().accountNum())
+                .isNull();
+        assertThat(writableNftStore.get(uniqueTokenIdSl2).spenderId().accountNum())
+                .isNull();
     }
 
     private TransactionBody cryptoDeleteAllowanceTransaction(final AccountID txnPayer) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -606,7 +606,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                             .tokenTypeNumber(TOKEN_531.tokenNum())
                             .serialNumber(1)
                             .build())
-                    .ownerNumber(TREASURY_ACCOUNT_9876.accountNumOrThrow())
+                    .ownerId(TREASURY_ACCOUNT_9876)
                     .build());
 
             final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, 0, 1L);
@@ -697,28 +697,28 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(1)
                                     .build())
-                            .ownerNumber(0) // treasury owns this NFT
+                            // do not set ownerId - default to null, meaning treasury owns this NFT
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(2)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(3)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(4)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build());
             final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, 0, 2L, 3L);
             final var context = mockContext(txn);
@@ -776,28 +776,28 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(1)
                                     .build())
-                            .ownerNumber(0) // treasury owns this NFT
+                            // do not set ownerId - default to null, meaning treasury owns this NFT
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(2)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(3)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(4)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build());
             final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, 0, 2L, 3L, 4L);
             final var context = mockContext(txn);
@@ -856,28 +856,28 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(1)
                                     .build())
-                            .ownerNumber(0) // treasury owns this NFT
+                            // do not set ownerId - default to null, meaning treasury owns this NFT
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(2)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(3)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_531.tokenNum())
                                     .serialNumber(4)
                                     .build())
-                            .ownerNumber(ACCOUNT_4680.accountNumOrThrow())
+                            .ownerId(ACCOUNT_4680)
                             .build());
             final var txn = newWipeTxn(ACCOUNT_4680, TOKEN_531, 0, 2L, 2L, 3L, 3L, 4L, 4L, 2L, 3L, 4L);
             final var context = mockContext(txn);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
@@ -602,12 +602,13 @@ class TokenBurnHandlerTest extends ParityTestBase {
                     .balance(10)
                     .build());
             // this owner number isn't the treasury
+            AccountID ownerId = AccountID.newBuilder().accountNum(999).build();
             writableNftStore = newWritableStoreWithNfts(Nft.newBuilder()
                     .id(UniqueTokenId.newBuilder()
                             .tokenTypeNumber(TOKEN_123.tokenNum())
                             .serialNumber(1L)
                             .build())
-                    .ownerNumber(999)
+                    .ownerId(ownerId)
                     .build());
 
             final var txn = newBurnTxn(TOKEN_123, 0, 1L);
@@ -640,7 +641,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .tokenTypeNumber(TOKEN_123.tokenNum())
                             .serialNumber(1L)
                             .build())
-                    .ownerNumber(0)
+                    // do not set ownerId - default to null
                     .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L);
             final var context = mockContext(txn);
@@ -676,14 +677,14 @@ class TokenBurnHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(1L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(2L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L);
             final var context = mockContext(txn);
@@ -720,21 +721,21 @@ class TokenBurnHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(1L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(2L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(3L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L);
             final var context = mockContext(txn);
@@ -780,21 +781,21 @@ class TokenBurnHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(1L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(2L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(3L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L, 3L);
             final var context = mockContext(txn);
@@ -841,21 +842,21 @@ class TokenBurnHandlerTest extends ParityTestBase {
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(1L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(2L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build(),
                     Nft.newBuilder()
                             .id(UniqueTokenId.newBuilder()
                                     .tokenTypeNumber(TOKEN_123.tokenNum())
                                     .serialNumber(3L)
                                     .build())
-                            .ownerNumber(0)
+                            // do not set ownerId - default to null
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L, 3L, 1L, 2L, 3L, 3L, 1L, 1L, 2L);
             final var context = mockContext(txn);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetNftInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetNftInfoHandlerTest.java
@@ -201,7 +201,7 @@ class TokenGetNftInfoHandlerTest extends CryptoTokenHandlerTestBase {
         final var expectedInfo = getExpectedInfo();
 
         nftSl1 = nftSl1.copyBuilder()
-                .spenderNumber(spenderId.accountNum())
+                .spenderId(spenderId)
                 .mintTime(consensusTimestamp)
                 .metadata(Bytes.wrap(evmAddress))
                 .build();
@@ -222,7 +222,7 @@ class TokenGetNftInfoHandlerTest extends CryptoTokenHandlerTestBase {
                 .build();
         final var expectedInfo = getExpectedInfo();
         nftSl1 = nftSl1.copyBuilder()
-                .spenderNumber(spenderId.accountNum())
+                .spenderId(spenderId)
                 .mintTime(consensusTimestamp)
                 .metadata(Bytes.wrap(evmAddress))
                 .build();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
@@ -646,10 +646,7 @@ public class CryptoTokenHandlerTestBase extends StateBuilderUtil {
     }
 
     protected Nft givenNft(UniqueTokenId uniqueTokenId) {
-        return Nft.newBuilder()
-                .ownerNumber(ownerId.accountNum())
-                .id(uniqueTokenId)
-                .build();
+        return Nft.newBuilder().ownerId(ownerId).id(uniqueTokenId).build();
     }
 
     protected CustomFee withFixedFee(final FixedFee fixedFee) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/AllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/AllowanceValidatorTest.java
@@ -91,8 +91,8 @@ class AllowanceValidatorTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void validatesOwner() {
-        assertThat(isValidOwner(nftSl1, spenderId.accountNum(), fungibleToken)).isFalse();
-        assertThat(isValidOwner(nftSl1, ownerId.accountNum(), nonFungibleToken)).isTrue();
+        assertThat(isValidOwner(nftSl1, spenderId, fungibleToken)).isFalse();
+        assertThat(isValidOwner(nftSl1, ownerId, nonFungibleToken)).isTrue();
     }
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -103,7 +103,7 @@ gradleEnterprise {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
+val hapiProtoBranchOrTag = "change-numbers-to-ids-nft-proto" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
**Description**:
Use IDs instead of longs in NFT

**Related issue(s)**:

Fixes #7244 
Related to [PR #289](https://github.com/hashgraph/hedera-protobufs/pull/289) in hedera-protobufs repo 

**Notes for reviewer**:

This PR relies on a temporary branch `change-numbers-to-ids-nft-proto ` in hedera-protobufs repo. The plan is to:
1) Merge this PR
2) Merge [PR #289](https://github.com/hashgraph/hedera-protobufs/pull/289) in hedera-protobufs repo, but DO NOT DELETE THE ASSOCIATED BRANCH YET. Until Step 3 is completed, hedera-services still relies on the branch
3) Create and merge another PR in hedera-services to reset the protobufs branch in use back to add-pbj-types-for-state
4) Delete the hedera-protobufs branch associated with step 2
