### PR TITLE
Refresh congestion multipliers in config callback

### DIFF
--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.service.mono.context.domain.security.HapiOpPermission
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.context.properties.PropertySource;
 import com.hedera.node.app.service.mono.context.properties.PropertySources;
+import com.hedera.node.app.service.mono.fees.congestion.MultiplierSources;
 import com.hedera.node.app.service.mono.ledger.SigImpactHistorian;
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleNetworkContext;
@@ -87,6 +88,9 @@ class ConfigCallbacksTest {
     private PropertySource properties;
 
     @Mock
+    private MultiplierSources multiplierSources;
+
+    @Mock
     private SigImpactHistorian sigImpactHistorian;
 
     @Mock
@@ -110,7 +114,8 @@ class ConfigCallbacksTest {
                 () -> networkCtx,
                 () -> MerkleMapLike.from(stakingInfos),
                 sigImpactHistorian,
-                fileNumbers);
+                fileNumbers,
+                multiplierSources);
     }
 
     @Test
@@ -138,6 +143,7 @@ class ConfigCallbacksTest {
         verify(dynamicProps).reload();
         verify(functionalityThrottling, times(3)).applyGasConfig();
         verify(networkCtx).renumberBlocksToMatch(blockValues);
+        verify(multiplierSources).resetExpectations();
         // and:
         final var updatedNode0Info = stakingInfos.get(EntityNum.fromLong(0L));
         assertStakes(updatedNode0Info, historicalMaxStake / 2, overrideMaxStake);

--- a/hedera-node/settings.txt
+++ b/hedera-node/settings.txt
@@ -13,4 +13,4 @@ waitAtStartup,                                 false
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 maxEventQueueForCons,                          1000
 merkleDb.hashesRamToDiskThreshold,             8388608
-event.creation.maxCreationRate,               1
+event.creation.maxCreationRate,                20

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
@@ -17,24 +17,33 @@
 package com.hedera.services.bdd.suites.issues;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileDelete;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static java.util.stream.Collectors.toList;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hedera.services.bdd.suites.HapiSuite;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
 
 public class Issue305Spec extends HapiSuite {
     private static final Logger log = LogManager.getLogger(Issue305Spec.class);
@@ -46,9 +55,11 @@ public class Issue305Spec extends HapiSuite {
 
     @Override
     public List<HapiSpec> getSpecsInSuite() {
-        return IntStream.range(0, 5)
+        final var repeatedSpecs = new ArrayList<>(IntStream.range(0, 5)
                 .mapToObj(ignore -> createDeleteInSameRoundWorks())
-                .collect(toList());
+                .toList());
+        repeatedSpecs.add(congestionMultipliersRefreshOnPropertyUpdate());
+        return repeatedSpecs;
     }
 
     private HapiSpec createDeleteInSameRoundWorks() {
@@ -71,6 +82,57 @@ public class Issue305Spec extends HapiSuite {
                         fileCreate("tbd").key(KEY).deferStatusResolution(),
                         fileDelete(nextFileId::get).signedBy(GENESIS, KEY).logged(),
                         getFileInfo(nextFileId::get).logged());
+    }
+
+    private HapiSpec congestionMultipliersRefreshOnPropertyUpdate() {
+        final var civilian = "civilian";
+        final var preCongestionTxn = "preCongestionTxn";
+        final var postCongestionTxn = "postCongestionTxn";
+        final var multipurposeContract = "Multipurpose";
+        final var normalPrice = new AtomicLong();
+        final var multipliedPrice = new AtomicLong();
+
+        return propertyPreservingHapiSpec("CongestionMultipliersRefreshOnPropertyUpdate")
+                .preserving("fees.percentCongestionMultipliers", "fees.minCongestionPeriod", "contracts.maxGasPerSec")
+                .given(
+                        cryptoCreate(civilian).balance(10 * ONE_HUNDRED_HBARS),
+                        uploadInitCode(multipurposeContract),
+                        contractCreate(multipurposeContract).payingWith(GENESIS).logging(),
+                        contractCall(multipurposeContract)
+                                .payingWith(civilian)
+                                .fee(10 * ONE_HBAR)
+                                .sending(ONE_HBAR)
+                                .via(preCongestionTxn),
+                        getTxnRecord(preCongestionTxn).providingFeeTo(normalPrice::set),
+                        overridingThree(
+                                "contracts.maxGasPerSec", "3_000_000",
+                                "fees.percentCongestionMultipliers", "1,5x",
+                                "fees.minCongestionPeriod", "1"))
+                .when(withOpContext((spec, opLog) -> {
+                    for (int i = 0; i < 25; i++) {
+                        TimeUnit.MILLISECONDS.sleep(50);
+                        allRunFor(
+                                spec,
+                                contractCall(multipurposeContract)
+                                        .payingWith(civilian)
+                                        .gas(200_000)
+                                        .fee(10 * ONE_HBAR)
+                                        .sending(ONE_HBAR)
+                                        .deferStatusResolution());
+                    }
+                }))
+                .then(
+                        contractCall(multipurposeContract)
+                                .payingWith(civilian)
+                                .fee(10 * ONE_HBAR)
+                                .sending(ONE_HBAR)
+                                .via(postCongestionTxn),
+                        getTxnRecord(postCongestionTxn).providingFeeTo(multipliedPrice::set),
+                        withOpContext((spec, opLog) -> Assertions.assertEquals(
+                                5.0,
+                                (1.0 * multipliedPrice.get()) / normalPrice.get(),
+                                0.1,
+                                "~5x multiplier should be in affect!")));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -221,6 +221,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -293,7 +294,8 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 transferErc20TokenFromErc721TokenFails(),
                 contractCreateNoncesExternalizationHappyPath(),
                 contractCreateFollowedByContractCallNoncesExternalization(),
-                shouldReturnNullWhenContractsNoncesExternalizationFlagIsDisabled());
+                shouldReturnNullWhenContractsNoncesExternalizationFlagIsDisabled(),
+                congestionMultipliersRefreshOnPropertyUpdate());
     }
 
     private HapiSpec transferErc20TokenFromErc721TokenFails() {
@@ -2309,6 +2311,57 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         }))
                 .when()
                 .then();
+    }
+
+    private HapiSpec congestionMultipliersRefreshOnPropertyUpdate() {
+        final var civilian = "civilian";
+        final var preCongestionTxn = "preCongestionTxn";
+        final var postCongestionTxn = "postCongestionTxn";
+        final var multipurposeContract = "Multipurpose";
+        final var normalPrice = new AtomicLong();
+        final var multipliedPrice = new AtomicLong();
+
+        return propertyPreservingHapiSpec("CongestionMultipliersRefreshOnPropertyUpdate")
+                .preserving("fees.percentCongestionMultipliers", "fees.minCongestionPeriod", "contracts.maxGasPerSec")
+                .given(
+                        cryptoCreate(civilian).balance(10 * ONE_HUNDRED_HBARS),
+                        uploadInitCode(multipurposeContract),
+                        contractCreate(multipurposeContract).payingWith(GENESIS).logging(),
+                        contractCall(multipurposeContract)
+                                .payingWith(civilian)
+                                .fee(10 * ONE_HBAR)
+                                .sending(ONE_HBAR)
+                                .via(preCongestionTxn),
+                        getTxnRecord(preCongestionTxn).providingFeeTo(normalPrice::set),
+                        overridingThree(
+                                "contracts.maxGasPerSec", "3_000_000",
+                                "fees.percentCongestionMultipliers", "1,5x",
+                                "fees.minCongestionPeriod", "1"))
+                .when(withOpContext((spec, opLog) -> {
+                    for (int i = 0; i < 25; i++) {
+                        TimeUnit.MILLISECONDS.sleep(50);
+                        allRunFor(
+                                spec,
+                                contractCall(multipurposeContract)
+                                        .payingWith(civilian)
+                                        .gas(200_000)
+                                        .fee(10 * ONE_HBAR)
+                                        .sending(ONE_HBAR)
+                                        .deferStatusResolution());
+                    }
+                }))
+                .then(
+                        contractCall(multipurposeContract)
+                                .payingWith(civilian)
+                                .fee(10 * ONE_HBAR)
+                                .sending(ONE_HBAR)
+                                .via(postCongestionTxn),
+                        getTxnRecord(postCongestionTxn).providingFeeTo(multipliedPrice::set),
+                        withOpContext((spec, opLog) -> Assertions.assertEquals(
+                                5.0,
+                                (1.0 * multipliedPrice.get()) / normalPrice.get(),
+                                0.1,
+                                "~5x multiplier should be in affect!")));
     }
 
     @Override


### PR DESCRIPTION
**Description**:
 - Closes #7768 
 - _Note to reviewer:_ To validate fix locally, run `congestionMultipliersRefreshOnPropertyUpdate()` with and without [the `resetExpectations()` call](https://github.com/hashgraph/hedera-services/pull/7780/files#diff-5ec9034b5d1b8575aeab53a936027845b22856b5b4a11d27362de77694a9e834R119); observe multipliers do not take effect without it.