### PR TITLE
06988 - Reconnect Verify Platform and Learned State AddressBook Match

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookUtils.java
@@ -239,4 +239,37 @@ public class AddressBookUtils {
                 externalPort,
                 memoToUse);
     }
+
+    /**
+     * Verifies that all addresses and the nextNodeId are the same between the two address books, otherwise an
+     * IllegalStateException is thrown.  All other fields in the address book are intentionally ignored. This comparison
+     * is used during reconnect to verify that the address books align enough to proceed.
+     *
+     * @param addressBook1 the first address book to compare.
+     * @param addressBook2 the second address book to compare.
+     * @throws IllegalStateException if the address books are not compatible for reconnect.
+     */
+    public static void verifyReconnectAddressBooks(
+            @NonNull final AddressBook addressBook1, @NonNull final AddressBook addressBook2)
+            throws IllegalStateException {
+        if (!addressBook1.getNextNodeId().equals(addressBook2.getNextNodeId())) {
+            throw new IllegalStateException("The next node ids are not the same.");
+        }
+        final int addressCount = addressBook1.getSize();
+        if (addressCount != addressBook2.getSize()) {
+            throw new IllegalStateException("The address books do not have the same number of addresses.");
+        }
+        for (int i = 0; i < addressCount; i++) {
+            final NodeId nodeId1 = addressBook1.getNodeId(i);
+            final NodeId nodeId2 = addressBook2.getNodeId(i);
+            if (!nodeId1.equals(nodeId2)) {
+                throw new IllegalStateException("The address books do not have the same node ids.");
+            }
+            final Address address1 = addressBook1.getAddress(nodeId1);
+            final Address address2 = addressBook2.getAddress(nodeId2);
+            if (!address1.equals(address2)) {
+                throw new IllegalStateException("The address books do not have the same addresses.");
+            }
+        }
+    }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -56,6 +56,7 @@ import com.swirlds.common.system.SoftwareVersion;
 import com.swirlds.common.system.SwirldState;
 import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
+import com.swirlds.common.system.address.AddressBookUtils;
 import com.swirlds.common.system.status.PlatformStatus;
 import com.swirlds.common.system.status.PlatformStatusManager;
 import com.swirlds.common.system.status.actions.DoneReplayingEventsAction;
@@ -855,6 +856,9 @@ public class SwirldsPlatform implements Platform, Startable {
                                 + reconnectHash + ", new hash is "
                                 + signedState.getState().getHash());
             }
+
+            // Before attempting to load the state, verify that the platform AB matches the state AB.
+            AddressBookUtils.verifyReconnectAddressBooks(getAddressBook(), signedState.getAddressBook());
 
             swirldStateManager.loadFromSignedState(signedState);
 


### PR DESCRIPTION
Fixes #6988

Manual Verification Procedures
1. Compile and run locally
2. turn off PCES recording. 
3. run app to generate new states from genesis, then stop app.
4. Turn off state saving. 
5. delete all the saved states for 1 node. 
6. modify the config.txt address book.
7. start the app.  The node with no saved state will start from genesis and use the config.txt address book while the nodes with saved state will use the loaded saved state.  
8. Verify that the reconnecting node fails to connect with all other nodes that started with saved states. 