### PR TITLE
HapiTestEngine improvements

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -242,6 +242,7 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
                         return true;
                     })
                     .map(method -> new MethodTestDescriptor(method, this))
+                    .filter(method -> !method.shouldBeSkipped(null).isSkipped())
                     .forEach(this::addChild);
 
             // Skip construction of the Hedera instance if there are no test methods
@@ -464,7 +465,7 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
         }
 
         @Override
-        public SkipResult shouldBeSkipped(HapiTestEngineExecutionContext context) throws Exception {
+        public SkipResult shouldBeSkipped(HapiTestEngineExecutionContext context) {
             final var annotation = AnnotationSupport.findAnnotation(testMethod, Disabled.class);
             if (!AnnotationSupport.isAnnotated(testMethod, HapiTest.class)) {
                 return SkipResult.skip("No @HapiTest annotation");

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngineExecutionContext.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngineExecutionContext.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.bdd.junit;
 
+import java.nio.file.Path;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 
 /**
@@ -25,4 +26,21 @@ import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
  * server here. But the HAPI test system stores that information statically, so we don't need to do it here. So for
  * now this class is just empty (we need it to satisfy the API, but we don't use it).
  */
-public class HapiTestEngineExecutionContext implements EngineExecutionContext {}
+public class HapiTestEngineExecutionContext implements EngineExecutionContext {
+
+    private final Path savedStateDirectory;
+    private final Path eventsLogDir;
+
+    public HapiTestEngineExecutionContext(final Path savedStateDirectory, final Path eventsLogDir) {
+        this.savedStateDirectory = savedStateDirectory;
+        this.eventsLogDir = eventsLogDir;
+    }
+
+    public Path getSavedStateDirectory() {
+        return savedStateDirectory;
+    }
+
+    public Path getEventsLogDir() {
+        return eventsLogDir;
+    }
+}


### PR DESCRIPTION
**Description**:
Making a couple of improvements in HapiTestEngine

**Notes for reviewer**:
**Improvement 1:** Filtering the whole HapiTestSuite if there are no HapiTest inside.
After merging https://github.com/hashgraph/hedera-services/pull/7710(where we put @HapiTestSuite annotation to all suites) when we run all tests we were calling the `before` and `after` methods. The `before` method was starting a node and this is not needed since there are no tests that will be executed. This results in a really slow execution of the tests.
_Before the fix:_
![Screenshot 2023-08-02 at 12 23 02](https://github.com/hashgraph/hedera-services/assets/99957253/24c9466e-cc01-4ee5-956a-55540d647e0f)

_After the fix:_
![Screenshot 2023-08-02 at 12 43 01](https://github.com/hashgraph/hedera-services/assets/99957253/7724427c-676d-43f0-8ff7-b50c05850ee2)
**Note**: the tests are just some suites I'm testing with locally(they are not pushed)

**Improvement 2:** Cleaning the test data after each suite.
The problem is that each suite is creating its own `SwirldsPlatform` where there is some data related to it. When we start executing more than one suite at a time the data is interfering and the suites are failing. The solution is at the end of the `before` method we get the paths to the data and pass it to the `HapiTestEngineExecutionContext`. Then in the `after`method in `ClassTestDescriptor` class we have access to the folders and we can clean them.
_Before the fix:_
![Screenshot 2023-08-02 at 12 44 35](https://github.com/hashgraph/hedera-services/assets/99957253/74e0e038-c20b-4aa6-80e0-f1706a364b4d)

_After the fix:_
![Screenshot 2023-08-02 at 12 50 42](https://github.com/hashgraph/hedera-services/assets/99957253/a42692f5-61b8-4cf5-90cb-f2c60d9c7c70)
