### PR TITLE
Add support for test package runs for HapiTestEngine

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -162,11 +162,6 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
             addChildToEngineDescriptor(javaClass, discoveryRequest, engineDescriptor);
         });
 
-        // In the EngineDiscoveryRequest, we only have access up to the main package, so there is no way to get a
-        // specific package path. This means that if you run the tests from whatever package, all HapiTests
-        // will be started. To support package test runs, we are introducing the PACKAGE_PATH environment variable.
-        // If a PACKAGE_PATH environment variable is passed, we filter the classes that belong to this package.
-        // Otherwise, we execute all tests.
         discoveryRequest.getSelectorsByType(ClasspathRootSelector.class).forEach(selector -> {
             appendTestsInClasspathRoot(selector.getClasspathRoot(), engineDescriptor, discoveryRequest);
         });

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -183,11 +183,9 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
     private void appendTestsInClasspathRoot(
             URI uri, TestDescriptor engineDescriptor, EngineDiscoveryRequest discoveryRequest) {
         ReflectionSupport.findAllClassesInClasspathRoot(uri, IS_HAPI_TEST_SUITE, name -> true).stream()
-            .filter(aClass ->
-                discoveryRequest.getFiltersByType(PackageNameFilter.class).stream()
-                    .map(Filter::toPredicate)
-                    .allMatch(predicate -> predicate.test(aClass.getPackageName()))
-            )
+                .filter(aClass -> discoveryRequest.getFiltersByType(PackageNameFilter.class).stream()
+                        .map(Filter::toPredicate)
+                        .allMatch(predicate -> predicate.test(aClass.getPackageName())))
                 .map(aClass -> new ClassTestDescriptor(aClass, engineDescriptor, discoveryRequest))
                 .filter(classTestDescriptor -> !classTestDescriptor.skip)
                 .forEach(engineDescriptor::addChild);


### PR DESCRIPTION
**Description**:
Adding support for running a test package

**Notes for reviewer**:
This feature will be helpful when we start migrating the tests to HapiTestEngine and I imagine we will do that package by package. The ability to run only your package instead of running all tests or test-by-test should save us some time.

Thanks, @netopyr for finding about `discoveryRequest.getFiltersByType(PackageNameFilter.class)` 🏆 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
