### PR TITLE
Reset hapiProtoBranch following merge of PR 7243

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
@@ -89,7 +89,6 @@ public class HapiUtils {
      */
     public static boolean isHollow(@NonNull final Account account) {
         requireNonNull(account);
-        requireNonNull(account.accountId());
         return (account.accountIdOrThrow().accountNum() > 1000
                 && account.keyOrElse(EMPTY_KEY_LIST).equals(EMPTY_KEY_LIST)
                 && account.alias() != null

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -103,8 +103,7 @@ gradleEnterprise {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-// val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
-val hapiProtoBranchOrTag = "7243-update-account-ids" // hapiProtoVersion
+val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
- Reset hapiProtoBranch following merge of https://github.com/hashgraph/hedera-protobufs/pull/291/files
- Minor cleanup of an unneeded line of code in HapiUtils

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/pull/7567

Fixes  #7243 

