### PR TITLE
Fix `curStakePeriod` while doing upgrade house keeping

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -160,4 +160,9 @@ public class StakePeriodManager {
     long getPrevConsensusSecs() {
         return prevConsensusSecs;
     }
+
+    @VisibleForTesting
+    public long getCurrentStakePeriod() {
+        return currentStakePeriod;
+    }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -148,6 +148,14 @@ public class StakePeriodManager {
         return StakingUtils.NA;
     }
 
+    /**
+     * Sets the stakePeriod to the given value. This is only called during upgrade housekeeping.
+     * @param currentStakePeriod the value to set the currentStakePeriod to
+     */
+    public void setCurrentStakePeriod(final long currentStakePeriod) {
+        this.currentStakePeriod = currentStakePeriod;
+    }
+
     @VisibleForTesting
     long getPrevConsensusSecs() {
         return prevConsensusSecs;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.ledger.accounts.staking;
 
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_REWARD_HISTORY_NUM_STORED_PERIODS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_STARTUP_HELPER_RECOMPUTE;
+import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakePeriodManager.ZONE_UTC;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.forEach;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.withLoggedDuration;
 
@@ -30,6 +31,8 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.system.address.AddressBook;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,15 +69,18 @@ public class StakeStartupHelper {
     private final PropertySource properties;
     private final StakeInfoManager stakeInfoManager;
     private final RewardCalculator rewardCalculator;
+    private final StakePeriodManager stakePeriodManager;
 
     @Inject
     public StakeStartupHelper(
             final StakeInfoManager stakeInfoManager,
             final @CompositeProps PropertySource properties,
-            final RewardCalculator rewardCalculator) {
+            final RewardCalculator rewardCalculator,
+            final StakePeriodManager stakePeriodManager) {
         this.properties = properties;
         this.stakeInfoManager = stakeInfoManager;
         this.rewardCalculator = rewardCalculator;
+        this.stakePeriodManager = stakePeriodManager;
     }
 
     /**
@@ -130,6 +136,9 @@ public class StakeStartupHelper {
         // Recompute anything requested by the staking.startupHelper.recompute property
         final var recomputeTypes = properties.getRecomputeTypesProperty(STAKING_STARTUP_HELPER_RECOMPUTE);
         if (!recomputeTypes.isEmpty()) {
+//            final var curStakePeriod = LocalDate.ofInstant(networkContext.consensusTimeOfLastHandledTxn(), ZONE_UTC)
+//                    .toEpochDay();
+//            stakePeriodManager.setCurrentStakePeriod(curStakePeriod);
             withLoggedDuration(
                     () -> recomputeQuantities(
                             recomputeTypes.contains(RecomputeType.NODE_STAKES),

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
@@ -31,7 +31,6 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.system.address.AddressBook;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -136,9 +135,13 @@ public class StakeStartupHelper {
         // Recompute anything requested by the staking.startupHelper.recompute property
         final var recomputeTypes = properties.getRecomputeTypesProperty(STAKING_STARTUP_HELPER_RECOMPUTE);
         if (!recomputeTypes.isEmpty()) {
-//            final var curStakePeriod = LocalDate.ofInstant(networkContext.consensusTimeOfLastHandledTxn(), ZONE_UTC)
-//                    .toEpochDay();
-//            stakePeriodManager.setCurrentStakePeriod(curStakePeriod);
+            // While doing upgrade housekeeping, the current stake period is calculated from the last consensus time
+            // that is recorded in state. This is needed because when we calculate effectivePeriod in rewardCalculator
+            // we need to know the current stake period.
+            final var curStakePeriod = LocalDate.ofInstant(networkContext.consensusTimeOfLastHandledTxn(), ZONE_UTC)
+                    .toEpochDay();
+            stakePeriodManager.setCurrentStakePeriod(curStakePeriod);
+
             withLoggedDuration(
                     () -> recomputeQuantities(
                             recomputeTypes.contains(RecomputeType.NODE_STAKES),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelperTest.java
@@ -88,6 +88,7 @@ class StakeStartupHelperTest {
 
     @Mock
     private RewardCalculator rewardCalculator;
+
     @Mock
     private TransactionContext txnCtx;
 
@@ -98,7 +99,7 @@ class StakeStartupHelperTest {
     private StakeStartupHelper subject;
 
     @BeforeEach
-    public void setUp(){
+    public void setUp() {
         stakePeriodManager = new StakePeriodManager(txnCtx, () -> networkContext, properties);
     }
 
@@ -200,7 +201,7 @@ class StakeStartupHelperTest {
                 }
                 final var pretendReward = r.nextInt(123) * 100_000_000L;
                 given(rewardCalculator.estimatePendingRewards(
-                        account, stakingInfos.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()))))
+                                account, stakingInfos.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()))))
                         .willReturn(pretendReward);
                 pendingRewards += pretendReward;
                 // Should this account decline rewards?


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/7758
- Fixed `curStakePeriod` that was not set during `upgrade` housekeeping

Testing:
Loaded mainnet state from `145234353` and validated fix will not have same error