### PR TITLE
07659-Rate-Limit-SocketException

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/AbstractGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/AbstractGossip.java
@@ -120,6 +120,7 @@ public abstract class AbstractGossip implements ConnectionTracker, Gossip {
      *
      * @param platformContext               the platform context
      * @param threadManager                 the thread manager
+     * @param time                          the time object used to get the current time
      * @param crypto                        can be used to sign things
      * @param addressBook                   the current address book
      * @param selfId                        this node's ID
@@ -136,11 +137,11 @@ public abstract class AbstractGossip implements ConnectionTracker, Gossip {
      * @param statusActionSubmitter         enables submitting platform status actions
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
-     * @param time                          the time object used to get the current time
      */
     protected AbstractGossip(
             @NonNull final PlatformContext platformContext,
             @NonNull final ThreadManager threadManager,
+            @NonNull final Time time,
             @NonNull final Crypto crypto,
             @NonNull final AddressBook addressBook,
             @NonNull final NodeId selfId,
@@ -156,8 +157,7 @@ public abstract class AbstractGossip implements ConnectionTracker, Gossip {
             @NonNull final EventObserverDispatcher eventObserverDispatcher,
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
-            @NonNull final Runnable clearAllPipelinesForReconnect,
-            @NonNull final Time time) {
+            @NonNull final Runnable clearAllPipelinesForReconnect) {
         this.platformContext = Objects.requireNonNull(platformContext);
         this.addressBook = Objects.requireNonNull(addressBook);
         this.selfId = Objects.requireNonNull(selfId);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/AbstractGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/AbstractGossip.java
@@ -21,6 +21,7 @@ import static com.swirlds.platform.SwirldsPlatform.PLATFORM_THREAD_POOL_NAME;
 
 import com.swirlds.base.state.LifecyclePhase;
 import com.swirlds.base.state.Startable;
+import com.swirlds.base.time.Time;
 import com.swirlds.common.config.BasicConfig;
 import com.swirlds.common.config.EventConfig;
 import com.swirlds.common.config.SocketConfig;
@@ -135,6 +136,7 @@ public abstract class AbstractGossip implements ConnectionTracker, Gossip {
      * @param statusActionSubmitter         enables submitting platform status actions
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
+     * @param time                          the time object used to get the current time
      */
     protected AbstractGossip(
             @NonNull final PlatformContext platformContext,
@@ -154,13 +156,14 @@ public abstract class AbstractGossip implements ConnectionTracker, Gossip {
             @NonNull final EventObserverDispatcher eventObserverDispatcher,
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
-            @NonNull final Runnable clearAllPipelinesForReconnect) {
-
+            @NonNull final Runnable clearAllPipelinesForReconnect,
+            @NonNull final Time time) {
         this.platformContext = Objects.requireNonNull(platformContext);
         this.addressBook = Objects.requireNonNull(addressBook);
         this.selfId = Objects.requireNonNull(selfId);
         this.statusActionSubmitter = Objects.requireNonNull(statusActionSubmitter);
         this.syncMetrics = Objects.requireNonNull(syncMetrics);
+        Objects.requireNonNull(time);
 
         threadConfig = platformContext.getConfiguration().getConfigData(ThreadConfig.class);
         criticalQuorum = buildCriticalQuorum();
@@ -186,7 +189,8 @@ public abstract class AbstractGossip implements ConnectionTracker, Gossip {
                 connectionManagers::newConnection,
                 socketConfig,
                 shouldDoVersionCheck(),
-                appVersion);
+                appVersion,
+                time);
         // allow other members to create connections to me
         final Address address = addressBook.getAddress(selfId);
         final ConnectionServer connectionServer = new ConnectionServer(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/GossipFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/GossipFactory.java
@@ -206,7 +206,8 @@ public final class GossipFactory {
                         syncMetrics,
                         statusActionSubmitter,
                         loadReconnectState,
-                        clearAllPipelinesForReconnect);
+                        clearAllPipelinesForReconnect,
+                        time);
             } else {
                 logger.info(STARTUP.getMarker(), "Using SyncGossip");
                 return new SyncGossip(
@@ -258,7 +259,8 @@ public final class GossipFactory {
                     syncMetrics,
                     statusActionSubmitter,
                     loadReconnectState,
-                    clearAllPipelinesForReconnect);
+                    clearAllPipelinesForReconnect,
+                    time);
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/GossipFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/GossipFactory.java
@@ -189,6 +189,7 @@ public final class GossipFactory {
                 return new SingleNodeSyncGossip(
                         platformContext,
                         threadManager,
+                        time,
                         crypto,
                         addressBook,
                         selfId,
@@ -206,8 +207,7 @@ public final class GossipFactory {
                         syncMetrics,
                         statusActionSubmitter,
                         loadReconnectState,
-                        clearAllPipelinesForReconnect,
-                        time);
+                        clearAllPipelinesForReconnect);
             } else {
                 logger.info(STARTUP.getMarker(), "Using SyncGossip");
                 return new SyncGossip(
@@ -241,6 +241,7 @@ public final class GossipFactory {
             return new LegacySyncGossip(
                     platformContext,
                     threadManager,
+                    time,
                     crypto,
                     addressBook,
                     selfId,
@@ -259,8 +260,7 @@ public final class GossipFactory {
                     syncMetrics,
                     statusActionSubmitter,
                     loadReconnectState,
-                    clearAllPipelinesForReconnect,
-                    time);
+                    clearAllPipelinesForReconnect);
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterGossip.java
@@ -187,7 +187,8 @@ public class ChatterGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect);
+                clearAllPipelinesForReconnect,
+                time);
 
         final BasicConfig basicConfig = platformContext.getConfiguration().getConfigData(BasicConfig.class);
         final ChatterConfig chatterConfig = platformContext.getConfiguration().getConfigData(ChatterConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterGossip.java
@@ -172,6 +172,7 @@ public class ChatterGossip extends AbstractGossip {
         super(
                 platformContext,
                 threadManager,
+                time,
                 crypto,
                 addressBook,
                 selfId,
@@ -187,8 +188,7 @@ public class ChatterGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect,
-                time);
+                clearAllPipelinesForReconnect);
 
         final BasicConfig basicConfig = platformContext.getConfiguration().getConfigData(BasicConfig.class);
         final ChatterConfig chatterConfig = platformContext.getConfiguration().getConfigData(ChatterConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/LegacySyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/LegacySyncGossip.java
@@ -20,6 +20,7 @@ import static com.swirlds.logging.LogMarker.RECONNECT;
 import static com.swirlds.platform.SwirldsPlatform.PLATFORM_THREAD_POOL_NAME;
 
 import com.swirlds.base.state.LifecyclePhase;
+import com.swirlds.base.time.Time;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.system.NodeId;
@@ -114,6 +115,7 @@ public class LegacySyncGossip extends AbstractGossip {
      * @param statusActionSubmitter         enables submitting platform status actions
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
+     * @param time                          the time object used to get the current time
      */
     public LegacySyncGossip(
             @NonNull final PlatformContext platformContext,
@@ -136,7 +138,8 @@ public class LegacySyncGossip extends AbstractGossip {
             @NonNull final SyncMetrics syncMetrics,
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
-            @NonNull final Runnable clearAllPipelinesForReconnect) {
+            @NonNull final Runnable clearAllPipelinesForReconnect,
+            @NonNull final Time time) {
         super(
                 platformContext,
                 threadManager,
@@ -155,7 +158,8 @@ public class LegacySyncGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect);
+                clearAllPipelinesForReconnect,
+                time);
 
         this.threadManager = Objects.requireNonNull(threadManager);
         this.eventIntakeLambda = Objects.requireNonNull(eventIntakeLambda);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/LegacySyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/LegacySyncGossip.java
@@ -95,6 +95,7 @@ public class LegacySyncGossip extends AbstractGossip {
      *
      * @param platformContext               the platform context
      * @param threadManager                 the thread manager
+     * @param time                          the time object used to get the current time
      * @param crypto                        can be used to sign things
      * @param addressBook                   the current address book
      * @param selfId                        this node's ID
@@ -115,11 +116,11 @@ public class LegacySyncGossip extends AbstractGossip {
      * @param statusActionSubmitter         enables submitting platform status actions
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
-     * @param time                          the time object used to get the current time
      */
     public LegacySyncGossip(
             @NonNull final PlatformContext platformContext,
             @NonNull final ThreadManager threadManager,
+            @NonNull final Time time,
             @NonNull final Crypto crypto,
             @NonNull final AddressBook addressBook,
             @NonNull final NodeId selfId,
@@ -138,11 +139,11 @@ public class LegacySyncGossip extends AbstractGossip {
             @NonNull final SyncMetrics syncMetrics,
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
-            @NonNull final Runnable clearAllPipelinesForReconnect,
-            @NonNull final Time time) {
+            @NonNull final Runnable clearAllPipelinesForReconnect) {
         super(
                 platformContext,
                 threadManager,
+                time,
                 crypto,
                 addressBook,
                 selfId,
@@ -158,8 +159,7 @@ public class LegacySyncGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect,
-                time);
+                clearAllPipelinesForReconnect);
 
         this.threadManager = Objects.requireNonNull(threadManager);
         this.eventIntakeLambda = Objects.requireNonNull(eventIntakeLambda);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SingleNodeSyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SingleNodeSyncGossip.java
@@ -19,6 +19,7 @@ package com.swirlds.platform.gossip.sync;
 import static com.swirlds.logging.LogMarker.RECONNECT;
 import static com.swirlds.platform.SwirldsPlatform.PLATFORM_THREAD_POOL_NAME;
 
+import com.swirlds.base.time.Time;
 import com.swirlds.common.config.BasicConfig;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
@@ -98,6 +99,7 @@ public class SingleNodeSyncGossip extends AbstractGossip {
      * @param statusActionSubmitter         enables submitting platform status actions
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
+     * @param time                          the time object used to get the current time
      */
     public SingleNodeSyncGossip(
             @NonNull PlatformContext platformContext,
@@ -119,7 +121,8 @@ public class SingleNodeSyncGossip extends AbstractGossip {
             @NonNull final SyncMetrics syncMetrics,
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
-            @NonNull final Runnable clearAllPipelinesForReconnect) {
+            @NonNull final Runnable clearAllPipelinesForReconnect,
+            @NonNull final Time time) {
         super(
                 platformContext,
                 threadManager,
@@ -138,7 +141,8 @@ public class SingleNodeSyncGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect);
+                clearAllPipelinesForReconnect,
+                time);
 
         this.eventIntakeLambda = Objects.requireNonNull(eventIntakeLambda);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SingleNodeSyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SingleNodeSyncGossip.java
@@ -80,6 +80,7 @@ public class SingleNodeSyncGossip extends AbstractGossip {
      *
      * @param platformContext               the platform context
      * @param threadManager                 the thread manager
+     * @param time                          the time object used to get the current time
      * @param crypto                        can be used to sign things
      * @param addressBook                   the current address book
      * @param selfId                        this node's ID
@@ -99,11 +100,11 @@ public class SingleNodeSyncGossip extends AbstractGossip {
      * @param statusActionSubmitter         enables submitting platform status actions
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
-     * @param time                          the time object used to get the current time
      */
     public SingleNodeSyncGossip(
             @NonNull PlatformContext platformContext,
             @NonNull ThreadManager threadManager,
+            @NonNull final Time time,
             @NonNull Crypto crypto,
             @NonNull AddressBook addressBook,
             @NonNull NodeId selfId,
@@ -121,11 +122,11 @@ public class SingleNodeSyncGossip extends AbstractGossip {
             @NonNull final SyncMetrics syncMetrics,
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
-            @NonNull final Runnable clearAllPipelinesForReconnect,
-            @NonNull final Time time) {
+            @NonNull final Runnable clearAllPipelinesForReconnect) {
         super(
                 platformContext,
                 threadManager,
+                time,
                 crypto,
                 addressBook,
                 selfId,
@@ -141,8 +142,7 @@ public class SingleNodeSyncGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect,
-                time);
+                clearAllPipelinesForReconnect);
 
         this.eventIntakeLambda = Objects.requireNonNull(eventIntakeLambda);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncGossip.java
@@ -175,7 +175,8 @@ public class SyncGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect);
+                clearAllPipelinesForReconnect,
+                time);
 
         final EventConfig eventConfig = platformContext.getConfiguration().getConfigData(EventConfig.class);
         this.eventIntakeLambda = Objects.requireNonNull(eventIntakeLambda);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncGossip.java
@@ -160,6 +160,7 @@ public class SyncGossip extends AbstractGossip {
         super(
                 platformContext,
                 threadManager,
+                time,
                 crypto,
                 addressBook,
                 selfId,
@@ -175,8 +176,7 @@ public class SyncGossip extends AbstractGossip {
                 eventObserverDispatcher,
                 statusActionSubmitter,
                 loadReconnectState,
-                clearAllPipelinesForReconnect,
-                time);
+                clearAllPipelinesForReconnect);
 
         final EventConfig eventConfig = platformContext.getConfiguration().getConfigData(EventConfig.class);
         this.eventIntakeLambda = Objects.requireNonNull(eventIntakeLambda);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/InboundConnectionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/InboundConnectionHandler.java
@@ -20,6 +20,7 @@ import static com.swirlds.logging.LogMarker.EXCEPTION;
 import static com.swirlds.logging.LogMarker.SOCKET_EXCEPTIONS;
 import static com.swirlds.logging.LogMarker.SYNC;
 
+import com.swirlds.base.time.Time;
 import com.swirlds.common.config.SocketConfig;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
@@ -27,6 +28,7 @@ import com.swirlds.common.system.NodeId;
 import com.swirlds.common.system.SoftwareVersion;
 import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.common.threading.interrupt.InterruptableConsumer;
+import com.swirlds.common.utility.throttle.RateLimitedLogger;
 import com.swirlds.platform.gossip.sync.SyncInputStream;
 import com.swirlds.platform.gossip.sync.SyncOutputStream;
 import com.swirlds.platform.network.ByteConstants;
@@ -37,6 +39,7 @@ import com.swirlds.platform.network.SocketConnection;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.Socket;
+import java.time.Duration;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,6 +57,8 @@ public class InboundConnectionHandler {
     private final SocketConfig socketConfig;
     private final boolean doVersionCheck;
     private final SoftwareVersion softwareVersion;
+    /** Rate Limited Logger for SocketExceptions */
+    private final RateLimitedLogger socketExceptionLogger;
 
     public InboundConnectionHandler(
             @NonNull final ConnectionTracker connectionTracker,
@@ -62,7 +67,8 @@ public class InboundConnectionHandler {
             @NonNull final InterruptableConsumer<Connection> newConnectionConsumer,
             @NonNull final SocketConfig socketConfig,
             final boolean doVersionCheck,
-            @NonNull final SoftwareVersion softwareVersion) {
+            @NonNull final SoftwareVersion softwareVersion,
+            @NonNull final Time time) {
         this.connectionTracker = Objects.requireNonNull(connectionTracker);
         this.selfId = Objects.requireNonNull(selfId);
         this.addressBook = Objects.requireNonNull(addressBook);
@@ -70,6 +76,8 @@ public class InboundConnectionHandler {
         this.socketConfig = Objects.requireNonNull(socketConfig);
         this.doVersionCheck = doVersionCheck;
         this.softwareVersion = Objects.requireNonNull(softwareVersion);
+        Objects.requireNonNull(time);
+        this.socketExceptionLogger = new RateLimitedLogger(logger, time, Duration.ofMinutes(1));
     }
 
     /**
@@ -124,17 +132,17 @@ public class InboundConnectionHandler {
             logger.warn(
                     SOCKET_EXCEPTIONS.getMarker(),
                     "Inbound connection from {} to {} was interrupted: {}",
+                    otherId == null ? "unknown" : otherId,
                     selfId,
-                    otherId,
                     formattedException);
             NetworkUtils.close(dis, dos, clientSocket);
         } catch (final IOException e) {
             String formattedException = NetworkUtils.formatException(e);
-            logger.warn(
+            socketExceptionLogger.warn(
                     SOCKET_EXCEPTIONS.getMarker(),
                     "Inbound connection from {} to {} had IOException: {}",
+                    otherId == null ? "unknown" : otherId,
                     selfId,
-                    otherId,
                     formattedException);
             NetworkUtils.close(dis, dos, clientSocket);
         } catch (final RuntimeException e) {


### PR DESCRIPTION
**Description**:
Fixes #7659 

Rate limiting just this logged exception.  The `Time` object has to be threaded through constructors that are rate limiting.  It feels out of scope to do that in more than this location.  I am just addressing the particular excessive log message that created this issue.  

I fixed the order of arguments to the exceptions and modified the `otherId` being null in the message to say `unknown`.  The cause of the exception being reported is preventing the determination of the otherId.  