### PR TITLE
Use fully qualified settings names.

### DIFF
--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -2,13 +2,11 @@
                                           #    Gossip / Networking    #
                                           #############################
 
-chatter.useChatter,                            false
-doUpnp,                                        false
-maxOutgoingSyncs,                              1                            # differs from mainnet
 numConnections,                                1000
-sync.syncAsProtocolEnabled,                    true
+socket.doUpnp,                                 false
+socket.useLoopbackIp,                          false
+sync.maxOutgoingSyncs,                         1                            # differs from mainnet
 sync.syncProtocolPermitCount,                  2                            # differs from mainnet
-useLoopbackIp,                                 false
 
                                           #############################
                                           #           State           #

--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -6,6 +6,7 @@ numConnections,                                1000
 socket.doUpnp,                                 false
 socket.useLoopbackIp,                          false
 sync.maxOutgoingSyncs,                         1                            # differs from mainnet
+sync.syncAsProtocolEnabled,                    true
 sync.syncProtocolPermitCount,                  2                            # differs from mainnet
 
                                           #############################

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -2,13 +2,11 @@
                                           #    Gossip / Networking    #
                                           #############################
 
-chatter.useChatter,                            false
-doUpnp,                                        false
-maxOutgoingSyncs,                              1                            # differs from mainnet
 numConnections,                                1000
-sync.syncAsProtocolEnabled,                    true
+socket.doUpnp,                                 false
+socket.useLoopbackIp,                          false
+sync.maxOutgoingSyncs,                         1                            # differs from mainnet
 sync.syncProtocolPermitCount,                  2                            # differs from mainnet
-useLoopbackIp,                                 false
 
                                           #############################
                                           #           State           #

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -6,6 +6,7 @@ numConnections,                                1000
 socket.doUpnp,                                 false
 socket.useLoopbackIp,                          false
 sync.maxOutgoingSyncs,                         1                            # differs from mainnet
+sync.syncAsProtocolEnabled,                    true
 sync.syncProtocolPermitCount,                  2                            # differs from mainnet
 
                                           #############################
@@ -43,4 +44,4 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 metrics.csvFileName,                           MainNetStats
 metrics.csvOutputFolder,                       data/stats
 showInternalStats,                             true
-prometheus.endpointEnabled,                    false                          # differs from mainnet
+prometheus.endpointEnabled,                    false                        # differs from mainnet

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -2,13 +2,11 @@
                                           #    Gossip / Networking    #
                                           #############################
 
-chatter.useChatter,                            false
-doUpnp,                                        false
-maxOutgoingSyncs,                              8
 numConnections,                                1000
-sync.syncAsProtocolEnabled,                    true
+socket.doUpnp,                                 false
+socket.useLoopbackIp,                          false
+sync.maxOutgoingSyncs,                         8
 sync.syncProtocolPermitCount,                  17
-useLoopbackIp,                                 false
 
                                           #############################
                                           #           State           #

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -6,6 +6,7 @@ numConnections,                                1000
 socket.doUpnp,                                 false
 socket.useLoopbackIp,                          false
 sync.maxOutgoingSyncs,                         8
+sync.syncAsProtocolEnabled,                    true
 sync.syncProtocolPermitCount,                  17
 
                                           #############################

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -2,13 +2,11 @@
                                           #    Gossip / Networking    #
                                           #############################
 
-chatter.useChatter,                            false
-doUpnp,                                        false
-maxOutgoingSyncs,                              4                          # differs from mainnet
 numConnections,                                1000
-sync.syncAsProtocolEnabled,                    true
-sync.syncProtocolPermitCount,                  4                          # differs from mainnet
-useLoopbackIp,                                 false
+socket.doUpnp,                                 false
+socket.useLoopbackIp,                          false
+sync.maxOutgoingSyncs,                         4                            # differs from mainnet
+sync.syncProtocolPermitCount,                  4                            # differs from mainnet
 
                                           #############################
                                           #           State           #

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -6,6 +6,7 @@ numConnections,                                1000
 socket.doUpnp,                                 false
 socket.useLoopbackIp,                          false
 sync.maxOutgoingSyncs,                         4                            # differs from mainnet
+sync.syncAsProtocolEnabled,                    true
 sync.syncProtocolPermitCount,                  4                            # differs from mainnet
 
                                           #############################

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -2,13 +2,11 @@
                                           #    Gossip / Networking    #
                                           #############################
 
-chatter.useChatter,                            false
-doUpnp,                                        false
-maxOutgoingSyncs,                              4                          # differs from mainnet
 numConnections,                                1000
-sync.syncAsProtocolEnabled,                    true
-sync.syncProtocolPermitCount,                  4                          # differs from mainnet
-useLoopbackIp,                                 false
+socket.doUpnp,                                 false
+socket.useLoopbackIp,                          false
+sync.maxOutgoingSyncs,                         4                            # differs from mainnet
+sync.syncProtocolPermitCount,                  4                            # differs from mainnet
 
                                           #############################
                                           #           State           #

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -6,6 +6,7 @@ numConnections,                                1000
 socket.doUpnp,                                 false
 socket.useLoopbackIp,                          false
 sync.maxOutgoingSyncs,                         4                            # differs from mainnet
+sync.syncAsProtocolEnabled,                    true
 sync.syncProtocolPermitCount,                  4                            # differs from mainnet
 
                                           #############################

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -2,13 +2,12 @@
                                           #    Gossip / Networking    #
                                           #############################
 
-chatter.useChatter,                            false
-doUpnp,                                        false
-maxOutgoingSyncs,                              4                          # differs from mainnet
 numConnections,                                1000
+socket.doUpnp,                                 false
+socket.useLoopbackIp,                          false
+sync.maxOutgoingSyncs,                         4                            # differs from mainnet
 sync.syncAsProtocolEnabled,                    true
-sync.syncProtocolPermitCount,                  4                          # differs from mainnet
-useLoopbackIp,                                 false
+sync.syncProtocolPermitCount,                  4                            # differs from mainnet
 
                                           #############################
                                           #           State           #


### PR DESCRIPTION
Closes #7336 

This PR does the following:

- replace several legacy settings with the new fully qualified setting name
- remove settings matching current defaults
   - sync.syncAsProtocolEnabled (default true)
   - chatter.useChatter (default false)
- make sure settings are in alphabetical order with the new prefixes
