### PR TITLE
Infrastructure Issue #4393 excessive log retention

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -15,9 +15,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="hgcaa-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -34,9 +34,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="queries-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -52,9 +52,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-sdk-*.log.gz">
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
@@ -70,9 +70,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-vmap-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -89,9 +89,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-hashstream/swirlds-hashstream-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -15,9 +15,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="hgcaa-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -34,9 +34,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="queries-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -52,9 +52,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-sdk-*.log.gz">
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
@@ -70,9 +70,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-vmap-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -89,9 +89,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-hashstream/swirlds-hashstream-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -15,9 +15,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="hgcaa-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -34,9 +34,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="queries-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -52,9 +52,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-sdk-*.log.gz">
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
@@ -70,9 +70,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-vmap-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -89,9 +89,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-hashstream/swirlds-hashstream-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -15,9 +15,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="hgcaa-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -34,9 +34,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="queries-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -52,9 +52,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-sdk-*.log.gz">
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
@@ -70,9 +70,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-vmap-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -89,9 +89,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-hashstream/swirlds-hashstream-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -15,9 +15,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="hgcaa-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -34,9 +34,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="queries-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -52,9 +52,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-sdk-*.log.gz">
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
@@ -70,9 +70,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-vmap-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -89,9 +89,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-hashstream/swirlds-hashstream-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -15,9 +15,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="hgcaa-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -34,9 +34,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="queries-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -52,9 +52,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-sdk-*.log.gz">
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
@@ -70,9 +70,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-vmap-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
@@ -89,9 +89,9 @@
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="20">
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="output" maxDepth="3">
+          <IfFileName glob="swirlds-hashstream/swirlds-hashstream-*.log.gz">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>


### PR DESCRIPTION
* Fixed the glob on log4j2.xml rollover strategy delete condition
   * The glob only looked in subfolders, rather than the current folder. * Modified to look in current folder, and up to 2 folders below that.
   * Adjusted the max index proerpty to 10 (from 20).
      * The current environments never exceed 3, so 10 is ample.
   * Retention duration was not modified.
