### PR TITLE
Reset protobuf branch back to add-pbj-types-for-state

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -103,7 +103,7 @@ gradleEnterprise {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-val hapiProtoBranchOrTag = "change-numbers-to-ids-nft-proto" // hapiProtoVersion
+val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
Reset protobuf branch in use by services back to `add-pbj-types-for-state`. This is a follow-up to PR #7288, which temporarily changed it to a different branch.

**Related issue(s)**:

Fixes #7244 

