### PR TITLE
Update `SignedStateHolder` to use `ReservedSignedState` correctly

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -14,32 +14,21 @@
  * limitations under the License.
  */
 
-package com.hedera.services.cli;
+package com.hedera.services.cli.signedstate;
 
-import com.hedera.services.cli.signedstate.SummarizeSignedStateFileCommand;
 import com.swirlds.cli.PlatformCli;
 import com.swirlds.cli.utility.AbstractCommand;
 import com.swirlds.cli.utility.SubcommandOf;
 import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.ParameterException;
-import picocli.CommandLine.Spec;
 
+/**
+ * A subcommand of the {@link PlatformCli}, for dealing with signed state files
+ */
 @CommandLine.Command(
-        name = "example",
+        name = "signed-state",
         mixinStandardHelpOptions = true,
-        description = "Example Pcli Plugin for Services",
-        subcommands = {SummarizeSignedStateFileCommand.class})
+        description = "Operations on signed-state files.")
 @SubcommandOf(PlatformCli.class)
-public final class ExamplePcliPlugin extends AbstractCommand {
-
-    @Spec
-    CommandSpec spec;
-
-    private ExamplePcliPlugin() {}
-
-    @Override
-    public Integer call() {
-        throw new ParameterException(spec.commandLine(), "Please specify a subcommand!");
-    }
+public final class SignedStateCommand extends AbstractCommand {
+    private SignedStateCommand() {}
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -19,23 +19,40 @@ package com.hedera.services.cli.signedstate;
 import com.hedera.node.app.service.mono.ServicesState;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
+import com.hedera.node.app.service.mono.state.virtual.ContractKey;
+import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey.Type;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
+import com.swirlds.common.AutoCloseableNonThrowing;
+import com.swirlds.common.config.ConfigUtils;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
+import com.swirlds.common.config.sources.LegacyFileConfigSource;
 import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.context.DefaultPlatformContext;
-import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedStateFileReader;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Navigates a signed state "file" and returns information from it
@@ -50,39 +67,42 @@ import java.util.Set;
  *
  * <p>Currently implements only operations needed for looking at contracts: - {@link
  * #getAllKnownContracts()} looks in all the accounts to get all the contract ids present, - {@link
- * #getAllContractContents(Collection)} returns a map, indexed by contract id, of the contract
+ * #getAllContractContents(Collection,Collection)} returns a map, indexed by contract id, of the contract
  * bytecodes.
  */
-public class SignedStateHolder {
+@SuppressWarnings("java:S5738") // deprecated classes (several current platform classes have no replacement yet)
+public class SignedStateHolder implements AutoCloseableNonThrowing {
+
+    static final int ESTIMATED_NUMBER_OF_CONTRACTS = 100_000;
+    static final int ESTIMATED_NUMBER_OF_DELETED_CONTRACTS = 10_000;
 
     @NonNull
-    private final Path swh;
+    private final Path swhPath;
 
     @NonNull
-    private ServicesState platformState;
+    private final ReservedSignedState reservedSignedState;
 
-    public SignedStateHolder(@NonNull final Path swhFile) throws Exception {
-        swh = swhFile;
-        platformState = dehydrate();
+    @NonNull
+    private final ServicesState servicesState;
+
+    public SignedStateHolder(@NonNull final Path swhPath, @NonNull final List<Path> configurationPaths) {
+        Objects.requireNonNull(swhPath, "swhPath");
+        Objects.requireNonNull(configurationPaths, "configurationPaths");
+
+        this.swhPath = swhPath;
+        final var state = dehydrate(configurationPaths);
+        reservedSignedState = state.getLeft();
+        servicesState = state.getRight();
     }
 
-    /** Deserialize the signed state file into an in-memory data structure. */
-    private ServicesState dehydrate() throws Exception {
-        // register all applicable classes on classpath before deserializing signed state
-        ConstructableRegistry.getInstance().registerConstructables("*");
-        final PlatformContext platformContext = new DefaultPlatformContext(
-                ConfigurationHolder.getInstance().get(), new NoOpMetrics(), CryptographyHolder.get());
+    @Override
+    public void close() {
+        reservedSignedState.close();
+    }
 
-        // note: reservedSignedState.get() is unsafe because it leaks a reference count
-        // Normally we would hold this with a try-with-resources block
-        // but this is a temporary ok-workaround because we're calling this from within a command-line utility
-        // that will go away immediately after the call
-        platformState = (ServicesState) (SignedStateFileReader.readStateFile(platformContext, swh)
-                .reservedSignedState()
-                .get()
-                .getSwirldState());
-        assertSignedStateComponentExists(platformState, "platform state (Swirlds)");
-        return platformState;
+    public enum Validity {
+        ACTIVE,
+        DELETED
     }
 
     /**
@@ -91,31 +111,37 @@ public class SignedStateHolder {
      * @param ids - direct from the signed state file there's one contract id for each bytecode, but
      *     there are duplicates which can be coalesced and then there's a set of ids for the single
      *     contract
-     * @param bytecode - bytecode of the contractd
+     * @param bytecode - bytecode of the contract
+     * @param validity - whether the contract is valid or note, aka active or deleted
      */
-    public record Contract(@NonNull Set</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode) {
+    public record Contract(
+            @NonNull Set</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode, @NonNull Validity validity) {
 
         @Override
-        public boolean equals(Object o) {
-            return o instanceof Contract other && ids.equals(other.ids) && Arrays.equals(bytecode, other.bytecode);
+        public boolean equals(final Object o) {
+            if (o == null) return false;
+            if (o == this) return true;
+            return o instanceof Contract other
+                    && new EqualsBuilder()
+                            .append(ids, other.ids)
+                            .append(bytecode, other.bytecode)
+                            .append(validity, other.validity)
+                            .isEquals();
         }
 
         @Override
         public int hashCode() {
-            return ids.hashCode() * 31 + Arrays.hashCode(bytecode);
+            return new HashCodeBuilder(17, 37)
+                    .append(ids)
+                    .append(bytecode)
+                    .append(validity)
+                    .toHashCode();
         }
 
         @Override
         public String toString() {
-
-            var csvIds = new StringBuilder(250);
-            for (var id : ids()) {
-                csvIds.append(id); // hides a `toString` which is why `String::join` isn't enough
-                csvIds.append(',');
-            }
-            csvIds.setLength(csvIds.length() - 1);
-
-            return "Contract{ids=(%s), bytecode=%s}".formatted(csvIds.toString(), Arrays.toString(bytecode));
+            var csvIds = ids.stream().map(Object::toString).collect(Collectors.joining(","));
+            return "Contract{ids=(%s), %s, bytecode=%s}".formatted(csvIds, validity, Arrays.toString(bytecode));
         }
     }
 
@@ -123,30 +149,79 @@ public class SignedStateHolder {
      * All contracts extracted from a signed state file
      *
      * @param contracts - dictionary of contract bytecodes indexed by their contract id (as a Long)
+     * @param deletedContracts - collection of ids of deleted contracts
      * @param registeredContractsCount - total #contracts known to the _accounts_ in the signed
      *     state file (not all actually have bytecodes in the file store, and of those, some have
      *     0-length bytecode files)
      */
-    public record Contracts(@NonNull Collection</*@NonNull*/ Contract> contracts, int registeredContractsCount) {}
+    public record Contracts(
+            @NonNull Collection</*@NonNull*/ Contract> contracts,
+            @NonNull Collection<Integer> deletedContracts,
+            int registeredContractsCount) {}
 
     /**
-     * Convenience method: Given the signed state file's name (the `.swh` file) return all the
-     * bytecodes for all the contracts in that state.
+     * Return all the bytecodes for all the contracts in this state.
      */
-    public static @NonNull Contracts getContracts(@NonNull final Path inputFile) throws Exception {
-        final var signedState = new SignedStateHolder(inputFile);
-        final var contractIds = signedState.getAllKnownContracts();
-        final var contractContents = signedState.getAllContractContents(contractIds);
-        return new Contracts(contractContents, contractIds.size());
+    @NonNull
+    public Contracts getContracts() {
+        final var contractIds = getAllKnownContracts();
+        final var deletedContractIds = getAllDeletedContracts();
+        final var contractContents = getAllContractContents(contractIds, deletedContractIds);
+        return new Contracts(contractContents, deletedContractIds, contractIds.size());
     }
 
-    public @NonNull ServicesState getPlatformState() {
-        return platformState;
+    /**
+     * Returns all contracts known via Hedera accounts, by their contract id (lowered to an Integer)
+     */
+    @NonNull
+    public Set</*@NonNull*/ Integer> getAllKnownContracts() {
+        final var ids = new HashSet<Integer>(ESTIMATED_NUMBER_OF_CONTRACTS);
+        getAccounts().forEach((k, v) -> {
+            if (null != k && null != v && v.isSmartContract()) ids.add(k.intValue());
+        });
+        return ids;
+    }
+
+    /** Returns the ids of all deleted contracts ("self-destructed") */
+    @NonNull
+    public Set</*@NonNull*/ Integer> getAllDeletedContracts() {
+        final var ids = new HashSet<Integer>(ESTIMATED_NUMBER_OF_DELETED_CONTRACTS);
+        getAccounts().forEach((k, v) -> {
+            if (null != k && null != v && v.isSmartContract() && v.isDeleted()) ids.add(k.intValue());
+        });
+        return ids;
+    }
+
+    /** Returns the bytecodes for all the requested contracts */
+    @NonNull
+    public Collection</*@NonNull*/ Contract> getAllContractContents(
+            @NonNull final Collection</*@NonNull*/ Integer> contractIds,
+            @NonNull final Collection</*@NonNull*/ Integer> deletedContractIds) {
+        Objects.requireNonNull(contractIds);
+        Objects.requireNonNull(deletedContractIds);
+
+        final var fileStore = getFileStore();
+        final var codes = new ArrayList<Contract>(ESTIMATED_NUMBER_OF_CONTRACTS);
+        for (final var cid : contractIds) {
+            final var vbk = new VirtualBlobKey(Type.CONTRACT_BYTECODE, cid);
+            if (fileStore.containsKey(vbk)) {
+                final var blob = fileStore.get(vbk);
+                if (null != blob) {
+                    final var c = new Contract(
+                            Set.of(cid),
+                            blob.getData(),
+                            deletedContractIds.contains(cid) ? Validity.DELETED : Validity.ACTIVE);
+                    codes.add(c);
+                }
+            }
+        }
+        return codes;
     }
 
     /** Gets all existing accounts */
-    public @NonNull AccountStorageAdapter getAccounts() {
-        final var accounts = platformState.accounts();
+    @NonNull
+    public AccountStorageAdapter getAccounts() {
+        final var accounts = servicesState.accounts();
         assertSignedStateComponentExists(accounts, "accounts");
         return accounts;
     }
@@ -156,49 +231,95 @@ public class SignedStateHolder {
      *
      * <p>The file state contains, among other things, all the contracts' bytecodes.
      */
-    public @NonNull VirtualMapLike<VirtualBlobKey, VirtualBlobValue> getFileStore() {
-        final var fileStore = platformState.storage();
+    @NonNull
+    public VirtualMapLike<VirtualBlobKey, VirtualBlobValue> getFileStore() {
+        final var fileStore = servicesState.storage();
         assertSignedStateComponentExists(fileStore, "fileStore");
         return fileStore;
     }
 
-    /**
-     * Returns all contracts known via Hedera accounts, by their contract id (lowered to an Integer)
-     */
-    public @NonNull Set</*@NonNull*/ Integer> getAllKnownContracts() {
-        var ids = new HashSet<Integer>();
-        getAccounts().forEach((k, v) -> {
-            if (null != k && null != v && v.isSmartContract()) ids.add(k.intValue());
-        });
-        return ids;
+    @NonNull
+    public VirtualMapLike<ContractKey, IterableContractValue> getRawContractStorage() {
+        final var rawContractStorage = servicesState.contractStorage();
+        assertSignedStateComponentExists(rawContractStorage, "contractStorage");
+        return rawContractStorage;
     }
 
-    /** Returns the bytecodes for all the requested contracts */
-    public @NonNull Collection</*@NonNull*/ Contract> getAllContractContents(
-            @NonNull final Collection</*@NonNull*/ Integer> contractIds) {
+    /** Deserialize the signed state file into an in-memory data structure. */
+    @NonNull
+    private Pair<ReservedSignedState, ServicesState> dehydrate(@NonNull final List<Path> configurationPaths) {
+        Objects.requireNonNull(configurationPaths, "configurationPaths");
 
-        final var fileStore = getFileStore();
-        var codes = new ArrayList<Contract>();
-        for (var cid : contractIds) {
-            final var vbk = new VirtualBlobKey(Type.CONTRACT_BYTECODE, cid);
-            if (fileStore.containsKey(vbk)) {
-                final var blob = fileStore.get(vbk);
-                if (null != blob) {
-                    final var c = new Contract(Set.of(cid), blob.getData());
-                    codes.add(c);
-                }
+        registerConstructables();
+
+        final var platformContext = new DefaultPlatformContext(
+                buildConfiguration(configurationPaths), new NoOpMetrics(), CryptographyHolder.get());
+
+        ReservedSignedState rss;
+        try {
+            rss = SignedStateFileReader.readStateFile(platformContext, swhPath).reservedSignedState();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        if (null == rss) throw new MissingSignedStateComponent("ReservedSignedState", swhPath);
+
+        final var swirldsState = rss.get().getSwirldState();
+        if (!(swirldsState instanceof ServicesState)) { // Java booboo: precedence level of `instanceof` is way too low
+            rss.close();
+            throw new MissingSignedStateComponent("ServicesState", swhPath);
+        }
+
+        return Pair.of(rss, (ServicesState) swirldsState);
+    }
+
+    /** Build a configuration object from the provided configuration paths. */
+    private Configuration buildConfiguration(@NonNull final List<Path> configurationPaths) {
+        Objects.requireNonNull(configurationPaths, "configurationPaths");
+
+        final var builder = ConfigurationBuilder.create();
+        ConfigUtils.scanAndRegisterAllConfigTypes(builder, Set.of("com.swirlds"));
+
+        for (@NonNull final var path : configurationPaths) {
+            Objects.requireNonNull(path, "path");
+            try {
+                builder.withSource(new LegacyFileConfigSource(path));
+            } catch (final IOException ex) {
+                throw new UncheckedIOException(ex);
             }
         }
-        return codes;
+
+        final var configuration = builder.build();
+        ConfigurationHolder.getInstance().setConfiguration(configuration);
+        return configuration;
+    }
+
+    /** register all applicable classes on classpath before deserializing signed state */
+    private void registerConstructables() {
+        try {
+            ConstructableRegistry.getInstance().registerConstructables("*");
+        } catch (final ConstructableRegistryException ex) {
+            throw new UncheckedConstructableRegistryException(ex);
+        }
+    }
+
+    public static class UncheckedConstructableRegistryException extends RuntimeException {
+        public UncheckedConstructableRegistryException(@NonNull final ConstructableRegistryException ex) {
+            super(ex);
+        }
     }
 
     public static class MissingSignedStateComponent extends NullPointerException {
-        public MissingSignedStateComponent(@NonNull final String component, @NonNull final Path swh) {
-            super("Expected non-null %s from signed state file %s".formatted(component, swh.toString()));
+        public MissingSignedStateComponent(@NonNull final String component, @NonNull final Path swhPath) {
+            super("Expected non-null %s from signed state file %s".formatted(component, swhPath.toString()));
+            Objects.requireNonNull(component, "component");
+            Objects.requireNonNull(swhPath, "swhPath");
         }
     }
 
-    private void assertSignedStateComponentExists(final Object component, @NonNull final String componentName) {
-        if (null == component) throw new MissingSignedStateComponent(componentName, swh);
+    private void assertSignedStateComponentExists(
+            @Nullable final Object component, @NonNull final String componentName) {
+        Objects.requireNonNull(componentName, "componentName");
+
+        if (null == component) throw new MissingSignedStateComponent(componentName, swhPath);
     }
 }

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module com.hedera.node.services.cli {
-    exports com.hedera.services.cli;
     exports com.hedera.services.cli.sign;
+    exports com.hedera.services.cli.signedstate;
 
     requires transitive com.swirlds.cli;
     requires transitive com.swirlds.common;


### PR DESCRIPTION
**Description**:

* Update `SignedStateHolder` to use `ReservedSignedState` correctly (so you use it under try-with-resources)
* Update `SummarizeSignedStateFileCommand` to be a subcommand of a new `SignedStateCommand` in preparation for adding state dump commands

**Related issue(s)**:

Part of issue #7620

**Reviewers**:

You'll have to provide your own signed state file but the command line you need looks like this:

```
./platform-sdk/swirlds-cli/pcli.sh \
    --load hedera-node/cli-clients/build/libs \
    --load hedera-node/data/lib/app-spi-0.40.0-SNAPSHOT.jar \
    --load hedera-node/data/lib/besu-datatypes-23.1.2.jar \
    --load hedera-node/data/lib/evm-23.1.2.jar \
    --load hedera-node/data/lib/guava-31.1-jre-module.jar \
    --load hedera-node/data/lib/plugin-api-23.1.2.jar \
    --load hedera-node/data/lib/rlp-23.1.2.jar \
    --load hedera-node/data/lib/tuweni-bytes-2.3.1-module.jar \
    --load hedera-node/data/lib/tuweni-units-2.3.1-module.jar \
    --load hedera-node/hapi-utils/build/libs \
    --load hedera-node/hapi/build/libs \
    --load hedera-node/hedera-evm/build/libs \
    --load hedera-node/hedera-mono-service/build/libs \
    --cli=com.hedera.services.cli.signedstate \
    signed-state summarize -f ~/StatesStreams/mainnet/state/2023-07-19.03.30/144543926/SignedState.swh
```

Also code coverage is zero because the class involved, `SignedStateHolder` requires an actual signed state to work with which we can't really provide in a unit test or even integration test.  And it is a CLI tool anyway which you test manually: It either reads a signed state or it doesn't.  It does.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
