### PR TITLE
Call staking updater via consensus time hook

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ConsensusTimeHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ConsensusTimeHook.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.workflows;
+
+import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakePeriodManager.DEFAULT_STAKING_PERIOD_MINS;
+import static com.hedera.node.app.service.mono.utils.Units.MINUTES_TO_MILLISECONDS;
+import static com.swirlds.common.stream.LinkedObjectStreamUtilities.getPeriod;
+import static java.time.ZoneOffset.UTC;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hedera.node.app.service.token.impl.handlers.staking.EndOfStakingPeriodUpdater;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.config.data.StakingConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Class responsible for running any actions that need to happen at the end of
+ * transaction handling. The reason it's called a consensus time hook is because
+ * the actions are (possibly) triggered by checking the previous transaction's
+ * consensus time against the consensus time of the current transaction.
+ */
+@Singleton
+public class ConsensusTimeHook {
+    private static final Logger logger = LogManager.getLogger(ConsensusTimeHook.class);
+
+    private final EndOfStakingPeriodUpdater stakingCalculator;
+    private Instant consensusTimeOfLastHandledTxn;
+
+    @Inject
+    public ConsensusTimeHook(@NonNull final EndOfStakingPeriodUpdater stakingPeriodCalculator) {
+        this.stakingCalculator = stakingPeriodCalculator;
+    }
+
+    /**
+     * Processing hook to run at the end of each transaction. There are certain actions that need
+     * to be taken once we have a new consensus timestamp. Any such actions should be done here
+     *
+     * @param consensusTime the consensus timestamp of the latest transaction being processed
+     * @param context the {@code HandleContext} context of the transaction being processed
+     */
+    public void process(@NonNull Instant consensusTime, @NonNull final HandleContext context) {
+        if (consensusTimeOfLastHandledTxn == null
+                || consensusTime.getEpochSecond() > consensusTimeOfLastHandledTxn.getEpochSecond()
+                        && isNextPeriod(consensusTimeOfLastHandledTxn, consensusTime, context)) {
+            // Handle the daily staking distributions and updates
+            try {
+                stakingCalculator.updateNodes(consensusTime, context);
+            } catch (final Exception e) {
+                logger.error("CATASTROPHIC failure updating end-of-day stakes", e);
+            }
+
+            // Advance the last consensus time to the given consensus time
+            consensusTimeOfLastHandledTxn = consensusTime;
+        }
+    }
+
+    @VisibleForTesting
+    void setLastConsensusTime(@Nullable final Instant lastConsensusTime) {
+        consensusTimeOfLastHandledTxn = lastConsensusTime;
+    }
+
+    @VisibleForTesting
+    static boolean isNextPeriod(
+            @NonNull final Instant lastConsensusTime,
+            @NonNull final Instant consensusTime,
+            @NonNull final HandleContext handleContext) {
+        final var stakingPeriod =
+                handleContext.configuration().getConfigData(StakingConfig.class).periodMins();
+        if (stakingPeriod == DEFAULT_STAKING_PERIOD_MINS) {
+            return !inSameUtcDay(lastConsensusTime, consensusTime);
+        } else {
+            return getPeriod(consensusTime, stakingPeriod * MINUTES_TO_MILLISECONDS)
+                    != getPeriod(lastConsensusTime, stakingPeriod * MINUTES_TO_MILLISECONDS);
+        }
+    }
+
+    private static boolean inSameUtcDay(@NonNull final Instant now, @NonNull final Instant then) {
+        return LocalDateTime.ofInstant(now, UTC).getDayOfYear()
+                == LocalDateTime.ofInstant(then, UTC).getDayOfYear();
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ConsensusTimeHookTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ConsensusTimeHookTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.workflows;
+
+import static com.hedera.node.app.service.token.impl.handlers.staking.StakePeriodManager.DEFAULT_STAKING_PERIOD_MINS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.hedera.node.app.service.token.impl.handlers.staking.EndOfStakingPeriodUpdater;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.config.data.StakingConfig;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.config.api.Configuration;
+import java.time.Duration;
+import java.time.Instant;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConsensusTimeHookTest {
+    private static final Instant CONSENSUS_TIME_1234567 = Instant.ofEpochSecond(1_234_567L);
+
+    @Mock
+    private EndOfStakingPeriodUpdater stakingPeriodCalculator;
+
+    private ConsensusTimeHook subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new ConsensusTimeHook(stakingPeriodCalculator);
+    }
+
+    @Test
+    void processUpdateSkippedForPreviousPeriod() {
+        verifyNoInteractions(stakingPeriodCalculator);
+    }
+
+    @Test
+    void processUpdateCalledForNullConsensusTime() {
+        subject.setLastConsensusTime(null);
+
+        subject.process(CONSENSUS_TIME_1234567, mock(HandleContext.class));
+
+        verify(stakingPeriodCalculator).updateNodes(notNull(), notNull());
+    }
+
+    @Test
+    void processUpdateSkippedForPreviousConsensusTime() {
+        final var beforeLastConsensusTime = CONSENSUS_TIME_1234567.minusSeconds(1);
+        subject.setLastConsensusTime(CONSENSUS_TIME_1234567);
+
+        subject.process(beforeLastConsensusTime, mock(HandleContext.class));
+
+        verifyNoInteractions(stakingPeriodCalculator);
+    }
+
+    @Test
+    void processUpdateCalledForNextPeriod() {
+        final var context = mock(HandleContext.class);
+        given(context.configuration()).willReturn(newPeriodMinsConfig());
+        // Use any number of seconds that gets isNextPeriod(...) to return true
+        var currentConsensusTime = CONSENSUS_TIME_1234567.plusSeconds(500_000);
+        subject.setLastConsensusTime(CONSENSUS_TIME_1234567);
+
+        // Pre-condition check
+        Assertions.assertThat(ConsensusTimeHook.isNextPeriod(CONSENSUS_TIME_1234567, currentConsensusTime, context))
+                .isTrue();
+
+        subject.process(currentConsensusTime, context);
+
+        verify(stakingPeriodCalculator).updateNodes(eq(currentConsensusTime), notNull());
+    }
+
+    @Test
+    void processUpdateExceptionIsCaught() {
+        doThrow(new RuntimeException("test exception"))
+                .when(stakingPeriodCalculator)
+                .updateNodes(any(), any());
+
+        Assertions.assertThatNoException().isThrownBy(() -> subject.process(Instant.now(), mock(HandleContext.class)));
+    }
+
+    @Test
+    void isNextPeriodDefaultStakingPeriodIsInSameUtcDay() {
+        final var context = mock(HandleContext.class);
+        given(context.configuration()).willReturn(newPeriodMinsConfig());
+
+        final var result = ConsensusTimeHook.isNextPeriod(
+                CONSENSUS_TIME_1234567, CONSENSUS_TIME_1234567.minusSeconds(300), context);
+
+        Assertions.assertThat(result).isFalse();
+    }
+
+    @Test
+    void isNextPeriodDefaultStakingPeriodIsNotInSameUtcDay() {
+        final var context = mock(HandleContext.class);
+        given(context.configuration()).willReturn(newPeriodMinsConfig());
+
+        final var result = ConsensusTimeHook.isNextPeriod(
+                CONSENSUS_TIME_1234567,
+                CONSENSUS_TIME_1234567.plusSeconds(Duration.ofDays(1).toSeconds()),
+                context);
+
+        Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    void isNextPeriodCustomStakingPeriodsMatch() {
+        final var periodMins = 990;
+        final var context = mock(HandleContext.class);
+        given(context.configuration()).willReturn(newPeriodMinsConfig(periodMins));
+
+        final var result = ConsensusTimeHook.isNextPeriod(
+                CONSENSUS_TIME_1234567,
+                CONSENSUS_TIME_1234567.plusSeconds(
+                        // periodMins * 60 seconds/min
+                        periodMins * 60),
+                context);
+
+        Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    void isNextPeriodCustomStakingPeriodsDontMatch() {
+        final var periodMins = 990;
+        final var context = mock(HandleContext.class);
+        given(context.configuration()).willReturn(newPeriodMinsConfig(periodMins));
+
+        final var result = ConsensusTimeHook.isNextPeriod(
+                CONSENSUS_TIME_1234567,
+                CONSENSUS_TIME_1234567.plusSeconds(
+                        // 10 min * 60 seconds/min
+                        10 * 60),
+                context);
+        Assertions.assertThat(result).isFalse();
+    }
+
+    private Configuration newPeriodMinsConfig() {
+        return newPeriodMinsConfig(DEFAULT_STAKING_PERIOD_MINS);
+    }
+
+    private Configuration newPeriodMinsConfig(final long periodMins) {
+        return HederaTestConfigBuilder.create()
+                .withConfigDataType(StakingConfig.class)
+                .withValue("staking.periodMins", periodMins)
+                .getOrCreateConfig();
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -46,6 +47,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.state.HederaRecordCache;
+import com.hedera.node.app.workflows.ConsensusTimeHook;
 import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.TransactionScenarioBuilder;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
@@ -144,6 +146,9 @@ class HandleWorkflowTest extends AppTestBase {
     @Mock
     private HederaRecordCache recordCache;
 
+    @Mock
+    private ConsensusTimeHook consensusTimeHook;
+
     private HandleWorkflow workflow;
 
     @BeforeEach
@@ -187,7 +192,8 @@ class HandleWorkflowTest extends AppTestBase {
                 serviceLookup,
                 configProvider,
                 instantSource,
-                recordCache);
+                recordCache,
+                consensusTimeHook);
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -205,7 +211,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -218,7 +225,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -231,7 +239,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -244,7 +253,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -257,7 +267,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -270,7 +281,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -283,7 +295,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -296,7 +309,8 @@ class HandleWorkflowTest extends AppTestBase {
                         null,
                         configProvider,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -309,7 +323,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         null,
                         instantSource,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -322,7 +337,8 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         null,
-                        recordCache))
+                        recordCache,
+                        consensusTimeHook))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new HandleWorkflow(
                         networkInfo,
@@ -335,6 +351,21 @@ class HandleWorkflowTest extends AppTestBase {
                         serviceLookup,
                         configProvider,
                         instantSource,
+                        null,
+                        consensusTimeHook))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new HandleWorkflow(
+                        networkInfo,
+                        preHandleWorkflow,
+                        dispatcher,
+                        blockRecordManager,
+                        signatureExpander,
+                        signatureVerifier,
+                        checker,
+                        serviceLookup,
+                        configProvider,
+                        instantSource,
+                        recordCache,
                         null))
                 .isInstanceOf(NullPointerException.class);
     }
@@ -1030,5 +1061,11 @@ class HandleWorkflowTest extends AppTestBase {
             verify(blockRecordManager).endUserTransaction(any(), eq(state));
             verify(blockRecordManager).endRound(eq(state));
         }
+    }
+
+    @Test
+    void testConsensusTimeHookCalled() {
+        workflow.handleRound(state, round);
+        verify(consensusTimeHook).process(eq(CONSENSUS_NOW), notNull());
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -78,8 +78,6 @@ public class EndOfStakingPeriodUpdater {
      * Updates all (relevant) staking-related values for all nodes, as well as any network reward information,
      * at the end of a staking period. This method must be invoked during handling of a transaction
      *
-     * TODO: this method is still not called by the handle workflow (will be done in issue #7721)
-     *
      * @param consensusTime the consensus time of the transaction used to end the staking period
      * @param context the context of the transaction used to end the staking period
      */


### PR DESCRIPTION
Port of the logic that determines if staking updates run. Called as part of the top-level transition in mono service code. 

Closes #7721 