### PR TITLE
Disable code that improperly finds judges.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeMetrics.java
@@ -110,11 +110,13 @@ class UptimeMetrics {
                         "The number of rounds since the last consensus event created by this node was observed");
         roundsSinceLastConsensusEvent.put(nodeId, metrics.getOrCreate(roundsSinceLastConensusEventConfig));
 
-        final RunningAverageMetric.Config roundsSinceLastJudgeConfig = new RunningAverageMetric.Config(
-                        CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId)
-                .withUnit("rounds")
-                .withDescription("The number of rounds since the last judge created by this node was observed");
-        roundsSinceLastJudge.put(nodeId, metrics.getOrCreate(roundsSinceLastJudgeConfig));
+        // Temporarily disabled until we properly detect judges in a round
+        //        final RunningAverageMetric.Config roundsSinceLastJudgeConfig = new RunningAverageMetric.Config(
+        //                        CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId)
+        //                .withUnit("rounds")
+        //                .withDescription("The number of rounds since the last judge created by this node was
+        // observed");
+        //        roundsSinceLastJudge.put(nodeId, metrics.getOrCreate(roundsSinceLastJudgeConfig));
     }
 
     /**
@@ -128,8 +130,9 @@ class UptimeMetrics {
         roundsSinceLastConsensusEvent.remove(nodeId);
         metrics.remove(new RunningAverageMetric.Config(CATEGORY, ROUNDS_SINCE_LAST_CONSENSUS_EVENT + nodeId));
 
-        roundsSinceLastJudge.remove(nodeId);
-        metrics.remove(new RunningAverageMetric.Config(CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId));
+        // Temporarily disabled until we properly detect judges in a round
+        //        roundsSinceLastJudge.remove(nodeId);
+        //        metrics.remove(new RunningAverageMetric.Config(CATEGORY, ROUNDS_SINCE_LAST_JUDGE + nodeId));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeTracker.java
@@ -163,11 +163,13 @@ public class UptimeTracker {
             @NonNull final Round round,
             @NonNull final Map<NodeId, ConsensusEvent> lastEventsInRoundByCreator,
             @NonNull final Map<NodeId, ConsensusEvent> judgesByCreator) {
+
         round.forEach(event -> {
             lastEventsInRoundByCreator.put(event.getCreatorId(), event);
-            if (((EventImpl) event).isFamous()) {
-                judgesByCreator.put(event.getCreatorId(), event);
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            if (((EventImpl) event).isFamous()) {
+            //                judgesByCreator.put(event.getCreatorId(), event);
+            //            }
         });
 
         final ConsensusEvent lastSelfEvent = lastEventsInRoundByCreator.get(selfId);
@@ -196,10 +198,11 @@ public class UptimeTracker {
                 uptimeData.recordLastEvent((EventImpl) lastEvent);
             }
 
-            final ConsensusEvent judge = judgesByCreator.get(address.getNodeId());
-            if (judge != null) {
-                uptimeData.recordLastJudge((EventImpl) judge);
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            final ConsensusEvent judge = judgesByCreator.get(address.getNodeId());
+            //            if (judge != null) {
+            //                uptimeData.recordLastJudge((EventImpl) judge);
+            //            }
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
@@ -153,13 +153,15 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            if (judge != null) {
+            //                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(1, genesisUptimeData.getLastEventRound(address.getNodeId()));
@@ -204,17 +206,21 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(
-                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(
-                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            if (judge != null) {
+            //                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(2, nextRoundUptimeData.getLastEventRound(address.getNodeId()));
@@ -286,13 +292,15 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            //            if (judge != null) {
+            //                assertEquals(1, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(1, genesisUptimeData.getLastEventRound(address.getNodeId()));
@@ -343,17 +351,21 @@ class UptimeTests {
                 lastEvent = event;
             }
 
-            if (judge != null) {
-                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(judge.getConsensusTimestamp(), nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            } else {
-                assertEquals(
-                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
-                assertEquals(
-                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
-                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
-            }
+            // Temporarily disabled until we properly detect judges in a round
+            assertEquals(NO_ROUND, genesisUptimeData.getLastJudgeRound(address.getNodeId()));
+            assertNull(genesisUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            if (judge != null) {
+            //                assertEquals(2, nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(judge.getConsensusTimestamp(),
+            // nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            } else {
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeRound(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeRound(address.getNodeId()));
+            //                assertEquals(
+            //                        genesisUptimeData.getLastJudgeTime(address.getNodeId()),
+            //                        nextRoundUptimeData.getLastJudgeTime(address.getNodeId()));
+            //            }
 
             if (lastEvent != null) {
                 assertEquals(2, nextRoundUptimeData.getLastEventRound(address.getNodeId()));


### PR DESCRIPTION
Fixes an ISS observed in testing. Related to #7369. Must be cherry picked to `develop` if merged after the 0.40 branch is cut.
