### PR TITLE
Accommodate sig map size variance in `canAutoCreateWithNftTransfersToAlias()`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -171,6 +171,13 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
         return this;
     }
 
+    public AccountInfoAsserts approxBalance(final long amount, final long epsilon) {
+        registerProvider((spec, o) -> assertTrue(
+                Math.abs(((AccountInfo) o).getBalance() - amount) <= epsilon,
+                "Bad balance, expected " + amount + " +/- " + epsilon + ", but was " + ((AccountInfo) o).getBalance()));
+        return this;
+    }
+
     public AccountInfoAsserts expectedBalanceWithChargedUsd(
             final long amount, final double expectedUsdToSubtract, final double allowedPercentDiff) {
         registerProvider((spec, o) -> {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -171,6 +171,13 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
         return this;
     }
 
+    /**
+     * Asserts that the account balance is within epsilon of the given amount.
+     *
+     * @param amount  the expected balance
+     * @param epsilon the allowed difference between the expected and actual balance
+     * @return this
+     */
     public AccountInfoAsserts approxBalance(final long amount, final long epsilon) {
         registerProvider((spec, o) -> assertTrue(
                 Math.abs(((AccountInfo) o).getBalance() - amount) <= epsilon,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -359,7 +359,10 @@ public class AutoAccountCreationSuite extends HapiSuite {
 
     private HapiSpec canAutoCreateWithNftTransfersToAlias() {
         final var civilianBal = 10 * ONE_HBAR;
-        final var transferFee = 0.44012644 * ONE_HBAR;
+        // The expected fee to transfer four serial numbers of two token types to a receiver with
+        // no auto-creation; note it is approximate because the fee will vary slightly with the
+        // size of the sig map, depending on the lengths of the public key prefixes required
+        final var approxTransferFee = 0.44012644 * ONE_HBAR;
         final var multiNftTransfer = "multiNftTransfer";
 
         return defaultHapiSpec("canAutoCreateWithNftTransfersToAlias")
@@ -432,7 +435,11 @@ public class AutoAccountCreationSuite extends HapiSuite {
                                         .maxAutoAssociations(2)
                                         .ownedNfts(4))
                                 .logged(),
-                        getAccountInfo(CIVILIAN).has(accountWith().balance((long) (civilianBal - transferFee))))
+                        // A single extra byte in the signature map will cost just ~130 tinybar more, so allowing
+                        // a delta of 2600 tinybar will stabilize this test indefinitely (the spec would have to
+                        // randomly choose two public keys with a shared prefix of length 10, which is...unlikely)
+                        getAccountInfo(CIVILIAN)
+                                .has(accountWith().approxBalance((long) (civilianBal - approxTransferFee), 2600)))
                 .then();
     }
 


### PR DESCRIPTION
**Description**:
 - Closes #7485 