### PR TITLE
7728: MiscUtils.asUsableFcKey() creates many exceptions

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
@@ -459,6 +459,9 @@ public final class MiscUtils {
     }
 
     public static Optional<JKey> asUsableFcKey(final Key key) {
+        if (key.getKeyCase() == Key.KeyCase.KEY_NOT_SET) {
+            return Optional.empty();
+        }
         try {
             final var fcKey = JKey.mapKey(key);
             if (!fcKey.isValid()) {


### PR DESCRIPTION
**Description**:
`Token.fromGrpcOpAndMeta()` calls `MiscUtils.asUsableFcKey()` on a variety of keys that may be specified for a token. If a particular key is not specified, an exception is thrown by `JKey.mapKey(key)` and caught by `asUsableFcKey()`, which in that case returns `Optional.empty().` This is very expensive: a token creation benchmark shows 20% time wasted by the transaction handling thread on handling those exceptions.
A simple check if a key is set is appropriate here.
