### PR TITLE
Differential testing analytical engine: Dump accounts, as text, from state file

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
+import com.hedera.node.app.service.mono.state.migration.HederaAccount;
+import com.hedera.services.cli.signedstate.DumpStateCommand.Format;
+import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import com.hedera.services.cli.utils.ThingsToStrings;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+
+// TODO: SPS/TSL -1 is default, not 0
+// TODO: Validate both CSV and elided output does output all fields correctly
+
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+public class DumpAccountsSubcommand {
+
+    static void doit(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path accountPath,
+            final int limit,
+            @NonNull final Format format,
+            @NonNull final Verbosity verbosity) {
+        new DumpAccountsSubcommand(state, accountPath, limit, format, verbosity).doit();
+    }
+
+    @NonNull
+    final SignedStateHolder state;
+
+    @NonNull
+    final Path accountPath;
+
+    @NonNull
+    final Verbosity verbosity;
+
+    @NonNull
+    final Format format;
+
+    final int limit;
+
+    DumpAccountsSubcommand(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path accountPath,
+            final int limit,
+            @NonNull final Format format,
+            @NonNull final Verbosity verbosity) {
+        this.state = state;
+        this.accountPath = accountPath;
+        this.limit = limit >= 0 ? limit : Integer.MAX_VALUE;
+        this.format = format;
+        this.verbosity = verbosity;
+    }
+
+    void doit() {
+        final var accountsStore = state.getAccounts();
+        System.out.printf(
+                "=== %d accounts %s%n", accountsStore.size(), accountsStore.areOnDisk() ? "on disk" : "in memory");
+
+        final var accountsArr = gatherAccounts(accountsStore);
+
+        final var sb = new StringBuilder(1000);
+        final var reportSize = new int[1];
+
+        try (final var fileWriter = new FileWriter(accountPath.toFile(), StandardCharsets.UTF_8);
+                final var writer = new BufferedWriter(fileWriter)) {
+
+            if (format == Format.CSV) {
+                writer.write("account#");
+                writer.write(FIELD_SEPARATOR);
+                writer.write(formatCsvHeader(allFieldNamesInOrder()));
+                writer.newLine();
+            }
+
+            Arrays.stream(accountsArr).map(a -> formatAccount(sb, a)).forEachOrdered(s -> {
+                try {
+                    writer.write(s);
+                    writer.newLine();
+                } catch (final IOException ex) {
+                    System.err.printf("Error writing to '%s':%n", accountPath);
+                    throw new UncheckedIOException(ex);
+                }
+                reportSize[0] += s.length() + 1;
+            });
+        } catch (final IOException ex) {
+            System.err.printf("Error creating or closing '%s'%n", accountPath);
+            throw new UncheckedIOException(ex); // CLI program: Java will print the exception + stacktrace
+        }
+
+        System.out.printf("=== report is %d bytes%n", reportSize[0]);
+    }
+
+    @NonNull
+    HederaAccount[] gatherAccounts(@NonNull AccountStorageAdapter accountStore) {
+        final var accounts = new ConcurrentLinkedQueue<HederaAccount>();
+        final var processed = new AtomicInteger();
+        accountStore.forEach((entityNum, hederaAccount) -> {
+            final var n = processed.incrementAndGet();
+            if (n > limit) return;
+            accounts.add(hederaAccount);
+        });
+        final var accountsArr = accounts.toArray(new HederaAccount[0]);
+        Arrays.parallelSort(accountsArr, Comparator.comparingInt(HederaAccount::number));
+        System.out.printf(
+                "=== %d accounts iterated over (%d saved, %d limit)%n", processed.get(), accountsArr.length, limit);
+        return accountsArr;
+    }
+
+    static final String FIELD_SEPARATOR = ";";
+    static final String SUBFIELD_SEPARATOR = ",";
+    static final String NAME_TO_VALUE_SEPARATOR = ":";
+
+    @NonNull
+    String formatCsvHeader(@NonNull final List<String> names) {
+        return String.join(FIELD_SEPARATOR, names);
+    }
+
+    @NonNull
+    List<String> allFieldNamesInOrder() {
+        final var r = new ArrayList<String>(50);
+        r.addAll(getFieldNamesInOrder(booleanFieldsMapping));
+        r.addAll(getFieldNamesInOrder(intFieldsMapping));
+        r.addAll(getFieldNamesInOrder(longFieldsMapping));
+        r.addAll(getFieldNamesInOrder(getFieldAccessors(new StringBuilder(), getMockAccount()), false));
+        return r.stream().map(s -> fieldNameMap.getOrDefault(s, s)).toList();
+    }
+
+    @NonNull
+    HederaAccount getMockAccount() {
+        return (HederaAccount) Proxy.newProxyInstance(
+                HederaAccount.class.getClassLoader(), new Class<?>[] {HederaAccount.class}, (p, m, as) -> null);
+    }
+
+    @NonNull
+    String formatAccount(@NonNull final StringBuilder sb, @NonNull final HederaAccount a) {
+        sb.setLength(0);
+        sb.append(a.number());
+        formatAccountBooleans(sb, a, "bools");
+        formatAccountInts(sb, a, "ints");
+        formatAccountLongs(sb, a, "longs");
+        formatAccountOtherFields(sb, a);
+        return sb.toString();
+    }
+
+    static final Map<String, String> fieldNameMap = toMap(
+            "#+B", "numPositiveBalances",
+            "#A", "numAssociations",
+            "#KV", "numContractKvPairs",
+            "#NFT", "numNftsOwned",
+            "#TT", "numTreasuryTitles",
+            "#UAA", "numUsedAutoAssociations",
+            "AR", "hasAutoRenewAccount",
+            "ARS", "autoRenewSecs",
+            "B", "balance",
+            "BR", "hasBeenRewardedSinceLastStakeMetaChange",
+            "DL", "deleted",
+            "DR", "declinedReward",
+            "ER", "expiredAndPendingRemoval",
+            "EX", "expiry",
+            "HA", "hasAlias",
+            "HNSN", "headNftSerialNum",
+            "HNTN", "headNftTokenNum",
+            "HTI", "headTokenId",
+            "IM", "immutable",
+            "N", "ethereumNonce",
+            "PR", "mayHavePendingReward",
+            "RSR", "receiverSigRequired",
+            "SC", "smartContract",
+            "SID", "stakedId",
+            "SNID", "stakedNodeAddressBookId",
+            "SPS", "stakePeriodStart",
+            "STM", "stakedToMe",
+            "TS", "totalStake",
+            "TSL", "totalStakeAtStartOfLastRewardedPeriod",
+            "TT", "tokenTreasury",
+            "^AA", "maxAutomaticAssociations");
+
+    @NonNull
+    static Map<String, String> toMap(String... es) {
+        if (0 != es.length % 2)
+            throw new IllegalArgumentException(
+                    "must have even number of args to `toMap`, %d given".formatted(es.length));
+        final var r = new TreeMap<String, String>();
+        for (int i = 0; i < es.length; i += 2) {
+            r.put(es[i], es[i + 1]);
+        }
+        return r;
+    }
+
+    void formatFieldSep(@NonNull final StringBuilder sb, @NonNull final String name) {
+        sb.append(FIELD_SEPARATOR);
+        sb.append(name);
+        sb.append(NAME_TO_VALUE_SEPARATOR);
+    }
+
+    /** A mapping for all `boolean`-valued fields that takes the field name to the field extractor. */
+    static final List<Pair<String, Function<HederaAccount, Boolean>>> booleanFieldsMapping = List.of(
+            Pair.of("AR", HederaAccount::hasAutoRenewAccount),
+            Pair.of("BR", HederaAccount::hasBeenRewardedSinceLastStakeMetaChange),
+            Pair.of("DL", HederaAccount::isDeleted),
+            Pair.of("DR", HederaAccount::isDeclinedReward),
+            Pair.of("ER", HederaAccount::isExpiredAndPendingRemoval),
+            Pair.of("HA", HederaAccount::hasAlias),
+            Pair.of("IM", HederaAccount::isImmutable),
+            Pair.of("PR", HederaAccount::mayHavePendingReward),
+            Pair.of("RSR", HederaAccount::isReceiverSigRequired),
+            Pair.of("SC", HederaAccount::isSmartContract),
+            Pair.of("TT", HederaAccount::isTokenTreasury));
+
+    /** Formats all the `boolean`-valued fields of an account, using the mapping `booleanFieldsMapping`. */
+    void formatAccountBooleans(
+            @NonNull final StringBuilder sb, @NonNull final HederaAccount a, @NonNull final String name) {
+        formatAccountFieldsForDifferentOutputFormats(
+                sb, a, name, booleanFieldsMapping, b -> !b, DumpAccountsSubcommand::tagOnlyFieldFormatter);
+    }
+
+    /** A mapping for all `int`-valued fields that takes the field name to the field extractor. */
+    static final List<Pair<String, Function<HederaAccount, Integer>>> intFieldsMapping = List.of(
+            Pair.of("#+B", HederaAccount::getNumPositiveBalances),
+            Pair.of("#A", HederaAccount::getNumAssociations),
+            Pair.of("#KV", HederaAccount::getNumContractKvPairs),
+            Pair.of("#TT", HederaAccount::getNumTreasuryTitles),
+            Pair.of("#UAA", HederaAccount::getUsedAutoAssociations),
+            Pair.of("^AA", HederaAccount::getMaxAutomaticAssociations));
+
+    /** Formats all the `int`-valued fields of an account, using the mapping `intFieldsMapping`. */
+    void formatAccountInts(
+            @NonNull final StringBuilder sb, @NonNull final HederaAccount a, @NonNull final String name) {
+        formatAccountFieldsForDifferentOutputFormats(
+                sb, a, name, intFieldsMapping, n -> n == 0, DumpAccountsSubcommand::taggedFieldFormatter);
+    }
+
+    /** A mapping for all `long`-valued fields that takes the field name to the field extractor. */
+    static final List<Pair<String, Function<HederaAccount, Long>>> longFieldsMapping = List.of(
+            Pair.of("#NFT", HederaAccount::getNftsOwned),
+            Pair.of("ARS", HederaAccount::getAutoRenewSecs),
+            Pair.of("B", HederaAccount::getBalance),
+            Pair.of("EX", HederaAccount::getExpiry),
+            Pair.of("HNSN", HederaAccount::getHeadNftSerialNum),
+            Pair.of("HNTN", HederaAccount::getHeadNftTokenNum),
+            Pair.of("HTI", HederaAccount::getHeadTokenId),
+            Pair.of("N", HederaAccount::getEthereumNonce),
+            Pair.of("SID", HederaAccount::getStakedId),
+            Pair.of("SNID", HederaAccount::getStakedNodeAddressBookId),
+            Pair.of("SPS", HederaAccount::getStakePeriodStart),
+            Pair.of("STM", HederaAccount::getStakedToMe),
+            Pair.of("TS", HederaAccount::totalStake),
+            Pair.of("TSL", HederaAccount::totalStakeAtStartOfLastRewardedPeriod));
+
+    /** Formats all the `long`-valued fields of an account, using the mapping `longFieldsMapping`. */
+    void formatAccountLongs(
+            @NonNull final StringBuilder sb, @NonNull final HederaAccount a, @NonNull final String name) {
+        formatAccountFieldsForDifferentOutputFormats(
+                sb, a, name, longFieldsMapping, n -> n == 0, DumpAccountsSubcommand::taggedFieldFormatter);
+    }
+
+    /** A mapping for all account fields that are _not_ of primitive type.  Takes the field name to a `Field`, which
+     * holds the field name, the field extractor ,and the field formatter. And it _is_ a "mapping" even though it isn't
+     * actually a `Map` data structure like the other mappings for primitive typed fields. */
+    @SuppressWarnings({"java:S1452", "java:S2681"})
+    // 1452: generic wildcard types should not be used in return types - yes, but this is a collection of `Field`s
+    // of unrelated types, yet `Object` is not appropriate either
+    // 2681: a complaint about no braces around `then` clause - yep, intentional, and correct
+    // spotless:off
+    List<Field<?>> getFieldAccessors(@NonNull final StringBuilder sb, @NonNull final HederaAccount a) {
+        return Stream.of(
+                Field.of("1stContractStorageKey", a::getFirstContractStorageKey, doWithBuilder(sb, ThingsToStrings::toStringOfContractKey)),
+                Field.of("accountKey", a::getAccountKey, doWithBuilder(sb, ThingsToStrings::toStringOfJKey)),
+                Field.of("alias", a::getAlias, doWithBuilder(sb, ThingsToStrings::toStringOfByteString)),
+                Field.of("approveForAllNfts", a::getApproveForAllNfts, doWithBuilder(sb, ThingsToStrings::toStringOfFcTokenAllowanceIdSet)),
+                Field.of("autoRenewAccount", a::getAutoRenewAccount, doWithBuilder(sb, ThingsToStrings::toStringOfEntityId)),
+                Field.of("cryptoAllowances", a::getCryptoAllowances, doWithBuilder(sb, ThingsToStrings::toStringOfMapEnLong)),
+                Field.of("firstUint256Key", a::getFirstUint256Key, doWithBuilder(sb, ThingsToStrings::toStringOfIntArray)),
+                Field.of("fungibleTokenAllowances", a::getFungibleTokenAllowances, doWithBuilder(sb, ThingsToStrings::toStringOfMapFcLong)),
+                Field.of("headNftKey", a::getHeadNftKey, doWithBuilder(sb, ThingsToStrings::toStringOfEntityNumPair)),
+                Field.of("latestAssociation", a::getLatestAssociation, doWithBuilder(sb, ThingsToStrings::toStringOfEntityNumPair)),
+                Field.of("memo", a::getMemo, s -> { if (s.isEmpty()) return false; sb.append(ThingsToStrings.quoteForCsv(s)); return true; }),
+                Field.of("proxy", a::getProxy, doWithBuilder(sb, ThingsToStrings::toStringOfEntityId))
+        ).sorted(Comparator.comparing(Field::name)).toList();
+    }
+    // spotless:on
+
+    record Field<T>(@NonNull String name, @NonNull Supplier<T> supplier, @NonNull Predicate<T> formatter) {
+
+        static <U> Field<U> of(
+                @NonNull final String name,
+                @NonNull final Supplier<U> supplier,
+                @NonNull final Predicate<U> formatter) {
+            return new Field<>(name, supplier, formatter);
+        }
+
+        /** Convenience method to extract the field from the account then apply the formatter to it. */
+        boolean apply() {
+            return formatter.test(supplier.get());
+        }
+    }
+
+    /** Apply a formatter, given a `StringBuilder` and return whether (or not) the field _existed_ and should be
+     * emitted. */
+    <T> Predicate<T> doWithBuilder(@NonNull final StringBuilder sb, @NonNull final BiPredicate<StringBuilder, T> bifn) {
+        return t -> bifn.test(sb, t);
+    }
+
+    /** Given a mapping from field names to both a field extraction function (extract from an account) and a field
+     * formatter (type-specific), produce the formatted form of all the fields given in the mapping.  Can do either of
+     * the `Format`s: CSV or compressed fields.
+     */
+    void formatAccountOtherFields(@NonNull final StringBuilder sb, @NonNull HederaAccount a) {
+        final var fieldAccessors = getFieldAccessors(sb, a);
+        for (final var fieldAccessor : fieldAccessors) {
+            final var l = sb.length();
+            final var r =
+                    switch (format) {
+                        case CSV:
+                            sb.append(FIELD_SEPARATOR);
+                            yield fieldAccessor.apply();
+                        case ELIDED_DEFAULT_FIELDS: {
+                            formatFieldSep(sb, fieldAccessor.name());
+                            yield fieldAccessor.apply();
+                        }
+                    };
+            if (!r) sb.setLength(l);
+        }
+    }
+
+    /** Given a mapping from field names (or abbreviations) to a field extraction function (extract from an account)
+     * produce the formatted form of all the fields given in the mapping.  Can do either of the `Format`s: CSV or
+     * compressed fields.
+     * @param sb Accumulating `StringBuffer`
+     * @param a Account to get field from
+     * @param mapping Mapping of field name (or abbreviation) to its extraction method
+     * @param isDefaultValue Predicate to decide if this field has its default value (and can be elided)
+     * @param formatField Method taking field name _and_ value to a string
+     */
+    <T extends Comparable<T>> void formatAccountFieldsForDifferentOutputFormats(
+            @NonNull final StringBuilder sb,
+            @NonNull final HederaAccount a,
+            @NonNull final String name,
+            @NonNull List<Pair<String, Function<HederaAccount, T>>> mapping,
+            @NonNull Predicate<T> isDefaultValue,
+            @NonNull Function<Pair<String, T>, String> formatField) {
+        final var l = sb.length();
+        final var r =
+                switch (format) {
+                    case CSV:
+                        sb.append(FIELD_SEPARATOR);
+                        formatAccountFields(
+                                sb,
+                                a,
+                                mapping,
+                                ignored -> false,
+                                DumpAccountsSubcommand::fieldOnlyFieldFormatter,
+                                noWrappingJoiner);
+                        yield true;
+                    case ELIDED_DEFAULT_FIELDS:
+                        formatFieldSep(sb, name);
+                        formatAccountFields(sb, a, mapping, isDefaultValue, formatField, parenWrappingJoiner);
+                        yield sb.length() - l > 0;
+                };
+        if (!r) sb.setLength(l);
+    }
+
+    /** Given a mapping from field names (or abbreviations) to a field extraction function (extract from an account)
+     * produce the formatted form of all the fields given in the mapping. Takes some additional function arguments
+     * that "customize" the formatting of this field
+     * @param sb Accumulating `StringBuffer`
+     * @param a Account to get field from
+     * @param mapping Mapping of field name (or abbreviation) to its extraction method
+     * @param isDefaultValue Predicate to decide if this field has its default value (and can be elided)
+     * @param formatField Method taking field name _and_ value to a string
+     * @param joinFields Stream collector to join multiple field values
+     */
+    <T extends Comparable<T>> void formatAccountFields(
+            @NonNull final StringBuilder sb,
+            @NonNull final HederaAccount a,
+            @NonNull List<Pair<String, Function<HederaAccount, T>>> mapping,
+            @NonNull Predicate<T> isDefaultValue,
+            @NonNull Function<Pair<String, T>, String> formatField,
+            @NonNull Collector<CharSequence, ?, String> joinFields) {
+        sb.append(mapping.stream()
+                .map(p -> Pair.of(p.getLeft(), applySwallowingExceptions(p.getRight(), a)))
+                .filter(p -> p.getRight() != null && !isDefaultValue.test(p.getRight()))
+                .sorted(Comparator.comparing(Pair::getLeft))
+                .map(formatField)
+                .collect(joinFields));
+    }
+
+    /** Given one of the primitive-type mappings above, extract the field names, and sort them */
+    <T extends Comparable<T>> List<String> getFieldNamesInOrder(
+            @NonNull List<Pair<String, Function<HederaAccount, T>>> mapping) {
+        return mapping.stream().map(Pair::getLeft).sorted().toList();
+    }
+
+    /** Given the field mappings above, extract the field names, and sort them */
+    // (Overload needed because of type erasure; ugly but seemed to me less ugly than an alternate name, YMMV)
+    @SuppressWarnings("java:S1172") // "remove unused method parameter 'ignored'" - nope, needed as described aboved
+    List<String> getFieldNamesInOrder(@NonNull final List<Field<?>> fields, final boolean ignored) {
+        return fields.stream().map(Field::name).sorted().toList();
+    }
+
+    /** Exceptions coming out of lambdas need to be swallowed.  This is ok because the cause is always a missing field
+     * that should not have been accessed, and the check is always made by the caller to see if anything got added to
+     * the accumulating stringbuffer, or not.
+     */
+    @Nullable
+    static <R> R applySwallowingExceptions(
+            @NonNull final Function<HederaAccount, R> fn, @NonNull final HederaAccount a) {
+        try {
+            return fn.apply(a);
+        } catch (final RuntimeException ex) {
+            return null;
+        }
+    }
+
+    /** A Field formatter that emits fields as "name:value". Used for non-boolean fields in compressed format. */
+    @NonNull
+    static <T> String taggedFieldFormatter(Pair<String, T> p) {
+        return p.getLeft() + NAME_TO_VALUE_SEPARATOR + p.getRight();
+    }
+
+    /** A field formatter that only emits the _name_ of the field.  Used for boolean fields in compressed format. */
+    @NonNull
+    static <T> String tagOnlyFieldFormatter(Pair<String, T> p) {
+        return p.getLeft();
+    }
+
+    /** A field formatter that only emits the value of the field itself.  Used for CSV output. */
+    @NonNull
+    static <T> String fieldOnlyFieldFormatter(Pair<String, T> p) {
+        return p.getRight().toString();
+    }
+
+    /** A field joiner that joins _subfields_ with the CSV field separator. */
+    static final Collector<CharSequence, ?, String> noWrappingJoiner = Collectors.joining(FIELD_SEPARATOR);
+
+    /** A field joiner that joins _subfields_ with `,` (i.e., _not_ the CSV field separator) and wraps the entire
+     * thing in parentheses. */
+    static final Collector<CharSequence, ?, String> parenWrappingJoiner =
+            Collectors.joining(SUBFIELD_SEPARATOR, "(", ")");
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
@@ -66,9 +66,16 @@ public class DumpContractBytecodesSubcommand {
     @NonNull
     final Path bytecodePath;
 
+    @NonNull
     final EmitSummary emitSummary;
+
+    @NonNull
     final Uniqify uniqify;
+
+    @NonNull
     final WithIds withIds;
+
+    @NonNull
     final Verbosity verbosity;
 
     DumpContractBytecodesSubcommand(

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -59,8 +59,13 @@ public class DumpContractStoresSubcommand {
     @NonNull
     final Path storePath;
 
+    @NonNull
     final EmitSummary emitSummary;
+
+    @NonNull
     final WithSlots withSlots;
+
+    @NonNull
     final Verbosity verbosity;
 
     DumpContractStoresSubcommand(

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -59,6 +59,11 @@ public class DumpStateCommand extends AbstractCommand {
         YES
     }
 
+    enum Format {
+        CSV,
+        ELIDED_DEFAULT_FIELDS
+    }
+
     // We want to open the signed state file only once but run a bunch of dumps against it
     // (because it takes a long time to open the signed state file).  So we can specify
     // more than one of these subcommands on the single command line.  But we don't get
@@ -123,6 +128,37 @@ public class DumpStateCommand extends AbstractCommand {
                 storePath,
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 withSlots ? WithSlots.YES : WithSlots.NO,
+                parent.verbosity);
+        finish();
+    }
+
+    @Command(name = "accounts")
+    void accounts(
+            @Option(
+                            names = {"--account"},
+                            arity = "1",
+                            description = "Output file for accounts dump")
+                    @NonNull
+                    final Path accountPath,
+            @Option(
+                            names = {"--csv"},
+                            arity = "0..1",
+                            description = "If present output is in pure csv form")
+                    final boolean doCsv,
+            @Option(
+                            names = {"--limit"},
+                            arity = "0..1",
+                            defaultValue = "-1",
+                            description = "Limit #of accounts processed (default: all)")
+                    int limit) {
+        Objects.requireNonNull(accountPath);
+        init();
+        System.out.println("=== accounts ===");
+        DumpAccountsSubcommand.doit(
+                parent.signedState,
+                accountPath,
+                limit,
+                doCsv ? Format.CSV : Format.ELIDED_DEFAULT_FIELDS,
                 parent.verbosity);
         finish();
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -23,6 +23,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Set;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -146,18 +147,29 @@ public class DumpStateCommand extends AbstractCommand {
                             description = "If present output is in pure csv form")
                     final boolean doCsv,
             @Option(
-                            names = {"--limit"},
+                            names = {"--low"},
                             arity = "0..1",
-                            defaultValue = "-1",
-                            description = "Limit #of accounts processed (default: all)")
-                    int limit) {
+                            defaultValue = "0",
+                            description = "Lowest acount number (inclusive) to dump")
+                    int lowLimit,
+            @Option(
+                            names = {"--high"},
+                            arity = "0..1",
+                            defaultValue = "2147483647",
+                            description = "highest account number (inclusive) to dump")
+                    int highLimit) {
         Objects.requireNonNull(accountPath);
+        if (lowLimit > highLimit)
+            throw new CommandLine.ParameterException(
+                    parent.getSpec().commandLine(), "--highLimit must be >= --lowLimit");
+
         init();
         System.out.println("=== accounts ===");
         DumpAccountsSubcommand.doit(
                 parent.signedState,
                 accountPath,
-                limit,
+                lowLimit,
+                highLimit,
                 doCsv ? Format.CSV : Format.ELIDED_DEFAULT_FIELDS,
                 parent.verbosity);
         finish();

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.utils;
+
+import com.google.protobuf.ByteString;
+import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
+import com.hedera.node.app.service.mono.state.submerkle.EntityId;
+import com.hedera.node.app.service.mono.state.submerkle.FcTokenAllowanceId;
+import com.hedera.node.app.service.mono.state.virtual.ContractKey;
+import com.hedera.node.app.service.mono.utils.EntityNum;
+import com.hedera.node.app.service.mono.utils.EntityNumPair;
+import com.swirlds.common.crypto.CryptographyHolder;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ThingsToStrings {
+
+    private static final Pattern quotesNeeded = Pattern.compile("[\"\n;]");
+
+    @NonNull
+    public static String quoteForCsv(@Nullable String s) {
+        if (s == null) s = "";
+        s = s.replace("\"", "\"\""); // quote double-quotes
+        if (quotesNeeded.matcher(s).find()) s = '"' + s + '"';
+        return s;
+    }
+
+    // All of these converters from something to a String will check to see if that something is a "null" or is
+    // an "empty" (whatever "empty" might mean for that thing).  They return `true` iff the thing _existed, otherwise
+    // (null or "empty") return false.  (Thus, they are predicates.)
+
+    // P.S. I had started by naming nearly all of them simply `toString`.  (The couple of exceptions were the ones
+    // taking a `Set` or `Map` which couldn't be named that way because of erasure: They'd collide.) But I soon had
+    // to give them different names as it turns out that method references and overloading don't mix, with Java.
+
+    private static final HexFormat hexer = HexFormat.of().withUpperCase();
+
+    public static boolean toStringOfByteString(@NonNull final StringBuilder sb, @Nullable final ByteString bs) {
+        if (bs == null || bs.size() == 0) return false;
+
+        final var a = bs.toByteArray();
+        hexer.formatHex(sb, a);
+        return true;
+    }
+
+    public static boolean toStringOfByteArray(@NonNull final StringBuilder sb, @Nullable final byte[] bs) {
+        if (bs == null || bs.length == 0) return false;
+
+        hexer.formatHex(sb, bs);
+        return true;
+    }
+
+    public static boolean toStringOfEntityNumPair(
+            @NonNull final StringBuilder sb, @Nullable final EntityNumPair entityNumPair) {
+        if (entityNumPair == null || entityNumPair.equals(EntityNumPair.MISSING_NUM_PAIR)) return false;
+
+        sb.append("(");
+        sb.append(entityNumPair.getHiOrderAsLong());
+        sb.append(",");
+        sb.append(entityNumPair.getLowOrderAsLong());
+        sb.append(")");
+        return true;
+    }
+
+    public static boolean toStringOfEntityNum(@NonNull final StringBuilder sb, @Nullable final EntityNum entityNum) {
+        if (entityNum == null || entityNum.equals(EntityNum.MISSING_NUM)) return false;
+
+        sb.append(entityNum.longValue());
+        return true;
+    }
+
+    public static boolean toStringOfEntityId(@NonNull final StringBuilder sb, @Nullable final EntityId entityId) {
+        if (entityId == null || entityId.equals(EntityId.MISSING_ENTITY_ID)) return false;
+
+        sb.append(entityId.toAbbrevString());
+        return true;
+    }
+
+    public static boolean toStringOfIntArray(@NonNull final StringBuilder sb, @Nullable final int[] ints) {
+        if (ints == null || ints.length == 0) return false;
+
+        sb.append(Arrays.stream(ints).mapToObj(Integer::toString).collect(Collectors.joining(",", "(", ")")));
+        return true;
+    }
+
+    /** Writes a cryptographic hash of the actual key */
+    @SuppressWarnings(
+            "java:S5738") // 'deprecated' code marked for removal - it's practically impossible to use the platform sdk
+    // these days w/o running into deprecated methods
+    public static boolean toStringOfJKey(@NonNull final StringBuilder sb, @Nullable final JKey jkey) {
+        if (jkey == null || jkey.isEmpty()) return false;
+
+        try {
+            final var ser = jkey.serialize();
+            final var hash = CryptographyHolder.get().digestSync(ser).getValue();
+            toStringOfByteArray(sb, hash);
+        } catch (final IOException ex) {
+            sb.append("**EXCEPTION**");
+        }
+        return true;
+    }
+
+    public static boolean toStringOfContractKey(@NonNull final StringBuilder sb, @Nullable final ContractKey ckey) {
+        if (ckey == null) return false;
+
+        sb.append("(");
+        sb.append(ckey.getContractId());
+        sb.append(",");
+        sb.append(ckey.getKeyAsBigInteger());
+        sb.append(")");
+        return true;
+    }
+
+    public static boolean toStringOfFcTokenAllowanceId(
+            @NonNull final StringBuilder sb, @Nullable final FcTokenAllowanceId id) {
+        if (id == null) return false;
+
+        var r = true;
+        sb.append("(");
+        r &= toStringOfEntityNum(sb, id.getTokenNum());
+        sb.append(",");
+        r &= toStringOfEntityNum(sb, id.getSpenderNum());
+        sb.append(")");
+        return r;
+    }
+
+    public static boolean toStringOfFcTokenAllowanceIdSet(
+            @NonNull final StringBuilder sb, @Nullable final Set<FcTokenAllowanceId> ids) {
+        if (ids == null || ids.isEmpty()) return false;
+
+        final var orderedIds = ids.stream().sorted().toList();
+        sb.append("(");
+        for (final var id : orderedIds) {
+            toStringOfFcTokenAllowanceId(sb, id);
+            sb.append(",");
+        }
+        sb.setLength(sb.length() - 1);
+        sb.append(")");
+        return true;
+    }
+
+    public static boolean toStringOfMapEnLong(
+            @NonNull final StringBuilder sb, @Nullable final Map<EntityNum, Long> map) {
+        if (map == null || map.isEmpty()) return false;
+
+        final var orderedEntries = new TreeMap<>(map);
+        sb.append("(");
+        for (final var kv : orderedEntries.entrySet()) {
+            toStringOfEntityNum(sb, kv.getKey());
+            sb.append("->");
+            sb.append(kv.getValue());
+            sb.append(",");
+        }
+        sb.setLength(sb.length() - 1);
+        sb.append(")");
+        return true;
+    }
+
+    public static boolean toStringOfMapFcLong(
+            @NonNull final StringBuilder sb, @Nullable final Map<FcTokenAllowanceId, Long> map) {
+        if (map == null || map.isEmpty()) return false;
+
+        final var orderedEntries = new TreeMap<>(map);
+        sb.append("(");
+        for (final var kv : orderedEntries.entrySet()) {
+            toStringOfFcTokenAllowanceId(sb, kv.getKey());
+            sb.append("->");
+            sb.append(kv.getValue());
+            sb.append(",");
+        }
+        sb.setLength(sb.length() - 1);
+        sb.append(")");
+        return true;
+    }
+
+    private ThingsToStrings() {}
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
@@ -48,7 +48,7 @@ public class ThingsToStrings {
     }
 
     // All of these converters from something to a String will check to see if that something is a "null" or is
-    // an "empty" (whatever "empty" might mean for that thing).  They return `true` iff the thing _existed, otherwise
+    // an "empty" (whatever "empty" might mean for that thing).  They return `true` if the thing _existed_, otherwise
     // (null or "empty") return false.  (Thus, they are predicates.)
 
     // P.S. I had started by naming nearly all of them simply `toString`.  (The couple of exceptions were the ones

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -13,7 +13,8 @@ module com.hedera.node.app.service.mono {
             com.hedera.node.app.service.token.impl.test,
             com.hedera.node.app.service.networkadmin.impl.test,
             com.hedera.node.app.service.consensus.impl,
-            com.hedera.node.app.service.consensus.impl.test;
+            com.hedera.node.app.service.consensus.impl.test,
+            com.hedera.node.services.cli;
     exports com.hedera.node.app.service.mono.exceptions to
             com.hedera.node.app.service.mono.test.fixtures,
             com.hedera.node.app.service.schedule.impl,
@@ -33,7 +34,8 @@ module com.hedera.node.app.service.mono {
             com.hedera.node.app,
             com.hedera.node.app.service.consensus.impl.test,
             com.hedera.node.app.service.schedule.impl,
-            com.hedera.node.app.service.file.impl;
+            com.hedera.node.app.service.file.impl,
+            com.hedera.node.services.cli;
     exports com.hedera.node.app.service.mono.utils to
             com.hedera.node.app.service.mono.test.fixtures,
             com.hedera.node.app.service.schedule.impl,


### PR DESCRIPTION
**Description**:
Add dump (to text) of account store.

**Related issue(s)**:
Fixes #7738

**Notes for reviewer**: 

(At this exact moment javadoc is mostly missing.  Will be added shortly.)

Somewhat tedious to review, I'm afraid, though it does have its interesting moments to be sure.  Tried to make it as "data driven" as possible to reduce duplication; I'd be interested to know if you thought that it improves or hinders readability.

Lots of fiddly formatting of strings.  And some complexity due to the desire to emit alternatively CSV vs a "compressed field" representation".

_release engineering reviewer_: Changed a `module-info.java` to expose more stuff from the mono-service to the services' `cli-client` module.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (CLI tool: manual testing, inspection of resulting text output file)

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>

