### PR TITLE
Add deleted account beneficiaries to `SingleTransactionRecordBuilder`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -49,6 +49,7 @@ import com.hedera.node.app.service.file.impl.records.CreateFileRecordBuilder;
 import com.hedera.node.app.service.token.impl.records.CryptoCreateRecordBuilder;
 import com.hedera.node.app.service.token.impl.records.CryptoDeleteRecordBuilder;
 import com.hedera.node.app.service.token.impl.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.impl.records.CryptoUpdateRecordBuilder;
 import com.hedera.node.app.service.token.impl.records.TokenCreateRecordBuilder;
 import com.hedera.node.app.service.token.impl.records.TokenMintRecordBuilder;
 import com.hedera.node.app.service.util.impl.records.PrngRecordBuilder;
@@ -56,7 +57,6 @@ import com.hedera.node.app.spi.HapiUtils;
 import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hederahashgraph.api.proto.java.TokenRelation;
 import com.swirlds.common.crypto.DigestType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -95,7 +95,8 @@ public class SingleTransactionRecordBuilderImpl
                 TokenCreateRecordBuilder,
                 ContractCreateRecordBuilder,
                 ContractCallRecordBuilder,
-                CryptoDeleteRecordBuilder {
+                CryptoDeleteRecordBuilder,
+                CryptoUpdateRecordBuilder {
     // base transaction data
     private Transaction transaction;
     private Bytes transactionBytes = Bytes.EMPTY;
@@ -118,9 +119,7 @@ public class SingleTransactionRecordBuilderImpl
     private List<AbstractMap.SimpleEntry<ContractBytecode, Boolean>> contractBytecodes = new ArrayList<>();
 
     // Fields that are not in TransactionRecord, but are needed for computing staking rewards
-    // and building transferList correctly
     private Map<AccountID, AccountID> deletedAccountBeneficiaries = new HashMap<>();
-    private List<TokenRelation> autoAssociations = new ArrayList<>();
 
     /**
      * Creates new transaction record builder.
@@ -835,15 +834,10 @@ public class SingleTransactionRecordBuilderImpl
     }
 
     /**
-     * Adds the token relations that are auto associations. This information is needed while building
-     * the transfer list, to set the auto association flag.
-     * @param tokenRelation the token relation that is created by auto association
-     * @return the builder
+     * Gets the map of deleted account ID to beneficiary account ID.
+     * @return the map of deleted account ID to beneficiary account ID
      */
-    @NonNull
-    public SingleTransactionRecordBuilderImpl addAutoAssociation(@NonNull final TokenRelation tokenRelation) {
-        requireNonNull(tokenRelation, "tokenRelation must not be null");
-        autoAssociations.add(tokenRelation);
-        return this;
+    public Map<AccountID, AccountID> getDeletedAccountBeneficiaries() {
+        return deletedAccountBeneficiaries;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -119,6 +119,7 @@ public class SingleTransactionRecordBuilderImpl
     private List<AbstractMap.SimpleEntry<ContractBytecode, Boolean>> contractBytecodes = new ArrayList<>();
 
     // Fields that are not in TransactionRecord, but are needed for computing staking rewards
+    // These are not persisted to the record file
     private Map<AccountID, AccountID> deletedAccountBeneficiaries = new HashMap<>();
 
     /**
@@ -815,7 +816,7 @@ public class SingleTransactionRecordBuilderImpl
         return this;
     }
 
-    /* ------------- information needed by token service for building transfer list and staking -------- */
+    // ------------- Information needed by token service for redirecting staking rewards to appropriate accounts
 
     /**
      * Adds a beneficiary for a deleted account into the map. This is needed while computing staking rewards.
@@ -837,6 +838,7 @@ public class SingleTransactionRecordBuilderImpl
      * Gets the map of deleted account ID to beneficiary account ID.
      * @return the map of deleted account ID to beneficiary account ID
      */
+    @NonNull
     public Map<AccountID, AccountID> getDeletedAccountBeneficiaries() {
         return deletedAccountBeneficiaries;
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.TokenAssociation;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenSupplyType;
 import com.hedera.hapi.node.state.token.Account;
@@ -303,8 +304,9 @@ public class BaseTokenHandler {
      * @param accountStore the account store
      * @param tokenRelStore the token relation store
      * @param context the handle context
+     * @return the new token relation added
      */
-    protected void autoAssociate(
+    protected TokenRelation autoAssociate(
             @NonNull final Account account,
             @NonNull final Token token,
             @NonNull final WritableAccountStore accountStore,
@@ -350,6 +352,7 @@ public class BaseTokenHandler {
 
         accountStore.put(copyAccount);
         tokenRelStore.put(newTokenRel);
+        return newTokenRel;
     }
 
     /**
@@ -429,5 +432,18 @@ public class BaseTokenHandler {
     public static boolean isValidTokenId(final TokenID tokenId) {
         if (tokenId == null) return false;
         return tokenId.tokenNum() > 0;
+    }
+
+    /**
+     * Creates a new {@link TokenAssociation} with the given tokenId and accountId.
+     * @param tokenId the token id
+     * @param accountId the account id
+     * @return the new token association
+     */
+    public static TokenAssociation asTokenAssociation(final TokenID tokenId, final AccountID accountId) {
+        return TokenAssociation.newBuilder()
+                .tokenId(tokenId)
+                .accountId(accountId)
+                .build();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
@@ -35,6 +35,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoDeleteTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
+import com.hedera.node.app.service.token.impl.records.CryptoDeleteRecordBuilder;
 import com.hedera.node.app.spi.validation.EntityType;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -100,6 +101,12 @@ public class CryptoDeleteHandler implements TransactionHandler {
         final var updatedDeleteAccount = accountStore.get(op.deleteAccountID());
         validateTrue(updatedDeleteAccount != null, ACCOUNT_ID_DOES_NOT_EXIST);
         accountStore.put(updatedDeleteAccount.copyBuilder().deleted(true).build());
+
+        // add the transfer account for this deleted account to record builder.
+        // This is needed while computing staking rewards. In the future it will also be added
+        // to the transaction record exported to mirror node.
+        final var cryptoDeleteBuilder = context.recordBuilder(CryptoDeleteRecordBuilder.class);
+        cryptoDeleteBuilder.addBeneficiaryForDeletedAccount(op.deleteAccountID(), op.transferAccountID());
     }
 
     /* ----------------------------- Helper methods -------------------------------- */

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -48,6 +48,7 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
+import com.hedera.node.app.service.token.impl.records.CryptoUpdateRecordBuilder;
 import com.hedera.node.app.service.token.impl.validators.TokenUpdateValidator;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -110,6 +111,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         final var txn = context.body();
         final var op = txn.tokenUpdateOrThrow();
         final var tokenId = op.tokenOrThrow();
+        final var recordBuilder = context.recordBuilder(CryptoUpdateRecordBuilder.class);
 
         // validate fields that involve config or state
         final var validationResult = tokenUpdateValidator.validateSemantics(context, op);
@@ -136,7 +138,9 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
             // If there is no treasury relationship, then we need to create one if auto associations are available.
             // If not fail
             if (newTreasuryRel == null) {
-                autoAssociate(newTreasuryAccount, token, accountStore, tokenRelStore, context);
+                final var newRelation = autoAssociate(newTreasuryAccount, token, accountStore, tokenRelStore, context);
+                recordBuilder.addAutomaticTokenAssociation(
+                        asTokenAssociation(newRelation.tokenId(), newRelation.accountId()));
             }
             // Treasury can be modified when it owns NFTs when the property "tokens.nfts.useTreasuryWildcards"
             // is enabled.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
@@ -80,7 +80,7 @@ public class StakingRewardsDistributor {
 
                 // We cannot reward a deleted account, so keep redirecting to the beneficiaries of deleted
                 // accounts until we find a non-deleted account to try to reward (it may still decline)
-                if (originalAccount.deleted()) {
+                if (modifiedAccount.deleted()) {
                     final var beneficiaries = recordBuilder.getDeletedAccountBeneficiaries();
                     final var maxRedirects = beneficiaries.size();
                     var j = 1;

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
@@ -24,8 +24,6 @@ import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
 import com.hedera.node.app.service.token.impl.records.CryptoDeleteRecordBuilder;
-import com.hedera.node.app.service.token.impl.records.CryptoTransferRecordBuilder;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.HashMap;

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -32,7 +32,6 @@ import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
 import com.hedera.node.app.service.token.impl.records.CryptoDeleteRecordBuilder;
-import com.hedera.node.app.service.token.impl.records.CryptoTransferRecordBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.data.AccountsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -83,8 +82,7 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
         final var rewardReceivers = getPossibleRewardReceivers(writableStore);
         // Pay rewards to all possible reward receivers, returns all rewards paid
         final var rewardsPaid = rewardsPayer.payRewardsIfPending(
-                rewardReceivers, writableStore, stakingRewardsStore,
-                stakingInfoStore, consensusNow, recordBuilder);
+                rewardReceivers, writableStore, stakingRewardsStore, stakingInfoStore, consensusNow, recordBuilder);
         // Adjust stakes for nodes
         adjustStakeMetadata(writableStore, stakingInfoStore, stakingRewardsStore, consensusNow, rewardsPaid);
         // Decrease staking reward account balance by rewardPaid amount

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -86,7 +86,7 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
      * @param accountStore  The account store
      * @param tokenRelStore The token relation store
      * @param handleContext The context
-     * @param recordBuilder
+     * @param recordBuilder The record builder
      */
     private void validateAndAutoAssociate(
             @NonNull final AccountID accountId,

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
+import com.hedera.node.app.service.token.impl.records.CryptoTransferRecordBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -52,6 +53,7 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
         final var tokenStore = handleContext.writableStore(WritableTokenStore.class);
         final var tokenRelStore = handleContext.writableStore(WritableTokenRelationStore.class);
         final var accountStore = handleContext.writableStore(WritableAccountStore.class);
+        final var recordBuilder = handleContext.recordBuilder(CryptoTransferRecordBuilder.class);
 
         for (final var xfers : op.tokenTransfersOrElse(emptyList())) {
             final var tokenId = xfers.tokenOrThrow();
@@ -59,7 +61,8 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
 
             for (final var aa : xfers.transfersOrElse(emptyList())) {
                 final var accountId = aa.accountID();
-                validateAndAutoAssociate(accountId, tokenId, token, accountStore, tokenRelStore, handleContext);
+                validateAndAutoAssociate(
+                        accountId, tokenId, token, accountStore, tokenRelStore, handleContext, recordBuilder);
             }
 
             for (final var aa : xfers.nftTransfersOrElse(emptyList())) {
@@ -67,7 +70,8 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
                 final var senderId = aa.senderAccountID();
                 // sender should be associated already. If not throw exception
                 validateTrue(tokenRelStore.get(senderId, tokenId) != null, TOKEN_NOT_ASSOCIATED_TO_ACCOUNT);
-                validateAndAutoAssociate(receiverId, tokenId, token, accountStore, tokenRelStore, handleContext);
+                validateAndAutoAssociate(
+                        receiverId, tokenId, token, accountStore, tokenRelStore, handleContext, recordBuilder);
             }
         }
     }
@@ -75,12 +79,14 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
     /**
      * Associates the token with the account if it is not already associated. It is auto-associated only if there are
      * open auto-associations available on the account.
-     * @param accountId The account to associate the token with
-     * @param tokenId The tokenID of the token to associate with the account
-     * @param token The token to associate with the account
-     * @param accountStore The account store
+     *
+     * @param accountId     The account to associate the token with
+     * @param tokenId       The tokenID of the token to associate with the account
+     * @param token         The token to associate with the account
+     * @param accountStore  The account store
      * @param tokenRelStore The token relation store
      * @param handleContext The context
+     * @param recordBuilder
      */
     private void validateAndAutoAssociate(
             @NonNull final AccountID accountId,
@@ -88,12 +94,15 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
             @NonNull final Token token,
             @NonNull final WritableAccountStore accountStore,
             @NonNull final WritableTokenRelationStore tokenRelStore,
-            @NonNull final HandleContext handleContext) {
+            @NonNull final HandleContext handleContext,
+            @NonNull final CryptoTransferRecordBuilder recordBuilder) {
         final var account = getIfUsable(accountId, accountStore, handleContext.expiryValidator(), INVALID_ACCOUNT_ID);
         final var tokenRel = tokenRelStore.get(accountId, tokenId);
 
         if (tokenRel == null && account.maxAutoAssociations() > 0) {
-            autoAssociate(account, token, accountStore, tokenRelStore, handleContext);
+            final var newRelation = autoAssociate(account, token, accountStore, tokenRelStore, handleContext);
+            recordBuilder.addAutomaticTokenAssociation(
+                    asTokenAssociation(newRelation.tokenId(), newRelation.accountId()));
         } else {
             validateTrue(tokenRel != null, TOKEN_NOT_ASSOCIATED_TO_ACCOUNT);
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoDeleteRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoDeleteRecordBuilder.java
@@ -19,6 +19,8 @@ package com.hedera.node.app.service.token.impl.records;
 import com.hedera.hapi.node.base.AccountID;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import java.util.Map;
+
 /**
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
  * transaction.
@@ -33,4 +35,12 @@ public interface CryptoDeleteRecordBuilder {
     @NonNull
     CryptoDeleteRecordBuilder addBeneficiaryForDeletedAccount(
             @NonNull final AccountID deletedAccountID, @NonNull final AccountID beneficiaryForDeletedAccount);
+
+    /**
+     * Gets the deleted account beneficiaries.
+     * @return the deleted account beneficiaries
+     */
+    // TODO: Not sure if this should be here or in SingleTranssactionRecordBuilder
+    @NonNull
+    Map<AccountID, AccountID> getDeletedAccountBeneficiaries();
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoDeleteRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoDeleteRecordBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token.impl.records;
+
+import com.hedera.hapi.node.base.AccountID;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
+ * transaction.
+ */
+public interface CryptoDeleteRecordBuilder {
+    /**
+     * Adds a beneficiary for a deleted account.
+     * @param deletedAccountID the deleted account ID
+     * @param beneficiaryForDeletedAccount the beneficiary account ID
+     * @return the builder
+     */
+    @NonNull
+    CryptoDeleteRecordBuilder addBeneficiaryForDeletedAccount(
+            @NonNull final AccountID deletedAccountID, @NonNull final AccountID beneficiaryForDeletedAccount);
+}

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoDeleteRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoDeleteRecordBuilder.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.service.token.impl.records;
 
 import com.hedera.hapi.node.base.AccountID;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.util.Map;
 
 /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoTransferRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoTransferRecordBuilder.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.token.impl.records;
 
 import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.TokenAssociation;
 import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.transaction.AssessedCustomFee;
@@ -55,12 +56,20 @@ public interface CryptoTransferRecordBuilder {
      * @return this builder
      */
     @NonNull
-    CryptoTransferRecordBuilder assessedCustomFees(List<AssessedCustomFee> assessedCustomFees);
+    CryptoTransferRecordBuilder assessedCustomFees(@NonNull final List<AssessedCustomFee> assessedCustomFees);
 
     /**
      * Tracks the total amount of hbars paid as staking rewards in the transaction
      * @param paidStakingRewards the total amount of hbars paid as staking rewards
      * @return this builder
      */
-    CryptoTransferRecordBuilder paidStakingRewards(List<AccountAmount> paidStakingRewards);
+    CryptoTransferRecordBuilder paidStakingRewards(@NonNull final List<AccountAmount> paidStakingRewards);
+
+    /**
+     * Adds the token relations that are created by auto associations.
+     * This information is needed while building the transfer list, to set the auto association flag.
+     * @param tokenAssociation the token association that is created by auto association
+     * @return the builder
+     */
+    CryptoTransferRecordBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/records/CryptoUpdateRecordBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token.impl.records;
+
+import com.hedera.hapi.node.base.TokenAssociation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A {@code RecordBuilder} specialization for tracking the effects of a {@code CryptoUpdate}
+ * transaction.
+ */
+public interface CryptoUpdateRecordBuilder {
+    /**
+     * Adds the token relations that are created by auto associations.
+     * This information is needed while building the transfer list, to set the auto association flag.
+     * @param tokenAssociation the token association that is created by auto association
+     * @return the builder
+     */
+    CryptoUpdateRecordBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
+}

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -35,6 +35,7 @@ import com.hedera.node.app.service.token.impl.handlers.staking.StakeRewardCalcul
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsDistributor;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHandlerImpl;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper;
+import com.hedera.node.app.service.token.impl.records.CryptoDeleteRecordBuilder;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.ConfigProvider;
@@ -56,6 +57,9 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     private HandleContext handleContext;
+
+    @Mock
+    private CryptoDeleteRecordBuilder recordBuilder;
 
     private StakingRewardsHandlerImpl subject;
     private StakePeriodManager stakePeriodManager;
@@ -432,13 +436,14 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
                 .build();
         addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
 
-        writableAccountStore.put(account.copyBuilder()
-                .tinybarBalance(accountBalance - HBARS_TO_TINYBARS)
+        writableAccountStore.put(payerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(0)
                 .stakedNodeId(0L)
                 .build());
-        writableAccountStore.put(ownerAccount
+        writableAccountStore.put(ownerAccountBefore
                 .copyBuilder()
-                .tinybarBalance(ownerBalance + HBARS_TO_TINYBARS)
+                .tinybarBalance(ownerBalance + accountBalance)
                 .stakedNodeId(0L)
                 .build());
 
@@ -447,9 +452,13 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
                         .atStartOfDay(ZoneOffset.UTC)
                         .toInstant());
         given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(handleContext.recordBuilder(CryptoDeleteRecordBuilder.class)).willReturn(recordBuilder);
+        given(recordBuilder.getDeletedAccountBeneficiaries()).willReturn(Map.of(payerId, ownerId));
 
-        // TODO: this will change once transfer to beneficiary is implemented
-        assertThatThrownBy(() -> subject.applyStakingRewards(handleContext)).isInstanceOf(IllegalStateException.class);
+        final var rewards = subject.applyStakingRewards(handleContext);
+        assertThat(rewards).hasSize(1);
+        // because the transferId is owner for the deleted payer account
+        assertThat(rewards).containsEntry(ownerId, 178900L);
     }
 
     @Test
@@ -641,22 +650,152 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         // Only worthwhile to update stakedPeriodStart for an account staking to a node
         assertThat(modifiedPayer.stakePeriodStart()).isEqualTo(stakePeriodStart);
     }
-    //
-    //    @Test
-    //    void rewardsUltimateBeneficiaryInsteadOfDeletedAccount() {
-    //        TODO: Need to add this test once implemented
-    //    }
-    //
-    //    @Test
-    //    void doesntTrackAnythingIfRedirectBeneficiaryDeclinedReward() {
-    //        TODO: Need to add this test once implemented
-    //    }
-    //
-    //    @Test
-    //    void failsHardIfMoreRedirectsThanDeletedEntitiesAreNeeded() {
-    //        TODO: Need to add this test once implemented
-    //    }
-    //
+
+    @Test
+    void rewardsUltimateBeneficiaryInsteadOfDeletedAccount() {
+        final var accountBalance = 555L * HBARS_TO_TINYBARS;
+        final var ownerBalance = 111L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .build();
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        writableAccountStore.put(payerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(0)
+                .stakedNodeId(0L)
+                .build());
+        writableAccountStore.put(ownerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(ownerBalance + accountBalance)
+                .stakedNodeId(0L)
+                .build());
+
+        given(handleContext.consensusNow())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart + 2)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(handleContext.recordBuilder(CryptoDeleteRecordBuilder.class)).willReturn(recordBuilder);
+        given(recordBuilder.getDeletedAccountBeneficiaries()).willReturn(Map.of(payerId, ownerId));
+
+        final var rewards = subject.applyStakingRewards(handleContext);
+        assertThat(rewards).hasSize(1);
+        // because the transferId is owner for the deleted payer account
+        assertThat(rewards).containsEntry(ownerId, 178900L);
+    }
+
+    @Test
+    void doesntTrackAnythingIfRedirectBeneficiaryDeclinedReward() {
+        final var accountBalance = 555L * HBARS_TO_TINYBARS;
+        final var ownerBalance = 111L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .build();
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(true)
+                .withDeleted(false)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        writableAccountStore.put(payerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(0)
+                .stakedNodeId(0L)
+                .build());
+        writableAccountStore.put(ownerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(ownerBalance + accountBalance)
+                .stakedNodeId(0L)
+                .build());
+
+        given(handleContext.consensusNow())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart + 2)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(handleContext.recordBuilder(CryptoDeleteRecordBuilder.class)).willReturn(recordBuilder);
+        given(recordBuilder.getDeletedAccountBeneficiaries()).willReturn(Map.of(payerId, ownerId));
+
+        final var rewards = subject.applyStakingRewards(handleContext);
+        // because the transferId is owner and it declined reward
+        assertThat(rewards).hasSize(0);
+    }
+
+    @Test
+    void failsHardIfMoreRedirectsThanDeletedEntitiesAreNeeded() {
+        final var accountBalance = 555L * HBARS_TO_TINYBARS;
+        final var ownerBalance = 111L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .build();
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .build();
+        final var spenderAccountBefore = new AccountCustomizer()
+                .withAccount(spenderAccount)
+                .withBalance(0L)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore, spenderId, spenderAccountBefore));
+
+        writableAccountStore.put(payerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(0)
+                .stakedNodeId(0L)
+                .build());
+        writableAccountStore.put(ownerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(ownerBalance + accountBalance)
+                .stakedNodeId(0L)
+                .build());
+
+        given(handleContext.consensusNow())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart + 2)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(handleContext.recordBuilder(CryptoDeleteRecordBuilder.class)).willReturn(recordBuilder);
+        given(recordBuilder.getDeletedAccountBeneficiaries()).willReturn(Map.of(payerId, ownerId, ownerId, spenderId));
+
+        assertThatThrownBy(() -> subject.applyStakingRewards(handleContext)).isInstanceOf(IllegalStateException.class);
+    }
+
     @Test
     void updatesStakedToMeSideEffects() {
         final var accountBalance = 55L * HBARS_TO_TINYBARS;
@@ -846,7 +985,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         writableAccountStore.put(account.copyBuilder()
                 .tinybarBalance(100L)
                 .stakedNodeId(0L)
-                .declineReward(true)
+                .declineReward(false)
                 .build());
         given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
     }


### PR DESCRIPTION
Fixes #7713 

- Adds a `deletedAccountBeneficiaries` map in `SingleTransactionRecordBuilder` 
- Sets the `automaticTokenAssociations` missing to be set in `CryptoUpdateHandler` and `CryptoTransferHandler`