### PR TITLE
07393 - AddressBookInitializer Check For Genesis State

### DIFF
--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -32,7 +32,6 @@ import static com.swirlds.logging.LogMarker.STARTUP;
 import static com.swirlds.platform.state.address.AddressBookInitializer.CONFIG_ADDRESS_BOOK_HEADER;
 import static com.swirlds.platform.state.address.AddressBookInitializer.CONFIG_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_HEADER;
-import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_NULL;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
 
@@ -404,13 +403,14 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
 
         final AddressBook platformAddressBook = platform.getAddressBook();
         final AddressBook configAddressBook = getConfigAddressBook();
+        final AddressBook stateAddressBook = getStateAddressBook();
         final AddressBook usedAddressBook = getUsedAddressBook();
         final AddressBook updatedAddressBook = updateWeight(configAddressBook.copy(), context);
 
         return equalsAsConfigText(platformAddressBook, configAddressBook, true)
                 && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
-                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false)
-                && theStateAddressBookWasNull(true);
+                && equalsAsConfigText(platformAddressBook, stateAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false);
     }
 
     private boolean genesisForceUseOfConfigAddressBookTrue(@NonNull final AddressBookTestScenario testScenario)
@@ -421,13 +421,14 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
 
         final AddressBook platformAddressBook = platform.getAddressBook();
         final AddressBook configAddressBook = getConfigAddressBook();
+        final AddressBook stateAddressBook = getStateAddressBook();
         final AddressBook usedAddressBook = getUsedAddressBook();
         final AddressBook updatedAddressBook = updateWeight(configAddressBook.copy(), context);
 
         return equalsAsConfigText(platformAddressBook, configAddressBook, true)
                 && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, stateAddressBook, true)
                 && equalsAsConfigText(platformAddressBook, updatedAddressBook, false)
-                && theStateAddressBookWasNull(true)
                 && theConfigurationAddressBookWasUsed();
     }
 
@@ -505,28 +506,6 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
                         EXCEPTION.getMarker(),
                         "The address books are equal as config text. {}",
                         StackTrace.getStackTrace());
-            }
-        }
-        return pass;
-    }
-
-    /**
-     * This test passes if expectedResult is true and the state address book was null, or if expectedResult is false and
-     * the state address book was not null.
-     *
-     * @param expectedResult the expected result of the test.
-     * @return true if the test passes, false otherwise.
-     */
-    private boolean theStateAddressBookWasNull(final boolean expectedResult) throws IOException {
-        final String fileContents = getLastAddressBookFileEndsWith(DEBUG);
-        final String textAfterStateHeader = getTextAfterHeader(fileContents, STATE_ADDRESS_BOOK_HEADER);
-        final boolean pass = textAfterStateHeader.contains(STATE_ADDRESS_BOOK_NULL) == expectedResult;
-        if (!pass) {
-            if (expectedResult) {
-                logger.error(
-                        EXCEPTION.getMarker(), "The state address book was not null. {}", StackTrace.getStackTrace());
-            } else {
-                logger.error(EXCEPTION.getMarker(), "The state address book was null. {}", StackTrace.getStackTrace());
             }
         }
         return pass;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -19,7 +19,6 @@ package com.swirlds.platform;
 import static com.swirlds.platform.state.address.AddressBookInitializer.CONFIG_ADDRESS_BOOK_HEADER;
 import static com.swirlds.platform.state.address.AddressBookInitializer.CONFIG_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_HEADER;
-import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_NULL;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +43,6 @@ import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.test.framework.config.TestConfigBuilder;
 import com.swirlds.test.framework.context.TestPlatformContextBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -64,31 +62,11 @@ class AddressBookInitializerTest {
     Path testDirectory;
 
     @Test
-    @DisplayName("Force the use of the config address book, null signed state")
-    void forceUseOfConfigAddressBookNullSignedState() throws IOException {
+    @DisplayName("Force the use of the config address book")
+    void forceUseOfConfigAddressBook() throws IOException {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
-        final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(2),
-                // no software upgrade
-                false,
-                getMockSignedState(0),
-                configAddressBook,
-                getPlatformContext(true));
-        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
-        assertEquals(
-                configAddressBook,
-                inititializedAddressBook,
-                "The initial address book must equal the config address book.");
-        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
-    }
-
-    @Test
-    @DisplayName("Force the use of the config address book, non-null signed state")
-    void forceUseOfConfigAddressBookNonNullSignedState() throws IOException {
-        clearTestDirectory();
-        final AddressBook configAddressBook = getRandomAddressBook();
-        SignedState signedState = getMockSignedState(1);
+        final SignedState signedState = getMockSignedState7WeightRandomAddressBook();
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
@@ -106,15 +84,16 @@ class AddressBookInitializerTest {
     }
 
     @Test
-    @DisplayName("No state loaded from disk. Config.txt Initializes Address Book.")
+    @DisplayName("Genesis. Config.txt Initializes Address Book.")
     void noStateLoadedFromDisk() throws IOException {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
+        final SignedState signedState = getMockSignedState(10, configAddressBook, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
-                getMockSignedState(0),
+                signedState,
                 configAddressBook,
                 getPlatformContext(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
@@ -122,7 +101,8 @@ class AddressBookInitializerTest {
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the expected address book.");
-        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
     }
 
     @Test
@@ -130,11 +110,12 @@ class AddressBookInitializerTest {
     void noStateLoadedFromDiskGenesisStateSetZeroWeight() throws IOException {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
+        final SignedState signedState = getMockSignedState(10, configAddressBook, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
-                getMockSignedState(0),
+                signedState,
                 configAddressBook,
                 getPlatformContext(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
@@ -142,7 +123,8 @@ class AddressBookInitializerTest {
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the config address book.");
-        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
     }
 
     @Test
@@ -150,11 +132,12 @@ class AddressBookInitializerTest {
     void noStateLoadedFromDiskGenesisStateChangedAddressBook() throws IOException {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
+        final SignedState signedState = getMockSignedState(7, configAddressBook, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
-                getMockSignedState(0),
+                signedState,
                 configAddressBook,
                 getPlatformContext(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
@@ -162,14 +145,15 @@ class AddressBookInitializerTest {
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the config address book.");
-        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
     }
 
     @Test
     @DisplayName("Current software version is equal to state software version.")
     void currentVersionEqualsStateVersion() throws IOException {
         clearTestDirectory();
-        final SignedState signedState = getMockSignedState(2);
+        final SignedState signedState = getMockSignedState(2, getRandomAddressBook(), false);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 10);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
@@ -191,7 +175,7 @@ class AddressBookInitializerTest {
     @DisplayName("Version upgrade, SwirldState set 0 weight.")
     void versionUpgradeSwirldStateZeroWeight() throws IOException {
         clearTestDirectory();
-        final SignedState signedState = getMockSignedState(2, 0);
+        final SignedState signedState = getMockSignedState(0, getRandomAddressBook(), false);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 10);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(3),
@@ -213,7 +197,7 @@ class AddressBookInitializerTest {
     @DisplayName("Version upgrade, Swirld State modified the address book.")
     void versionUpgradeSwirldStateModifiedAddressBook() throws IOException {
         clearTestDirectory();
-        final SignedState signedState = getMockSignedState(2, 2);
+        final SignedState signedState = getMockSignedState(2, getRandomAddressBook(), false);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 3);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(3),
@@ -235,7 +219,7 @@ class AddressBookInitializerTest {
     @DisplayName("Version upgrade, Swirld State updates weight successfully.")
     void versionUpgradeSwirldStateWeightUpdateWorks() throws IOException {
         clearTestDirectory();
-        final SignedState signedState = getMockSignedState(2);
+        final SignedState signedState = getMockSignedState7WeightRandomAddressBook();
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 5);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(3),
@@ -298,48 +282,39 @@ class AddressBookInitializerTest {
     }
 
     /**
-     * Creates a mock signed state with the given scenario and a SwirldState that sets all addresses to have weight =
-     * 7.
+     * Creates a mock signed state and a SwirldState that sets all addresses to have weight = 7.
      *
-     * @param scenario The scenario of mock signed state to create.
-     * @return The mock SignedState with the input scenario loaded.
+     * @return The mock SignedState.
      */
-    private SignedState getMockSignedState(final int scenario) {
-        return getMockSignedState(scenario, 7);
+    private SignedState getMockSignedState7WeightRandomAddressBook() {
+        return getMockSignedState(7, getRandomAddressBook(), false);
     }
 
     /**
-     * Creates a mock signed state with the given scenario and a SwirldState that sets all addresses to the given
-     * weightValue.
+     * Creates a mock signed state and a SwirldState that sets all addresses to the given weightValue.
      *
-     * @param scenario    The scenario of mock signed state to create.
-     * @param weightValue The weight value that the SwirldState should set all addresses to in its updateWeight method.
-     * @return The mock SignedState with the input scenario loaded and SwirldState configured to set all addresses with
-     * given weightValue.
+     * @param weightValue      The weight value that the SwirldState should set all addresses to in its updateWeight
+     *                         method.
+     * @param stateAddressBook The address book that the SignedState should return in its getAddressBook method.
+     * @param fromGenesis      Whether the state should be from genesis or not.
+     * @return The mock SignedState and SwirldState configured to set all addresses with given weightValue.
      */
-    private SignedState getMockSignedState(final int scenario, final int weightValue) {
+    private SignedState getMockSignedState(
+            final int weightValue, @NonNull final AddressBook stateAddressBook, boolean fromGenesis) {
         final SignedState signedState = mock(SignedState.class);
-        switch (scenario) {
-                // case 0: null SignedState
-            case 0:
-                return null;
-                // default case: swirldstate exists with given weighting scenario
-            default:
-                final SoftwareVersion softwareVersion = getMockSoftwareVersion(2);
-                final SwirldState swirldState =
-                        getMockSwirldStateSupplier(weightValue).get();
-                final AddressBook stateAddressBook = getRandomAddressBook();
-                when(signedState.getAddressBook()).thenReturn(stateAddressBook);
-                when(signedState.getSwirldState()).thenReturn(swirldState);
-                final PlatformData platformData = mock(PlatformData.class);
-                when(platformData.getCreationSoftwareVersion()).thenReturn(softwareVersion);
-                final PlatformState platformState = mock(PlatformState.class);
-                when(platformState.getPlatformData()).thenReturn(platformData);
-                final State state = mock(State.class);
-                when(state.getPlatformState()).thenReturn(platformState);
-                when(signedState.getState()).thenReturn(state);
-                return signedState;
-        }
+        final SoftwareVersion softwareVersion = getMockSoftwareVersion(2);
+        final SwirldState swirldState = getMockSwirldStateSupplier(weightValue).get();
+        when(signedState.getAddressBook()).thenReturn(stateAddressBook);
+        when(signedState.getSwirldState()).thenReturn(swirldState);
+        final PlatformData platformData = mock(PlatformData.class);
+        when(platformData.getCreationSoftwareVersion()).thenReturn(softwareVersion);
+        final PlatformState platformState = mock(PlatformState.class);
+        when(platformState.getPlatformData()).thenReturn(platformData);
+        final State state = mock(State.class);
+        when(state.getPlatformState()).thenReturn(platformState);
+        when(signedState.getState()).thenReturn(state);
+        when(signedState.isGenesisState()).thenReturn(fromGenesis);
+        return signedState;
     }
 
     /**
@@ -425,7 +400,7 @@ class AddressBookInitializerTest {
     private void assertAddressBookFileContent(
             @NonNull final AddressBookInitializer initializer,
             @NonNull final AddressBook configAddressBook,
-            @Nullable final AddressBook stateAddressBook,
+            @NonNull final AddressBook stateAddressBook,
             @NonNull final AddressBook usedAddressBook)
             throws IOException {
         Objects.requireNonNull(initializer, "The initializer must not be null.");
@@ -463,9 +438,7 @@ class AddressBookInitializerTest {
                 "The configAddressBook content is not:\n" + configText + "\n\n debugFileContent:\n" + debugFileContent);
 
         // check stateAddressBook content
-        final String stateText = stateAddressBook == null
-                ? STATE_ADDRESS_BOOK_HEADER + "\n" + STATE_ADDRESS_BOOK_NULL
-                : STATE_ADDRESS_BOOK_HEADER + "\n" + stateAddressBook.toConfigText();
+        final String stateText = STATE_ADDRESS_BOOK_HEADER + "\n" + stateAddressBook.toConfigText();
         assertTrue(
                 debugFileContent.contains(stateText),
                 "The stateAddressBook content is not:\n" + stateText + "\n\n debugFileContent:\n" + debugFileContent);


### PR DESCRIPTION
**Description**:
The `AddressBookInitializer` will no longer receive a null loaded state from disk, it receives an initial state that must be checked for genesis.  The logic has been updated.  The `AddressBookTestingToolState` and unit tests have been updated to reflect the changed logic. 

**Related issue(s)**:

Fixes #7393 
