### PR TITLE
Disable code that improperly finds judges.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeMetrics.java
@@ -128,18 +128,21 @@ class UptimeMetrics {
                         "The number of rounds since the last consensus event created by this node was observed");
         roundsSinceLastConsensusEvent.put(nodeId, metrics.getOrCreate(roundsSinceLastConensusEventConfig));
 
-        final RunningAverageMetric.Config timeSinceLastJudgeConfig = new RunningAverageMetric.Config(
-                        CATEGORY, TIME_SINCE_LAST_JUDGE + nodeId)
-                .withUnit("seconds")
-                .withDescription(
-                        "The consensus time in seconds since the last judge created by this node was observed");
-        timeSinceLastJudge.put(nodeId, metrics.getOrCreate(timeSinceLastJudgeConfig));
-
-        final RunningAverageMetric.Config roundsSinceLastJudgeConfig = new RunningAverageMetric.Config(
-                        CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId)
-                .withUnit("rounds")
-                .withDescription("The number of rounds since the last judge created by this node was observed");
-        roundsSinceLastJudge.put(nodeId, metrics.getOrCreate(roundsSinceLastJudgeConfig));
+        // Temporarily disabled until we properly detect judges in a round
+        //        final RunningAverageMetric.Config timeSinceLastJudgeConfig = new RunningAverageMetric.Config(
+        //                        CATEGORY, TIME_SINCE_LAST_JUDGE + nodeId)
+        //                .withUnit("seconds")
+        //                .withDescription(
+        //                        "The consensus time in seconds since the last judge created by this node was
+        // observed");
+        //        timeSinceLastJudge.put(nodeId, metrics.getOrCreate(timeSinceLastJudgeConfig));
+        //
+        //        final RunningAverageMetric.Config roundsSinceLastJudgeConfig = new RunningAverageMetric.Config(
+        //                        CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId)
+        //                .withUnit("rounds")
+        //                .withDescription("The number of rounds since the last judge created by this node was
+        // observed");
+        //        roundsSinceLastJudge.put(nodeId, metrics.getOrCreate(roundsSinceLastJudgeConfig));
     }
 
     /**
@@ -155,11 +158,12 @@ class UptimeMetrics {
         roundsSinceLastConsensusEvent.remove(nodeId);
         metrics.remove(new RunningAverageMetric.Config(CATEGORY, ROUNDS_SINCE_LAST_CONSENSUS_EVENT + nodeId));
 
-        timeSinceLastJudge.remove(nodeId);
-        metrics.remove(new RunningAverageMetric.Config(CATEGORY, TIME_SINCE_LAST_JUDGE + nodeId));
-
-        roundsSinceLastJudge.remove(nodeId);
-        metrics.remove(new RunningAverageMetric.Config(CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId));
+        // Temporarily disabled until we properly detect judges in a round
+        //        timeSinceLastJudge.remove(nodeId);
+        //        metrics.remove(new RunningAverageMetric.Config(CATEGORY, TIME_SINCE_LAST_JUDGE + nodeId));
+        //
+        //        roundsSinceLastJudge.remove(nodeId);
+        //        metrics.remove(new RunningAverageMetric.Config(CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeTracker.java
@@ -165,11 +165,13 @@ public class UptimeTracker {
             @NonNull final Round round,
             @NonNull final Map<NodeId, ConsensusEvent> lastEventsInRoundByCreator,
             @NonNull final Map<NodeId, ConsensusEvent> judgesByCreator) {
+
         round.forEach(event -> {
             lastEventsInRoundByCreator.put(new NodeId(event.getCreatorId()), event);
-            if (((EventImpl) event).isFamous()) {
-                judgesByCreator.put(new NodeId(event.getCreatorId()), event);
-            }
+            // Temporarily disabled -- this is not the correct way to find a judge for the current round.
+            //            if (((EventImpl) event).isFamous()) {
+            //                judgesByCreator.put(new NodeId(event.getCreatorId()), event);
+            //            }
         });
 
         final ConsensusEvent lastSelfEvent = lastEventsInRoundByCreator.get(selfId);
@@ -237,18 +239,19 @@ public class UptimeTracker {
                 uptimeMetrics.getRoundsSinceLastConsensusEventMetric(id).update(currentRound - lastEventRound);
             }
 
-            final Instant lastJudgeTime = uptimeData.getLastJudgeTime(id);
-            if (lastJudgeTime != null) {
-                final Duration timeSinceLastJudge = Duration.between(lastJudgeTime, lastRoundEndTime);
-                uptimeMetrics
-                        .getTimeSinceLastJudgeMetric(id)
-                        .update(UNIT_MILLISECONDS.convertTo(timeSinceLastJudge.toMillis(), UNIT_SECONDS));
-            }
-
-            final long lastJudgeRound = uptimeData.getLastJudgeRound(id);
-            if (lastJudgeRound != NO_ROUND) {
-                uptimeMetrics.getRoundsSinceLastJudgeMetric(id).update(currentRound - lastJudgeRound);
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            final Instant lastJudgeTime = uptimeData.getLastJudgeTime(id);
+            //            if (lastJudgeTime != null) {
+            //                final Duration timeSinceLastJudge = Duration.between(lastJudgeTime, lastRoundEndTime);
+            //                uptimeMetrics
+            //                        .getTimeSinceLastJudgeMetric(id)
+            //                        .update(UNIT_MILLISECONDS.convertTo(timeSinceLastJudge.toMillis(), UNIT_SECONDS));
+            //            }
+            //
+            //            final long lastJudgeRound = uptimeData.getLastJudgeRound(id);
+            //            if (lastJudgeRound != NO_ROUND) {
+            //                uptimeMetrics.getRoundsSinceLastJudgeMetric(id).update(currentRound - lastJudgeRound);
+            //            }
         }
 
         final double fractionOfNetworkAlive = (double) nonDegradedConsensusWeight / addressBook.getTotalWeight();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
@@ -154,13 +154,15 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            if (judge != null) {
+            //                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(1, genesisUptimeData.getLastEventRound(address.getNodeId()));
@@ -205,17 +207,21 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(
-                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(
-                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            if (judge != null) {
+            //                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(2, nextRoundUptimeData.getLastEventRound(address.getNodeId()));
@@ -289,13 +295,15 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            if (judge != null) {
+            //                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(1, genesisUptimeData.getLastEventRound(address.getNodeId()));
@@ -346,17 +354,21 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(
-                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(
-                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            if (judge != null) {
+            //                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(2, nextRoundUptimeData.getLastEventRound(address.getNodeId()));


### PR DESCRIPTION
Related to #7369 

Once this merges we need to port it to 0.40 and 0.41.
