### PR TITLE
Adhoc Docker images from branches

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -56,7 +56,6 @@ jobs:
     with:
       version-policy: branch-commit
       trigger-env-deploy: none
-      trigger-docker-images: true
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
       java-version: ${{ github.event.inputs.java-version || '17.0.7' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
@@ -111,7 +110,6 @@ jobs:
       version-policy: specified
       new-version: ${{ needs.prepare-tag-release.outputs.version }}
       trigger-env-deploy: preview
-      trigger-docker-images: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -56,6 +56,7 @@ jobs:
     with:
       version-policy: branch-commit
       trigger-env-deploy: none
+      trigger-docker-images: true
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
       java-version: ${{ github.event.inputs.java-version || '17.0.7' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
@@ -110,6 +111,7 @@ jobs:
       version-policy: specified
       new-version: ${{ needs.prepare-tag-release.outputs.version }}
       trigger-env-deploy: preview
+      trigger-docker-images: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -435,13 +435,13 @@ jobs:
             "${{ needs.Artifact.outputs.version }}" \
             "[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/network-node-base:${{ needs.Artifact.outputs.version }})" \
             "linux/amd64, linux/arm64" >> "${GITHUB_STEP_SUMMARY}"
-          
+
           printf "| %s | %s | %s | %s |\n" \
             "${{ steps.set-registry.outputs.docker-tag-base }}/network-node-haveged" \
             "${{ needs.Artifact.outputs.version }}" \
             "[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/network-node-haveged:${{ needs.Artifact.outputs.version }})" \
             "linux/amd64, linux/arm64" >> "${GITHUB_STEP_SUMMARY}"
-          
+
           printf "| %s | %s | %s | %s |\n" \
             "${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node" \
             "${{ needs.Artifact.outputs.version }}" \

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -29,11 +29,6 @@ on:
         type: string
         required: true
         default: "none"
-      trigger-docker-images:
-        description: "Build Docker Images:"
-        type: boolean
-        required: false
-        default: false
       new-version:
         description: "New Version:"
         type: string
@@ -348,7 +343,7 @@ jobs:
     runs-on: [ self-hosted, Linux, large, ephemeral ]
     needs:
       - Artifact
-    if: ${{ inputs.dry-run-enabled != true && inputs.trigger-docker-images == true && !cancelled() && !failure() }}
+    if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -29,6 +29,11 @@ on:
         type: string
         required: true
         default: "none"
+      trigger-docker-images:
+        description: "Build Docker Images:"
+        type: boolean
+        required: false
+        default: false
       new-version:
         description: "New Version:"
         type: string
@@ -343,7 +348,7 @@ jobs:
     runs-on: [ self-hosted, Linux, large, ephemeral ]
     needs:
       - Artifact
-    if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}
+    if: ${{ inputs.dry-run-enabled != true && inputs.trigger-docker-images == true && !cancelled() && !failure() }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -395,7 +395,7 @@ jobs:
       - name: Stage SDK Artifacts
         run: |
           mkdir -p hedera-node/infrastructure/docker/containers/local-node/main-network-node/sdk
-          cp -rvf ${{ env.HOME }}/artifact-build/* hedera-node/infrastructure/docker/containers/local-node/main-network-node/sdk/
+          cp -rvf ~/artifact-build/* hedera-node/infrastructure/docker/containers/local-node/main-network-node/sdk/
 
       - name: Build Haveged Image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # pin@v4

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -424,6 +424,8 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: IMAGE_TAG=${{ needs.Artifact.outputs.version }}
+          build-args: |
+           IMAGE_TAG=${{ needs.Artifact.outputs.version }}
+           IMAGE_PREFIX=${{ steps.set-registry.outputs.docker-tag-base }}/
           context: hedera-node/infrastructure/docker/containers/local-node/main-network-node
           tags: ${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node:${{ needs.Artifact.outputs.version }}

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin@v3
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         with:
-          path: ${{ env.HOME }}/artifact-build
+          path: ~/artifact-build
           key: node-build-artifacts-${{ steps.effective-version.outputs.number }}-${{ github.sha }}
 
       - name: Stage Artifact Build Folder
@@ -356,6 +356,17 @@ jobs:
           workload_identity_provider: "projects/235822363393/locations/global/workloadIdentityPools/hedera-builds-pool/providers/hedera-builds-gh-actions"
           service_account: "swirlds-automation@hedera-registry.iam.gserviceaccount.com"
 
+      - name: Set Image Registry
+        id: set-registry
+        run: |
+         DOCKER_REGISTRY="gcr.io"
+         [[ "${{ inputs.version-policy }}" == "branch-commit" ]] && DOCKER_REGISTRY="us-docker.pkg.dev"
+         echo "docker-registry=${DOCKER_REGISTRY}" >>"${GITHUB_OUTPUT}"
+
+         DOCKER_TAG_BASE="gcr.io/hedera-registry"
+         [[ "${{ inputs.version-policy }}" == "branch-commit" ]] && DOCKER_TAG_BASE="us-docker.pkg.dev/swirlds-registry/local-node"
+         echo "docker-tag-base=${DOCKER_TAG_BASE}" >>"${GITHUB_OUTPUT}"
+
       - name: Setup QEmu Support
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # pin@v2
 
@@ -365,7 +376,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # pin@v2
         with:
-          registry: gcr.io
+          registry: ${{ steps.set-registry.outputs.docker-registry }}
           username: oauth2accesstoken
           password: ${{ steps.google-auth.outputs.access_token }}
 
@@ -373,7 +384,7 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin@v3
         with:
           fail-on-cache-miss: true
-          path: ${{ env.HOME }}/artifact-build
+          path: ~/artifact-build
           key: node-build-artifacts-${{ needs.Artifact.outputs.version }}-${{ github.sha }}
 
       - name: Stage SDK Artifacts
@@ -389,7 +400,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           context: hedera-node/infrastructure/docker/containers/local-node/network-node-haveged
-          tags: gcr.io/hedera-registry/network-node-haveged:${{ needs.Artifact.outputs.version }}
+          tags: ${{ steps.set-registry.outputs.docker-tag-base }}/network-node-haveged:${{ needs.Artifact.outputs.version }}
 
       - name: Build Base Image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # pin@v4
@@ -399,7 +410,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           context: hedera-node/infrastructure/docker/containers/local-node/network-node-base
-          tags: gcr.io/hedera-registry/network-node-base:${{ needs.Artifact.outputs.version }}
+          tags: ${{ steps.set-registry.outputs.docker-tag-base }}/network-node-base:${{ needs.Artifact.outputs.version }}
 
       - name: Build Network Node Image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # pin@v4
@@ -410,4 +421,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: IMAGE_TAG=${{ needs.Artifact.outputs.version }}
           context: hedera-node/infrastructure/docker/containers/local-node/main-network-node
-          tags: gcr.io/hedera-registry/main-network-node:${{ needs.Artifact.outputs.version }}
+          tags: ${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node:${{ needs.Artifact.outputs.version }}

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -424,3 +424,28 @@ jobs:
            IMAGE_PREFIX=${{ steps.set-registry.outputs.docker-tag-base }}/
           context: hedera-node/infrastructure/docker/containers/local-node/main-network-node
           tags: ${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node:${{ needs.Artifact.outputs.version }}
+
+      - name: Render Job Summary
+        run: |
+          printf "### Published Docker Images\n" >> "${GITHUB_STEP_SUMMARY}"
+          printf "| Image Name | Version | URL | Supported Architectures |\n" >> "${GITHUB_STEP_SUMMARY}"
+          printf "| ---------- | ------- | --- | ----------------------- |\n" >> "${GITHUB_STEP_SUMMARY}"
+          printf "| %s | %s | %s | %s |\n" \
+            "${{ steps.set-registry.outputs.docker-tag-base }}/network-node-base" \
+            "${{ needs.Artifact.outputs.version }}" \
+            "[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/network-node-base:${{ needs.Artifact.outputs.version }})" \
+            "linux/amd64, linux/arm64" >> "${GITHUB_STEP_SUMMARY}"
+          
+          printf "| %s | %s | %s | %s |\n" \
+            "${{ steps.set-registry.outputs.docker-tag-base }}/network-node-haveged" \
+            "${{ needs.Artifact.outputs.version }}" \
+            "[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/network-node-haveged:${{ needs.Artifact.outputs.version }})" \
+            "linux/amd64, linux/arm64" >> "${GITHUB_STEP_SUMMARY}"
+          
+          printf "| %s | %s | %s | %s |\n" \
+            "${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node" \
+            "${{ needs.Artifact.outputs.version }}" \
+            "[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node:${{ needs.Artifact.outputs.version }})" \
+            "linux/amd64, linux/arm64" >> "${GITHUB_STEP_SUMMARY}"
+
+          printf "\n\n" >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
**Description**:
This PR modifies the `Node: Deploy Release Artifact` workflow in order to support the easy creation of Docker images from feature branches, it also enables the automatic building of Docker images on merge to `develop` branch.
* Modify workflow

**Related issue(s)**:

Fixes #7882 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
An example of a successful run is [here](https://github.com/hashgraph/hedera-services/actions/runs/5789731760)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
