### PR TITLE
7582: `MerkleHashBuilder` does not scale

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -17,21 +17,20 @@
 package com.swirlds.common.merkle.hash;
 
 import static com.swirlds.common.crypto.engine.CryptoEngine.THREAD_COMPONENT_NAME;
-import static com.swirlds.common.merkle.iterators.MerkleIterationOrder.POST_ORDERED_DEPTH_FIRST_RANDOM;
 import static com.swirlds.common.merkle.utility.MerkleConstants.MERKLE_DIGEST_TYPE;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
-import com.swirlds.common.merkle.iterators.MerkleIterator;
 import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.common.threading.futures.StandardFuture;
 import com.swirlds.common.threading.manager.ThreadManager;
 import java.util.Iterator;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,7 +43,7 @@ import org.apache.logging.log4j.Logger;
 public class MerkleHashBuilder {
     private static final Logger logger = LogManager.getLogger(MerkleHashBuilder.class);
 
-    private final Executor threadPool;
+    private final ForkJoinPool threadPool;
 
     private final int cpuThreadCount;
 
@@ -81,7 +80,7 @@ public class MerkleHashBuilder {
                 })
                 .buildFactory();
 
-        this.threadPool = Executors.newFixedThreadPool(cpuThreadCount, threadFactory);
+        this.threadPool = new ForkJoinPool(cpuThreadCount);
     }
 
     /**
@@ -125,7 +124,7 @@ public class MerkleHashBuilder {
         final Iterator<MerkleNode> iterator = root.treeIterator()
                 .setFilter(MerkleHashBuilder::filter)
                 .setDescendantFilter(MerkleHashBuilder::descendantFilter);
-        hashSubtree(iterator, null);
+        hashSubtree(iterator);
         return root.getHash();
     }
 
@@ -143,44 +142,10 @@ public class MerkleHashBuilder {
             return new StandardFuture<>(root.getHash());
         } else {
             final FutureMerkleHash result = new FutureMerkleHash();
-            AtomicInteger activeThreadCount = new AtomicInteger(cpuThreadCount);
-            for (int threadIndex = 0; threadIndex < cpuThreadCount; threadIndex++) {
-                threadPool.execute(createHashingRunnable(threadIndex, activeThreadCount, result, root));
-            }
+            threadPool.submit(new NodeTask(root,
+                    () -> result.set(root.getHash())));
             return result;
         }
-    }
-
-    /**
-     * Create a thread that will attempt to hash the tree starting at the root.
-     *
-     * @param threadId
-     * 		Used to generate a randomized iteration order
-     */
-    private Runnable createHashingRunnable(
-            final int threadId, AtomicInteger activeThreadCount, final FutureMerkleHash result, final MerkleNode root) {
-
-        return () -> {
-            final MerkleIterator<MerkleNode> it = root.treeIterator()
-                    .setFilter(MerkleHashBuilder::filter)
-                    .setDescendantFilter(MerkleHashBuilder::descendantFilter);
-            if (threadId > 0) {
-                // One thread can iterate in-order, all others will use random order.
-                it.setOrder(POST_ORDERED_DEPTH_FIRST_RANDOM);
-            }
-
-            try {
-                hashSubtree(it, activeThreadCount);
-
-                // The last thread to terminate is responsible for setting the future
-                int remainingActiveThreads = activeThreadCount.getAndDecrement() - 1;
-                if (remainingActiveThreads == 0) {
-                    result.set(root.getHash());
-                }
-            } catch (final Throwable t) {
-                result.cancelWithException(t);
-            }
-        };
     }
 
     /**
@@ -188,31 +153,69 @@ public class MerkleHashBuilder {
      *
      * @param it
      * 		An iterator that walks through the tree.
-     * @param activeThreadCount
-     * 		If single threaded then this is null, otherwise contains the number of threads
-     * 		that are actively hashing. Once the active thread count dips below the maximum,
-     * 		this means that one thread has either finished or exploded.
      */
-    private void hashSubtree(final Iterator<MerkleNode> it, final AtomicInteger activeThreadCount) {
+    private void hashSubtree(final Iterator<MerkleNode> it) {
         while (it.hasNext()) {
             final MerkleNode node = it.next();
-            // Potential optimization: if this node is currently locked, do not wait here. Skip it and continue.
-            // This would require a lock object that support the "try lock" paradigm.
-            synchronized (node) {
-                if (activeThreadCount != null && activeThreadCount.get() != cpuThreadCount) {
-                    break;
-                }
 
-                if (node.getHash() != null) {
-                    continue;
-                }
-
-                if (node.isLeaf()) {
-                    merkleCryptography.digestSync(node.asLeaf(), MERKLE_DIGEST_TYPE);
-                } else {
-                    merkleCryptography.digestSync(node.asInternal(), MERKLE_DIGEST_TYPE);
-                }
+            if (node.getHash() != null) {
+                continue;
             }
+
+            merkleCryptography.digestSync(node, MERKLE_DIGEST_TYPE);
         }
     }
+
+    class NodeTask extends ForkJoinTask<Void> {
+        MerkleNode node;
+        Runnable done;
+
+        NodeTask(final MerkleNode node, final Runnable done) {
+            this.node = node;
+            this.done = done;
+        }
+
+        @Override
+        public Void getRawResult() {
+            return null;
+        }
+
+        @Override
+        protected void setRawResult(Void value) {
+        }
+
+        @Override
+        public boolean exec() {
+            try {
+                if (node == null || node.getHash() != null) {
+                    done.run();
+                } else if (node.isLeaf()) {
+                    complete();
+                } else {
+                    MerkleInternal internal = node.asInternal();
+                    int nChildren = internal.getNumberOfChildren();
+                    if (nChildren == 0) {
+                        complete();
+                    } else {
+                        final AtomicInteger subTasks = new AtomicInteger(nChildren);
+                        for (int childIndex = 0; childIndex < nChildren; childIndex++) {
+                            MerkleNode child = internal.getChild(childIndex);
+                            new NodeTask(child, () -> {
+                                if (subTasks.decrementAndGet() == 0) complete();
+                            }).fork();
+                        }
+                    }
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+            return true;
+        }
+
+        void complete() {
+            merkleCryptography.digestSync(node, MERKLE_DIGEST_TYPE);
+            done.run();
+        }
+    }
+
 }


### PR DESCRIPTION
This is a POC implementation of a new task based approach to hashing a Merkle tree.

For better comparison of sequential and parallel algorithms in `MerkleHashBuilder`, a simpler version of `hashSubtree` stripped of all synchronization overhead is provided. With the number of iterations increased 10x for better accuracy, the measurements on a 10-core Mac laptop and a 40-core Linux GCP instance are:

```
---------------------+--------------+---------------+-----------
Average time to hash |    Sync(us)  |	Async(us)   |	Speedup
---------------------+--------------+---------------+-----------
Mac                  |              |               |
Hash Small Trees     |	6093.5059   |	4815.7013   |	1.27
Hash Large Trees     |	117384.588  |	75344.401   |	1.56
Hash Huge Trees	     |	1202051.4   |	711233.94   |	1.69
---------------------+--------------+---------------+-----------
Linux                |              |               |
Hash Small Trees     |	8150.0404   |	10278.0878  |	0.79
Hash Large Trees     |	165283.117  |	188204.701  |	0.88
Hash Huge Trees	     |	1682274.01  |	1771549.37  |	0.95
```

The task based implementation in this PR scales better though far from ideal:
```
-------------------+----------------+---------------+-----------
                   |	Sync(us)    |	Async(us)   |	Speedup
-------------------+----------------+---------------+-----------
Mac                |                |               |
Hash Small Trees   |	6242.5819   |	2792.135    |	2.24
Hash Large Trees   |	119947.152  |	52856.913   |	2.27
Hash Huge Trees	   |	1198773.25  |	540906.9    |	2.22
-------------------+----------------+---------------+-----------
Linux              |                |               |
Hash Small Trees   |	8648.2466   |	6942.2488   |	1.25
Hash Large Trees   |	172870.602  |	116463.008  |	1.48
Hash Huge Trees	   |	1717001.11  |	1126450.6   |	1.52
```

**Related issue(s)**:

POC for #7582

