### PR TITLE
Cherry-pick to 0.39 : Fix `curStakePeriod` while upgrade

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -148,8 +148,21 @@ public class StakePeriodManager {
         return StakingUtils.NA;
     }
 
+    /**
+     * Sets the stakePeriod to the given value. This is only called during upgrade housekeeping.
+     * @param currentStakePeriod the value to set the currentStakePeriod to
+     */
+    public void setCurrentStakePeriod(final long currentStakePeriod) {
+        this.currentStakePeriod = currentStakePeriod;
+    }
+
     @VisibleForTesting
     long getPrevConsensusSecs() {
         return prevConsensusSecs;
+    }
+
+    @VisibleForTesting
+    public long getCurrentStakePeriod() {
+        return currentStakePeriod;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.ledger.accounts.staking;
 
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_REWARD_HISTORY_NUM_STORED_PERIODS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_STARTUP_HELPER_RECOMPUTE;
+import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakePeriodManager.ZONE_UTC;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.forEach;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.withLoggedDuration;
 
@@ -30,6 +31,7 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.system.address.AddressBook;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,15 +68,18 @@ public class StakeStartupHelper {
     private final PropertySource properties;
     private final StakeInfoManager stakeInfoManager;
     private final RewardCalculator rewardCalculator;
+    private final StakePeriodManager stakePeriodManager;
 
     @Inject
     public StakeStartupHelper(
             final StakeInfoManager stakeInfoManager,
             final @CompositeProps PropertySource properties,
-            final RewardCalculator rewardCalculator) {
+            final RewardCalculator rewardCalculator,
+            final StakePeriodManager stakePeriodManager) {
         this.properties = properties;
         this.stakeInfoManager = stakeInfoManager;
         this.rewardCalculator = rewardCalculator;
+        this.stakePeriodManager = stakePeriodManager;
     }
 
     /**
@@ -130,6 +135,12 @@ public class StakeStartupHelper {
         // Recompute anything requested by the staking.startupHelper.recompute property
         final var recomputeTypes = properties.getRecomputeTypesProperty(STAKING_STARTUP_HELPER_RECOMPUTE);
         if (!recomputeTypes.isEmpty()) {
+            // While doing upgrade housekeeping, the current stake period is calculated from the last consensus time
+            // that is recorded in state. This is needed because when we calculate effectivePeriod in rewardCalculator
+            // we need to know the current stake period.
+            final var curStakePeriod = LocalDate.ofInstant(networkContext.consensusTimeOfLastHandledTxn(), ZONE_UTC)
+                    .toEpochDay();
+            stakePeriodManager.setCurrentStakePeriod(curStakePeriod);
             withLoggedDuration(
                     () -> recomputeQuantities(
                             recomputeTypes.contains(RecomputeType.NODE_STAKES),


### PR DESCRIPTION
Cherry-pick https://github.com/hashgraph/hedera-services/pull/7755

Fixed curStakePeriod that was not set during upgrade housekeeping
Testing:
Loaded mainnet state from 145234353 and validated fix will not have same error