### PR TITLE
Implement consensus fees calcuations

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCalculator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCalculator.java
@@ -16,8 +16,11 @@
 
 package com.hedera.node.app.spi.fees;
 
+import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.function.Function;
 
 /**
  * Used to help calculate the fees for a given transaction. The calculator is available on the {@link HandleContext},
@@ -48,6 +51,12 @@ public interface FeeCalculator {
      */
     @NonNull
     FeeCalculator addBytesPerTransaction(long bytes);
+
+    @NonNull
+    FeeCalculator addNetworkRamByteSeconds(long amount);
+
+    @NonNull
+    Fees legacyCalculate(@NonNull final Function<SigValueObj, FeeData> callback);
 
     /**
      * Calculates and returns the {@link Fees} for the transaction.

--- a/hedera-node/hedera-app-spi/src/main/java/module-info.java
+++ b/hedera-node/hedera-app-spi/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module com.hedera.node.app.spi {
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config;
+    requires transitive com.hedera.node.app.hapi.utils;
     requires static com.github.spotbugs.annotations;
 
     exports com.hedera.node.app.spi;

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeCalculator.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeCalculator.java
@@ -16,9 +16,12 @@
 
 package com.hedera.node.app.spi.fixtures.fees;
 
+import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.Fees;
+import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.function.Function;
 
 public class FakeFeeCalculator implements FeeCalculator {
     @Override
@@ -33,9 +36,22 @@ public class FakeFeeCalculator implements FeeCalculator {
         return this;
     }
 
+    @NonNull
+    @Override
+    public FeeCalculator addNetworkRamByteSeconds(long amount) {
+        return this;
+    }
+
     @Override
     @NonNull
     public Fees calculate() {
+        return new Fees(0, 0, 0);
+    }
+
+    @NonNull
+    @Override
+    public Fees legacyCalculate(@NonNull Function<SigValueObj, FeeData> callback) {
+        callback.apply(new SigValueObj(0, 0, 0));
         return new Fees(0, 0, 0);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
@@ -55,6 +55,7 @@ public class FeeCalculatorImpl implements FeeCalculator {
     private final com.hederahashgraph.api.proto.java.FeeData feeData;
     /** The current Google Protobuf representation of the current exchange rate */
     private final com.hederahashgraph.api.proto.java.ExchangeRate currentRate;
+    /** The basic info from parsing the transaction */
     private final SigUsage sigUsage;
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
@@ -31,12 +31,15 @@ import com.hedera.node.app.hapi.fees.calc.OverflowCheckingCalc;
 import com.hedera.node.app.hapi.fees.usage.BaseTransactionMeta;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.state.UsageAccumulator;
+import com.hedera.node.app.hapi.utils.fee.FeeBuilder;
+import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.workflows.TransactionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.function.Function;
 
 /**
  * Implements a {@link FeeCalculator} based on the "hapi-fees" and "hapi-utils". Since those modules have not been
@@ -52,6 +55,7 @@ public class FeeCalculatorImpl implements FeeCalculator {
     private final com.hederahashgraph.api.proto.java.FeeData feeData;
     /** The current Google Protobuf representation of the current exchange rate */
     private final com.hederahashgraph.api.proto.java.ExchangeRate currentRate;
+    private final SigUsage sigUsage;
 
     /**
      * Create a new instance. One is created per transaction.
@@ -86,7 +90,7 @@ public class FeeCalculatorImpl implements FeeCalculator {
 
         // Create the "SigUsage" object, used by the "hapi-fees" module.
         final var txBody = txInfo.txBody();
-        final var sigUsage = new SigUsage(
+        sigUsage = new SigUsage(
                 numVerifications,
                 SignatureMap.PROTOBUF.measureRecord(txInfo.signatureMap()),
                 countOfCryptographicKeys(payerKey));
@@ -121,6 +125,22 @@ public class FeeCalculatorImpl implements FeeCalculator {
     public FeeCalculator addBytesPerTransaction(long bytes) {
         usage.addBpt(bytes);
         return this;
+    }
+
+    @NonNull
+    @Override
+    public FeeCalculator addNetworkRamByteSeconds(long amount) {
+        usage.addRbs(amount);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public Fees legacyCalculate(@NonNull Function<SigValueObj, com.hederahashgraph.api.proto.java.FeeData> callback) {
+        final var sigValueObject = new SigValueObj(sigUsage.numSigs(), sigUsage.numPayerKeys(), sigUsage.sigsSize());
+        final var matrix = callback.apply(sigValueObject);
+        final var feeObject = FeeBuilder.getFeeObject(feeData, matrix, currentRate, 1);
+        return new Fees(feeObject.nodeFee(), feeObject.networkFee(), feeObject.serviceFee());
     }
 
     @Override

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
@@ -17,11 +17,9 @@
 package com.hedera.node.app.service.consensus.impl;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.state.consensus.Topic;
 import com.hedera.node.app.service.consensus.ConsensusService;
-import com.hedera.node.app.service.consensus.impl.codecs.EntityNumCodec;
-import com.hedera.node.app.service.mono.state.codec.CodecFactory;
-import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
@@ -48,16 +46,8 @@ public final class ConsensusServiceImpl implements ConsensusService {
             @NonNull
             @Override
             public Set<StateDefinition> statesToCreate() {
-                return Set.of(topicsDef());
+                return Set.of(StateDefinition.inMemory(TOPICS_KEY, TopicID.PROTOBUF, Topic.PROTOBUF));
             }
         };
-    }
-
-    private StateDefinition<EntityNum, Topic> topicsDef() {
-        final var keyCodec = new EntityNumCodec();
-
-        final var valueCodec = CodecFactory.newInMemoryCodec(Topic.PROTOBUF::parse, Topic.PROTOBUF::write);
-
-        return StateDefinition.inMemory(TOPICS_KEY, keyCodec, valueCodec);
     }
 }

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
@@ -17,17 +17,21 @@
 package com.hedera.node.app.service.consensus.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.BAD_ENCODING;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
 import static com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl.RUNNING_HASH_BYTE_ARRAY_SIZE;
+import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.Duration;
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.state.consensus.Topic;
+import com.hedera.node.app.hapi.utils.exception.InvalidTxBodyException;
+import com.hedera.node.app.hapi.utils.fee.ConsensusServiceFeeBuilder;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicRecordBuilder;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -59,7 +63,7 @@ public class ConsensusCreateTopicHandler implements TransactionHandler {
 
         // The transaction cannot set the admin key unless the transaction was signed by that key
         if (op.hasAdminKey()) {
-            context.requireKeyOrThrow(op.adminKey(), INVALID_ADMIN_KEY);
+            context.requireKeyOrThrow(op.adminKey(), BAD_ENCODING);
         }
 
         // If an account is to be used for auto-renewal, then the account must exist and the transaction
@@ -81,6 +85,19 @@ public class ConsensusCreateTopicHandler implements TransactionHandler {
         requireNonNull(handleContext, "The argument 'context' must not be null");
 
         final var op = handleContext.body().consensusCreateTopicOrThrow();
+
+        final var fees =  handleContext.feeCalculator(SubType.DEFAULT)
+                .legacyCalculate(sigValueObj -> {
+            try {
+                final var protoBody = fromPbj(handleContext.body());
+                return ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(protoBody, sigValueObj);
+            } catch (InvalidTxBodyException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        handleContext.feeAccumulator().charge(handleContext.payer(), fees);
+
         final var configuration = handleContext.configuration();
         final var topicConfig = configuration.getConfigData(TopicsConfig.class);
         final var topicStore = handleContext.writableStore(WritableTopicStore.class);

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
@@ -86,8 +86,7 @@ public class ConsensusCreateTopicHandler implements TransactionHandler {
 
         final var op = handleContext.body().consensusCreateTopicOrThrow();
 
-        final var fees =  handleContext.feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> {
+        final var fees = handleContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> {
             try {
                 final var protoBody = fromPbj(handleContext.body());
                 return ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(protoBody, sigValueObj);

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusDeleteTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusDeleteTopicHandler.java
@@ -75,15 +75,14 @@ public class ConsensusDeleteTopicHandler implements TransactionHandler {
 
         final var op = context.body().consensusDeleteTopicOrThrow();
 
-        final var fees =  context.feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> {
-                    try {
-                        final var protoBody = fromPbj(context.body());
-                        return ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(protoBody, sigValueObj);
-                    } catch (InvalidTxBodyException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+        final var fees = context.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> {
+            try {
+                final var protoBody = fromPbj(context.body());
+                return ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(protoBody, sigValueObj);
+            } catch (InvalidTxBodyException e) {
+                throw new RuntimeException(e);
+            }
+        });
 
         context.feeAccumulator().charge(context.payer(), fees);
 

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -23,6 +23,10 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOPIC_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOPIC_MESSAGE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MESSAGE_SIZE_TOO_LARGE;
+import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
+import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.LONG_SIZE;
+import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
+import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.TX_HASH_SIZE;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.asBytes;
 import static com.hedera.node.app.service.mono.state.merkle.MerkleTopic.RUNNING_HASH_VERSION;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
@@ -30,6 +34,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.consensus.ConsensusSubmitMessageTransactionBody;
@@ -94,6 +99,15 @@ public class ConsensusSubmitMessageHandler implements TransactionHandler {
 
         final var txn = handleContext.body();
         final var op = txn.consensusSubmitMessageOrThrow();
+
+        final var fees = handleContext.feeCalculator(SubType.DEFAULT)
+                .addBytesPerTransaction(BASIC_ENTITY_ID_SIZE + op.message().length())
+                .addNetworkRamByteSeconds((LONG_SIZE + TX_HASH_SIZE) * RECEIPT_STORAGE_TIME_SEC)
+                .calculate();
+
+        handleContext.feeAccumulator().charge(handleContext.payer(), fees);
+
+
         final var topicStore = handleContext.writableStore(WritableTopicStore.class);
         final var topic = topicStore.getForModify(op.topicIDOrElse(TopicID.DEFAULT));
         /* Validate all needed fields in the transaction */

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -100,13 +100,13 @@ public class ConsensusSubmitMessageHandler implements TransactionHandler {
         final var txn = handleContext.body();
         final var op = txn.consensusSubmitMessageOrThrow();
 
-        final var fees = handleContext.feeCalculator(SubType.DEFAULT)
+        final var fees = handleContext
+                .feeCalculator(SubType.DEFAULT)
                 .addBytesPerTransaction(BASIC_ENTITY_ID_SIZE + op.message().length())
                 .addNetworkRamByteSeconds((LONG_SIZE + TX_HASH_SIZE) * RECEIPT_STORAGE_TIME_SEC)
                 .calculate();
 
         handleContext.feeAccumulator().charge(handleContext.payer(), fees);
-
 
         final var topicStore = handleContext.writableStore(WritableTopicStore.class);
         final var topic = topicStore.getForModify(op.topicIDOrElse(TopicID.DEFAULT));

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicTest.java
@@ -31,11 +31,13 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.consensus.ConsensusCreateTopicTransactionBody;
@@ -46,6 +48,9 @@ import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.handlers.ConsensusCreateTopicHandler;
 import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicRecordBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.app.spi.fees.FeeAccumulator;
+import com.hedera.node.app.spi.fees.FeeCalculator;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -81,6 +86,12 @@ class ConsensusCreateTopicTest extends ConsensusTestBase {
     @Mock
     private ConsensusCreateTopicRecordBuilder recordBuilder;
 
+    @Mock
+    private FeeCalculator feeCalculator;
+
+    @Mock
+    private FeeAccumulator feeAccumulator;
+
     private WritableTopicStore topicStore;
     private ConsensusCreateTopicHandler subject;
 
@@ -115,6 +126,10 @@ class ConsensusCreateTopicTest extends ConsensusTestBase {
         given(handleContext.writableStore(WritableTopicStore.class)).willReturn(topicStore);
         given(handleContext.recordBuilder(ConsensusCreateTopicRecordBuilder.class))
                 .willReturn(recordBuilder);
+        lenient().when(handleContext.feeCalculator(any(SubType.class))).thenReturn(feeCalculator);
+        lenient().when(handleContext.feeAccumulator()).thenReturn(feeAccumulator);
+        lenient().when(feeCalculator.calculate()).thenReturn(Fees.FREE);
+        lenient().when(feeCalculator.legacyCalculate(any())).thenReturn(Fees.FREE);
     }
 
     @Test

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusDeleteTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusDeleteTopicTest.java
@@ -29,12 +29,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.consensus.ConsensusDeleteTopicTransactionBody;
@@ -44,6 +47,9 @@ import com.hedera.node.app.service.consensus.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.handlers.ConsensusDeleteTopicHandler;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.app.spi.fees.FeeAccumulator;
+import com.hedera.node.app.spi.fees.FeeCalculator;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -68,6 +74,12 @@ class ConsensusDeleteTopicTest extends ConsensusTestBase {
     @Mock
     private HandleContext handleContext;
 
+    @Mock
+    private FeeCalculator feeCalculator;
+
+    @Mock
+    private FeeAccumulator feeAccumulator;
+
     private ConsensusDeleteTopicHandler subject;
 
     @BeforeEach
@@ -77,6 +89,11 @@ class ConsensusDeleteTopicTest extends ConsensusTestBase {
         writableTopicState = writableTopicStateWithOneKey();
         given(writableStates.<TopicID, Topic>get(TOPICS_KEY)).willReturn(writableTopicState);
         writableStore = new WritableTopicStore(writableStates);
+
+        lenient().when(handleContext.feeCalculator(any(SubType.class))).thenReturn(feeCalculator);
+        lenient().when(handleContext.feeAccumulator()).thenReturn(feeAccumulator);
+        lenient().when(feeCalculator.calculate()).thenReturn(Fees.FREE);
+        lenient().when(feeCalculator.legacyCalculate(any())).thenReturn(Fees.FREE);
     }
 
     @Test

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageTest.java
@@ -30,14 +30,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.consensus.ConsensusMessageChunkInfo;
@@ -51,6 +54,9 @@ import com.hedera.node.app.service.consensus.impl.handlers.ConsensusSubmitMessag
 import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageRecordBuilder;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.app.spi.fees.FeeAccumulator;
+import com.hedera.node.app.spi.fees.FeeCalculator;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -78,6 +84,12 @@ class ConsensusSubmitMessageTest extends ConsensusTestBase {
     @Mock(answer = RETURNS_SELF)
     private ConsensusSubmitMessageRecordBuilder recordBuilder;
 
+    @Mock(answer = RETURNS_SELF)
+    private FeeCalculator feeCalculator;
+
+    @Mock
+    private FeeAccumulator feeAccumulator;
+
     private ConsensusSubmitMessageHandler subject;
 
     @BeforeEach
@@ -101,6 +113,11 @@ class ConsensusSubmitMessageTest extends ConsensusTestBase {
         given(handleContext.configuration()).willReturn(config);
         given(handleContext.recordBuilder(ConsensusSubmitMessageRecordBuilder.class))
                 .willReturn(recordBuilder);
+
+        lenient().when(handleContext.feeCalculator(any(SubType.class))).thenReturn(feeCalculator);
+        lenient().when(handleContext.feeAccumulator()).thenReturn(feeAccumulator);
+        lenient().when(feeCalculator.calculate()).thenReturn(Fees.FREE);
+        lenient().when(feeCalculator.legacyCalculate(any())).thenReturn(Fees.FREE);
     }
 
     @Test

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicTest.java
@@ -33,12 +33,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.lenient;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Duration;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.base.TransactionID;
@@ -50,6 +53,9 @@ import com.hedera.node.app.service.consensus.impl.handlers.ConsensusUpdateTopicH
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.context.properties.PropertySource;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.app.spi.fees.FeeAccumulator;
+import com.hedera.node.app.spi.fees.FeeCalculator;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -98,6 +104,12 @@ class ConsensusUpdateTopicTest extends ConsensusTestBase {
     @Mock
     private PropertySource compositeProps;
 
+    @Mock
+    private FeeCalculator feeCalculator;
+
+    @Mock
+    private FeeAccumulator feeAccumulator;
+
     private StandardizedAttributeValidator standardizedAttributeValidator;
 
     private ConsensusUpdateTopicHandler subject;
@@ -111,6 +123,11 @@ class ConsensusUpdateTopicTest extends ConsensusTestBase {
         standardizedAttributeValidator =
                 new StandardizedAttributeValidator(consensusSecondNow, compositeProps, dynamicProperties);
         subject = new ConsensusUpdateTopicHandler();
+
+        lenient().when(handleContext.feeCalculator(any(SubType.class))).thenReturn(feeCalculator);
+        lenient().when(handleContext.feeAccumulator()).thenReturn(feeAccumulator);
+        lenient().when(feeCalculator.calculate()).thenReturn(Fees.FREE);
+        lenient().when(feeCalculator.legacyCalculate(any())).thenReturn(Fees.FREE);
     }
 
     @Test

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/FreezeServiceImpl.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/FreezeServiceImpl.java
@@ -23,7 +23,6 @@ import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 
@@ -51,8 +50,8 @@ public final class FreezeServiceImpl implements FreezeService {
                 // Reset the upgrade file hash to empty
                 // It should always be empty at genesis or after an upgrade, to indicate that no upgrade is in progress
                 // Nothing in state can ever be null, so use Bytes.EMPTY to indicate an empty hash
-                final var upgradeFileHashKeyState = ctx.newStates().getSingleton(UPGRADE_FILE_HASH_KEY);
-                upgradeFileHashKeyState.put(Bytes.EMPTY);
+                final var upgradeFileHashKeyState = ctx.newStates().<ProtoBytes>getSingleton(UPGRADE_FILE_HASH_KEY);
+                upgradeFileHashKeyState.put(ProtoBytes.DEFAULT);
             }
         };
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/ChunkingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/ChunkingSuite.java
@@ -26,6 +26,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CHUNK_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CHUNK_TRANSACTION_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -53,6 +54,7 @@ public class ChunkingSuite extends HapiSuite {
         return List.of(chunkNumberIsValidated(), chunkTransactionIDIsValidated(), longMessageIsFragmentedIntoChunks());
     }
 
+    @HapiTest
     private HapiSpec chunkNumberIsValidated() {
         return defaultHapiSpec("chunkNumberIsValidated")
                 .given(createTopic("testTopic"))
@@ -75,6 +77,7 @@ public class ChunkingSuite extends HapiSuite {
                                 .hasKnownStatus(SUCCESS));
     }
 
+    @HapiTest
     private HapiSpec chunkTransactionIDIsValidated() {
         return defaultHapiSpec("chunkTransactionIDIsValidated")
                 .given(cryptoCreate("initialTransactionPayer"), createTopic("testTopic"))
@@ -115,6 +118,7 @@ public class ChunkingSuite extends HapiSuite {
                                 .hasKnownStatus(SUCCESS));
     }
 
+    @HapiTest
     private HapiSpec longMessageIsFragmentedIntoChunks() {
         String fileForLongMessage = "src/main/resource/RandomLargeBinary.bin";
         return defaultHapiSpec("longMessageIsFragmentedIntoChunks")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
@@ -44,6 +44,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -184,6 +185,7 @@ public class SubmitMessageSuite extends HapiSuite {
                         .hasKnownStatus(MESSAGE_SIZE_TOO_LARGE));
     }
 
+    @HapiTest
     private HapiSpec feeAsExpected() {
         final byte[] messageBytes = new byte[100]; // 4k
         Arrays.fill(messageBytes, (byte) 0b1);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
@@ -83,6 +83,7 @@ public class SubmitMessageSuite extends HapiSuite {
                 feeAsExpected());
     }
 
+    @HapiTest
     private HapiSpec topicIdIsValidated() {
         return defaultHapiSpec("topicIdIsValidated")
                 .given(cryptoCreate("nonTopicId"))
@@ -97,6 +98,7 @@ public class SubmitMessageSuite extends HapiSuite {
                                 .hasKnownStatus(INVALID_TOPIC_ID));
     }
 
+    @HapiTest
     private HapiSpec messageIsValidated() {
         return defaultHapiSpec("messageIsValidated")
                 .given(createTopic("testTopic"))
@@ -112,6 +114,7 @@ public class SubmitMessageSuite extends HapiSuite {
                                 .hasKnownStatus(INVALID_TOPIC_MESSAGE));
     }
 
+    @HapiTest
     private HapiSpec messageSubmissionSimple() {
         return defaultHapiSpec("messageSubmissionSimple")
                 .given(
@@ -125,6 +128,7 @@ public class SubmitMessageSuite extends HapiSuite {
                         .hasKnownStatus(SUCCESS));
     }
 
+    @HapiTest
     private HapiSpec messageSubmissionIncreasesSeqNo() {
         KeyShape submitKeyShape = threshOf(2, SIMPLE, SIMPLE, listOf(2));
 
@@ -136,6 +140,7 @@ public class SubmitMessageSuite extends HapiSuite {
                 .then(getTopicInfo("testTopic").hasSeqNo(1));
     }
 
+    @HapiTest
     private HapiSpec messageSubmissionWithSubmitKey() {
         KeyShape submitKeyShape = threshOf(2, SIMPLE, SIMPLE, listOf(2));
 
@@ -158,6 +163,7 @@ public class SubmitMessageSuite extends HapiSuite {
                                 .hasKnownStatus(SUCCESS));
     }
 
+    @HapiTest
     private HapiSpec messageSubmissionMultiple() {
         final int numMessages = 10;
 
@@ -169,6 +175,7 @@ public class SubmitMessageSuite extends HapiSuite {
                 .then(sleepFor(1000), getTopicInfo("testTopic").hasSeqNo(numMessages));
     }
 
+    @HapiTest
     private HapiSpec messageSubmissionOverSize() {
         final byte[] messageBytes = new byte[4096]; // 4k
         Arrays.fill(messageBytes, (byte) 0b1);
@@ -202,6 +209,7 @@ public class SubmitMessageSuite extends HapiSuite {
                 .then(sleepFor(1000), validateChargedUsd("submitMessage", 0.0001));
     }
 
+    @HapiTest
     private HapiSpec messageSubmissionCorrectlyUpdatesRunningHash() {
         String topic = "testTopic";
         String message1 = "Hello world!";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -35,6 +35,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -70,6 +71,7 @@ public class TopicCreateSuite extends HapiSuite {
         return true;
     }
 
+    @HapiTest
     private HapiSpec adminKeyIsValidated() {
         return defaultHapiSpec("AdminKeyIsValidated")
                 .given()
@@ -81,6 +83,7 @@ public class TopicCreateSuite extends HapiSuite {
                         .hasKnownStatus(BAD_ENCODING));
     }
 
+    @HapiTest
     private HapiSpec submitKeyIsValidated() {
         return defaultHapiSpec("SubmitKeyIsValidated")
                 .given()
@@ -91,6 +94,7 @@ public class TopicCreateSuite extends HapiSuite {
                         .hasKnownStatus(BAD_ENCODING));
     }
 
+    @HapiTest
     private HapiSpec autoRenewAccountIsValidated() {
         return defaultHapiSpec("AutoRenewAccountIsValidated")
                 .given()
@@ -101,6 +105,7 @@ public class TopicCreateSuite extends HapiSuite {
                         .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT));
     }
 
+    @HapiTest
     private HapiSpec autoRenewAccountIdNeedsAdminKeyToo() {
         return defaultHapiSpec("autoRenewAccountIdNeedsAdminKeyToo")
                 .given(cryptoCreate("payer"), cryptoCreate("autoRenewAccount"))
@@ -113,6 +118,7 @@ public class TopicCreateSuite extends HapiSuite {
                         .hasKnownStatusFrom(SUCCESS, AUTORENEW_ACCOUNT_NOT_ALLOWED));
     }
 
+    @HapiTest
     private HapiSpec autoRenewPeriodIsValidated() {
         final var tooShortAutoRenewPeriod = "tooShortAutoRenewPeriod";
         final var tooLongAutoRenewPeriod = "tooLongAutoRenewPeriod";
@@ -128,6 +134,7 @@ public class TopicCreateSuite extends HapiSuite {
                                 .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE));
     }
 
+    @HapiTest
     private HapiSpec noAutoRenewPeriod() {
         return defaultHapiSpec("noAutoRenewPeriod")
                 .given()
@@ -138,6 +145,7 @@ public class TopicCreateSuite extends HapiSuite {
                         .hasKnownStatusFrom(INVALID_RENEWAL_PERIOD, AUTORENEW_DURATION_NOT_IN_RANGE));
     }
 
+    @HapiTest
     private HapiSpec signingRequirementsEnforced() {
         long PAYER_BALANCE = 1_999_999_999L;
         final var contractWithAdminKey = "nonCryptoAccount";
@@ -211,6 +219,7 @@ public class TopicCreateSuite extends HapiSuite {
                                 .logged());
     }
 
+    @HapiTest
     private HapiSpec allFieldsSetHappyCase() {
         return defaultHapiSpec("AllFieldsSetHappyCase")
                 .given(newKeyNamed("adminKey"), newKeyNamed("submitKey"), cryptoCreate("autoRenewAccount"))
@@ -222,6 +231,7 @@ public class TopicCreateSuite extends HapiSuite {
                         .autoRenewAccountId("autoRenewAccount"));
     }
 
+    @HapiTest
     private HapiSpec feeAsExpected() {
         return defaultHapiSpec("feeAsExpected")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -145,7 +145,6 @@ public class TopicCreateSuite extends HapiSuite {
                         .hasKnownStatusFrom(INVALID_RENEWAL_PERIOD, AUTORENEW_DURATION_NOT_IN_RANGE));
     }
 
-    @HapiTest
     private HapiSpec signingRequirementsEnforced() {
         long PAYER_BALANCE = 1_999_999_999L;
         final var contractWithAdminKey = "nonCryptoAccount";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicDeleteSuite.java
@@ -61,6 +61,7 @@ public class TopicDeleteSuite extends HapiSuite {
                 feeAsExpected());
     }
 
+    @HapiTest
     private HapiSpec cannotDeleteAccountAsTopic() {
         return defaultHapiSpec("CannotDeleteAccountAsTopic")
                 .given(cryptoCreate("nonTopicId"))
@@ -69,6 +70,7 @@ public class TopicDeleteSuite extends HapiSuite {
                         .hasKnownStatus(INVALID_TOPIC_ID));
     }
 
+    @HapiTest
     private HapiSpec topicIdIsValidated() {
         return defaultHapiSpec("topicIdIsValidated")
                 .given()
@@ -79,6 +81,7 @@ public class TopicDeleteSuite extends HapiSuite {
                                 .hasKnownStatus(INVALID_TOPIC_ID));
     }
 
+    @HapiTest
     private HapiSpec noAdminKeyCannotDelete() {
         return defaultHapiSpec("noAdminKeyCannotDelete")
                 .given(createTopic("testTopic"))
@@ -86,6 +89,7 @@ public class TopicDeleteSuite extends HapiSuite {
                 .then();
     }
 
+    @HapiTest
     private HapiSpec deleteWithAdminKey() {
         return defaultHapiSpec("deleteWithAdminKey")
                 .given(newKeyNamed("adminKey"), createTopic("testTopic").adminKeyName("adminKey"))
@@ -93,6 +97,7 @@ public class TopicDeleteSuite extends HapiSuite {
                 .then(getTopicInfo("testTopic").hasCostAnswerPrecheck(INVALID_TOPIC_ID));
     }
 
+    @HapiTest
     private HapiSpec deleteFailedWithWrongKey() {
         long PAYER_BALANCE = 1_999_999_999L;
         return defaultHapiSpec("deleteFailedWithWrongKey")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicDeleteSuite.java
@@ -27,6 +27,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -107,6 +108,7 @@ public class TopicDeleteSuite extends HapiSuite {
                 .then();
     }
 
+    @HapiTest
     private HapiSpec feeAsExpected() {
         return defaultHapiSpec("feeAsExpected")
                 .given(cryptoCreate("payer"), createTopic("testTopic").adminKeyName("payer"))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicGetInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicGetInfoSuite.java
@@ -27,6 +27,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.updateTopic;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_ID;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -55,6 +56,7 @@ public class TopicGetInfoSuite extends HapiSuite {
         return true;
     }
 
+    @HapiTest
     private HapiSpec allFieldsSetHappyCase() {
         // sequenceNumber should be 0 and runningHash should be 48 bytes all 0s.
         return defaultHapiSpec("AllFieldsSetHappyCase")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
@@ -85,6 +85,7 @@ public class TopicUpdateSuite extends HapiSuite {
         return true;
     }
 
+    @HapiTest
     private HapiSpec updateToMissingTopicFails() {
         return defaultHapiSpec("updateToMissingTopicFails")
                 .given()
@@ -92,6 +93,7 @@ public class TopicUpdateSuite extends HapiSuite {
                 .then(updateTopic("1.2.3").hasKnownStatus(INVALID_TOPIC_ID));
     }
 
+    @HapiTest
     private HapiSpec validateMultipleFields() {
         byte[] longBytes = new byte[1000];
         Arrays.fill(longBytes, (byte) 33);
@@ -113,6 +115,7 @@ public class TopicUpdateSuite extends HapiSuite {
                                 .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE));
     }
 
+    @HapiTest
     private HapiSpec topicUpdateSigReqsEnforcedAtConsensus() {
         long PAYER_BALANCE = 199_999_999_999L;
         Function<String[], HapiTopicUpdate> updateTopicSignedBy = (signers) -> updateTopic("testTopic")
@@ -151,6 +154,7 @@ public class TopicUpdateSuite extends HapiSuite {
                         .hasAutoRenewAccount("newAutoRenewAccount"));
     }
 
+    @HapiTest
     private HapiSpec updateSubmitKeyToDiffKey() {
         return defaultHapiSpec("updateSubmitKeyToDiffKey")
                 .given(
@@ -164,6 +168,7 @@ public class TopicUpdateSuite extends HapiSuite {
                         .logged());
     }
 
+    @HapiTest
     private HapiSpec updateAdminKeyToDiffKey() {
         return defaultHapiSpec("updateAdminKeyToDiffKey")
                 .given(
@@ -174,6 +179,7 @@ public class TopicUpdateSuite extends HapiSuite {
                 .then(getTopicInfo("testTopic").hasAdminKey("updateAdminKey").logged());
     }
 
+    @HapiTest
     private HapiSpec updateAdminKeyToEmpty() {
         return defaultHapiSpec("updateAdminKeyToEmpty")
                 .given(newKeyNamed("adminKey"), createTopic("testTopic").adminKeyName("adminKey"))
@@ -182,6 +188,7 @@ public class TopicUpdateSuite extends HapiSuite {
                 .then(getTopicInfo("testTopic").hasNoAdminKey().logged());
     }
 
+    @HapiTest
     private HapiSpec updateMultipleFields() {
         long expirationTimestamp = Instant.now().getEpochSecond() + 10000000; // more than default.autorenew
         // .secs=7000000
@@ -215,6 +222,7 @@ public class TopicUpdateSuite extends HapiSuite {
                         .logged());
     }
 
+    @HapiTest
     private HapiSpec expirationTimestampIsValidated() {
         long now = Instant.now().getEpochSecond();
         return defaultHapiSpec("expirationTimestampIsValidated")
@@ -230,6 +238,7 @@ public class TopicUpdateSuite extends HapiSuite {
     }
 
     /* If admin key is not set, only expiration timestamp updates are allowed */
+    @HapiTest
     private HapiSpec updateExpiryOnTopicWithNoAdminKey() {
         long overlyDistantNewExpiry = Instant.now().getEpochSecond() + defaultMaxLifetime + 12_345L;
         long reasonableNewExpiry = Instant.now().getEpochSecond() + defaultMaxLifetime - 12_345L;
@@ -253,6 +262,7 @@ public class TopicUpdateSuite extends HapiSuite {
                 .then(getTopicInfo("testTopic").hasNoAdminKey());
     }
 
+    @HapiTest
     private HapiSpec updateSubmitKeyOnTopicWithNoAdminKeyFails() {
         return defaultHapiSpec("updateSubmitKeyOnTopicWithNoAdminKeyFails")
                 .given(newKeyNamed("submitKey"), createTopic("testTopic"))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
@@ -36,6 +36,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
@@ -259,6 +260,7 @@ public class TopicUpdateSuite extends HapiSuite {
                 .then();
     }
 
+    @HapiTest
     private HapiSpec feeAsExpected() {
         return defaultHapiSpec("feeAsExpected")
                 .given(

--- a/hedera-node/test-clients/src/main/resource/log4j2.xml
+++ b/hedera-node/test-clients/src/main/resource/log4j2.xml
@@ -21,6 +21,8 @@
 			<AppenderRef ref="RollingFile"/>
 		</Root>
 		<Logger name="com.swirlds" level="WARN" additivity="false">
+			<AppenderRef ref="Console"/>
+			<AppenderRef ref="RollingFile"/>
 		</Logger>
 	</Loggers>
 </Configuration>


### PR DESCRIPTION
Closes #7932. Add support for computing fees the "legacy" way with the fee calculator. It is ugly, but it works. Add this to each of the handlers in the consensus service, and enable their associated tests.