### PR TITLE
Cherry-pick to 0.41: Fix `curStakePeriod` while upgrade

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -148,8 +148,21 @@ public class StakePeriodManager {
         return StakingUtils.NA;
     }
 
+    /**
+     * Sets the stakePeriod to the given value. This is only called during upgrade housekeeping.
+     * @param currentStakePeriod the value to set the currentStakePeriod to
+     */
+    public void setCurrentStakePeriod(final long currentStakePeriod) {
+        this.currentStakePeriod = currentStakePeriod;
+    }
+
     @VisibleForTesting
     long getPrevConsensusSecs() {
         return prevConsensusSecs;
+    }
+
+    @VisibleForTesting
+    public long getCurrentStakePeriod() {
+        return currentStakePeriod;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.ledger.accounts.staking;
 
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_REWARD_HISTORY_NUM_STORED_PERIODS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_STARTUP_HELPER_RECOMPUTE;
+import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakePeriodManager.ZONE_UTC;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.forEach;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.withLoggedDuration;
 
@@ -30,6 +31,7 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.system.address.AddressBook;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,15 +68,18 @@ public class StakeStartupHelper {
     private final PropertySource properties;
     private final StakeInfoManager stakeInfoManager;
     private final RewardCalculator rewardCalculator;
+    private final StakePeriodManager stakePeriodManager;
 
     @Inject
     public StakeStartupHelper(
             final StakeInfoManager stakeInfoManager,
             final @CompositeProps PropertySource properties,
-            final RewardCalculator rewardCalculator) {
+            final RewardCalculator rewardCalculator,
+            final StakePeriodManager stakePeriodManager) {
         this.properties = properties;
         this.stakeInfoManager = stakeInfoManager;
         this.rewardCalculator = rewardCalculator;
+        this.stakePeriodManager = stakePeriodManager;
     }
 
     /**
@@ -130,6 +135,12 @@ public class StakeStartupHelper {
         // Recompute anything requested by the staking.startupHelper.recompute property
         final var recomputeTypes = properties.getRecomputeTypesProperty(STAKING_STARTUP_HELPER_RECOMPUTE);
         if (!recomputeTypes.isEmpty()) {
+            // While doing upgrade housekeeping, the current stake period is calculated from the last consensus time
+            // that is recorded in state. This is needed because when we calculate effectivePeriod in rewardCalculator
+            // we need to know the current stake period.
+            final var curStakePeriod = LocalDate.ofInstant(networkContext.consensusTimeOfLastHandledTxn(), ZONE_UTC)
+                    .toEpochDay();
+            stakePeriodManager.setCurrentStakePeriod(curStakePeriod);
             withLoggedDuration(
                     () -> recomputeQuantities(
                             recomputeTypes.contains(RecomputeType.NODE_STAKES),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelperTest.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.ledger.accounts.staking;
 
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.STAKING_STARTUP_HELPER_RECOMPUTE;
+import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakePeriodManager.ZONE_UTC;
 import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakeStartupHelper.RecomputeType.NODE_STAKES;
 import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakeStartupHelper.RecomputeType.PENDING_REWARDS;
 import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakingUtils.roundedToHbar;
@@ -25,8 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
+import com.hedera.node.app.service.mono.context.TransactionContext;
 import com.hedera.node.app.service.mono.context.properties.PropertyNames;
 import com.hedera.node.app.service.mono.context.properties.PropertySource;
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
@@ -46,6 +49,8 @@ import com.swirlds.fcqueue.FCQueue;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.merkle.tree.MerkleBinaryTree;
 import com.swirlds.merkle.tree.MerkleTreeInternalNode;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +58,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SplittableRandom;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -71,6 +77,7 @@ class StakeStartupHelperTest {
     private static final SplittableRandom r = new SplittableRandom(1_234_567L);
     private static final int numStakingAccounts = 50;
     private static final long currentStakingPeriod = 1_234_567L;
+    private static final Instant consTime = Instant.ofEpochSecond(currentStakingPeriod);
 
     @Mock
     private StakeInfoManager stakeInfoManager;
@@ -87,10 +94,20 @@ class StakeStartupHelperTest {
     @Mock
     private RewardCalculator rewardCalculator;
 
+    @Mock
+    private TransactionContext txnCtx;
+
     private MerkleMap<EntityNum, MerkleAccount> accounts;
     private MerkleMap<EntityNum, MerkleStakingInfo> stakingInfos;
+    private StakePeriodManager stakePeriodManager;
 
     private StakeStartupHelper subject;
+
+    @BeforeEach
+    public void setUp() {
+        lenient().when(networkContext.consensusTimeOfLastHandledTxn()).thenReturn(consTime);
+        stakePeriodManager = new StakePeriodManager(txnCtx, () -> networkContext, properties);
+    }
 
     @Test
     void alwaysPrepsStakeInfoManagerForNewAddressBookAndUpdatesMap() {
@@ -140,6 +157,7 @@ class StakeStartupHelperTest {
                 MerkleMapLike.from(stakingInfos));
 
         verify(networkContext).setPendingRewards(expectedQuantities.pendingRewards);
+        assertEquals(LocalDate.ofInstant(consTime, ZONE_UTC).toEpochDay(), stakePeriodManager.getCurrentStakePeriod());
 
         for (final var postUpgradeInfo : stakingInfos.values()) {
             final var num = postUpgradeInfo.getKey();
@@ -209,21 +227,21 @@ class StakeStartupHelperTest {
 
     private void givenGenesisSubject() {
         givenGenesisAddressBook();
-        subject = new StakeStartupHelper(stakeInfoManager, properties, rewardCalculator);
+        subject = new StakeStartupHelper(stakeInfoManager, properties, rewardCalculator, stakePeriodManager);
     }
 
     private void givenPostRestartSubject() {
         givenWellKnownAddressBookAndInfosMap();
         given(properties.getIntProperty(PropertyNames.STAKING_REWARD_HISTORY_NUM_STORED_PERIODS))
                 .willReturn(365);
-        subject = new StakeStartupHelper(stakeInfoManager, properties, rewardCalculator);
+        subject = new StakeStartupHelper(stakeInfoManager, properties, rewardCalculator, stakePeriodManager);
     }
 
     private void givenPostUpgradeSubjectDoing(final StakeStartupHelper.RecomputeType... types) {
         given(properties.getRecomputeTypesProperty(STAKING_STARTUP_HELPER_RECOMPUTE))
                 .willReturn(Set.of(types));
 
-        subject = new StakeStartupHelper(stakeInfoManager, properties, rewardCalculator);
+        subject = new StakeStartupHelper(stakeInfoManager, properties, rewardCalculator, stakePeriodManager);
     }
 
     void givenGenesisAddressBook() {


### PR DESCRIPTION
Cherry-pick https://github.com/hashgraph/hedera-services/pull/7755

Fixed curStakePeriod that was not set during upgrade housekeeping
Testing:
Loaded mainnet state from 145234353 and validated fix will not have same error