### PR TITLE
Tolerate null exitCode in ManualWiring.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/wiring/ManualWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/wiring/ManualWiring.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.platform.components.wiring;
 
+import static com.swirlds.common.system.SystemExitCode.FATAL_ERROR;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 
 import com.swirlds.common.config.WiringConfig;
@@ -66,6 +67,7 @@ public class ManualWiring {
     private final ThreadManager threadManager;
     private final AddressBook addressBook;
     private final FreezeManager freezeManager;
+    private final Shutdown shutdown;
     /** A list of all formal platform components */
     private final List<PlatformComponent> platformComponentList = new ArrayList<>();
     /** A list of all informal platform components that need to be started and/or registered as dispatch observers. */
@@ -87,6 +89,7 @@ public class ManualWiring {
         this.addressBook = addressBook;
         this.freezeManager = freezeManager;
         this.wiringMetrics = new WiringMetrics(platformContext.getMetrics());
+        this.shutdown = new Shutdown();
 
         final WiringConfig wiringConfig = platformContext.getConfiguration().getConfigData(WiringConfig.class);
         asyncLatestCompleteStateQueue = new QueueThreadConfiguration<Runnable>(threadManager)
@@ -206,11 +209,26 @@ public class ManualWiring {
     private void handleFatalError(
             @Nullable final String msg, @Nullable final Throwable throwable, @NonNull final SystemExitCode exitCode) {
 
-        Objects.requireNonNull(exitCode);
-
+        // Log this fatal error first, to make sure it ends up in the logs, no matter what else happens
         logFatalError(msg, throwable);
+
+        // Let each platform component attempt to handle the fatal error
         platformComponentList.forEach(PlatformComponent::onFatalError);
-        new Shutdown().shutdown(msg, exitCode);
+
+        // It may be that null was passed in, despite our compiler warnings. In that case, we want to log this fact
+        // with a stack trace for who called this method, so we can track down what code is passing in null.
+        //noinspection ConstantValue
+        if (exitCode == null) {
+            try {
+                throw new NullPointerException("exitCode was null");
+            } catch (final NullPointerException e) {
+                logger.error("exitCode was null. Exiting anyway with FATAL_ERROR", e);
+            }
+        }
+
+        // We will either exit with the code given to us, or FATAL_ERROR if somebody failed to give us a code
+        //noinspection ConstantValue
+        shutdown.shutdown(msg, exitCode == null ? FATAL_ERROR : exitCode);
     }
 
     private static void logFatalError(final String msg, final Throwable throwable) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateHasher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateHasher.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.platform.state.signed;
 
+import static com.swirlds.common.system.SystemExitCode.FATAL_ERROR;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 
 import com.swirlds.common.crypto.Hash;
@@ -30,7 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Hashes signed states after all modifications for a round have been compoleted.
+ * Hashes signed states after all modifications for a round have been completed.
  */
 public class SignedStateHasher {
     /**
@@ -91,7 +92,7 @@ public class SignedStateHasher {
             stateHashedTrigger.dispatch(signedState.getRound(), hash);
 
         } catch (final ExecutionException e) {
-            fatalErrorConsumer.fatalError("Exception occurred during SignedState hashing", e, null);
+            fatalErrorConsumer.fatalError("Exception occurred during SignedState hashing", e, FATAL_ERROR);
         } catch (final InterruptedException e) {
             logger.error(EXCEPTION.getMarker(), "Interrupted while hashing state. Expect buggy behavior.");
             Thread.currentThread().interrupt();


### PR DESCRIPTION
Update ManualWiring so it is tolerant of null values passed to the exit handler. Sonar was a little grumpy about this, because it trusts the `@NonNull` annotation, but in this particular case our debugging was stymied because a null exit code caused us to swallow the actual error. So instead we log noisly if somebody passes a null exit code, but we actually exit anyway with FATAL_ERROR.

Also contains the 1-line fix for one place that was passing null erroneously.