### PR TITLE
Use `0.40.0` + `v0.40.0` proto assets

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -102,8 +102,8 @@ gradleEnterprise {
 
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
-val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
+val hapiProtoVersion = "0.40.0"
+val hapiProtoBranchOrTag = "v0.40.0" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
**Description**:
Updates _settings.gradle.kts_ with stable proto assets.

**Note to reviewers:** The `itest` [failure](https://scans.gradle.com/s/pdgucgmm2klzg/tests/task/:test-clients:itest/details/AllIntegrationTests/concurrentSpecs()%5B1%5D?top-execution=1) is a clearly flaky test that just happened to surface on this PR. Diagnosed and created [this issue](https://github.com/hashgraph/hedera-services/issues/6486) to fix it.