### PR TITLE
07502 Don't compact the files that are have current level of compaction.

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
@@ -19,6 +19,7 @@ package com.swirlds.benchmark;
 import com.swirlds.merkledb.collections.LongList;
 import com.swirlds.merkledb.collections.LongListOffHeap;
 import com.swirlds.merkledb.files.DataFileCollection;
+import com.swirlds.merkledb.files.DataFileCompactor;
 import com.swirlds.merkledb.files.DataFileReader;
 import java.io.IOException;
 import java.util.List;
@@ -59,6 +60,7 @@ public class DataFileCollectionBench extends BaseBench {
                         return readDataItem(dataLocation);
                     }
                 };
+        final var compactor = new DataFileCompactor(store);
         System.out.println();
 
         // Write files
@@ -79,7 +81,7 @@ public class DataFileCollectionBench extends BaseBench {
         // Merge files
         start = System.currentTimeMillis();
         final List<DataFileReader<BenchmarkRecord>> filesToMerge = store.getAllCompletedFiles();
-        store.compactFiles(index, filesToMerge);
+        compactor.compact(index, null, null);
         System.out.println(
                 "Merged " + filesToMerge.size() + " files in " + (System.currentTimeMillis() - start) + "ms");
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
@@ -18,7 +18,6 @@ package com.swirlds.benchmark;
 
 import com.swirlds.merkledb.files.hashmap.HalfDiskHashMap;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicLong;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -70,7 +69,6 @@ public class HalfDiskMapBench extends BaseBench {
 
         // Merge files
         start = System.currentTimeMillis();
-        final AtomicLong count = new AtomicLong(0);
         store.compact(null, null);
         System.out.println("Compacted files in " + (System.currentTimeMillis() - start) + "ms");
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
@@ -71,15 +71,8 @@ public class HalfDiskMapBench extends BaseBench {
         // Merge files
         start = System.currentTimeMillis();
         final AtomicLong count = new AtomicLong(0);
-        store.merge(
-                list -> {
-                    count.set(list.size());
-                    return list;
-                },
-                2,
-                null,
-                null);
-        System.out.println("Merged " + count.get() + " files in " + (System.currentTimeMillis() - start) + "ms");
+        store.compact(null, null);
+        System.out.println("Compacted files in " + (System.currentTimeMillis() - start) + "ms");
 
         // Verify merged content
         if (verify) {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -18,7 +18,6 @@ package com.swirlds.benchmark;
 
 import com.swirlds.merkledb.collections.LongListOffHeap;
 import com.swirlds.merkledb.files.MemoryIndexDiskKeyValueStore;
-import java.util.concurrent.atomic.AtomicLong;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -70,16 +69,8 @@ public class KeyValueStoreBench extends BaseBench {
 
         // Merge files
         start = System.currentTimeMillis();
-        final AtomicLong count = new AtomicLong(0);
-        store.merge(
-                list -> {
-                    count.set(list.size());
-                    return list;
-                },
-                2,
-                null,
-                null);
-        System.out.println("Merged " + count.get() + " files in " + (System.currentTimeMillis() - start) + "ms");
+        store.compact(null, null);
+        System.out.println("Compacted files in " + (System.currentTimeMillis() - start) + "ms");
 
         // Verify merged content
         if (verify) {

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/CompactionType.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/CompactionType.java
@@ -20,13 +20,24 @@ package com.swirlds.merkledb;
  * Data file collection compaction type.
  */
 public enum CompactionType {
+    NO_COMPACTION(0),
 
     /** Small compactions */
-    SMALL,
+    SMALL(1),
 
     /** Medium compactions */
-    MEDIUM,
+    MEDIUM(2),
 
     /** Full (large) compactions */
-    FULL
+    FULL(3);
+
+    CompactionType(int level) {
+        this.level = level;
+    }
+
+    private int level;
+
+    public int getLevel() {
+        return level;
+    }
 }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -40,7 +40,6 @@ import com.swirlds.merkledb.collections.LongListDisk;
 import com.swirlds.merkledb.collections.LongListOffHeap;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.DataFileCollection;
-import com.swirlds.merkledb.files.DataFileCommon;
 import com.swirlds.merkledb.files.DataFileReader;
 import com.swirlds.merkledb.files.MemoryIndexDiskKeyValueStore;
 import com.swirlds.merkledb.files.VirtualHashRecordSerializer;
@@ -66,8 +65,6 @@ import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.time.Instant;
-import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -81,7 +78,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.IntConsumer;
-import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -192,10 +188,10 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
     private final VirtualLeafRecord[] leafRecordCache;
 
     /** ScheduledThreadPool for executing merges */
-    private final ScheduledThreadPoolExecutor mergingExecutor;
+    private final ScheduledThreadPoolExecutor compactingExecutor;
 
     /** Future for scheduled merging thread */
-    private ScheduledFuture<?> mergingFuture = null;
+    private ScheduledFuture<?> compactingFuture = null;
 
     /** Thread pool storing internal records */
     private final ExecutorService storeInternalExecutor;
@@ -222,19 +218,10 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
 
     private final AtomicBoolean compactionEnabled = new AtomicBoolean();
 
-    /** When was the last medium-sized merge, only touched from single merge thread. */
-    private Instant lastMediumMerge;
-
-    /** When was the last full merge, only touched from single merge thread. */
-    private Instant lastFullMerge;
-
     /** Paths to all database files and directories */
     private final MerkleDbPaths dbPaths;
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
-
-    /** A nanosecond-precise Clock */
-    private final NanoClock clock = new NanoClock();
 
     public MerkleDbDataSource(
             final MerkleDb database,
@@ -253,7 +240,7 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         // create thread group with label
         final ThreadGroup threadGroup = new ThreadGroup("MerkleDb-" + tableName);
         // create scheduledThreadPool for executing merges
-        mergingExecutor = new ScheduledThreadPoolExecutor(
+        compactingExecutor = new ScheduledThreadPoolExecutor(
                 NUMBER_OF_MERGING_THREADS,
                 new ThreadConfiguration(getStaticThreadManager())
                         .setThreadGroup(threadGroup)
@@ -401,16 +388,6 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         leafRecordCacheSize = config.leafRecordCacheSize();
         leafRecordCache = (leafRecordCacheSize > 0) ? new VirtualLeafRecord[leafRecordCacheSize] : null;
 
-        // Compute initial merge periods to a randomized value of now +/- 50% of merge period. So
-        // each node will do
-        // medium and full merges at random times.
-        lastMediumMerge = Instant.now()
-                .minus(config.mediumMergePeriod() / 2, config.mergePeriodUnit())
-                .plus((long) (config.mediumMergePeriod() * Math.random()), config.mergePeriodUnit());
-        lastFullMerge = Instant.now()
-                .minus(config.fullMergePeriod() / 2, config.mergePeriodUnit())
-                .plus((long) (config.fullMergePeriod() * Math.random()), config.mergePeriodUnit());
-
         // If merging is enabled start merging service
         if (compactionEnabled) {
             startBackgroundCompaction();
@@ -436,10 +413,13 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
     @Override
     public void startBackgroundCompaction() {
         compactionEnabled.set(true);
-        synchronized (mergingExecutor) {
-            if (mergingFuture == null || mergingFuture.isCancelled()) {
-                mergingFuture = mergingExecutor.scheduleAtFixedRate(
-                        this::doMerge, config.mergeActivatePeriod(), config.mergeActivatePeriod(), TimeUnit.SECONDS);
+        synchronized (compactingExecutor) {
+            if (compactingFuture == null || compactingFuture.isCancelled()) {
+                compactingFuture = compactingExecutor.scheduleAtFixedRate(
+                        this::doCompaction,
+                        config.mergeActivatePeriod(),
+                        config.mergeActivatePeriod(),
+                        TimeUnit.SECONDS);
             }
         }
     }
@@ -447,10 +427,10 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
     /** Stop background compaction process, if it is running. */
     @Override
     public void stopBackgroundCompaction() {
-        synchronized (mergingExecutor) {
-            if (mergingFuture != null) {
-                mergingFuture.cancel(true);
-                mergingFuture = null;
+        synchronized (compactingExecutor) {
+            if (compactingFuture != null) {
+                compactingFuture.cancel(true);
+                compactingFuture = null;
             }
         }
         compactionEnabled.set(false);
@@ -791,7 +771,7 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
                 stopBackgroundCompaction();
                 // shut down all four DB threads
                 shutdownThreadsAndWait(
-                        mergingExecutor, storeInternalExecutor, storeKeyToPathExecutor, snapshotExecutor);
+                        compactingExecutor, storeInternalExecutor, storeKeyToPathExecutor, snapshotExecutor);
             } finally {
                 // close all closable data stores
                 logger.info(MERKLE_DB.getMarker(), "Closing Data Source [{}]", tableName);
@@ -1333,7 +1313,7 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
     }
 
     /**
-     * Start a Merge if needed, this is called by default every 30 seconds if a merge is not already
+     * Start a compaction if needed, this is called by default every second if a merge is not already
      * running. This implements the logic for how often and with what files we merge.
      *
      * <b> IMPORTANT: This method is called on a thread that can be interrupted, so it needs to
@@ -1347,68 +1327,29 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
      *     occurred.
      */
     @SuppressWarnings({"rawtypes", "unchecked", "ConstantConditions"})
-    boolean doMerge() {
+    boolean doCompaction() {
         try {
-            Instant timestamp = Instant.now(clock);
-
-            final UnaryOperator<List<DataFileReader>> filesToMergeFilter;
-            final CompactionType compactionType;
-            if (isTimeForFullMerge(timestamp)) {
-                lastFullMerge = timestamp;
-                /* Filter nothing during a full merge */
-                filesToMergeFilter = dataFileReaders -> dataFileReaders;
-                compactionType = CompactionType.FULL;
-                logger.info(MERKLE_DB.getMarker(), "[{}] Starting Large Merge", tableName);
-            } else if (isTimeForMediumMerge(timestamp)) {
-                lastMediumMerge = timestamp;
-                filesToMergeFilter = DataFileCommon.newestFilesSmallerThan(
-                        config.mediumMergeCutoffMb(), config.maxNumberOfFilesInMerge());
-                compactionType = CompactionType.MEDIUM;
-                logger.info(MERKLE_DB.getMarker(), "[{}] Starting Medium Merge", tableName);
-            } else {
-                filesToMergeFilter = DataFileCommon.newestFilesSmallerThan(
-                        config.smallMergeCutoffMb(), config.maxNumberOfFilesInMerge());
-                compactionType = CompactionType.SMALL;
-                logger.info(MERKLE_DB.getMarker(), "[{}] Starting Small Merge", tableName);
-            }
-
             int totalFileSizeMb = 0;
             // we need to merge disk files for internal hashes if they exist and pathToHashKeyValue store
             if (hasDiskStoreForHashes) {
-                // horrible hack to get around generics because file filters work on any type of
-                // DataFileReader
-                final UnaryOperator<List<DataFileReader<VirtualHashRecord>>> internalRecordFileFilter =
-                        (UnaryOperator<List<DataFileReader<VirtualHashRecord>>>) ((Object) filesToMergeFilter);
-                hashStoreDisk.merge(
-                        internalRecordFileFilter,
-                        config.minNumberOfFilesInMerge(),
-                        time -> statistics.setHashesStoreCompactionTimeMs(compactionType, time),
-                        savedSpace -> statistics.setHashesStoreCompactionSavedSpaceMb(compactionType, savedSpace));
+                hashStoreDisk.compact(
+                        (compactionType, time) -> statistics.setHashesStoreCompactionTimeMs(compactionType, time),
+                        (compactionType, savedSpace) ->
+                                statistics.setHashesStoreCompactionSavedSpaceMb(compactionType, savedSpace));
                 totalFileSizeMb += updateHashesStoreFileStats();
             }
             // merge objectKeyToPath files
             if (objectKeyToPath != null) {
-                // horrible hack to get around generics because file filters work on any type of
-                // DataFileReader
-                final UnaryOperator<List<DataFileReader<Bucket<K>>>> bucketFileFilter =
-                        (UnaryOperator<List<DataFileReader<Bucket<K>>>>) ((Object) filesToMergeFilter);
-                objectKeyToPath.merge(
-                        bucketFileFilter,
-                        config.minNumberOfFilesInMerge(),
-                        time -> statistics.setLeafKeysStoreCompactionTimeMs(compactionType, time),
-                        savedSpace -> statistics.setLeafKeysStoreCompactionSavedSpaceMb(compactionType, savedSpace));
+                objectKeyToPath.compact(
+                        (compactionType, time) -> statistics.setLeafKeysStoreCompactionTimeMs(compactionType, time),
+                        (compactionType, savedSpace) ->
+                                statistics.setLeafKeysStoreCompactionSavedSpaceMb(compactionType, savedSpace));
                 totalFileSizeMb += updateLeafKeysStoreFileStats();
             }
-            // now do main merge of pathToKeyValue store
-            // horrible hack to get around generics because file filters work on any type of
-            // DataFileReader
-            final UnaryOperator<List<DataFileReader<VirtualLeafRecord<K, V>>>> leafRecordFileFilter =
-                    (UnaryOperator<List<DataFileReader<VirtualLeafRecord<K, V>>>>) ((Object) filesToMergeFilter);
-            pathToKeyValue.merge(
-                    leafRecordFileFilter,
-                    config.minNumberOfFilesInMerge(),
-                    time -> statistics.setLeavesStoreCompactionTimeMs(compactionType, time),
-                    savedSpace -> statistics.setLeavesStoreCompactionSavedSpaceMb(compactionType, savedSpace));
+            pathToKeyValue.compact(
+                    (compactionType, time) -> statistics.setLeavesStoreCompactionTimeMs(compactionType, time),
+                    (compactionType, savedSpace) ->
+                            statistics.setLeavesStoreCompactionSavedSpaceMb(compactionType, savedSpace));
             totalFileSizeMb += updateLeavesStoreFileStats();
 
             // Update total file size stat
@@ -1427,18 +1368,6 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
             logger.error(EXCEPTION.getMarker(), "[{}] Compaction failed", tableName, e);
             return false;
         }
-    }
-
-    private boolean isTimeForFullMerge(final Instant startMerge) {
-        return startMerge
-                .minus(config.fullMergePeriod(), config.mergePeriodUnit())
-                .isAfter(lastFullMerge);
-    }
-
-    private boolean isTimeForMediumMerge(final Instant startMerge) {
-        return startMerge
-                .minus(config.mediumMergePeriod(), config.mergePeriodUnit())
-                .isAfter(lastMediumMerge);
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -494,6 +494,7 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionTimeMs(final CompactionType type, final long value) {
         final LongAccumulator metric =
                 switch (type) {
+                    case NO_COMPACTION -> null;
                     case SMALL -> hashesStoreSmallCompactionTimeMs;
                     case MEDIUM -> hashesStoreMediumCompactionTimeMs;
                     case FULL -> hashesStoreFullCompactionTimeMs;
@@ -513,6 +514,7 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionSavedSpaceMb(final CompactionType type, final double value) {
         final DoubleAccumulator metric =
                 switch (type) {
+                    case NO_COMPACTION -> null;
                     case SMALL -> hashesStoreSmallCompactionSavedSpaceMb;
                     case MEDIUM -> hashesStoreMediumCompactionSavedSpaceMb;
                     case FULL -> hashesStoreFullCompactionSavedSpaceMb;
@@ -532,6 +534,7 @@ public class MerkleDbStatistics {
     public void setLeavesStoreCompactionTimeMs(final CompactionType type, final long value) {
         final LongAccumulator metric =
                 switch (type) {
+                    case NO_COMPACTION -> null;
                     case SMALL -> leavesStoreSmallCompactionTimeMs;
                     case MEDIUM -> leavesStoreMediumCompactionTimeMs;
                     case FULL -> leavesStoreFullCompactionTimeMs;
@@ -551,6 +554,7 @@ public class MerkleDbStatistics {
     public void setLeavesStoreCompactionSavedSpaceMb(final CompactionType type, final double value) {
         final DoubleAccumulator metric =
                 switch (type) {
+                    case NO_COMPACTION -> null;
                     case SMALL -> leavesStoreSmallCompactionSavedSpaceMb;
                     case MEDIUM -> leavesStoreMediumCompactionSavedSpaceMb;
                     case FULL -> leavesStoreFullCompactionSavedSpaceMb;
@@ -570,6 +574,7 @@ public class MerkleDbStatistics {
     public void setLeafKeysStoreCompactionTimeMs(final CompactionType type, final long value) {
         final LongAccumulator metric =
                 switch (type) {
+                    case NO_COMPACTION -> null;
                     case SMALL -> leafKeysStoreSmallCompactionTimeMs;
                     case MEDIUM -> leafKeysStoreMediumCompactionTimeMs;
                     case FULL -> leafKeysStoreFullCompactionTimeMs;
@@ -589,6 +594,7 @@ public class MerkleDbStatistics {
     public void setLeafKeysStoreCompactionSavedSpaceMb(final CompactionType type, final double value) {
         final DoubleAccumulator metric =
                 switch (type) {
+                    case NO_COMPACTION -> null;
                     case SMALL -> leafKeysStoreSmallCompactionSavedSpaceMb;
                     case MEDIUM -> leafKeysStoreMediumCompactionSavedSpaceMb;
                     case FULL -> leafKeysStoreFullCompactionSavedSpaceMb;

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -115,6 +116,7 @@ public class ImmutableIndexedObjectListUsingArray<T extends IndexedObject> imple
             return this;
         }
 
+        Set<T> objectsToDeleteSet = Set.copyOf(objectsToDelete);
         // Create a temp array list with just non-null objects that belong to the new list
         final List<T> newDataArray = new ArrayList<>();
         for (final T datum : dataArray) {
@@ -122,7 +124,7 @@ public class ImmutableIndexedObjectListUsingArray<T extends IndexedObject> imple
                 continue;
             }
 
-            if (objectsToDelete.contains(datum)) {
+            if (objectsToDeleteSet.contains(datum)) {
                 continue;
             }
 

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -116,7 +115,6 @@ public class ImmutableIndexedObjectListUsingArray<T extends IndexedObject> imple
             return this;
         }
 
-        Set<T> objectsToDeleteSet = Set.copyOf(objectsToDelete);
         // Create a temp array list with just non-null objects that belong to the new list
         final List<T> newDataArray = new ArrayList<>();
         for (final T datum : dataArray) {
@@ -124,7 +122,7 @@ public class ImmutableIndexedObjectListUsingArray<T extends IndexedObject> imple
                 continue;
             }
 
-            if (objectsToDeleteSet.contains(datum)) {
+            if (objectsToDelete.contains(datum)) {
                 continue;
             }
 

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -49,7 +49,7 @@ import java.time.temporal.ChronoUnit;
  * 		to be one of the constants of the {@link ChronoUnit} enum ("SECONDS", "MINUTES", or "HOURS" are the most
  * 		likely to be used). Default is MINUTES.
  * @param maxNumberOfFilesInMerge
- * 		The maximum number of files to include in a single merge. Sets a maximum value for the number of files we will
+ *  	(Deprecated, no longer in use) The maximum number of files to include in a single merge. Sets a maximum value for the number of files we will
  * 		permit to be used in a single merge. The merging algorithm scales at something near O(n^2), and under some
  * 		conditions can get into a runaway state where we are never able to merge all the files. By keeping the number
  * 		fixed, we can use a fixed amount of memory no matter how many files there are, and we can keep each merge round
@@ -112,8 +112,7 @@ public record MerkleDbConfig(
         @ConfigProperty(defaultValue = "10240") int mediumMergeCutoffMb,
         @ConfigProperty(defaultValue = "3072") int smallMergeCutoffMb,
         @ConfigProperty(defaultValue = "MINUTES") ChronoUnit mergePeriodUnit,
-        @ConstraintMethod("maxNumberOfFilesInMergeValidation") @ConfigProperty(defaultValue = "64")
-                int maxNumberOfFilesInMerge,
+        @Deprecated(forRemoval = true) @ConfigProperty(defaultValue = "64") int maxNumberOfFilesInMerge,
         @ConstraintMethod("minNumberOfFilesInMergeValidation") @ConfigProperty(defaultValue = "8")
                 int minNumberOfFilesInMerge,
         @Min(0) @ConfigProperty(defaultValue = "1") long mergeActivatePeriod,
@@ -133,31 +132,13 @@ public record MerkleDbConfig(
 
     static double UNIT_FRACTION_PERCENT = 100.0;
 
-    public ConfigViolation maxNumberOfFilesInMergeValidation(final Configuration configuration) {
-        final long maxNumberOfFilesInMerge =
-                configuration.getConfigData(MerkleDbConfig.class).maxNumberOfFilesInMerge();
-        final long minNumberOfFilesInMerge =
-                configuration.getConfigData(MerkleDbConfig.class).minNumberOfFilesInMerge();
-        if (maxNumberOfFilesInMerge <= minNumberOfFilesInMerge) {
-            return new DefaultConfigViolation(
-                    "maxNumberOfFilesInMerge",
-                    "%d".formatted(maxNumberOfFilesInMerge),
-                    true,
-                    "Cannot configure maxNumberOfFilesInMerge to " + maxNumberOfFilesInMerge + ", it must be > "
-                            + minNumberOfFilesInMerge);
-        }
-        return null;
-    }
-
     public ConfigViolation minNumberOfFilesInMergeValidation(final Configuration configuration) {
-        final long maxNumberOfFilesInMerge =
-                configuration.getConfigData(MerkleDbConfig.class).maxNumberOfFilesInMerge();
         final long minNumberOfFilesInMerge =
                 configuration.getConfigData(MerkleDbConfig.class).minNumberOfFilesInMerge();
         if (minNumberOfFilesInMerge < 2) {
             return new DefaultConfigViolation(
-                    "maxNumberOfFilesInMerge",
-                    "%d".formatted(maxNumberOfFilesInMerge),
+                    "minNumberOfFilesInMerge",
+                    "%d".formatted(minNumberOfFilesInMerge),
                     true,
                     "Cannot configure minNumberOfFilesInMerge to " + minNumberOfFilesInMerge + ", it must be >= 2");
         }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -23,6 +23,7 @@ import static com.swirlds.merkledb.KeyRange.INVALID_KEY_RANGE;
 import static com.swirlds.merkledb.files.DataFileCommon.byteOffsetFromDataLocation;
 import static com.swirlds.merkledb.files.DataFileCommon.fileIndexFromDataLocation;
 import static com.swirlds.merkledb.files.DataFileCommon.isFullyWrittenDataFile;
+import static com.swirlds.merkledb.files.DataFileCompactor.DEFAULT_COMPACTION_LEVEL;
 import static java.util.Collections.singletonList;
 
 import com.swirlds.merkledb.KeyRange;
@@ -42,7 +43,6 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -50,8 +50,6 @@ import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -123,7 +121,7 @@ public class DataFileCollection<D> implements Snapshotable {
     /**
      * The list of current files in this data file collection. The files are added to this list
      * during flushes in {@link #endWriting(long, long)}, after the file is completely written. They
-     * are also added during compaction in {@link #compactFiles(CASableLongIndex, List)}, even
+     * are also added during compaction in {@link DataFileCompactor#compactFiles(CASableLongIndex, List)}, even
      * before compaction is complete. In the end of compaction, all the compacted files are removed
      * from this list.
      *
@@ -134,7 +132,7 @@ public class DataFileCollection<D> implements Snapshotable {
      * collection. If compaction is in progress, the last file in the list isn't fully written yet,
      * so it can't be hard linked easily. To solve it, before a snapshot is taken, the current
      * compaction file is flushed to disk, and compaction is put on hold using {@link
-     * #snapshotCompactionLock} and then resumed after snapshot is complete.
+     * DataFileCompactor#snapshotCompactionLock} and then resumed after snapshot is complete.
      */
     private final AtomicReference<ImmutableIndexedObjectList<DataFileReader<D>>> dataFiles = new AtomicReference<>();
 
@@ -157,42 +155,6 @@ public class DataFileCollection<D> implements Snapshotable {
      */
     private final ConcurrentSkipListSet<Integer> setOfNewFileIndexes =
             logger.isTraceEnabled() ? new ConcurrentSkipListSet<>() : null;
-
-    // Compactions
-
-    /** Start time of the current compaction, or null if compaction isn't running */
-    private final AtomicReference<Instant> currentCompactionStartTime = new AtomicReference<>();
-    /**
-     * Current data file writer during compaction, or null if compaction isn't running. The writer
-     * is created at compaction start. If compaction is interrupted by a snapshot, the writer is
-     * closed before the snapshot, and then a new writer / new file is created after the snapshot is
-     * taken.
-     */
-    private final AtomicReference<DataFileWriter<D>> currentCompactionWriter = new AtomicReference<>();
-    /** Currrent data file reader for the compaction writer above. */
-    private final AtomicReference<DataFileReader<D>> currentCompactionReader = new AtomicReference<>();
-    /**
-     * The list of new files created during compaction. Usually, all files to process are compacted
-     * to a single new file, but if compaction is interrupted by a snapshot, there may be more than
-     * one file created.
-     */
-    private final List<Path> newCompactedFiles = new ArrayList<>();
-    /**
-     * A lock used for synchronization between snapshots and compactions. While a compaction is in
-     * progress, it runs on its own without any synchronization. However, a few critical sections
-     * are protected with this lock: to create a new compaction writer/reader when compaction is
-     * started, to copy data items to the current writer and update the corresponding index item,
-     * and to close the compaction writer. This mechanism allows snapshots to effectively put
-     * compaction on hold, which is critical as snapshots should be as fast as possible, while
-     * compactions are just background processes.
-     */
-    private final Semaphore snapshotCompactionLock = new Semaphore(1);
-    /**
-     * Indicates whether compaction is in progress at the time when {@link #pauseCompaction()}
-     * is called. This flag is then checked in {@link #resumeCompaction()} to start a new
-     * compacted file or not.
-     */
-    private final AtomicBoolean compactionWasInProgress = new AtomicBoolean(false);
 
     /**
      * Construct a new DataFileCollection.
@@ -369,217 +331,6 @@ public class DataFileCollection<D> implements Snapshotable {
                         .summaryStatistics();
     }
 
-    /**
-     * Merges all files in filesToMerge.
-     *
-     * @param index takes a map of moves from old location to new location. Once it is finished and
-     *     returns it is assumed all readers will no longer be looking in old location, so old files
-     *     can be safely deleted.
-     * @param filesToMerge list of files to merge
-     * @return list of files created during the merge
-     * @throws IOException If there was a problem merging
-     * @throws InterruptedException If the merge thread was interrupted
-     */
-    public synchronized List<Path> compactFiles(
-            final CASableLongIndex index, final List<DataFileReader<D>> filesToMerge)
-            throws IOException, InterruptedException {
-        if (filesToMerge.size() < 2) {
-            // nothing to do we have merged since the last data update
-            logger.debug(MERKLE_DB.getMarker(), "No files were available for merging [{}]", storeName);
-            return Collections.emptyList();
-        }
-
-        // create a merge time stamp, this timestamp is the newest time of the set of files we are
-        // merging
-        final Instant startTime = filesToMerge.stream()
-                .map(file -> file.getMetadata().getCreationDate())
-                .max(Instant::compareTo)
-                .get();
-        snapshotCompactionLock.acquire();
-        try {
-            currentCompactionStartTime.set(startTime);
-            newCompactedFiles.clear();
-            startNewCompactionFile();
-        } finally {
-            snapshotCompactionLock.release();
-        }
-
-        // We need a map to find readers by file index below. It doesn't have to be synchronized
-        // as it will be accessed in this thread only, so it can be a simple HashMap or alike.
-        // However, standard Java maps can only work with Integer, not int (yet), so auto-boxing
-        // will put significant load on GC. Let's do something different
-        int minFileIndex = Integer.MAX_VALUE;
-        int maxFileIndex = 0;
-        for (final DataFileReader<D> r : filesToMerge) {
-            minFileIndex = Math.min(minFileIndex, r.getIndex());
-            maxFileIndex = Math.max(maxFileIndex, r.getIndex());
-        }
-        final int firstIndexInc = minFileIndex;
-        final int lastIndexExc = maxFileIndex + 1;
-        final DataFileReader<D>[] readers = new DataFileReader[lastIndexExc - firstIndexInc];
-        for (DataFileReader<D> r : filesToMerge) {
-            readers[r.getIndex() - firstIndexInc] = r;
-        }
-
-        boolean allDataItemsProcessed = false;
-        try {
-            final KeyRange keyRange = validKeyRange;
-            index.forEach((path, dataLocation) -> {
-                if (!keyRange.withinRange(path)) {
-                    return;
-                }
-                final int fileIndex = DataFileCommon.fileIndexFromDataLocation(dataLocation);
-                if ((fileIndex < firstIndexInc) || (fileIndex >= lastIndexExc)) {
-                    return;
-                }
-                final DataFileReader<D> reader = readers[fileIndex - firstIndexInc];
-                if (reader == null) {
-                    return;
-                }
-                final long fileOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
-                // Take the lock. If a snapshot is started in a different thread, this call
-                // will block until the snapshot is done. The current file will be flushed,
-                // and current data file writer and reader will point to a new file
-                snapshotCompactionLock.acquire();
-                try {
-                    final DataFileWriter<D> newFileWriter = currentCompactionWriter.get();
-                    long serializationVersion = reader.getMetadata().getSerializationVersion();
-                    final long newLocation = newFileWriter.writeCopiedDataItem(
-                            serializationVersion, reader.readDataItemBytes(fileOffset));
-                    // update the index
-                    index.putIfEqual(path, dataLocation, newLocation);
-                } catch (final ClosedByInterruptException e) {
-                    logger.info(
-                            MERKLE_DB.getMarker(),
-                            "Failed to copy data item {} / {} due to thread interruption",
-                            fileIndex,
-                            fileOffset,
-                            e);
-                    throw e;
-                } catch (final IOException z) {
-                    logger.error(EXCEPTION.getMarker(), "Failed to copy data item {} / {}", fileIndex, fileOffset, z);
-                    throw z;
-                } finally {
-                    snapshotCompactionLock.release();
-                }
-            });
-            allDataItemsProcessed = true;
-        } finally {
-            // Even if the thread is interrupted, make sure the new compacted file is properly closed
-            // and is included to future compactions
-            snapshotCompactionLock.acquire();
-            try {
-                // Finish writing the last file. In rare cases, it may be an empty file
-                finishCurrentCompactionFile();
-                // Clear compaction start time
-                currentCompactionStartTime.set(null);
-                if (allDataItemsProcessed) {
-                    // Close the readers and delete compacted files
-                    deleteFiles(filesToMerge);
-                }
-            } finally {
-                snapshotCompactionLock.release();
-            }
-        }
-
-        return newCompactedFiles;
-    }
-
-    /**
-     * Opens a new file for writing during compaction. This method is called, when compaction is
-     * started. If compaction is interrupted and resumed by data source snapshot using {@link
-     * #pauseCompaction()} and {@link #resumeCompaction()}, a new file is created for writing using
-     * this method before compaction is resumed.
-     *
-     * This method must be called under snapshot/compaction lock.
-     *
-     * @throws IOException If an I/O error occurs
-     */
-    private void startNewCompactionFile() throws IOException {
-        final Instant startTime = currentCompactionStartTime.get();
-        assert startTime != null;
-        final DataFileWriter<D> newFileWriter = newDataFile(startTime);
-        currentCompactionWriter.set(newFileWriter);
-        final Path newFileCreated = newFileWriter.getPath();
-        newCompactedFiles.add(newFileCreated);
-        final DataFileMetadata newFileMetadata = newFileWriter.getMetadata();
-        final DataFileReader<D> newFileReader = addNewDataFileReader(newFileCreated, newFileMetadata);
-        currentCompactionReader.set(newFileReader);
-    }
-
-    /**
-     * Closes the current compaction file. This method is called in the end of compaction process,
-     * and also before a snapshot is taken to make sure the current file is fully written and safe
-     * to include to snapshots.
-     *
-     * This method must be called under snapshot/compaction lock.
-     *
-     * @throws IOException If an I/O error occurs
-     */
-    private void finishCurrentCompactionFile() throws IOException {
-        currentCompactionWriter.get().finishWriting();
-        currentCompactionWriter.set(null);
-        // Now include the file in future compactions
-        currentCompactionReader.get().setFileCompleted();
-        currentCompactionReader.set(null);
-    }
-
-    /**
-     * Puts file compaction on hold, if it's currently in progress. If not in progress, it will
-     * prevent compaction from starting until {@link #resumeCompaction()} is called. The most
-     * important thing this method does is it makes data files consistent and read only, so they can
-     * be included to snapshots as easily as to create hard links. In particular, if compaction is
-     * in progress, and a new data file is being written to, this file is flushed to disk, no files
-     * are created and no index entries are updated until compaction is resumed.
-     *
-     * This method should not be called on the compaction thread.
-     *
-     * <b>This method must be always balanced with and called before {@link #resumeCompaction()}. If
-     * there are more / less calls to resume compactions than to pause, or if they are called in a
-     * wrong order, it will result in deadlocks.</b>
-     *
-     * @throws IOException If an I/O error occurs
-     */
-    public void pauseCompaction() throws IOException {
-        snapshotCompactionLock.acquireUninterruptibly();
-        // Check if compaction is currently in progress. If so, flush and close the current file, so
-        // it's included to the snapshot
-        final DataFileWriter<D> compactionWriter = currentCompactionWriter.get();
-        if (compactionWriter != null) {
-            compactionWasInProgress.set(true);
-            finishCurrentCompactionFile();
-            // Don't start a new compaction file here, as it would be included to snapshots, but
-            // it shouldn't, as it isn't fully written yet. Instead, a new file will be started
-            // right after snapshot is taken, in resumeCompaction()
-        }
-        // Don't release the lock here, it will be done later in resumeCompaction(). If there is no
-        // compaction currently running, the lock will prevent starting a new one until snapshot is
-        // done
-    }
-
-    /**
-     * Resumes compaction previously put on hold with {@link #pauseCompaction()}. If there was no
-     * compaction running at that moment, but new compaction was started (and blocked) since {@link
-     * #pauseCompaction()}, this new compaction is resumed.
-     *
-     * <b>This method must be always balanced with and called after {@link #pauseCompaction()}. If
-     * there are more / less calls to resume compactions than to pause, or if they are called in a
-     * wrong order, it will result in deadlocks.</b>
-     *
-     * @throws IOException If an I/O error occurs
-     */
-    public void resumeCompaction() throws IOException {
-        try {
-            if (compactionWasInProgress.getAndSet(false)) {
-                assert currentCompactionWriter.get() == null;
-                assert currentCompactionReader.get() == null;
-                startNewCompactionFile();
-            }
-        } finally {
-            snapshotCompactionLock.release();
-        }
-    }
-
     /** Close all the data files */
     public void close() throws IOException {
         // finish writing if we still are
@@ -608,7 +359,7 @@ public class DataFileCollection<D> implements Snapshotable {
         if (activeDataFileWriter != null) {
             throw new IOException("Tried to start writing when we were already writing.");
         }
-        final DataFileWriter<D> writer = newDataFile(Instant.now());
+        final DataFileWriter<D> writer = newDataFile(Instant.now(), DEFAULT_COMPACTION_LEVEL);
         currentDataFileWriter.set(writer);
         final DataFileMetadata metadata = writer.getMetadata();
         final DataFileReader<D> reader = addNewDataFileReader(writer.getPath(), metadata);
@@ -851,8 +602,7 @@ public class DataFileCollection<D> implements Snapshotable {
      * @param metadata The metadata for the file at filePath, to save reading from file
      * @return The newly added DataFileReader.
      */
-    private DataFileReader<D> addNewDataFileReader(final Path filePath, final DataFileMetadata metadata)
-            throws IOException {
+    DataFileReader<D> addNewDataFileReader(final Path filePath, final DataFileMetadata metadata) throws IOException {
         final DataFileReader<D> newDataFileReader = new DataFileReader<>(filePath, dataItemSerializer, metadata);
         dataFiles.getAndUpdate(currentFileList -> {
             try {
@@ -873,12 +623,14 @@ public class DataFileCollection<D> implements Snapshotable {
      * @param filesToDelete the list of files to delete
      * @throws IOException If there was a problem deleting the files
      */
-    private void deleteFiles(@NonNull final Collection<DataFileReader<D>> filesToDelete) throws IOException {
+    void deleteFiles(@NonNull final Collection<?> filesToDelete) throws IOException {
+        // necessary workaround to remove compiler requirement for certain generic type which not required for deletion
+        Collection<DataFileReader<D>> files = (Collection<DataFileReader<D>>) filesToDelete;
         // remove files from index
-        dataFiles.getAndUpdate(currentFileList ->
-                (currentFileList == null) ? null : currentFileList.withDeletedObjects(filesToDelete));
+        dataFiles.getAndUpdate(
+                currentFileList -> (currentFileList == null) ? null : currentFileList.withDeletedObjects(files));
         // now close and delete all the files
-        for (final DataFileReader<D> fileReader : filesToDelete) {
+        for (final DataFileReader<?> fileReader : files) {
             fileReader.close();
             Files.delete(fileReader.getPath());
         }
@@ -891,12 +643,17 @@ public class DataFileCollection<D> implements Snapshotable {
      *     case of merge.
      * @return the newly created data file
      */
-    private DataFileWriter<D> newDataFile(final Instant creationTime) throws IOException {
+    DataFileWriter<D> newDataFile(final Instant creationTime, int compactionLevel) throws IOException {
         final int newFileIndex = nextFileIndex.getAndIncrement();
         if (logger.isTraceEnabled()) {
             setOfNewFileIndexes.add(newFileIndex);
         }
-        return new DataFileWriter<>(storeName, storeDir, newFileIndex, dataItemSerializer, creationTime);
+        return new DataFileWriter<>(
+                storeName, storeDir, newFileIndex, dataItemSerializer, creationTime, compactionLevel);
+    }
+
+    String getStoreName() {
+        return storeName;
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -46,6 +46,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Set;
@@ -625,12 +626,12 @@ public class DataFileCollection<D> implements Snapshotable {
      */
     void deleteFiles(@NonNull final Collection<?> filesToDelete) throws IOException {
         // necessary workaround to remove compiler requirement for certain generic type which not required for deletion
-        Collection<DataFileReader<D>> files = (Collection<DataFileReader<D>>) filesToDelete;
+        Collection<DataFileReader<D>> files = (Collection<DataFileReader<D>>) new HashSet<>(filesToDelete);
         // remove files from index
         dataFiles.getAndUpdate(
                 currentFileList -> (currentFileList == null) ? null : currentFileList.withDeletedObjects(files));
         // now close and delete all the files
-        for (final DataFileReader<?> fileReader : files) {
+        for (final DataFileReader<D> fileReader : files) {
             fileReader.close();
             Files.delete(fileReader.getPath());
         }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.merkledb.files;
+
+import static com.swirlds.logging.LogMarker.EXCEPTION;
+import static com.swirlds.logging.LogMarker.MERKLE_DB;
+import static com.swirlds.merkledb.files.DataFileCommon.formatSizeBytes;
+import static com.swirlds.merkledb.files.DataFileCommon.getSizeOfFiles;
+import static com.swirlds.merkledb.files.DataFileCommon.getSizeOfFilesByPath;
+import static com.swirlds.merkledb.files.DataFileCommon.logMergeStats;
+
+import com.swirlds.common.config.singleton.ConfigurationHolder;
+import com.swirlds.common.units.UnitConstants;
+import com.swirlds.merkledb.CompactionType;
+import com.swirlds.merkledb.KeyRange;
+import com.swirlds.merkledb.NanoClock;
+import com.swirlds.merkledb.collections.CASableLongIndex;
+import com.swirlds.merkledb.config.MerkleDbConfig;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.UnaryOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This class is responsible performing compaction of data files in a {@link DataFileCollection}.
+ * The compaction is supposed to happen in the background and can be paused and resumed with {@link #pauseCompaction()}
+ * and {@link #resumeCompaction()} to prevent compaction from interfering with snapshots.
+ */
+public class DataFileCompactor {
+
+    private static final Logger logger = LogManager.getLogger(DataFileCompactor.class);
+
+    /**
+     * Since {@code com.swirlds.platform.Browser} populates settings, and it is loaded before any
+     * application classes that might instantiate a data source, the {@link ConfigurationHolder}
+     * holder will have been configured by the time this static initializer runs.
+     */
+    private static final MerkleDbConfig config = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
+
+    private static final Comparator<DataFileReader> DATA_FILE_READER_CREATION_TIME_COMPARATOR =
+            Comparator.comparing(o -> o.getMetadata().getCreationDate());
+    /** Comparator for comparing DataFileReaders by file creation time reversed */
+    private static final Comparator<DataFileReader> DATA_FILE_READER_CREATION_TIME_COMPARATOR_REVERSED =
+            DATA_FILE_READER_CREATION_TIME_COMPARATOR.reversed();
+
+    public static final int DEFAULT_COMPACTION_LEVEL = 0;
+
+    /**
+     * Base name for the data files, allowing more than one DataFileCollection to share a directory
+     */
+    private final String storeName;
+
+    /**
+     * A lock used for synchronization between snapshots and compactions. While a compaction is in
+     * progress, it runs on its own without any synchronization. However, a few critical sections
+     * are protected with this lock: to create a new compaction writer/reader when compaction is
+     * started, to copy data items to the current writer and update the corresponding index item,
+     * and to close the compaction writer. This mechanism allows snapshots to effectively put
+     * compaction on hold, which is critical as snapshots should be as fast as possible, while
+     * compactions are just background processes.
+     */
+    private final Semaphore snapshotCompactionLock = new Semaphore(1);
+
+    /** Start time of the current compaction, or null if compaction isn't running */
+    private final AtomicReference<Instant> currentCompactionStartTime = new AtomicReference<>();
+    /**
+     * Current data file writer during compaction, or null if compaction isn't running. The writer
+     * is created at compaction start. If compaction is interrupted by a snapshot, the writer is
+     * closed before the snapshot, and then a new writer / new file is created after the snapshot is
+     * taken.
+     */
+    private final AtomicReference<DataFileWriter<?>> currentCompactionWriter = new AtomicReference<>();
+    /** Currrent data file reader for the compaction writer above. */
+    private final AtomicReference<DataFileReader<?>> currentCompactionReader = new AtomicReference<>();
+    /**
+     * The list of new files created during compaction. Usually, all files to process are compacted
+     * to a single new file, but if compaction is interrupted by a snapshot, there may be more than
+     * one file created.
+     */
+    private final List<Path> newCompactedFiles = new ArrayList<>();
+
+    /**
+     * Indicates whether compaction is in progress at the time when {@link #pauseCompaction()}
+     * is called. This flag is then checked in {@link DataFileCompactor#resumeCompaction()} )} to start a new
+     * compacted file or not.
+     */
+    private final AtomicBoolean compactionWasInProgress = new AtomicBoolean(false);
+
+    /**
+     * This variable keeps track of the compaction level that was in progress at the time when it was suspended.
+     * Once the compaction is resumed, this level is used to start a new compacted file, and then it's reset to 0.
+     */
+    private final AtomicInteger compactionLevelInProgress = new AtomicInteger(0);
+
+    /** When was the last medium-sized merge, only touched from single merge thread. */
+    private Instant lastMediumMerge;
+
+    /** When was the last full merge, only touched from single merge thread. */
+    private Instant lastFullMerge;
+
+    /** A nanosecond-precise Clock */
+    private final NanoClock clock = new NanoClock();
+
+    /** The data file collection to compact */
+    private final DataFileCollection<?> dataFileCollection;
+
+    public DataFileCompactor(DataFileCollection<?> dataFileCollection) {
+        this.dataFileCollection = dataFileCollection;
+        this.storeName = dataFileCollection.getStoreName();
+        // Compute initial merge periods to a randomized value of now +/- 50% of merge period. So
+        // each node will do
+        // medium and full merges at random times.
+        lastMediumMerge = Instant.now()
+                .minus(config.mediumMergePeriod() / 2, config.mergePeriodUnit())
+                .plus((long) (config.mediumMergePeriod() * Math.random()), config.mergePeriodUnit());
+        lastFullMerge = Instant.now()
+                .minus(config.fullMergePeriod() / 2, config.mergePeriodUnit())
+                .plus((long) (config.fullMergePeriod() * Math.random()), config.mergePeriodUnit());
+    }
+
+    /**
+     * Compacts all files in filesToCompact.
+     *
+     * @param index          takes a map of moves from old location to new location. Once it is finished and
+     *                       returns it is assumed all readers will no longer be looking in old location, so old files
+     *                       can be safely deleted.
+     * @param filesToCompact   list of files to compact
+     * @return list of files created during the compaction
+     * @throws IOException          If there was a problem with the compaction
+     * @throws InterruptedException If the compaction thread was interrupted
+     */
+    // visible for testing
+    synchronized List<Path> compactFiles(final CASableLongIndex index, final List<DataFileReader<?>> filesToCompact)
+            throws IOException, InterruptedException {
+        if (filesToCompact.size() < 2) {
+            // nothing to do we have merged since the last data update
+            logger.debug(MERKLE_DB.getMarker(), "No files were available for merging [{}]", storeName);
+            return Collections.emptyList();
+        }
+
+        int currentLevel = filesToCompact.get(0).getMetadata().getCompactionLevel();
+        // create a merge time stamp, this timestamp is the newest time of the set of files we are
+        // merging
+        final Instant startTime = filesToCompact.stream()
+                .map(file -> file.getMetadata().getCreationDate())
+                .max(Instant::compareTo)
+                .get();
+        snapshotCompactionLock.acquire();
+        try {
+            currentCompactionStartTime.set(startTime);
+            newCompactedFiles.clear();
+            startNewCompactionFile(currentLevel + 1);
+        } finally {
+            snapshotCompactionLock.release();
+        }
+
+        // We need a map to find readers by file index below. It doesn't have to be synchronized
+        // as it will be accessed in this thread only, so it can be a simple HashMap or alike.
+        // However, standard Java maps can only work with Integer, not int (yet), so auto-boxing
+        // will put significant load on GC. Let's do something different
+        int minFileIndex = Integer.MAX_VALUE;
+        int maxFileIndex = 0;
+        for (final DataFileReader<?> r : filesToCompact) {
+            minFileIndex = Math.min(minFileIndex, r.getIndex());
+            maxFileIndex = Math.max(maxFileIndex, r.getIndex());
+        }
+        final int firstIndexInc = minFileIndex;
+        final int lastIndexExc = maxFileIndex + 1;
+        final DataFileReader<?>[] readers = new DataFileReader[lastIndexExc - firstIndexInc];
+        for (DataFileReader<?> r : filesToCompact) {
+            readers[r.getIndex() - firstIndexInc] = r;
+        }
+
+        boolean allDataItemsProcessed = false;
+        try {
+            final KeyRange keyRange = dataFileCollection.getValidKeyRange();
+            index.forEach((path, dataLocation) -> {
+                if (!keyRange.withinRange(path)) {
+                    return;
+                }
+                final int fileIndex = DataFileCommon.fileIndexFromDataLocation(dataLocation);
+                if ((fileIndex < firstIndexInc) || (fileIndex >= lastIndexExc)) {
+                    return;
+                }
+                final DataFileReader<?> reader = readers[fileIndex - firstIndexInc];
+                if (reader == null) {
+                    return;
+                }
+                final long fileOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
+                // Take the lock. If a snapshot is started in a different thread, this call
+                // will block until the snapshot is done. The current file will be flushed,
+                // and current data file writer and reader will point to a new file
+                snapshotCompactionLock.acquire();
+                try {
+                    final DataFileWriter<?> newFileWriter = currentCompactionWriter.get();
+                    long serializationVersion = reader.getMetadata().getSerializationVersion();
+                    final long newLocation = newFileWriter.writeCopiedDataItem(
+                            serializationVersion, reader.readDataItemBytes(fileOffset));
+                    // update the index
+                    index.putIfEqual(path, dataLocation, newLocation);
+                } catch (final IOException z) {
+                    logger.error(EXCEPTION.getMarker(), "Failed to copy data item {} / {}", fileIndex, fileOffset, z);
+                    throw z;
+                } finally {
+                    snapshotCompactionLock.release();
+                }
+            });
+            allDataItemsProcessed = true;
+        } finally {
+            // Even if the thread is interrupted, make sure the new compacted file is properly closed
+            // and is included to future compactions
+            snapshotCompactionLock.acquire();
+            try {
+                // Finish writing the last file. In rare cases, it may be an empty file
+                finishCurrentCompactionFile();
+                // Clear compaction start time
+                currentCompactionStartTime.set(null);
+                if (allDataItemsProcessed) {
+                    // Close the readers and delete compacted files
+                    dataFileCollection.deleteFiles(filesToCompact);
+                }
+            } finally {
+                snapshotCompactionLock.release();
+            }
+        }
+
+        return newCompactedFiles;
+    }
+
+    /**
+     * Opens a new file for writing during compaction. This method is called, when compaction is
+     * started. If compaction is interrupted and resumed by data source snapshot using {@link
+     * #pauseCompaction()} and {@link #resumeCompaction()}, a new file is created for writing using
+     * this method before compaction is resumed.
+     *
+     * This method must be called under snapshot/compaction lock.
+     *
+     * @throws IOException If an I/O error occurs
+     */
+    private void startNewCompactionFile(int compactionLevel) throws IOException {
+        final Instant startTime = currentCompactionStartTime.get();
+        assert startTime != null;
+        final DataFileWriter<?> newFileWriter = dataFileCollection.newDataFile(startTime, compactionLevel);
+        currentCompactionWriter.set(newFileWriter);
+        final Path newFileCreated = newFileWriter.getPath();
+        newCompactedFiles.add(newFileCreated);
+        final DataFileMetadata newFileMetadata = newFileWriter.getMetadata();
+        final DataFileReader<?> newFileReader =
+                dataFileCollection.addNewDataFileReader(newFileCreated, newFileMetadata);
+        currentCompactionReader.set(newFileReader);
+    }
+
+    /**
+     * Closes the current compaction file. This method is called in the end of compaction process,
+     * and also before a snapshot is taken to make sure the current file is fully written and safe
+     * to include to snapshots.
+     *
+     * This method must be called under snapshot/compaction lock.
+     *
+     * @throws IOException If an I/O error occurs
+     */
+    private void finishCurrentCompactionFile() throws IOException {
+        currentCompactionWriter.get().finishWriting();
+        currentCompactionWriter.set(null);
+        // Now include the file in future compactions
+        currentCompactionReader.get().setFileCompleted();
+        currentCompactionReader.set(null);
+    }
+
+    /**
+     * Puts file compaction on hold, if it's currently in progress. If not in progress, it will
+     * prevent compaction from starting until {@link #resumeCompaction()} is called. The most
+     * important thing this method does is it makes data files consistent and read only, so they can
+     * be included to snapshots as easily as to create hard links. In particular, if compaction is
+     * in progress, and a new data file is being written to, this file is flushed to disk, no files
+     * are created and no index entries are updated until compaction is resumed.
+     *
+     * This method should not be called on the compaction thread.
+     *
+     * <b>This method must be always balanced with and called before {@link DataFileCompactor#resumeCompaction()}. If
+     * there are more / less calls to resume compactions than to pause, or if they are called in a
+     * wrong order, it will result in deadlocks.</b>
+     *
+     * @see #resumeCompaction()
+     * @throws IOException If an I/O error occurs
+     */
+    public void pauseCompaction() throws IOException {
+        snapshotCompactionLock.acquireUninterruptibly();
+        // Check if compaction is currently in progress. If so, flush and close the current file, so
+        // it's included to the snapshot
+        final DataFileWriter<?> compactionWriter = currentCompactionWriter.get();
+        if (compactionWriter != null) {
+            compactionWasInProgress.set(true);
+            compactionLevelInProgress.set(compactionWriter.getMetadata().getCompactionLevel());
+            finishCurrentCompactionFile();
+            // Don't start a new compaction file here, as it would be included to snapshots, but
+            // it shouldn't, as it isn't fully written yet. Instead, a new file will be started
+            // right after snapshot is taken, in resumeCompaction()
+        }
+        // Don't release the lock here, it will be done later in resumeCompaction(). If there is no
+        // compaction currently running, the lock will prevent starting a new one until snapshot is
+        // done
+    }
+
+    /**
+     * Resumes compaction previously put on hold with {@link #pauseCompaction()}. If there was no
+     * compaction running at that moment, but new compaction was started (and blocked) since {@link
+     * #pauseCompaction()}, this new compaction is resumed.
+     *
+     * <b>This method must be always balanced with and called after {@link #pauseCompaction()}. If
+     * there are more / less calls to resume compactions than to pause, or if they are called in a
+     * wrong order, it will result in deadlocks.</b>
+     *
+     * @throws IOException If an I/O error occurs
+     */
+    public void resumeCompaction() throws IOException {
+        try {
+            if (compactionWasInProgress.getAndSet(false)) {
+                assert currentCompactionWriter.get() == null;
+                assert currentCompactionReader.get() == null;
+                startNewCompactionFile(compactionLevelInProgress.getAndSet(0));
+            }
+        } finally {
+            snapshotCompactionLock.release();
+        }
+    }
+
+    /**
+     * Compact (merge) all files that match the given filter.
+     *
+     * @param reportDurationMetricFunction function to report how long compaction took, in ms
+     * @param reportSavedSpaceMetricFunction function to report how much space was compacted, in Mb
+     * @throws IOException if there was a problem merging
+     * @throws InterruptedException if the merge thread was interupted
+     */
+    @SuppressWarnings("unchecked")
+    public void compact(
+            CASableLongIndex index,
+            @Nullable final BiConsumer<CompactionType, Long> reportDurationMetricFunction,
+            @Nullable final BiConsumer<CompactionType, Double> reportSavedSpaceMetricFunction)
+            throws IOException, InterruptedException {
+        Instant timestamp = Instant.now(clock);
+
+        final UnaryOperator<List<DataFileReader<?>>> filesToMergeFilter;
+        final CompactionType compactionLevel;
+        if (isTimeForFullMerge(timestamp)) {
+            lastFullMerge = timestamp;
+            /* Filter nothing during a full merge */
+            filesToMergeFilter = dataFileReaders -> dataFileReaders;
+            compactionLevel = CompactionType.FULL;
+            logger.info(MERKLE_DB.getMarker(), "[{}] Starting Large Merge", storeName);
+        } else if (isTimeForMediumMerge(timestamp)) {
+            lastMediumMerge = timestamp;
+            filesToMergeFilter = readersOfLevel(1, config.maxNumberOfFilesInMerge());
+            compactionLevel = CompactionType.MEDIUM;
+            logger.info(MERKLE_DB.getMarker(), "[{}] Starting Medium Merge", storeName);
+        } else {
+            filesToMergeFilter = readersOfLevel(0, config.maxNumberOfFilesInMerge());
+            compactionLevel = CompactionType.SMALL;
+            logger.info(MERKLE_DB.getMarker(), "[{}] Starting Small Merge", storeName);
+        }
+
+        final List<? extends DataFileReader<?>> allCompactableFiles = dataFileCollection.getAllCompletedFiles();
+        final List<DataFileReader<?>> filesToCompact =
+                filesToMergeFilter.apply((List<DataFileReader<?>>) allCompactableFiles);
+        if (filesToCompact == null) {
+            // nothing to do
+            return;
+        }
+        final int filesCount = filesToCompact.size();
+        if (filesCount < config.minNumberOfFilesInMerge()) {
+            logger.debug(
+                    MERKLE_DB.getMarker(),
+                    "[{}] No need to merge as {} is less than the minimum {} files to merge.",
+                    storeName,
+                    filesCount,
+                    config.minNumberOfFilesInMerge());
+            return;
+        }
+
+        final long start = System.currentTimeMillis();
+
+        final long filesToMergeSize = getSizeOfFiles(filesToCompact);
+        logger.debug(
+                MERKLE_DB.getMarker(),
+                "[{}] Starting merging {} files / {}",
+                storeName,
+                filesCount,
+                formatSizeBytes(filesToMergeSize));
+
+        final List<Path> newFilesCreated = compactFiles(index, filesToCompact);
+
+        final long end = System.currentTimeMillis();
+        final long tookMillis = end - start;
+        if (reportDurationMetricFunction != null) {
+            reportDurationMetricFunction.accept(compactionLevel, tookMillis);
+        }
+
+        final long mergedFilesSize = getSizeOfFilesByPath(newFilesCreated);
+        if (reportSavedSpaceMetricFunction != null) {
+            reportSavedSpaceMetricFunction.accept(
+                    compactionLevel, (filesToMergeSize - mergedFilesSize) * UnitConstants.BYTES_TO_MEBIBYTES);
+        }
+
+        logMergeStats(storeName, tookMillis, filesToCompact, filesToMergeSize, newFilesCreated, dataFileCollection);
+        logger.debug(
+                MERKLE_DB.getMarker(),
+                "[{}] Finished merging {} files / {} in {} ms",
+                storeName,
+                filesCount,
+                formatSizeBytes(filesToMergeSize),
+                tookMillis);
+    }
+
+    private boolean isTimeForFullMerge(final Instant startMerge) {
+        return startMerge
+                .minus(config.fullMergePeriod(), config.mergePeriodUnit())
+                .isAfter(lastFullMerge);
+    }
+
+    private boolean isTimeForMediumMerge(final Instant startMerge) {
+        return startMerge
+                .minus(config.mediumMergePeriod(), config.mergePeriodUnit())
+                .isAfter(lastMediumMerge);
+    }
+
+    /**
+     * Create a filter to only return all new files that belong to certain compaction level
+     *
+     * @param expectedCompactionLevel compaction level to filter by
+     * @param maxNumberOfFilesInMerge The maximum number of files to process in a single merge
+     * @return filter to filter list of files
+     */
+    public static UnaryOperator<List<DataFileReader<?>>> readersOfLevel(
+            int expectedCompactionLevel, int maxNumberOfFilesInMerge) {
+        return dataFileReaders -> {
+            final List<DataFileReader<?>> filesNewestFirst = dataFileReaders.stream()
+                    .sorted(DATA_FILE_READER_CREATION_TIME_COMPARATOR_REVERSED)
+                    .toList();
+            final ArrayList<DataFileReader<?>> result = new ArrayList<>(filesNewestFirst.size());
+            for (final DataFileReader file : filesNewestFirst) {
+                if (file.getMetadata().getCompactionLevel() == expectedCompactionLevel) {
+                    result.add(file);
+                }
+            }
+
+            final var numFiles = result.size();
+            return numFiles > maxNumberOfFilesInMerge
+                    ? result.subList(numFiles - maxNumberOfFilesInMerge, numFiles)
+                    : result;
+        };
+    }
+}

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileMetadata.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileMetadata.java
@@ -64,7 +64,7 @@ public final class DataFileMetadata {
     /** Serialization version for data stored in the file */
     private final long serializationVersion;
     /** The level of compaction this file has. See {@link DataFileCompactor}*/
-    private final int compactionLevel;
+    private final byte compactionLevel;
 
     /**
      * Create a new DataFileMetadata with complete set of data
@@ -95,7 +95,7 @@ public final class DataFileMetadata {
         this.creationDate = creationDate;
         this.serializationVersion = serializationVersion;
         assert compactionLevel >= 0 && compactionLevel < 127;
-        this.compactionLevel = compactionLevel;
+        this.compactionLevel = (byte) compactionLevel;
     }
 
     /**
@@ -135,7 +135,7 @@ public final class DataFileMetadata {
         buf.putInt(this.index);
         buf.putLong(this.creationDate.getEpochSecond());
         buf.putInt(this.creationDate.getNano());
-        buf.put((byte) compactionLevel);
+        buf.put(compactionLevel);
         buf.putLong(this.serializationVersion);
         buf.rewind();
         return buf;

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileMetadata.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileMetadata.java
@@ -63,6 +63,8 @@ public final class DataFileMetadata {
     private final Instant creationDate;
     /** Serialization version for data stored in the file */
     private final long serializationVersion;
+    /** The level of compaction this file has. See {@link DataFileCompactor}*/
+    private final int compactionLevel;
 
     /**
      * Create a new DataFileMetadata with complete set of data
@@ -84,13 +86,16 @@ public final class DataFileMetadata {
             final long dataItemCount,
             final int index,
             final Instant creationDate,
-            final long serializationVersion) {
+            final long serializationVersion,
+            final int compactionLevel) {
         this.fileFormatVersion = fileFormatVersion;
         this.dataItemValueSize = dataItemValueSize;
         this.dataItemCount = dataItemCount;
         this.index = index;
         this.creationDate = creationDate;
         this.serializationVersion = serializationVersion;
+        assert compactionLevel >= 0 && compactionLevel < 127;
+        this.compactionLevel = compactionLevel;
     }
 
     /**
@@ -112,7 +117,7 @@ public final class DataFileMetadata {
             this.dataItemCount = buf.getLong();
             this.index = buf.getInt();
             this.creationDate = Instant.ofEpochSecond(buf.getLong(), buf.getInt());
-            buf.get(); // backwards compatibility: used to be a byte for isMergeFile
+            this.compactionLevel = buf.get();
             this.serializationVersion = buf.getLong();
         }
     }
@@ -130,7 +135,7 @@ public final class DataFileMetadata {
         buf.putInt(this.index);
         buf.putLong(this.creationDate.getEpochSecond());
         buf.putInt(this.creationDate.getNano());
-        buf.put((byte) 0); // backwards compatibility: used to be a byte for isMergeFile
+        buf.put((byte) compactionLevel);
         buf.putLong(this.serializationVersion);
         buf.rewind();
         return buf;
@@ -187,6 +192,10 @@ public final class DataFileMetadata {
     /** Get the serialization version for data stored in this file */
     public long getSerializationVersion() {
         return serializationVersion;
+    }
+
+    public int getCompactionLevel() {
+        return compactionLevel;
     }
 
     /** toString for debugging */

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -109,7 +109,8 @@ public final class DataFileWriter<D> {
             final Path dataFileDir,
             final int index,
             final DataItemSerializer<D> dataItemSerializer,
-            final Instant creationTime)
+            final Instant creationTime,
+            final int compactionLevel)
             throws IOException {
         this.index = index;
         this.dataItemSerializer = dataItemSerializer;

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CloseFlushTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CloseFlushTest.java
@@ -39,6 +39,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -60,6 +63,12 @@ public class CloseFlushTest {
     @BeforeAll
     public static void setup() throws IOException {
         tmpFileDir = TemporaryFileBuilder.buildTemporaryFile();
+        Configurator.setRootLevel(Level.WARN);
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        Configurator.reconfigure();
     }
 
     @Test

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MergeInterruptTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MergeInterruptTest.java
@@ -76,7 +76,7 @@ class MergeInterruptTest {
             createData(dataSource);
             // start merging
             final AtomicBoolean mergeResult = new AtomicBoolean();
-            final Thread mergingThread = new Thread(() -> mergeResult.set(dataSource.doMerge()));
+            final Thread mergingThread = new Thread(() -> mergeResult.set(dataSource.doCompaction()));
             mergingThread.start();
             // wait a small-time for merging to start
             MILLISECONDS.sleep(20);
@@ -125,7 +125,7 @@ class MergeInterruptTest {
             });
             // start merging
             final AtomicBoolean mergeResult = new AtomicBoolean();
-            final Thread mergingThread = new Thread(() -> mergeResult.set(dataSource.doMerge()));
+            final Thread mergingThread = new Thread(() -> mergeResult.set(dataSource.doCompaction()));
             mergingThread.start();
             // wait a small-time for merging to start
             MILLISECONDS.sleep(20);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
@@ -188,11 +188,11 @@ class MerkleDbDataSourceSnapshotMergeTest {
                         e.printStackTrace();
                     }
                 } else { // thread 1 does merge
-                    dataSource.doMerge();
+                    dataSource.doCompaction();
                     merging.set(false);
                 }
             });
-            dataSource.doMerge();
+            dataSource.doCompaction();
             checkData(COUNT2, testType, dataSource);
 
             // check the database statistics - starting with the five speedometers

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
@@ -21,6 +21,7 @@ import static com.swirlds.merkledb.MerkleDbStatistics.STAT_CATEGORY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -224,6 +225,7 @@ class MerkleDbStatisticsTest {
 
     private static String ctypeStr(final CompactionType c) {
         return switch (c) {
+            case NO_COMPACTION -> "No compaction";
             case SMALL -> "Small";
             case MEDIUM -> "Medium";
             case FULL -> "Full";
@@ -231,7 +233,10 @@ class MerkleDbStatisticsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(CompactionType.class)
+    @EnumSource(
+            value = CompactionType.class,
+            mode = EXCLUDE,
+            names = {"NO_COMPACTION"})
     void testSetHashesStoreMergeTime(final CompactionType compactionType) {
         // given
         final Metric metric = getMetric("compactions_", "hashes" + ctypeStr(compactionType) + "TimeMs_" + LABEL);
@@ -242,7 +247,10 @@ class MerkleDbStatisticsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(CompactionType.class)
+    @EnumSource(
+            value = CompactionType.class,
+            mode = EXCLUDE,
+            names = {"NO_COMPACTION"})
     void testSetHashesStoreSavedSpace(final CompactionType compactionType) {
         // given
         final Metric metric = getMetric("compactions_", "hashes" + ctypeStr(compactionType) + "SavedSpaceMb_" + LABEL);
@@ -253,7 +261,10 @@ class MerkleDbStatisticsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(CompactionType.class)
+    @EnumSource(
+            value = CompactionType.class,
+            mode = EXCLUDE,
+            names = {"NO_COMPACTION"})
     void testSetLeafKeysStoreMergeTime(final CompactionType compactionType) {
         // given
         final MetricKeyRegistry registry = mock(MetricKeyRegistry.class);
@@ -275,7 +286,10 @@ class MerkleDbStatisticsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(CompactionType.class)
+    @EnumSource(
+            value = CompactionType.class,
+            mode = EXCLUDE,
+            names = {"NO_COMPACTION"})
     void testSetLeafKeysStoreSavedSpace(final CompactionType compactionType) {
         // given
         final Metric metric =
@@ -287,7 +301,10 @@ class MerkleDbStatisticsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(CompactionType.class)
+    @EnumSource(
+            value = CompactionType.class,
+            mode = EXCLUDE,
+            names = {"NO_COMPACTION"})
     void testSetLeavesStoreMergeTime(final CompactionType compactionType) {
         // given
         final Metric metric = getMetric("compactions_", "leaves" + ctypeStr(compactionType) + "TimeMs_" + LABEL);
@@ -298,7 +315,10 @@ class MerkleDbStatisticsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(CompactionType.class)
+    @EnumSource(
+            value = CompactionType.class,
+            mode = EXCLUDE,
+            names = {"NO_COMPACTION"})
     void testSetLeavesStoreSavedSpace(final CompactionType compactionType) {
         // given
         final Metric metric = getMetric("compactions_", "leaves" + ctypeStr(compactionType) + "SavedSpaceMb_" + LABEL);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/config/MerkleDbConfigTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/config/MerkleDbConfigTest.java
@@ -34,24 +34,6 @@ class MerkleDbConfigTest {
     }
 
     @Test
-    public void testMaxNumberOfFilesInMergeViolation() {
-        // given
-        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
-                .withConfigDataTypes(MerkleDbConfig.class)
-                .withSources(new SimpleConfigSource("merkleDb.maxNumberOfFilesInMerge", 3))
-                .withSources(new SimpleConfigSource("merkleDb.minNumberOfFilesInMerge", 10));
-
-        // when
-        final ConfigViolationException configViolationException = Assertions.assertThrows(
-                ConfigViolationException.class,
-                () -> configurationBuilder.build(),
-                "A violation should cancel the initialization");
-
-        // then
-        Assertions.assertEquals(1, configViolationException.getViolations().size());
-    }
-
-    @Test
     public void testMinNumberOfFilesInMergeViolation() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeHammerTest.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.merkledb.files;
 
+import static com.swirlds.merkledb.CompactionType.SMALL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,7 +91,7 @@ class DataFileCollectionMergeHammerTest {
 
             final long start = System.currentTimeMillis();
             final var filesToMerge = (List<DataFileReader<?>>) (Object) coll.getAllCompletedFiles();
-            compactor.compactFiles(index, filesToMerge);
+            compactor.compactFiles(index, filesToMerge, SMALL);
             System.out.println(numFiles + " files took " + (System.currentTimeMillis() - start) + "ms");
             index.close();
         });
@@ -158,13 +159,13 @@ class DataFileCollectionMergeHammerTest {
                 try {
                     final List<DataFileReader<?>> filesToMerge =
                             (List<DataFileReader<?>>) (Object) coll.getAllCompletedFiles();
-                    if (filesToMerge.size() > compactor.getMinNumberOfFilesToMerge()) {
+                    if (filesToMerge.size() > compactor.getMinNumberOfFilesToCompact()) {
                         System.out.println(filesToMerge.size());
                     }
                     if (filesToMerge.size() > 10000) {
                         stop.set(true);
                     }
-                    compactor.compactFiles(index, filesToMerge);
+                    compactor.compactFiles(index, filesToMerge, SMALL);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeTest.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.merkledb.files;
 
+import static com.swirlds.merkledb.CompactionType.SMALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,7 +69,7 @@ class DataFileCollectionMergeTest {
         final var coll = new DataFileCollection<>(tempFileDir.resolve("mergeTest"), "mergeTest", serializer, null);
         final var compactor = new DataFileCompactor(coll) {
             @Override
-            int getMinNumberOfFilesToMerge() {
+            int getMinNumberOfFilesToCompact() {
                 return 2;
             }
         };
@@ -117,7 +118,7 @@ class DataFileCollectionMergeTest {
                 }
             }
         };
-        compactor.compactFiles(indexUpdater, getFilesToMerge(coll));
+        compactor.compactFiles(indexUpdater, getFilesToMerge(coll), SMALL);
 
         long prevKey = -1;
         for (int i = 5; i < 10; i++) {
@@ -161,7 +162,7 @@ class DataFileCollectionMergeTest {
                 new DataFileCollection<>(testDir, "testDoubleMerge", new ExampleFixedSizeDataSerializer(), null);
         final DataFileCompactor compactor = new DataFileCompactor(store) {
             @Override
-            int getMinNumberOfFilesToMerge() {
+            int getMinNumberOfFilesToCompact() {
                 return 2;
             }
         };
@@ -210,7 +211,7 @@ class DataFileCollectionMergeTest {
                     };
 
                     try {
-                        compactor.compactFiles(indexUpdater, filesToMerge);
+                        compactor.compactFiles(indexUpdater, filesToMerge, SMALL);
                         store.close();
                     } catch (Exception ex) {
                         ex.printStackTrace();
@@ -255,7 +256,7 @@ class DataFileCollectionMergeTest {
                     }
                 }
             };
-            compactor.compactFiles(indexUpdater, filesToMerge);
+            compactor.compactFiles(indexUpdater, filesToMerge, SMALL);
         } finally {
             store2.close();
         }
@@ -308,7 +309,7 @@ class DataFileCollectionMergeTest {
 
                 if (filesToMerge.size() > 1) {
                     try {
-                        compactor.compactFiles(indexUpdater, filesToMerge);
+                        compactor.compactFiles(indexUpdater, filesToMerge, SMALL);
                     } catch (Exception ex) {
                         ex.printStackTrace();
                     }
@@ -379,7 +380,7 @@ class DataFileCollectionMergeTest {
 
                 if (filesToMerge.size() > 1) {
                     try {
-                        compactor.compactFiles(indexUpdater, filesToMerge);
+                        compactor.compactFiles(indexUpdater, filesToMerge, SMALL);
                     } catch (Exception ex) {
                         ex.printStackTrace();
                     }
@@ -449,7 +450,7 @@ class DataFileCollectionMergeTest {
             try {
                 final List<DataFileReader<?>> filesToMerge = getFilesToMerge(store);
                 assertEquals(numFiles, filesToMerge.size());
-                compactor.compactFiles(index, filesToMerge);
+                compactor.compactFiles(index, filesToMerge, SMALL);
                 // Wait for the new file to be available. Without this wait, there
                 // may be 1 or 2
                 // files available for merge, as this thread may be complete before
@@ -585,7 +586,7 @@ class DataFileCollectionMergeTest {
         };
 
         try {
-            compactor.compactFiles(indexUpdater, filesToMerge);
+            compactor.compactFiles(indexUpdater, filesToMerge, SMALL);
             store.close();
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -618,7 +619,7 @@ class DataFileCollectionMergeTest {
         };
 
         try {
-            compactor.compactFiles(indexUpdater2, filesToMerge2);
+            compactor.compactFiles(indexUpdater2, filesToMerge2, SMALL);
         } finally {
             store2.close();
         }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeTest.java
@@ -159,7 +159,12 @@ class DataFileCollectionMergeTest {
         final Path testDir = tempFileDir.resolve("testDoubleMerge");
         final DataFileCollection<long[]> store =
                 new DataFileCollection<>(testDir, "testDoubleMerge", new ExampleFixedSizeDataSerializer(), null);
-        final DataFileCompactor compactor = new DataFileCompactor(store);
+        final DataFileCompactor compactor = new DataFileCompactor(store) {
+            @Override
+            int getMinNumberOfFilesToMerge() {
+                return 2;
+            }
+        };
 
         final int numFiles = 2;
         for (long i = 0; i < numFiles; i++) {

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionMergeTest.java
@@ -66,7 +66,12 @@ class DataFileCollectionMergeTest {
         final Map<Long, Long> index = new HashMap<>();
         final var serializer = new ExampleFixedSizeDataSerializer();
         final var coll = new DataFileCollection<>(tempFileDir.resolve("mergeTest"), "mergeTest", serializer, null);
-        final var compactor = new DataFileCompactor(coll);
+        final var compactor = new DataFileCompactor(coll) {
+            @Override
+            int getMinNumberOfFilesToMerge() {
+                return 2;
+            }
+        };
 
         coll.startWriting();
         index.put(1L, coll.storeDataItem(new long[] {1, APPLE}));

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -17,6 +17,7 @@
 package com.swirlds.merkledb.files;
 
 import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyTrue;
+import static com.swirlds.merkledb.CompactionType.SMALL;
 import static com.swirlds.merkledb.MerkleDbTestUtils.checkDirectMemoryIsCleanedUpToLessThanBaseUsage;
 import static com.swirlds.merkledb.MerkleDbTestUtils.getDirectMemoryUsedBytes;
 import static com.swirlds.merkledb.files.DataFileCommon.FOOTER_SIZE;
@@ -455,7 +456,7 @@ class DataFileCollectionTest {
                         }
                     };
 
-                    mergedFiles = fileCompactor.compactFiles(indexUpdater, filesToMerge);
+                    mergedFiles = fileCompactor.compactFiles(indexUpdater, filesToMerge, SMALL);
                     assertTrue(allKeysExpectedToBeThere.isEmpty(), "check there were no missed keys");
                     System.out.println(
                             "============= MERGE [" + numMoves.get() + "] MOVES DONE ===========================");
@@ -497,7 +498,7 @@ class DataFileCollectionTest {
         assertEquals(1, filesLeft.size(), "unexpected # of files #3");
 
         // and trying to merge just one file is a no-op
-        List<Path> secondMergeResults = fileCompactor.compactFiles(null, filesLeft);
+        List<Path> secondMergeResults = fileCompactor.compactFiles(null, filesLeft, SMALL);
         assertNotNull(secondMergeResults, "null merged files list");
         assertEquals(0, secondMergeResults.size(), "unexpected results from second merge");
     }
@@ -603,7 +604,7 @@ class DataFileCollectionTest {
                             storedOffsets.forEach(action);
                         }
                     };
-                    fileCompactor.compactFiles(indexUpdater, allFiles);
+                    fileCompactor.compactFiles(indexUpdater, allFiles, SMALL);
                     assertTrue(allKeysExpectedToBeThere.isEmpty(), "check there were no missed keys");
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -637,9 +638,9 @@ class DataFileCollectionTest {
     }
 
     private static DataFileCompactor createFileCompactor(DataFileCollection<long[]> fileCollection) {
-        return new DataFileCompactor(fileCollection){
+        return new DataFileCompactor(fileCollection) {
             @Override
-            int getMinNumberOfFilesToMerge() {
+            int getMinNumberOfFilesToCompact() {
                 return 2;
             }
         };
@@ -700,7 +701,7 @@ class DataFileCollectionTest {
         assertSame(10, fileCollection2.getAllCompletedFiles().size(), "Should be 10 files available for merging");
         // merge
         fileCompactor.compactFiles(
-                storedOffsets, (List<DataFileReader<?>>) (Object) fileCollection2.getAllCompletedFiles());
+                storedOffsets, (List<DataFileReader<?>>) (Object) fileCollection2.getAllCompletedFiles(), SMALL);
         // check 1 files were opened and data is correct
         assertSame(1, fileCollection2.getAllCompletedFiles().size(), "Should be 1 files");
         assertEquals(

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -389,7 +389,7 @@ class DataFileCollectionTest {
     @EnumSource(FilesTestType.class)
     void merge(final FilesTestType testType) throws Exception {
         final DataFileCollection<long[]> fileCollection = fileCollectionMap.get(testType);
-        final DataFileCompactor fileCompactor = new DataFileCompactor(fileCollection);
+        final DataFileCompactor fileCompactor = createFileCompactor(fileCollection);
         final LongListHeap storedOffsets = storedOffsetsMap.get(testType);
         final AtomicBoolean mergeComplete = new AtomicBoolean(false);
         final int NUM_OF_KEYS = 1000;
@@ -555,7 +555,7 @@ class DataFileCollectionTest {
     @EnumSource(FilesTestType.class)
     void merge2(final FilesTestType testType) throws Exception {
         final DataFileCollection<long[]> fileCollection = fileCollectionMap.get(testType);
-        final DataFileCompactor fileCompactor = new DataFileCompactor(fileCollection);
+        final DataFileCompactor fileCompactor = createFileCompactor(fileCollection);
         final LongListHeap storedOffsets = storedOffsetsMap.get(testType);
         final AtomicBoolean mergeComplete = new AtomicBoolean(false);
         // start compaction paused so that we can test pausing
@@ -634,6 +634,15 @@ class DataFileCollectionTest {
                         .filter(f -> f.toString().endsWith(".jdb"))
                         .count(),
                 "unexpected # of files");
+    }
+
+    private static DataFileCompactor createFileCompactor(DataFileCollection<long[]> fileCollection) {
+        return new DataFileCompactor(fileCollection){
+            @Override
+            int getMinNumberOfFilesToMerge() {
+                return 2;
+            }
+        };
     }
 
     @Order(203)

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileLowLevelTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileLowLevelTest.java
@@ -17,6 +17,7 @@
 package com.swirlds.merkledb.files;
 
 import static com.swirlds.merkledb.files.DataFileCommon.createDataFilePath;
+import static com.swirlds.merkledb.files.DataFileCompactor.DEFAULT_COMPACTION_LEVEL;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -109,7 +110,12 @@ class DataFileLowLevelTest {
     void createFile(FilesTestType testType) throws IOException {
         // open file and write data
         DataFileWriter<long[]> writer = new DataFileWriter<>(
-                "test_" + testType.name(), tempFileDir, DATA_FILE_INDEX, testType.dataItemSerializer, TEST_START);
+                "test_" + testType.name(),
+                tempFileDir,
+                DATA_FILE_INDEX,
+                testType.dataItemSerializer,
+                TEST_START,
+                DEFAULT_COMPACTION_LEVEL);
         LongArrayList listOfDataItemLocations = new LongArrayList(1000);
         for (int i = 0; i < 1000; i++) {
             long[] dataValue;
@@ -344,7 +350,8 @@ class DataFileLowLevelTest {
                 tempFileDir,
                 DATA_FILE_INDEX + 1,
                 testType.dataItemSerializer,
-                TEST_START.plus(1, ChronoUnit.SECONDS));
+                TEST_START.plus(1, ChronoUnit.SECONDS),
+                DEFAULT_COMPACTION_LEVEL);
 
         final var dataFile = dataFileMap.get(testType);
         final var dataFileMetadata = dataFileMetadataMap.get(testType);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileMetadataTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileMetadataTest.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.merkledb.files;
 
+import static com.swirlds.merkledb.files.DataFileCompactor.DEFAULT_COMPACTION_LEVEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -32,28 +33,72 @@ class DataFileMetadataTest {
         final int index = 4;
         final Instant creationDate = Instant.ofEpochSecond(1_234_567L);
         final long serializationVersion = 7;
+        final int compactionLevel = DEFAULT_COMPACTION_LEVEL;
 
         final DataFileMetadata base = new DataFileMetadata(
-                fileFormatVersion, dataItemValueSize, dataItemCount, index, creationDate, serializationVersion);
+                fileFormatVersion,
+                dataItemValueSize,
+                dataItemCount,
+                index,
+                creationDate,
+                serializationVersion,
+                compactionLevel);
         final DataFileMetadata differentFormatVersion = new DataFileMetadata(
-                fileFormatVersion + 1, dataItemValueSize, dataItemCount, index, creationDate, serializationVersion);
+                fileFormatVersion + 1,
+                dataItemValueSize,
+                dataItemCount,
+                index,
+                creationDate,
+                serializationVersion,
+                compactionLevel);
         final DataFileMetadata differentValueSize = new DataFileMetadata(
-                fileFormatVersion, dataItemValueSize + 1, dataItemCount, index, creationDate, serializationVersion);
+                fileFormatVersion,
+                dataItemValueSize + 1,
+                dataItemCount,
+                index,
+                creationDate,
+                serializationVersion,
+                compactionLevel);
         final DataFileMetadata differentItemCount = new DataFileMetadata(
-                fileFormatVersion, dataItemValueSize, dataItemCount + 1, index, creationDate, serializationVersion);
+                fileFormatVersion,
+                dataItemValueSize,
+                dataItemCount + 1,
+                index,
+                creationDate,
+                serializationVersion,
+                compactionLevel);
         final DataFileMetadata differentIndex = new DataFileMetadata(
-                fileFormatVersion, dataItemValueSize, dataItemCount, index + 1, creationDate, serializationVersion);
+                fileFormatVersion,
+                dataItemValueSize,
+                dataItemCount,
+                index + 1,
+                creationDate,
+                serializationVersion,
+                compactionLevel);
         final DataFileMetadata differentCreationDate = new DataFileMetadata(
                 fileFormatVersion,
                 dataItemValueSize,
                 dataItemCount,
                 index,
                 creationDate.plusSeconds(1),
-                serializationVersion);
+                serializationVersion,
+                compactionLevel);
         final DataFileMetadata differentSerVersion = new DataFileMetadata(
-                fileFormatVersion, dataItemValueSize, dataItemCount, index, creationDate, serializationVersion + 1);
+                fileFormatVersion,
+                dataItemValueSize,
+                dataItemCount,
+                index,
+                creationDate,
+                serializationVersion + 1,
+                compactionLevel);
         final DataFileMetadata otherButEqual = new DataFileMetadata(
-                fileFormatVersion, dataItemValueSize, dataItemCount, index, creationDate, serializationVersion);
+                fileFormatVersion,
+                dataItemValueSize,
+                dataItemCount,
+                index,
+                creationDate,
+                serializationVersion,
+                compactionLevel);
 
         assertEquals(base, otherButEqual, "Equivalent metadata are equal");
         assertNotEquals(base, differentFormatVersion, "Different format versions are unequal");

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderHammerTest.java
@@ -16,6 +16,8 @@
 
 package com.swirlds.merkledb.files;
 
+import static com.swirlds.merkledb.files.DataFileCompactor.DEFAULT_COMPACTION_LEVEL;
+
 import com.swirlds.common.io.utility.TemporaryFileBuilder;
 import com.swirlds.merkledb.serialize.DataItemHeader;
 import com.swirlds.merkledb.serialize.DataItemSerializer;
@@ -67,7 +69,8 @@ public class DataFileReaderHammerTest {
 
         final ExecutorService exec = Executors.newFixedThreadPool(readerThreads);
         final Random rand = new Random();
-        final DataFileMetadata metadata = new DataFileMetadata(0, itemSize, itemCount, 0, Instant.now(), 0);
+        final DataFileMetadata metadata =
+                new DataFileMetadata(0, itemSize, itemCount, 0, Instant.now(), 0, DEFAULT_COMPACTION_LEVEL);
         final DataFileReader<byte[]> dataReader =
                 new DataFileReader<>(tempFile, new TestDataItemSerializer(itemSize), metadata);
         final AtomicInteger activeReaders = new AtomicInteger(readerThreads);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreMergeHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreMergeHammerTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -463,31 +462,10 @@ class MemoryIndexDiskKeyValueStoreMergeHammerTest {
 
         @Override
         protected void doWork() throws Exception {
-            if (iteration % 100 == 0) {
-                // Do a big merge that includes everything
-                coll.merge(list -> list, 2, null, null);
-            } else if (iteration % 25 == 0) {
-                // Do a medium merge that just has medium size files
-                coll.merge(
-                        list -> list.stream()
-                                .filter(file -> file.getSize() > 1_000_000 && file.getSize() < 32_000_000)
-                                .collect(Collectors.toList()),
-                        2,
-                        null,
-                        null);
-            } else if (iteration % 5 == 0) {
-                // Do a small merge
-                coll.merge(
-                        list -> list.stream()
-                                .filter(file -> file.getSize() < 1_000_000)
-                                .collect(Collectors.toList()),
-                        2,
-                        null,
-                        null);
-            } else {
-                MILLISECONDS.sleep(10);
-            }
 
+            if (iteration % 5 == 0) {
+                coll.compact(null, null);
+            }
             iteration++;
         }
     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreMergeHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreMergeHammerTest.java
@@ -35,11 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -62,18 +58,12 @@ class MemoryIndexDiskKeyValueStoreMergeHammerTest {
 
     @BeforeAll
     public static void setup() {
-        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Configuration config = ctx.getConfiguration();
-        final LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-        currentLogLevel = loggerConfig.getLevel();
-        // To prevent excessive logging we reduce the log level to WARN for this test.
-        // See https://github.com/hashgraph/hedera-services/issues/7083 for the context
-        loggerConfig.setLevel(Level.WARN);
+        Configurator.setRootLevel(Level.WARN);
     }
 
     @AfterAll
     public static void cleanUp() {
-        Configurator.setLevel(LogManager.ROOT_LOGGER_NAME, currentLogLevel);
+        Configurator.reconfigure();
     }
 
     /**
@@ -180,6 +170,7 @@ class MemoryIndexDiskKeyValueStoreMergeHammerTest {
                 (ThrowingSupplier<Void>) modifierFuture::get, "Should not throw, something failed while modifying.");
         assertDoesNotThrow(
                 (ThrowingSupplier<Void>) mergeFuture::get, "Should not throw, something failed while merging.");
+        index.close();
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
@@ -151,7 +151,7 @@ class HalfDiskHashMapTest {
         createSomeData(testType, map, 1111, 10_000, 1);
         checkData(testType, map, 1, 10_000, 1);
         // do a merge
-        map.merge(dataFileReaders -> dataFileReaders, 2, null, null);
+        map.compact(null, null);
         // check all data after
         checkData(testType, map, 1, 10_000, 1);
     }


### PR DESCRIPTION
**Description**:

This PR introduces additional parameter to `DataFileMetadata` - `compactionLevel` . This parameter allows the compactor to decide if the file should be compacted or not. 

Refactoring:
-  Unified  compaction functionality in `HalfDiskHashMap` and `MemoryIndexDiskKeyValueStore` and extracted it to `DataFileCompactor`
- Removed deep validation functionality because now the State Validation Tool takes care of that. 

**Related issue(s)**:

Fixes #7502 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
