### PR TITLE
Restructured signed-state command and added dump (bytecode,store) commands

### DIFF
--- a/hedera-node/cli-clients/build.gradle.kts
+++ b/hedera-node/cli-clients/build.gradle.kts
@@ -31,6 +31,10 @@ configurations.all {
 
 dependencies {
     javaModuleDependencies {
+        implementation(gav("org.apache.logging.log4j"))
+        implementation(gav("org.apache.logging.log4j.core"))
+        implementation(gav("tuweni.bytes"))
+        implementation(gav("tuweni.units"))
         testImplementation(gav("org.junit.jupiter.api"))
         testImplementation(gav("org.mockito"))
         testImplementation(gav("org.mockito.junit.jupiter"))

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.signedstate.DumpStateCommand.Uniqify;
+import com.hedera.services.cli.signedstate.DumpStateCommand.WithIds;
+import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import com.hedera.services.cli.signedstate.SignedStateHolder.Contract;
+import com.hedera.services.cli.signedstate.SignedStateHolder.Contracts;
+import com.hedera.services.cli.signedstate.SignedStateHolder.Validity;
+import com.hedera.services.cli.utils.ByteArrayAsKey;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+
+/** Dump all the contract bytecodes in a signed state file in textual format, (optionally) deduped, and (optionally)
+ * with their contract ids.  Output is deterministic for a signed state - sorted by contract id, etc. - so that
+ * comparisons can be made between two signed states that are similar (e.g., mono-service vs modularized service when
+ * the same events are run through them).
+ */
+public class DumpContractBytecodesSubcommand {
+
+    static final int ESTIMATED_NUMBER_OF_CONTRACTS = 500_000;
+
+    static void doit(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path bytecodePath,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final Uniqify uniqify,
+            @NonNull final WithIds withIds,
+            @NonNull final Verbosity verbosity) {
+        new DumpContractBytecodesSubcommand(state, bytecodePath, emitSummary, uniqify, withIds, verbosity).doit();
+    }
+
+    @NonNull
+    final SignedStateHolder state;
+
+    @NonNull
+    final Path bytecodePath;
+
+    final EmitSummary emitSummary;
+    final Uniqify uniqify;
+    final WithIds withIds;
+    final Verbosity verbosity;
+
+    DumpContractBytecodesSubcommand(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path bytecodePath,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final Uniqify uniqify,
+            @NonNull final WithIds withIds,
+            @NonNull final Verbosity verbosity) {
+        this.state = state;
+        this.bytecodePath = bytecodePath;
+        this.emitSummary = emitSummary;
+        this.uniqify = uniqify;
+        this.withIds = withIds;
+        this.verbosity = verbosity;
+    }
+
+    void doit() {
+
+        var r = getNonTrivialContracts();
+        var contractsWithBytecode = r.getLeft();
+        var zeroLengthContracts = r.getRight();
+
+        final var totalContractsRegisteredWithAccounts = contractsWithBytecode.registeredContractsCount();
+        final var totalContractsPresentInFileStore =
+                contractsWithBytecode.contracts().size();
+        int totalUniqueContractsPresentInFileStore = totalContractsPresentInFileStore;
+
+        if (uniqify == DumpStateCommand.Uniqify.YES) {
+            r = uniqifyContracts(contractsWithBytecode, zeroLengthContracts);
+            contractsWithBytecode = r.getLeft();
+            zeroLengthContracts = r.getRight();
+            totalUniqueContractsPresentInFileStore =
+                    contractsWithBytecode.contracts().size();
+        }
+
+        final var sb = new StringBuilder(estimateReportSize(contractsWithBytecode));
+        if (emitSummary == DumpStateCommand.EmitSummary.YES) {
+            sb.append("%d registered contracts, %d with bytecode (%d are zero-length)%s, %d deleted contracts%n"
+                    .formatted(
+                            totalContractsRegisteredWithAccounts,
+                            totalContractsPresentInFileStore + zeroLengthContracts.size(),
+                            zeroLengthContracts.size(),
+                            uniqify == DumpStateCommand.Uniqify.YES
+                                    ? ", %d unique (by bytecode)".formatted(totalUniqueContractsPresentInFileStore)
+                                    : "",
+                            contractsWithBytecode.deletedContracts().size()));
+        }
+        appendFormattedContractLines(sb, contractsWithBytecode);
+
+        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Have %d byte report%n", sb.length());
+
+        writeReportToFile(sb.toString());
+    }
+
+    int estimateReportSize(@NonNull Contracts contracts) {
+        int totalBytecodeSize = contracts.contracts().stream()
+                .map(Contract::bytecode)
+                .mapToInt(bc -> bc.length)
+                .sum();
+        // Make a swag based on how many contracts there are plus bytecode size
+        int reportSizeEstimate = contracts.registeredContractsCount() * 75 + totalBytecodeSize * 2;
+        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Estimating %d byte report%n", reportSizeEstimate);
+        return reportSizeEstimate;
+    }
+
+    void writeReportToFile(@NonNull String report) {
+        try (final PrintWriter out = new PrintWriter(bytecodePath.toFile(), StandardCharsets.UTF_8)) {
+            out.print(report);
+            out.flush();
+        } catch (final FileNotFoundException ex) {
+            System.err.printf("*** Cannot create '%s' for writing%n", bytecodePath);
+        } catch (final IOException ex) {
+            System.err.printf("*** Exception when trying to write '%s'%n", bytecodePath);
+            throw new UncheckedIOException(ex); // This is a CLI program: Java will print the stack trace properly
+        }
+    }
+
+    /** Returns all _unique_ contracts (by their bytecode) from the signed state.
+     *
+     * Returns the set of all unique contracts (by their bytecode), each contract bytecode with _all_ of the
+     * contract ids that have that bytecode. Also returns the total number of contracts registered in the signed
+     * state.  The latter number may be larger than the number of contracts-with-bytecodes because some contracts
+     * known to accounts are not present in the file store.  Deleted contracts are _omitted_.
+     */
+    @NonNull
+    Pair<Contracts, List<Integer>> uniqifyContracts(
+            @NonNull final Contracts contracts, @NonNull final List<Integer> zeroLengthContracts) {
+        // First create a map where the bytecode is the key (have to wrap the byte[] for that) and the value is
+        // the set of all contract ids that have that bytecode
+        final var contractsByBytecode = new HashMap<ByteArrayAsKey, TreeSet<Integer>>(ESTIMATED_NUMBER_OF_CONTRACTS);
+        for (var contract : contracts.contracts()) {
+            if (contract.validity() == Validity.DELETED) continue;
+            final var bytecode = contract.bytecode();
+            final var cids = contract.ids();
+            contractsByBytecode.compute(new ByteArrayAsKey(bytecode), (k, v) -> {
+                if (v == null) v = new TreeSet<>();
+                v.addAll(cids);
+                return v;
+            });
+        }
+
+        // Second, flatten that map into a collection
+        final var uniqueContracts = new ArrayList<Contract>(contractsByBytecode.size());
+        for (final var kv : contractsByBytecode.entrySet()) {
+            uniqueContracts.add(new Contract(kv.getValue(), kv.getKey().array(), Validity.ACTIVE));
+        }
+
+        return Pair.of(
+                new Contracts(uniqueContracts, contracts.deletedContracts(), contracts.registeredContractsCount()),
+                zeroLengthContracts);
+    }
+
+    /** Returns all contracts with bytecodes from the signed state, plus the ids of contracts with 0-length bytecodes.
+     *
+     * Returns both the set of all contract ids with their bytecode, and the total number of contracts registered
+     * in the signed state file.  The latter number may be larger than the number of contracts-with-bytecodes
+     * returned because some contracts known to accounts are not present in the file store.
+     */
+    @NonNull
+    Pair<Contracts, List<Integer>> getNonTrivialContracts() {
+        final var knownContracts = state.getContracts();
+        final var zeroLengthContracts = new ArrayList<Integer>(10000);
+        knownContracts.contracts().removeIf(contract -> {
+            if (0 == contract.bytecode().length) {
+                zeroLengthContracts.addAll(contract.ids());
+                return true;
+            }
+            return false;
+        });
+        return Pair.of(knownContracts, zeroLengthContracts);
+    }
+
+    /** Format a collection of pairs of a set of contract ids with their associated bytecode */
+    void appendFormattedContractLines(@NonNull final StringBuilder sb, @NonNull final Contracts contracts) {
+        contracts.contracts().stream()
+                .sorted(Comparator.comparingInt(contract -> contract.ids().first()))
+                .forEach(contract -> appendFormattedContractLine(sb, contract));
+    }
+
+    private final HexFormat hexer = HexFormat.of().withUpperCase();
+
+    /** Format a single contract line - may want any id, may want _all_ ids */
+    void appendFormattedContractLine(@NonNull final StringBuilder sb, @NonNull final Contract contract) {
+        sb.append(hexer.formatHex(contract.bytecode()));
+
+        final var ids = contract.ids();
+        if (withIds == DumpStateCommand.WithIds.YES && !ids.isEmpty()) {
+            // Output canonical id - we choose the minimum id (so it is deterministic)
+            final var sortedIds = ids.stream().sorted().toList();
+            sb.append('\t');
+            sb.append(sortedIds.get(0));
+            // Now output _all_ ids in sorted order
+            sb.append('\t');
+            sb.append(sortedIds.stream().map(Object::toString).collect(Collectors.joining(",")));
+            sb.append('\n');
+        }
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.tuple.Pair;
  * comparisons can be made between two signed states that are similar (e.g., mono-service vs modularized service when
  * the same events are run through them).
  */
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 public class DumpContractBytecodesSubcommand {
 
     static final int ESTIMATED_NUMBER_OF_CONTRACTS = 500_000;

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Map.Entry.comparingByKey;
+
+import com.hedera.node.app.service.mono.state.virtual.ContractKey;
+import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
+import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.signedstate.DumpStateCommand.WithSlots;
+import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.BiConsumer;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+
+public class DumpContractStoresSubcommand {
+    static void doit(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path storePath,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final WithSlots withSlots,
+            @NonNull final Verbosity verbosity) {
+        new DumpContractStoresSubcommand(state, storePath, emitSummary, withSlots, verbosity).doit();
+    }
+
+    @NonNull
+    final SignedStateHolder state;
+
+    @NonNull
+    final Path storePath;
+
+    final EmitSummary emitSummary;
+    final WithSlots withSlots;
+    final Verbosity verbosity;
+
+    DumpContractStoresSubcommand(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path storePath,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final WithSlots withSlots,
+            @NonNull final Verbosity verbosity) {
+        this.state = state;
+        this.storePath = storePath;
+        this.emitSummary = emitSummary;
+        this.withSlots = withSlots;
+        this.verbosity = verbosity;
+    }
+
+    void doit() {
+
+        record ContractKeyLocal(long contractId, UInt256 key) {
+            public static ContractKeyLocal from(ContractKey ckey) {
+                return new ContractKeyLocal(ckey.getContractId(), toUint256FromPackedIntArray(ckey.getKey()));
+            }
+        }
+
+        // First grab all slot pairs from all contracts from the signed state
+        final var contractKeys = new ConcurrentLinkedQueue<ContractKeyLocal>();
+        final var contractState = new ConcurrentHashMap<Long, ConcurrentLinkedQueue<Pair<UInt256, UInt256>>>(5000);
+        final var traversalOk = iterateThroughContractStorage((ckey, iter) -> {
+            final var contractId = ckey.getContractId();
+            final var ckeyLocal = ContractKeyLocal.from(ckey);
+
+            contractKeys.add(ckeyLocal);
+
+            contractState.computeIfAbsent(contractId, k -> new ConcurrentLinkedQueue<>());
+            contractState.get(contractId).add(Pair.of(ckeyLocal.key(), iter.asUInt256()));
+        });
+
+        if (traversalOk) {
+
+            final var nDistinctContractIds = contractKeys.stream()
+                    .map(ContractKeyLocal::contractId)
+                    .distinct()
+                    .count();
+
+            final var nContractStateValues = contractState.values().stream()
+                    .mapToInt(ConcurrentLinkedQueue::size)
+                    .sum();
+
+            // I can't seriously be intending to cons up the _entire_ store of all contracts as a single string, can I?
+            // Well, Toto, this isn't the 1990s anymore ...
+
+            long reportSizeEstimate = (nDistinctContractIds * 20)
+                    + (nContractStateValues * 2 /*K/V*/ * (32 /*bytes*/ * 2 /*hexits/byte*/ + 3 /*whitespace+slop*/));
+            if (verbosity == Verbosity.VERBOSE)
+                System.out.printf("=== Estimating %d byte report%n", reportSizeEstimate);
+            final var sb = new StringBuilder((int) reportSizeEstimate);
+
+            if (verbosity == Verbosity.VERBOSE)
+                System.out.printf(
+                        "=== %d contract stores found, %d k/v pairs%n", nDistinctContractIds, nContractStateValues);
+
+            if (emitSummary == EmitSummary.YES)
+                sb.append("*** %d contract stores found, %d k/v pairs%n"
+                        .formatted(nDistinctContractIds, nContractStateValues));
+
+            // This list is generated in contract id order so that it is deterministic; also all the slot#/value pairs
+            // are sorted by slot# for the same reason
+            final var contractStates = contractState.entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey(), new ArrayList<>(entry.getValue())))
+                    .peek(entry -> entry.getRight().sort(naturalOrder()))
+                    .sorted(comparingByKey())
+                    .toList();
+
+            if (emitSummary == EmitSummary.YES) {
+                sb.append("%s%n%d contractKeys found, %d distinct; %d contract state entries, totalling %d values %n"
+                        .formatted(
+                                "=".repeat(80),
+                                contractKeys.size(),
+                                nDistinctContractIds,
+                                contractState.size(),
+                                nContractStateValues));
+                appendContractStoreSummary(sb, contractStates);
+            }
+
+            if (withSlots == WithSlots.YES)
+                for (final var aContractState : contractStates) appendSerializedContractStore(sb, aContractState);
+
+            if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Accual report size %d bytes%n", sb.length());
+
+            writeReportToFile(sb.toString());
+        } else {
+            System.err.printf("*** Traversal of the entire contract store did not complete (interrupted) ***%n");
+        }
+    }
+
+    /** Iterating through contract storage to get all slot/value pairs is done indirectly: You pass a visitor to the
+     * virtual merkle tree and it does the traversal on multiple threads.  (So the visitor needs to be able to handle
+     * multiple concurrent calls.)
+     */
+    boolean iterateThroughContractStorage(BiConsumer<ContractKey, IterableContractValue> visitor) {
+        final int THREAD_COUNT = 8; // size it for a laptop, why not?
+        final var contractStorageVMap = state.getRawContractStorage();
+
+        boolean didRunToCompletion = true;
+        try {
+            contractStorageVMap.extractVirtualMapData(
+                    getStaticThreadManager(),
+                    entry -> {
+                        final var contractKey = entry.getKey();
+                        final var iterableContractValue = entry.getValue();
+                        visitor.accept(contractKey, iterableContractValue);
+                    },
+                    THREAD_COUNT);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            didRunToCompletion = false;
+        }
+
+        return didRunToCompletion;
+    }
+
+    // Produce a report, one line per contract, summarizing the #slot pairs and the min/max slot#
+    void appendContractStoreSummary(
+            @NonNull final StringBuilder sb,
+            @NonNull final List<Pair<Long, ArrayList<Pair<UInt256, UInt256>>>> contractStates) {
+
+        sb.append("contractId  #slots    min       max    oob\n");
+        //         ----------: ------ --------- --------- ------
+        for (final var contractState : contractStates) {
+            final var contractId = contractState.getKey();
+            final var slots = contractState.getValue();
+
+            record Acc(long min, long max, long outOfBounds) {}
+            final var slotSummary = slots.stream()
+                    .reduce(
+                            new Acc(Long.MAX_VALUE, Long.MIN_VALUE, 0L),
+                            (r, e) -> {
+                                final var slot = e.getKey();
+                                final var itFits = slot.fitsLong();
+                                if (itFits) {
+                                    final var slotL = slot.toLong();
+                                    return new Acc(Long.min(r.min(), slotL), Long.max(r.max(), slotL), r.outOfBounds());
+                                } else return new Acc(r.min(), r.max(), r.outOfBounds + 1L);
+                            },
+                            (r1, r2) -> new Acc(
+                                    Long.min(r1.min(), r2.min()),
+                                    Long.max(r1.max(), r2.max()),
+                                    r1.outOfBounds() + r2.outOfBounds()));
+            sb.append("%10d; %6d %9d %9d %6d%n"
+                    .formatted(
+                            contractId, slots.size(), slotSummary.min(), slotSummary.max(), slotSummary.outOfBounds())
+                    .replace("-9223372036854775808", "      N/A") // fixup case where state had _no_
+                    .replace("9223372036854775807", "      N/A")); // slot#s that fit in a long
+        }
+    }
+
+    // Format a single contract's slot/value pairs on a single line
+    void appendSerializedContractStore(
+            @NonNull final StringBuilder sb,
+            @NonNull final Pair<Long, ArrayList<Pair<UInt256, UInt256>>> contractState) {
+
+        // First two fields are the contract id and the number of slot pairs it has
+        sb.append(contractState.getKey());
+        sb.append(" #");
+        sb.append(contractState.getValue().size());
+
+        // Now we emit the slots in increasing order by slot#. Format is "@slot# slotVal" for each one. But we do
+        // an optimization: If two slots are directly sequential we omit the slot# of the second.  This is because
+        // Solidity tends to allocate a dense group of slots first (for scalars and fixed size arrays and such) and
+        // then the rest of the slots (for variable size arrays and maps) have pretty random slot#s.
+        var nextSlot = 0L;
+        for (final var slotPair : contractState.getValue()) {
+            final var slot = slotPair.getKey();
+            if (slot.fitsLong()) {
+                final var slotL = slot.toLong();
+                if (nextSlot != slotL) {
+                    sb.append(" @");
+                    sb.append(slotL);
+                    nextSlot = slotL;
+                } else nextSlot++;
+            } else {
+                sb.append(" @");
+                sb.append(slot.toQuantityHexString().substring(2)); // strip off hex prefix
+            }
+            sb.append(" ");
+            sb.append(slotPair.getValue().toQuantityHexString().substring(2)); // strip off hex prefix
+        }
+    }
+
+    void writeReportToFile(@NonNull String report) {
+        try (final PrintWriter out = new PrintWriter(storePath.toFile(), StandardCharsets.UTF_8)) {
+            out.print(report);
+            out.flush();
+        } catch (final FileNotFoundException ex) {
+            System.err.printf("*** Cannot create '%s' for writing%n", storePath);
+        } catch (final IOException ex) {
+            System.err.printf("*** Exception when trying to write '%s'%n", storePath);
+            throw new UncheckedIOException(ex); // This is a CLI program: Java will print the stack trace properly
+        }
+    }
+
+    @NonNull
+    static UInt256 toUint256FromPackedIntArray(@NonNull final int[] packed) {
+        final var buf = ByteBuffer.allocate(32);
+        buf.asIntBuffer().put(packed);
+        return UInt256.fromBytes(Bytes.wrap(buf.array()));
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 public class DumpContractStoresSubcommand {
     static void doit(
             @NonNull final SignedStateHolder state,
@@ -75,6 +76,10 @@ public class DumpContractStoresSubcommand {
         this.verbosity = verbosity;
     }
 
+    @SuppressWarnings(
+            "java:S3864") // "Remove Stream.peek - should be used with caution" - conflicts with an IntelliJ inspection
+    // that says to put _in_ a `Stream.peek`; anyway, in this case I _want_ it, it makes sense, I
+    // _am in fact_ being properly cautious, thank you Sonar
     void doit() {
 
         record ContractKeyLocal(long contractId, UInt256 key) {

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -27,6 +27,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 @Command(
         name = "dump",
         subcommandsRepeatable = true,
@@ -153,6 +154,7 @@ public class DumpStateCommand extends AbstractCommand {
      *
      * Rather fragile if the subcommands are ever reorganized ... but maybe that won't happen soon ...
      */
+    @SuppressWarnings("java:S1488") // "immediately return expr" - Sonar doesn't understand value of parallel constructs
     @NonNull
     Set<String> getSubcommandsToRun() {
         final SignedStateCommand signedStateCommand = this.parent;

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import com.swirlds.cli.PlatformCli;
+import com.swirlds.cli.utility.AbstractCommand;
+import com.swirlds.cli.utility.SubcommandOf;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Set;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "dump",
+        subcommandsRepeatable = true,
+        mixinStandardHelpOptions = true,
+        description = "Dump state from signed state file (to stdout)")
+@SubcommandOf(SignedStateCommand.class)
+public class DumpStateCommand extends AbstractCommand {
+
+    @ParentCommand
+    SignedStateCommand parent;
+
+    enum EmitSummary {
+        NO,
+        YES
+    }
+
+    enum Uniqify {
+        NO,
+        YES
+    }
+
+    enum WithIds {
+        NO,
+        YES
+    }
+
+    enum WithSlots {
+        NO,
+        YES
+    }
+
+    // We want to open the signed state file only once but run a bunch of dumps against it
+    // (because it takes a long time to open the signed state file).  So we can specify
+    // more than one of these subcommands on the single command line.  But we don't get
+    // any hook at the beginning of the entire set of subcommands or after either.  So
+    // that we have to track ourselves, via `init` and `finish` methods that _each_
+    // subcommand is responsible for calling.
+
+    @Command(name = "contract-bytecodes")
+    void contractBytecodes(
+            @Option(
+                            names = {"-o", "--bytecode", "--contract-bytecode"},
+                            arity = "1",
+                            description = "Output file for contracts bytecode dump")
+                    @NonNull
+                    final Path bytecodePath,
+            @Option(
+                            names = {"-s", "--summary"},
+                            description = "Emit a summary line")
+                    final boolean emitSummary,
+            @Option(
+                            names = {"-u", "--unique"},
+                            description = "Emit each unique contract bytecode only once")
+                    final boolean uniqify,
+            @Option(
+                            names = {"-#", "--with-ids"},
+                            description = "Emit contract ids")
+                    final boolean withIds) {
+        Objects.requireNonNull(bytecodePath);
+        init();
+        System.out.println("=== bytecodes ===");
+        DumpContractBytecodesSubcommand.doit(
+                parent.signedState,
+                bytecodePath,
+                emitSummary ? EmitSummary.YES : EmitSummary.NO,
+                uniqify ? Uniqify.YES : Uniqify.NO,
+                withIds ? WithIds.YES : WithIds.NO,
+                parent.verbosity);
+        finish();
+    }
+
+    @Command(name = "contract-stores")
+    void contractStores(
+            @Option(
+                            names = {"-o", "--contract-store"},
+                            arity = "1",
+                            description = "Output file for contracts store dump")
+                    @NonNull
+                    final Path storePath,
+            @Option(
+                            names = {"-s", "--summary"},
+                            description = "Emit a summary line")
+                    final boolean emitSummary,
+            @Option(
+                            names = {"-k", "--slots"},
+                            description = "Emit the slot/value pairs for each contract's store")
+                    final boolean withSlots) {
+        Objects.requireNonNull(storePath);
+        init();
+        System.out.println("=== stores ===");
+        DumpContractStoresSubcommand.doit(
+                parent.signedState,
+                storePath,
+                emitSummary ? EmitSummary.YES : EmitSummary.NO,
+                withSlots ? WithSlots.YES : WithSlots.NO,
+                parent.verbosity);
+        finish();
+    }
+
+    /** Setup to run a dump subcommand: If _first_ subcommand being run then open signed state file */
+    void init() {
+        if (thisSubcommandisNumber == null) {
+            thisSubcommandisNumber = 0;
+            subcommandsToRun = getSubcommandsToRun();
+            parent.openSignedState();
+        } else {
+            thisSubcommandisNumber++;
+        }
+    }
+
+    /** Cleanup after running a dump subcommand: If _last_ subcommand being run then close signed state file */
+    void finish() {
+        if (thisSubcommandisNumber == subcommandsToRun.size() - 1) {
+            parent.closeSignedState();
+        }
+    }
+
+    Integer thisSubcommandisNumber;
+    Set<String> subcommandsToRun;
+
+    /** We need to find out how many subcommands we're going to run, so that we can manage the signed state file.
+     * Here we grovel around in picocli's parsed command line to find that information, returning the set of subcommand
+     * names.
+     *
+     * Rather fragile if the subcommands are ever reorganized ... but maybe that won't happen soon ...
+     */
+    @NonNull
+    Set<String> getSubcommandsToRun() {
+        final SignedStateCommand signedStateCommand = this.parent;
+        final PlatformCli platformCli = signedStateCommand.parent;
+        final var pcliCommandSpec = platformCli.getSpec();
+        final var signedStateCommandLine = pcliCommandSpec.subcommands().get("signed-state");
+        final var dumpCommandLine = signedStateCommandLine.getSubcommands().get("dump");
+        final var dumpSubcommands = dumpCommandLine.getSubcommands().keySet();
+        return dumpSubcommands;
+    }
+
+    private DumpStateCommand() {}
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/README.md
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/README.md
@@ -1,0 +1,31 @@
+(Better documentaiton will come later, but here are some sample command lines:)
+
+## Summarize contents of a signed state file
+
+```
+./platform-sdk/swirlds-cli/pcli.sh \
+   --memory 40 \
+    --ignore-jars \
+    --load hedera-node/data/lib \
+    --load hedera-node/cli-clients/build/libs \
+    --cli com.hedera.services.cli.signedstate \
+    signed-state -f /Users/davidbakin/StatesStreams/mainnet-2023-07-19/state/2023-07-19.00.00/144535932/SignedState.swh \
+      --verbose --log-level WARN \
+      summarize
+```
+
+## Dump the bytecodes and complete contract stores of a signed state file
+
+```
+./platform-sdk/swirlds-cli/pcli.sh \
+    --memory 40 \
+    --ignore-jars \
+    --load hedera-node/data/lib \
+    --load hedera-node/cli-clients/build/libs \
+    --cli com.hedera.services.cli.signedstate \
+    signed-state  -f /Users/davidbakin/StatesStreams/mainnet-2023-07-19/state/2023-07-19.00.00/144535932/SignedState.swh \
+        --verbose \
+    dump \
+        contract-bytecodes --contract-bytecode ./bytecode.lst --summary --unique --with-ids \
+        contract-stores    --contract-store    ./store.lst    --summary --slots
+```

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -19,7 +19,17 @@ package com.hedera.services.cli.signedstate;
 import com.swirlds.cli.PlatformCli;
 import com.swirlds.cli.utility.AbstractCommand;
 import com.swirlds.cli.utility.SubcommandOf;
+import com.swirlds.common.io.utility.FileUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
 
 /**
  * A subcommand of the {@link PlatformCli}, for dealing with signed state files
@@ -30,5 +40,111 @@ import picocli.CommandLine;
         description = "Operations on signed-state files.")
 @SubcommandOf(PlatformCli.class)
 public final class SignedStateCommand extends AbstractCommand {
+
+    @ParentCommand
+    PlatformCli parent;
+
+    enum Verbosity {
+        SILENT,
+        VERBOSE
+    }
+
+    @Option(
+            names = {"-f", "--file"},
+            arity = "1",
+            description = "Input signed state file")
+    Path inputFile;
+
+    @Option(
+            names = {"-c", "--config"},
+            description = "A path to where a configuration file can be found. If not provided then defaults are used.")
+    private void setConfigurationPath(@NonNull final List<Path> configurationPaths) {
+        Objects.requireNonNull(configurationPaths, "configurationPaths");
+
+        configurationPaths.forEach(this::pathMustExist);
+        this.configurationPaths = configurationPaths;
+    }
+
+    List<Path> configurationPaths = List.of();
+
+    @Option(
+            names = {"-v", "--verbose"},
+            arity = "0..1",
+            defaultValue = "false",
+            description = "Verbosity of command")
+    private void setVerbosity(final boolean doVerbose) {
+        verbosity = doVerbose ? Verbosity.VERBOSE : Verbosity.SILENT;
+    }
+
+    Verbosity verbosity;
+
+    @Option(
+            names = {"--log-level"},
+            arity = "1",
+            converter = LogLevelConverter.class,
+            defaultValue = "OFF",
+            description = "Log4j level for root logger (can be one of ${COMPLETION-CANDIDATES})")
+    private void setRootLogLevel(final Level loggingLevel) {
+        this.loggingLevel = loggingLevel;
+    }
+
+    Level loggingLevel;
+
+    private void setRootLoggingLevel() {
+        // BUG: This doesn't work.  Setting level to `WARN` I still see a message from `INFO STATE_TO_DISK`
+        if (verbosity == Verbosity.VERBOSE) System.out.printf("===Log level set to %s%n", loggingLevel);
+        var logger = LogManager.getRootLogger();
+        Configurator.setAllLevels(logger.getName(), loggingLevel);
+        logger = LogManager.getLogger(FileUtils.class);
+        Configurator.setAllLevels(logger.getName(), loggingLevel);
+    }
+
+    static class LogLevelConverter implements CommandLine.ITypeConverter<Level> {
+
+        @Override
+        public Level convert(String value) throws Exception {
+            return new org.apache.logging.log4j.core.config.plugins.convert.TypeConverters.LevelConverter()
+                    .convert(value);
+        }
+    }
+
+    // We want to open the signed state file only once but run a bunch of dumps against it
+    // (because it takes a long time to open the signed state file).  So we can specify
+    // more than one of these subcommands on the single command line.  But we don't get
+    // any hook at the beginning of the entire set of subcommands or after either.  So
+    // that we have to track for ourselves, and each subcommand is responsible for opening
+    // _and closing_ the signed state file appropriatel
+
+    SignedStateHolder signedState;
+
+    @NonNull
+    SignedStateHolder openSignedState() {
+        setRootLoggingLevel();
+        if (signedState == null) {
+            if (verbosity == Verbosity.VERBOSE) System.out.printf("=== opening signed state file '%s'%n", inputFile);
+
+            signedState = new SignedStateHolder(inputFile, configurationPaths);
+
+            if (verbosity == Verbosity.VERBOSE) System.out.printf("=== signed state file '%s' opened%n", inputFile);
+        } else {
+            System.out.printf("*** signed state file '%s' already opened%n", inputFile);
+        }
+        return signedState;
+    }
+
+    void closeSignedState() {
+        setRootLoggingLevel();
+        if (signedState != null) {
+            if (verbosity == Verbosity.VERBOSE) System.out.printf("=== closing signed state file '%s'%n", inputFile);
+
+            signedState.close();
+
+            if (verbosity == Verbosity.VERBOSE) System.out.printf("=== signed state file '%s' closed%n", inputFile);
+        } else {
+            System.out.printf("*** signed state file '%s' already closed%n", inputFile);
+        }
+        signedState = null;
+    }
+
     private SignedStateCommand() {}
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -34,6 +34,7 @@ import picocli.CommandLine.ParentCommand;
 /**
  * A subcommand of the {@link PlatformCli}, for dealing with signed state files
  */
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 @CommandLine.Command(
         name = "signed-state",
         mixinStandardHelpOptions = true,
@@ -90,6 +91,7 @@ public final class SignedStateCommand extends AbstractCommand {
 
     Level loggingLevel;
 
+    @SuppressWarnings("java:S4792") // "make sure this logger's configuration is safe"
     private void setRootLoggingLevel() {
         // BUG: This doesn't work.  Setting level to `WARN` I still see a message from `INFO STATE_TO_DISK`
         if (verbosity == Verbosity.VERBOSE) System.out.printf("===Log level set to %s%n", loggingLevel);

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -115,7 +116,7 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
      * @param validity - whether the contract is valid or note, aka active or deleted
      */
     public record Contract(
-            @NonNull Set</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode, @NonNull Validity validity) {
+            @NonNull TreeSet</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode, @NonNull Validity validity) {
 
         @Override
         public boolean equals(final Object o) {
@@ -208,9 +209,10 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
                 final var blob = fileStore.get(vbk);
                 if (null != blob) {
                     final var c = new Contract(
-                            Set.of(cid),
+                            new TreeSet<>(),
                             blob.getData(),
                             deletedContractIds.contains(cid) ? Validity.DELETED : Validity.ACTIVE);
+                    c.ids.add(cid);
                     codes.add(c);
                 }
             }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ByteArrayAsKey.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ByteArrayAsKey.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.utils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+
+/** Implements equality-of-content on a byte array so it can be used as a map key */
+public record ByteArrayAsKey(@NonNull byte[] array) {
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof ByteArrayAsKey other && Arrays.equals(array, other.array);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(array);
+    }
+
+    @Override
+    public String toString() {
+        return "ByteArrayAsKey{" + "array=" + Arrays.toString(array) + '}';
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -6,13 +6,17 @@ module com.hedera.node.services.cli {
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.platform;
     requires transitive info.picocli;
+    requires com.google.common;
+    requires com.google.protobuf;
     requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.app.service.mono;
     requires com.hedera.node.hapi;
-    requires com.google.common;
-    requires com.google.protobuf;
     requires com.swirlds.config;
     requires com.swirlds.virtualmap;
     requires org.apache.commons.lang3;
+    requires org.apache.logging.log4j.core;
+    requires org.apache.logging.log4j;
+    requires tuweni.bytes;
+    requires tuweni.units;
     requires static com.github.spotbugs.annotations;
 }


### PR DESCRIPTION
**Description**:

Adds PCLI plugin commands to dump contract bytecodes and state from a signed state file.

Can be extended for the rest of the services semantic data stored in the virtual merkle trees (accounts, tokens, topics, etc.)
Manages the signed state file uniformly for those subcommands.

**Related issue(s)**:

Fixes #7715 

**Notes for reviewer**:

If you would like a "top down" approach to review:

- `SignedStateCommand` is the simple parent of `SummarizeSignedStateFileCommand` and `DumpStateCommand` - that's the PCLI part with command line options pretty straightforward from `picocli`
- `SignedStateHolder` simply changed to return contracts in a known order (moving from `Set` to `TreeSet`)
- Then the two contract state dumpers are contained in `DumpContractBytecodesSubcommand` and `DumpContractStoresSubcommand` - when looking at that the important thing (IMO!) is to note is how _simple_ the traveral of the stores and gathering of information is - the annoying complexity is simply in formatting the data so it can be written in a textual format, and that part isn't even very interesting.

If you want to run this you need a signed state file (of course!) - and there are sample command lines at 
[`hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/README.md`](https://github.com/hashgraph/hedera-services/blob/07715-dump-contract-bytecodes-and-store/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/README.md)

(Internal) Notions page for differential testing: [_Differential Testing for Modularized Services vs Baseline “Mono” Service_](https://www.notion.so/swirldslabs/Differential-Testing-for-Modularized-Services-vs-Baseline-Mono-Service-366106721f9a433eb8833408ecd436eb?pvs=4)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (manual)
  - Code coverage is 0%, there are no unit or integration tests.  This is acceptable because this is a command line tool that is exercised (and tested) manually.  Also, it's quite difficult in the current environment to arrange to have a proper _minimal_ signed state file that could be used for acceptance testing.  There's very little that could actually be _unit_ tested without extensive mocking that would defeat the purpose.  IMO.
