### PR TITLE
7271: All data sources used by services set RAM to disk hashes threshold to 0

### DIFF
--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -15,6 +15,7 @@ sync.syncProtocolPermitCount,                  2                            # di
 
 jasperDb.iteratorInputBufferBytes,             16777216
 merkleDb.iteratorInputBufferBytes,             16777216
+merkleDb.hashesRamToDiskThreshold,             8388608
 state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         300                          # differs from mainnet
 state.signedStateDisk,                         3                            # differs from mainnet

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -15,6 +15,7 @@ sync.syncProtocolPermitCount,                  2                            # di
 
 jasperDb.iteratorInputBufferBytes,             16777216
 merkleDb.iteratorInputBufferBytes,             16777216
+merkleDb.hashesRamToDiskThreshold,             8388608
 state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         300                          # differs from mainnet
 state.signedStateDisk,                         5

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -15,6 +15,7 @@ sync.syncProtocolPermitCount,                  17
 
 jasperDb.iteratorInputBufferBytes,             16777216
 merkleDb.iteratorInputBufferBytes,             16777216
+merkleDb.hashesRamToDiskThreshold,             8388608
 state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -15,6 +15,7 @@ sync.syncProtocolPermitCount,                  4                            # di
 
 jasperDb.iteratorInputBufferBytes,             16777216
 merkleDb.iteratorInputBufferBytes,             16777216
+merkleDb.hashesRamToDiskThreshold,             8388608
 state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -15,6 +15,7 @@ sync.syncProtocolPermitCount,                  4                            # di
 
 jasperDb.iteratorInputBufferBytes,             16777216
 merkleDb.iteratorInputBufferBytes,             16777216
+merkleDb.hashesRamToDiskThreshold,             8388608
 state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -15,6 +15,7 @@ sync.syncProtocolPermitCount,                  4                            # di
 
 jasperDb.iteratorInputBufferBytes,             16777216
 merkleDb.iteratorInputBufferBytes,             16777216
+merkleDb.hashesRamToDiskThreshold,             8388608
 state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactory.java
@@ -58,7 +58,6 @@ public class VirtualMapFactory {
     private static final long MAX_ACCOUNTS = 100_000_000L;
     private static final long MAX_TOKEN_RELS = 100_000_000L;
     private static final long MAX_SCHEDULE_SECONDS = 500_000_000;
-    private static final long MAX_IN_MEMORY_HASHES = 0;
     private static final long MAX_MINTABLE_NFTS = 500_000_000L;
     private static final boolean PREFER_DISK_BASED_INDICIES = false;
 
@@ -116,7 +115,6 @@ public class VirtualMapFactory {
                     new VirtualBlobMerkleDbValueSerializer());
             tableConfig.maxNumberOfKeys(MAX_BLOBS);
             tableConfig.preferDiskIndices(PREFER_DISK_BASED_INDICIES);
-            tableConfig.hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
             dsBuilder = new MerkleDbDataSourceBuilder<>(storageDir, tableConfig);
         } else {
             final var blobKeySerializer = new VirtualBlobKeySerializer();
@@ -135,8 +133,7 @@ public class VirtualMapFactory {
                     .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                     .keySerializer(blobKeySerializer)
                     .maxNumOfKeys(MAX_BLOBS)
-                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                    .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         }
         return new VirtualMap<>(BLOBS_VM_NAME, dsBuilder);
     }
@@ -160,7 +157,6 @@ public class VirtualMapFactory {
                     new IterableContractMerkleDbValueSerializer());
             tableConfig.maxNumberOfKeys(MAX_STORAGE_ENTRIES);
             tableConfig.preferDiskIndices(PREFER_DISK_BASED_INDICIES);
-            tableConfig.hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
             dsBuilder = new MerkleDbDataSourceBuilder<>(storageDir, tableConfig);
         } else {
             final var storageKeySerializer = new ContractKeySerializer();
@@ -179,8 +175,7 @@ public class VirtualMapFactory {
                     .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                     .keySerializer(storageKeySerializer)
                     .maxNumOfKeys(MAX_STORAGE_ENTRIES)
-                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                    .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         }
         return new VirtualMap<>(ITERABLE_STORAGE_VM_NAME, dsBuilder);
     }
@@ -204,8 +199,7 @@ public class VirtualMapFactory {
                 .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                 .keySerializer(keySerializer)
                 .maxNumOfKeys(MAX_SCHEDULES)
-                .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         return new VirtualMap<>(SCHEDULE_LIST_STORAGE_VM_NAME, dsBuilder);
     }
 
@@ -229,8 +223,7 @@ public class VirtualMapFactory {
                 .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                 .keySerializer(keySerializer)
                 .maxNumOfKeys(MAX_SCHEDULE_SECONDS)
-                .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         return new VirtualMap<>(SCHEDULE_TEMPORAL_STORAGE_VM_NAME, dsBuilder);
     }
 
@@ -254,8 +247,7 @@ public class VirtualMapFactory {
                 .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                 .keySerializer(keySerializer)
                 .maxNumOfKeys(MAX_SCHEDULES)
-                .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         return new VirtualMap<>(SCHEDULE_EQUALITY_STORAGE_VM_NAME, dsBuilder);
     }
 
@@ -278,7 +270,6 @@ public class VirtualMapFactory {
                     new OnDiskAccountMerkleDbValueSerializer());
             tableConfig.maxNumberOfKeys(MAX_ACCOUNTS);
             tableConfig.preferDiskIndices(PREFER_DISK_BASED_INDICIES);
-            tableConfig.hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
             dsBuilder = new MerkleDbDataSourceBuilder<>(storageDir, tableConfig);
         } else {
             final var keySerializer = new EntityNumVirtualKeySerializer();
@@ -298,8 +289,7 @@ public class VirtualMapFactory {
                     .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                     .keySerializer(keySerializer)
                     .maxNumOfKeys(MAX_ACCOUNTS)
-                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                    .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         }
         return new VirtualMap<>(ON_DISK_ACCOUNT_STORAGE_VM_NAME, dsBuilder);
     }
@@ -323,7 +313,6 @@ public class VirtualMapFactory {
                     new OnDiskTokenRelMerkleDbValueSerializer());
             tableConfig.maxNumberOfKeys(MAX_TOKEN_RELS);
             tableConfig.preferDiskIndices(PREFER_DISK_BASED_INDICIES);
-            tableConfig.hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
             dsBuilder = new MerkleDbDataSourceBuilder<>(storageDir, tableConfig);
         } else {
             final var keySerializer = new EntityNumVirtualKeySerializer();
@@ -344,8 +333,7 @@ public class VirtualMapFactory {
                     .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                     .keySerializer(keySerializer)
                     .maxNumOfKeys(MAX_TOKEN_RELS)
-                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES)
-                    .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                    .preferDiskBasedIndexes(PREFER_DISK_BASED_INDICIES);
         }
         return new VirtualMap<>(ON_DISK_TOKEN_RELS_STORAGE_VM_NAME, dsBuilder);
     }
@@ -369,7 +357,6 @@ public class VirtualMapFactory {
                     new UniqueTokenMerkleDbValueSerializer());
             tableConfig.maxNumberOfKeys(MAX_MINTABLE_NFTS);
             tableConfig.preferDiskIndices(false);
-            tableConfig.hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
             dsBuilder = new MerkleDbDataSourceBuilder<>(storageDir, tableConfig);
         } else {
             final var storageKeySerializer = new UniqueTokenKeySerializer();
@@ -390,8 +377,7 @@ public class VirtualMapFactory {
                     .virtualInternalRecordSerializer(new VirtualHashRecordSerializer())
                     .keySerializer(storageKeySerializer)
                     .maxNumOfKeys(MAX_MINTABLE_NFTS)
-                    .preferDiskBasedIndexes(false)
-                    .hashesRamToDiskThreshold(MAX_IN_MEMORY_HASHES);
+                    .preferDiskBasedIndexes(false);
         }
         return new VirtualMap<>(UNIQUE_TOKENS_VM_NAME, dsBuilder);
     }

--- a/hedera-node/settings.txt
+++ b/hedera-node/settings.txt
@@ -12,3 +12,4 @@ useLoopbackIp,                                 false
 waitAtStartup,                                 false
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 maxEventQueueForCons,                          1000
+merkleDb.hashesRamToDiskThreshold,             8388608


### PR DESCRIPTION
Fix summary:

* Hard-coded RAM to disk threshold of 0 for hashes is removed from `VirtualMapFactory`. It lets the threshold to be set using config
* Default value in `MerkleDbConfig` for the threshold is 0. To benefit from RAM hashes, the value is overridden for all networks and dev to 8388608 (about 8Mb)

Fixes: https://github.com/hashgraph/hedera-services/issues/7271
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
