### PR TITLE
Avoid unwanted genesis migration records

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManager.java
@@ -127,24 +127,27 @@ public class MigrationRecordsManager {
             return;
         }
 
-        // We always publish creation records for 0.0.800, and 0.0.801 on a network reset
+        // Publish synthetic creation records for system and staking reward accounts ONLY at true network genesis,
+        // when the consensus time of the last handled txn is null...if we publish these unconditionally, then some
+        // genesis reconnect scenarios risk an ISS
         if (curNetworkCtx.consensusTimeOfLastHandledTxn() == null) {
             final var implicitAutoRenewPeriod = FUNDING_ACCOUNT_EXPIRY - now.getEpochSecond();
             final var stakingFundAccounts = List.of(
                     EntityNum.fromLong(accountNumbers.stakingRewardAccount()),
                     EntityNum.fromLong(accountNumbers.nodeRewardAccount()));
             stakingFundAccounts.forEach(num -> publishSyntheticCreationForStakingFund(num, implicitAutoRenewPeriod));
+            // Always publish records for any treasury clones that needed to be created
+            publishAccountsCreated(
+                    systemAccountsCreator.getTreasuryClonesCreated(), now, TREASURY_CLONE_MEMO, "treasury clone");
+            // Always publish records for any system accounts created at genesis start up
+            publishAccountsCreated(
+                    systemAccountsCreator.getSystemAccountsCreated(),
+                    now,
+                    SYSTEM_ACCOUNT_CREATION_MEMO,
+                    "system creation");
         } else if (grantingFreeAutoRenewals()) {
             publishContractFreeAutoRenewalRecords();
         }
-
-        // Always publish records for any treasury clones that needed to be created
-        publishAccountsCreated(
-                systemAccountsCreator.getTreasuryClonesCreated(), now, TREASURY_CLONE_MEMO, "treasury clone");
-
-        // Always publish records for any system accounts created at genesis start up
-        publishAccountsCreated(
-                systemAccountsCreator.getSystemAccountsCreated(), now, SYSTEM_ACCOUNT_CREATION_MEMO, "system creation");
 
         if (bootstrapProperties.getBooleanProperty(PropertyNames.ACCOUNTS_BLOCKLIST_ENABLED)) {
             publishAccountsCreated(


### PR DESCRIPTION
**Description**:
 - Only export synth creations at true genesis (when `lastHandled` time is null).