### PR TITLE
Scale max stake by a 1.1x factor

### DIFF
--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
@@ -125,6 +125,7 @@ class ConfigCallbacksTest {
         given(addressBook.getSize()).willReturn(numNodes);
         given(dynamicProps.knownBlockValues()).willReturn(blockValues);
         given(dynamicProps.nodeMaxMinStakeRatios()).willReturn(Map.of(0L, 2L, 1L, 8L));
+        final var historicalMaxStake = totalHbarSupply / numNodes;
         final var overrideMaxStake = totalHbarSupply / numNodes * 11 / 10;
         final var config = ServicesConfigurationList.getDefaultInstance();
 
@@ -139,11 +140,11 @@ class ConfigCallbacksTest {
         verify(networkCtx).renumberBlocksToMatch(blockValues);
         // and:
         final var updatedNode0Info = stakingInfos.get(EntityNum.fromLong(0L));
-        assertStakes(updatedNode0Info, overrideMaxStake / 2, overrideMaxStake);
+        assertStakes(updatedNode0Info, historicalMaxStake / 2, overrideMaxStake);
         final var updatedNode1Info = stakingInfos.get(EntityNum.fromLong(1L));
-        assertStakes(updatedNode1Info, overrideMaxStake / 8, overrideMaxStake);
+        assertStakes(updatedNode1Info, historicalMaxStake / 8, overrideMaxStake);
         final var updatedNode2Info = stakingInfos.get(EntityNum.fromLong(2L));
-        assertStakes(updatedNode2Info, overrideMaxStake / 4, overrideMaxStake);
+        assertStakes(updatedNode2Info, historicalMaxStake / 4, overrideMaxStake);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
@@ -116,16 +116,16 @@ class ConfigCallbacksTest {
     @Test
     void propertiesCbAsExpected() {
         final var numNodes = 10;
-        final var hbarFloat = 50_000_000_000L * 100_000_000L;
+        final var totalHbarSupply = 50_000_000_000L * 100_000_000L;
         final var expiryResourceLoc = "something.json";
         givenWellKnownStakingInfos();
-        given(properties.getLongProperty(LEDGER_TOTAL_TINY_BAR_FLOAT)).willReturn(hbarFloat);
+        given(properties.getLongProperty(LEDGER_TOTAL_TINY_BAR_FLOAT)).willReturn(totalHbarSupply);
         given(properties.getStringProperty(EXPIRY_THROTTLE_RESOURCE)).willReturn(expiryResourceLoc);
         given(properties.getAccessListProperty(EXPIRY_MIN_CYCLE_ENTRY_CAPACITY)).willReturn(minReqUnitOfWork);
         given(addressBook.getSize()).willReturn(numNodes);
         given(dynamicProps.knownBlockValues()).willReturn(blockValues);
         given(dynamicProps.nodeMaxMinStakeRatios()).willReturn(Map.of(0L, 2L, 1L, 8L));
-        final var overrideMaxStake = hbarFloat / numNodes;
+        final var overrideMaxStake = totalHbarSupply / numNodes * 11 / 10;
         final var config = ServicesConfigurationList.getDefaultInstance();
 
         // when:


### PR DESCRIPTION
**Description**:
 - Increases the max stake limit to `1.1 * 50B / (# of nodes)` instead of `50B / (# of nodes)`.