### PR TITLE
Change the mini version of running cron jobs of nightly regression

### DIFF
--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -51,7 +51,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 38 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 40 ]]; then
               continue
             fi
 


### PR DESCRIPTION
No longer need to run nightly regression for release/0.38 and release/0.39
