### PR TITLE
Differential testing analytical engine: Cleanup 7715 fix with additional reviewer comments handled

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
@@ -129,8 +129,10 @@ public class DumpContractBytecodesSubcommand {
                 .map(Contract::bytecode)
                 .mapToInt(bc -> bc.length)
                 .sum();
-        // Make a swag based on how many contracts there are plus bytecode size
-        int reportSizeEstimate = contracts.registeredContractsCount() * 75 + totalBytecodeSize * 2;
+        // Make a swag based on how many contracts there are plus bytecode size - each line has not just the bytecode
+        // but the list of contract ids, so the estimated size of the file accounts for the bytecodes (as hex) and the
+        // contract ids (as decimal)
+        int reportSizeEstimate = contracts.registeredContractsCount() * 20 + totalBytecodeSize * 2;
         if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Estimating %d byte report%n", reportSizeEstimate);
         return reportSizeEstimate;
     }
@@ -205,7 +207,7 @@ public class DumpContractBytecodesSubcommand {
     /** Format a collection of pairs of a set of contract ids with their associated bytecode */
     void appendFormattedContractLines(@NonNull final StringBuilder sb, @NonNull final Contracts contracts) {
         contracts.contracts().stream()
-                .sorted(Comparator.comparingInt(contract -> contract.ids().first()))
+                .sorted(Comparator.comparingInt(Contract::canonicalId))
                 .forEach(contract -> appendFormattedContractLine(sb, contract));
     }
 
@@ -215,15 +217,11 @@ public class DumpContractBytecodesSubcommand {
     void appendFormattedContractLine(@NonNull final StringBuilder sb, @NonNull final Contract contract) {
         sb.append(hexer.formatHex(contract.bytecode()));
 
-        final var ids = contract.ids();
-        if (withIds == DumpStateCommand.WithIds.YES && !ids.isEmpty()) {
-            // Output canonical id - we choose the minimum id (so it is deterministic)
-            final var sortedIds = ids.stream().sorted().toList();
+        if (withIds == DumpStateCommand.WithIds.YES && !contract.ids().isEmpty()) {
             sb.append('\t');
-            sb.append(sortedIds.get(0));
-            // Now output _all_ ids in sorted order
+            sb.append(contract.canonicalId());
             sb.append('\t');
-            sb.append(sortedIds.stream().map(Object::toString).collect(Collectors.joining(",")));
+            sb.append(contract.ids().stream().map(Object::toString).collect(Collectors.joining(",")));
             sb.append('\n');
         }
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/README.md
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/README.md
@@ -1,4 +1,4 @@
-(Better documentaiton will come later, but here are some sample command lines:)
+(Better documentation will come later, but here are some sample command lines:)
 
 ## Summarize contents of a signed state file
 

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -19,14 +19,11 @@ package com.hedera.services.cli.signedstate;
 import com.swirlds.cli.PlatformCli;
 import com.swirlds.cli.utility.AbstractCommand;
 import com.swirlds.cli.utility.SubcommandOf;
-import com.swirlds.common.io.utility.FileUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.config.Configurator;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -79,28 +76,6 @@ public final class SignedStateCommand extends AbstractCommand {
 
     Verbosity verbosity;
 
-    @Option(
-            names = {"--log-level"},
-            arity = "1",
-            converter = LogLevelConverter.class,
-            defaultValue = "OFF",
-            description = "Log4j level for root logger (can be one of ${COMPLETION-CANDIDATES})")
-    private void setRootLogLevel(final Level loggingLevel) {
-        this.loggingLevel = loggingLevel;
-    }
-
-    Level loggingLevel;
-
-    @SuppressWarnings("java:S4792") // "make sure this logger's configuration is safe"
-    private void setRootLoggingLevel() {
-        // BUG: This doesn't work.  Setting level to `WARN` I still see a message from `INFO STATE_TO_DISK`
-        if (verbosity == Verbosity.VERBOSE) System.out.printf("===Log level set to %s%n", loggingLevel);
-        var logger = LogManager.getRootLogger();
-        Configurator.setAllLevels(logger.getName(), loggingLevel);
-        logger = LogManager.getLogger(FileUtils.class);
-        Configurator.setAllLevels(logger.getName(), loggingLevel);
-    }
-
     static class LogLevelConverter implements CommandLine.ITypeConverter<Level> {
 
         @Override
@@ -121,7 +96,6 @@ public final class SignedStateCommand extends AbstractCommand {
 
     @NonNull
     SignedStateHolder openSignedState() {
-        setRootLoggingLevel();
         if (signedState == null) {
             if (verbosity == Verbosity.VERBOSE) System.out.printf("=== opening signed state file '%s'%n", inputFile);
 
@@ -135,7 +109,6 @@ public final class SignedStateCommand extends AbstractCommand {
     }
 
     void closeSignedState() {
-        setRootLoggingLevel();
         if (signedState != null) {
             if (verbosity == Verbosity.VERBOSE) System.out.printf("=== closing signed state file '%s'%n", inputFile);
 

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -111,12 +111,19 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
      *
      * @param ids - direct from the signed state file there's one contract id for each bytecode, but
      *     there are duplicates which can be coalesced and then there's a set of ids for the single
-     *     contract
+     *     contract; kept in sorted order by the container `TreeSet` so it's easy to get the canonical
+     *     id for the contract, and also you can't forget to process them in a deterministic order
      * @param bytecode - bytecode of the contract
      * @param validity - whether the contract is valid or note, aka active or deleted
      */
     public record Contract(
             @NonNull TreeSet</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode, @NonNull Validity validity) {
+
+        // For any set of contract ids with the same bytecode, the lowest contract id is used as the "canonical"
+        // id for that bytecode (useful for ordering contracts deterministically)
+        public int canonicalId() {
+            return ids.first();
+        }
 
         @Override
         public boolean equals(final Object o) {


### PR DESCRIPTION
**Description**:

Cleanup from PR #7729, leftover reviewer comments.

Biggest single change is removing broken logging overrides.  Another useful change is fixing up the sorting of contract ids so it is really centralized in one place and applied throughout without having to take care of it.

**Related issue(s)**:

Fixes #7715

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
