### PR TITLE
03527 Added handling of a special case of NULL_CLASS_ID when handling…

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -150,6 +150,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -150,6 +150,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -150,6 +150,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -150,6 +150,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -150,6 +150,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -150,6 +150,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/log4j2-prod.xml
+++ b/hedera-node/log4j2-prod.xml
@@ -9,6 +9,7 @@
 
     <!-- Exceptions -->
     <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
     <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
     <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
     <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="ACCEPT"     onMismatch="NEUTRAL"/>
@@ -91,6 +92,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="ACCEPT"     onMismatch="NEUTRAL"/>

--- a/hedera-node/log4j2.xml
+++ b/hedera-node/log4j2.xml
@@ -65,6 +65,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/test-clients/src/eet/resources/network/config/log4j2.xml
+++ b/hedera-node/test-clients/src/eet/resources/network/config/log4j2.xml
@@ -65,6 +65,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/hedera-node/test-clients/src/itest/resources/network/config/log4j2.xml
+++ b/hedera-node/test-clients/src/itest/resources/network/config/log4j2.xml
@@ -65,6 +65,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
@@ -439,7 +439,7 @@ public class PlatformTestingToolState extends PartialNaryMerkleInternal implemen
             case ChildIndices.CONFIG:
                 return childClassId == PayloadCfgSimple.CLASS_ID;
             case ChildIndices.NEXT_SEQUENCE_CONSENSUS:
-                return childClassId == NextSeqConsList.CLASS_ID;
+                return childClassId == NextSeqConsList.CLASS_ID || childClassId == NULL_CLASS_ID;
             case ChildIndices.FCM_FAMILY:
                 return childClassId == FCMFamily.CLASS_ID || childClassId == NULL_CLASS_ID;
             case ChildIndices.TRANSACTION_COUNTER:

--- a/platform-sdk/sdk/log4j2.xml
+++ b/platform-sdk/sdk/log4j2.xml
@@ -34,6 +34,7 @@
 
 		<!-- Exceptions -->
 		<MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"    onMismatch="NEUTRAL"/>
@@ -133,6 +134,7 @@
 
 				<!-- Exceptions -->
 				<MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+				<MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 				<MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 				<MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 				<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"    onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-benchmarks/src/jmh/resources/log4j2.xml
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/resources/log4j2.xml
@@ -97,6 +97,7 @@
 
         <!-- Exceptions -->
         <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-cli/log4j2-stdout.xml
+++ b/platform-sdk/swirlds-cli/log4j2-stdout.xml
@@ -34,6 +34,7 @@
 
 		<!-- Exceptions -->
 		<MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"    onMismatch="NEUTRAL"/>
@@ -123,6 +124,7 @@
 
 				<!-- Exceptions -->
 				<MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+				<MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 				<MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 				<MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
 				<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"    onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-logging/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-logging/src/test/resources/log4j2-test.xml
@@ -33,6 +33,7 @@
 
 		<!-- Exceptions -->
 		<MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-platform-core/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-platform-core/src/test/resources/log4j2-test.xml
@@ -21,6 +21,7 @@
 		<!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
 		<!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
 		<MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR"                  onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SYNC" onMatch="DENY" onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/resources/log4j2ForTest.xml
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/resources/log4j2ForTest.xml
@@ -23,6 +23,7 @@
 
 		<!-- Exceptions -->
 		<MarkerFilter marker="EXCEPTION" 				onMatch="ACCEPT" 	onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR"                    onMatch="ACCEPT"    onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS" 		onMatch="ACCEPT" 	onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS" 		onMatch="ACCEPT" 	onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" 	onMatch="DENY" 		onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/resources/log4j2-test.xml
@@ -23,6 +23,7 @@
 
 		<!-- Exceptions -->
 		<MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/resources/log4j2-test.xml
@@ -21,6 +21,7 @@
 		<!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
 		<!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
 		<MarkerFilter marker="EXCEPTION" 				onMatch="ACCEPT" 	onMismatch="NEUTRAL"/>
+		<MarkerFilter marker="ERROR"                    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="TESTING_EXCEPTIONS" 			onMatch="ACCEPT" 	onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SOCKET_EXCEPTIONS" 			onMatch="ACCEPT" 		onMismatch="NEUTRAL"/>
 		<MarkerFilter marker="SYNC"                   onMatch="DENY"    onMismatch="NEUTRAL"/>


### PR DESCRIPTION
Added handling of a special case of NULL_CLASS_ID when handling reconnect with a node in genesis state.

The following exception
```
2023-07-14 06:45:57.394 126      ERROR RECONNECT        <<work group learning-synchronizer: send-and-receive #2>> LearnerThread: exception in the learner's receiving thread
com.swirlds.common.merkle.exceptions.IllegalChildTypeException: Invalid class ID -9223372036854775808(0x8000000000000000) at index 2 for parent with class com.swirlds.demo.platform.PlatformTestingToolState
	at com.swirlds.common.merkle.impl.internal.AbstractMerkleInternal.throwIfInvalidChild(AbstractMerkleInternal.java:157) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at com.swirlds.common.merkle.impl.internal.AbstractMerkleInternal.setChild(AbstractMerkleInternal.java:100) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at com.swirlds.common.merkle.interfaces.MerkleParent.setChild(MerkleParent.java:108) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at com.swirlds.common.merkle.synchronization.views.StandardLearnerTreeView.setChild(StandardLearnerTreeView.java:149) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at com.swirlds.common.merkle.synchronization.views.StandardLearnerTreeView.setChild(StandardLearnerTreeView.java:37) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at com.swirlds.common.merkle.synchronization.internal.LearnerThread.run(LearnerThread.java:265) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at com.swirlds.common.threading.pool.StandardWorkGroup.lambda$execute$1(StandardWorkGroup.java:126) ~[swirlds-common-0.40.0-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

happens because `PlatformTestingToolState `couldn't handle null class id properly (`SerializableStreamConstants#NULL_CLASS_ID`) in case of handling `NEXT_SEQUENCE_CONSENSUS` child index. Given the fact that such value is valid (for example, for genesis state), `PlatformTestingToolState#childHasExpectedType` should allow it for `NEXT_SEQUENCE_CONSENSUS`.

Fixes #https://github.com/swirlds/swirlds-platform-regression/issues/3527

