### PR TITLE
Fix round 1 replay

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransactionalLedger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransactionalLedger.java
@@ -397,12 +397,6 @@ public class TransactionalLedger<K, P extends Enum<P> & BeanProperty<A>, A>
 
     /** {@inheritDoc} */
     @Override
-    public Set<K> idSet() {
-        return entities.idSet();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public long size() {
         return entities.size();
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccounts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccounts.java
@@ -76,11 +76,6 @@ public class BackingAccounts implements BackingStore<AccountID, HederaAccount> {
     }
 
     @Override
-    public Set<AccountID> idSet() {
-        return existingAccounts;
-    }
-
-    @Override
     public long size() {
         return delegate.get().size();
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingNfts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingNfts.java
@@ -19,10 +19,7 @@ package com.hedera.node.app.service.mono.ledger.backing;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
 import com.hedera.node.app.service.mono.store.models.NftId;
-import com.hedera.node.app.service.mono.utils.EntityNumPair;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -59,18 +56,6 @@ public class BackingNfts implements BackingStore<NftId, UniqueTokenAdapter> {
     @Override
     public boolean contains(final NftId id) {
         return delegate.get().containsKey(id);
-    }
-
-    @Override
-    public Set<NftId> idSet() {
-        if (delegate.get().isVirtual()) {
-            throw new UnsupportedOperationException();
-        }
-        LOG.warn("idSet() called for BackingNfts. This is a slow operation.");
-        return delegate.get().merkleMap().keySet().stream()
-                .map(EntityNumPair::asTokenNumAndSerialPair)
-                .map(pair -> NftId.withDefaultShardRealm(pair.getLeft(), pair.getRight()))
-                .collect(Collectors.toSet());
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingStore.java
@@ -16,8 +16,6 @@
 
 package com.hedera.node.app.service.mono.ledger.backing;
 
-import java.util.Set;
-
 /**
  * Defines a type that provides safe and unsafe access to a collection of accounts. ("Safe" implies
  * a defensive copy is returned from the accessor, while "unsafe" implies a reference to the element
@@ -73,15 +71,6 @@ public interface BackingStore<K, A> {
      * @return a flag for existence
      */
     boolean contains(K id);
-
-    /**
-     * Returns the set of extant account ids. <b>This is a very computation-intensive operation.
-     * <i>idSet</i> should only be called at state initialisation Avoid using this method in a
-     * normal handleTransaction flow.</b>
-     *
-     * @return the set of extant account ids
-     */
-    Set<K> idSet();
 
     /**
      * Returns the count of extant entities stored in the correspondent collection

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRels.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRels.java
@@ -24,7 +24,6 @@ import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.utils.EntityNumPair;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
-import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -67,11 +66,6 @@ public class BackingTokenRels implements BackingStore<Pair<AccountID, TokenID>, 
     @Override
     public HederaTokenRel getImmutableRef(Pair<AccountID, TokenID> key) {
         return delegate.get().get(fromAccountTokenRel(key));
-    }
-
-    @Override
-    public Set<Pair<AccountID, TokenID>> idSet() {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokens.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokens.java
@@ -22,9 +22,7 @@ import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.TokenID;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class BackingTokens implements BackingStore<TokenID, MerkleToken> {
     private final Supplier<MerkleMapLike<EntityNum, MerkleToken>> delegate;
@@ -55,11 +53,6 @@ public class BackingTokens implements BackingStore<TokenID, MerkleToken> {
     @Override
     public void remove(TokenID id) {
         delegate.get().remove(fromTokenId(id));
-    }
-
-    @Override
-    public Set<TokenID> idSet() {
-        return delegate.get().keySet().stream().map(EntityNum::toGrpcTokenId).collect(Collectors.toSet());
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccounts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccounts.java
@@ -17,14 +17,11 @@
 package com.hedera.node.app.service.mono.ledger.backing.pure;
 
 import static com.hedera.node.app.service.mono.utils.EntityNum.fromAccountId;
-import static java.util.stream.Collectors.toSet;
 
 import com.hedera.node.app.service.mono.ledger.backing.BackingStore;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
-import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
-import java.util.Set;
 import java.util.function.Supplier;
 
 public class PureBackingAccounts implements BackingStore<AccountID, HederaAccount> {
@@ -57,11 +54,6 @@ public class PureBackingAccounts implements BackingStore<AccountID, HederaAccoun
     @Override
     public boolean contains(AccountID id) {
         return delegate.get().containsKey(fromAccountId(id));
-    }
-
-    @Override
-    public Set<AccountID> idSet() {
-        return delegate.get().keySet().stream().map(EntityNum::toGrpcAccountId).collect(toSet());
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreator.java
@@ -32,11 +32,13 @@ import com.hedera.node.app.service.mono.ledger.backing.BackingStore;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JEd25519Key;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
+import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.spi.numbers.HederaAccountNumbers;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.swirlds.common.system.address.AddressBook;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -81,13 +83,30 @@ public class BackedSystemAccountsCreator implements SystemAccountsCreator {
     @Override
     public void ensureSystemAccounts(
             final BackingStore<AccountID, HederaAccount> accounts, final AddressBook addressBook) {
+        internalEnsureSystemAccounts(accounts);
+    }
+
+    @Override
+    public void ensureSynthRecordsPresentOnFirstEverTransaction() {
+        // Called during the first-ever handleTransaction(); if we don't have a record of creating
+        // system accounts, then we're doing a event replay from a saved round one state, and need
+        // to ensure we have pending synthetic records ready to export
+        if (systemAccountsCreated.isEmpty()) {
+            // Pass null here so we don't actually create any accounts, but just ensure we have
+            // "prepared" synthetic records of all creations that happen during genesis init
+            internalEnsureSystemAccounts(null);
+        }
+    }
+
+    private void internalEnsureSystemAccounts(final @Nullable BackingStore<AccountID, HederaAccount> accounts) {
         final long systemAccounts = properties.getIntProperty(LEDGER_NUM_SYSTEM_ACCOUNTS);
         final long expiry = properties.getLongProperty(BOOTSTRAP_SYSTEM_ENTITY_EXPIRY);
         final long tinyBarFloat = properties.getLongProperty(LEDGER_TOTAL_TINY_BAR_FLOAT);
+        final var shouldSkipExtantAndCreateMissing = accounts != null;
 
         for (long num = 1; num <= systemAccounts; num++) {
             final var id = STATIC_PROPERTIES.scopedAccountWith(num);
-            if (accounts.contains(id)) {
+            if (shouldSkipExtantAndCreateMissing && accounts.contains(id)) {
                 continue;
             }
             final HederaAccount account;
@@ -96,7 +115,11 @@ public class BackedSystemAccountsCreator implements SystemAccountsCreator {
             } else {
                 account = accountWith(ZERO_BALANCE, expiry);
             }
-            accounts.put(id, account);
+            if (shouldSkipExtantAndCreateMissing) {
+                accounts.put(id, account);
+            } else {
+                account.setEntityNum(EntityNum.fromLong(num));
+            }
             systemAccountsCreated.add(account);
         }
 
@@ -106,30 +129,33 @@ public class BackedSystemAccountsCreator implements SystemAccountsCreator {
         final var nodeRewardAccountId = STATIC_PROPERTIES.scopedAccountWith(nodeRewardAccountNum);
         final var stakingFundAccounts = List.of(stakingRewardAccountId, nodeRewardAccountId);
         for (final var id : stakingFundAccounts) {
-            if (!accounts.contains(id)) {
-                final var stakingFundAccount = accountSupplier.get();
-                customizeAsStakingFund(stakingFundAccount);
-                accounts.put(id, stakingFundAccount);
+            final var stakingFundAccount = accountSupplier.get();
+            customizeAsStakingFund(stakingFundAccount);
+            if (shouldSkipExtantAndCreateMissing) {
+                if (!accounts.contains(id)) {
+                    accounts.put(id, stakingFundAccount);
+                    stakingFundAccountsCreated.add(stakingFundAccount);
+                }
+            } else {
+                stakingFundAccount.setEntityNum(EntityNum.fromLong(id.getAccountNum()));
                 stakingFundAccountsCreated.add(stakingFundAccount);
             }
         }
         for (long num = 900; num <= 1000; num++) {
             final var id = STATIC_PROPERTIES.scopedAccountWith(num);
-            if (!accounts.contains(id)) {
-                final var account = accountWith(ZERO_BALANCE, expiry);
-                accounts.put(id, account);
+            final var account = accountWith(ZERO_BALANCE, expiry);
+            if (shouldSkipExtantAndCreateMissing) {
+                if (!accounts.contains(id)) {
+                    accounts.put(id, account);
+                    systemAccountsCreated.add(account);
+                }
+            } else {
+                account.setEntityNum(EntityNum.fromLong(num));
                 systemAccountsCreated.add(account);
             }
         }
 
-        treasuryCloner.ensureTreasuryClonesExist();
-
-        var ledgerFloat = 0L;
-        final var allIds = accounts.idSet();
-        for (final var id : allIds) {
-            ledgerFloat += accounts.getImmutableRef(id).getBalance();
-        }
-        log.info("Ledger float is {} tinyBars in {} accounts.", ledgerFloat, allIds.size());
+        treasuryCloner.ensureTreasuryClonesExist(shouldSkipExtantAndCreateMissing);
     }
 
     public static void customizeAsStakingFund(final HederaAccount account) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemAccountsCreator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemAccountsCreator.java
@@ -18,8 +18,10 @@ package com.hedera.node.app.service.mono.state.initialization;
 
 import com.hedera.node.app.service.mono.ledger.backing.BackingStore;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
+import com.hedera.node.app.service.mono.state.migration.MigrationRecordsManager;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.common.system.address.AddressBook;
+import java.time.Instant;
 
 public interface SystemAccountsCreator {
     /**
@@ -31,4 +33,11 @@ public interface SystemAccountsCreator {
      * @param addressBook the current address book
      */
     void ensureSystemAccounts(BackingStore<AccountID, HederaAccount> backingAccounts, AddressBook addressBook);
+
+    /**
+     * Called in {@link MigrationRecordsManager#publishMigrationRecords(Instant)} to ensure that
+     * event replay from a round one state will export the same synthetic records that would occur
+     * when starting from genesis without a restart.
+     */
+    void ensureSynthRecordsPresentOnFirstEverTransaction();
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManager.java
@@ -131,6 +131,10 @@ public class MigrationRecordsManager {
         // when the consensus time of the last handled txn is null...if we publish these unconditionally, then some
         // genesis reconnect scenarios risk an ISS
         if (curNetworkCtx.consensusTimeOfLastHandledTxn() == null) {
+            // If we just started from genesis, we'll have records of actually creating the system accounts. But if
+            // we're only replaying events from round one, those system accounts were already created. So call this
+            // to ensure we'll publish the same synthetic records.
+            systemAccountsCreator.ensureSynthRecordsPresentOnFirstEverTransaction();
             final var implicitAutoRenewPeriod = FUNDING_ACCOUNT_EXPIRY - now.getEpochSecond();
             // Always publish records for any staking fund accounts created
             publishStakingFundAccountsCreated(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransactionalLedgerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransactionalLedgerTest.java
@@ -65,7 +65,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -765,17 +764,6 @@ class TransactionalLedgerTest {
         testLedger.commit();
 
         assertEquals(AMOUNT_EXCEEDS_ALLOWANCE, testLedger.validate(1L, scopedCheck));
-    }
-
-    @Test
-    void idSetPropagatesCallToEntities() {
-        setupTestLedger();
-
-        final Set<Long> idSet = Set.of(1L, 2L, 3L);
-        given(backingTestAccounts.idSet()).willReturn(idSet);
-
-        assertEquals(idSet, testLedger.idSet());
-        verify(backingTestAccounts).idSet();
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/BackingTokensTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/BackingTokensTest.java
@@ -29,7 +29,6 @@ import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.merkle.map.MerkleMap;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,13 +57,6 @@ class BackingTokensTest {
         assertTrue(subject.contains(a));
         assertFalse(subject.contains(b));
         // and:
-    }
-
-    @Test
-    void delegatesIdSet() {
-        var expectedIds = Set.of(a);
-        // expect:
-        assertEquals(expectedIds, subject.idSet());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccountsTest.java
@@ -37,7 +37,6 @@ import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.merkle.utility.KeyedMerkleLong;
 import com.swirlds.merkle.map.MerkleMap;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,14 +92,6 @@ class BackingAccountsTest {
     }
 
     @Test
-    void idSetIsDedicatedAuxiliary() {
-        final var firstIdSet = subject.idSet();
-        final var secondIdSet = subject.idSet();
-
-        assertSame(firstIdSet, secondIdSet);
-    }
-
-    @Test
     void containsDelegatesToKnownActive() {
         // expect:
         assertTrue(subject.contains(a));
@@ -149,15 +140,6 @@ class BackingAccountsTest {
 
         // then:
         assertEquals(bValue, immutable);
-    }
-
-    @Test
-    void returnsExpectedIds() {
-        // setup:
-        final var s = Set.of(a, b);
-
-        // expect:
-        assertEquals(s, subject.idSet());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingNftsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingNftsTest.java
@@ -20,23 +20,19 @@ import static com.hedera.node.app.service.mono.state.submerkle.EntityId.MISSING_
 import static com.hedera.node.app.service.mono.state.submerkle.RichInstant.MISSING_INSTANT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleUniqueToken;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.RichInstant;
-import com.hedera.node.app.service.mono.state.virtual.UniqueTokenKey;
 import com.hedera.node.app.service.mono.state.virtual.UniqueTokenValue;
 import com.hedera.node.app.service.mono.store.models.NftId;
 import com.hedera.node.app.service.mono.utils.EntityNumPair;
 import com.hedera.test.utils.ResponsibleVMapUser;
 import com.swirlds.merkle.map.MerkleMap;
-import com.swirlds.virtualmap.VirtualMap;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,17 +73,7 @@ class BackingNftsTest extends ResponsibleVMapUser {
         subject = new BackingNfts(() -> UniqueTokenMapAdapter.wrap(delegate));
 
         // expect:
-        assertNotNull(subject.idSet());
         assertEquals(2, subject.size());
-    }
-
-    @Test
-    void virtualMapDoesNotSupportIdSet() {
-        subject = new BackingNfts(() -> UniqueTokenMapAdapter.wrap(
-                VirtualMapLike.from(this.<UniqueTokenKey, UniqueTokenValue>trackedMap(new VirtualMap<>()))));
-
-        // expect:
-        assertThrows(UnsupportedOperationException.class, subject::idSet);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRelsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRelsTest.java
@@ -24,7 +24,6 @@ import static com.hedera.test.utils.IdUtils.asToken;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
@@ -153,12 +152,6 @@ class BackingTokenRelsTest {
         // and:
         verify(rels, times(2)).getForModify(any());
         verify(rels, times(1)).get(any());
-    }
-
-    @Test
-    void irrelevantMethodsNotSupported() {
-        // expect:
-        assertThrows(UnsupportedOperationException.class, subject::idSet);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingAccounts.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingAccounts.java
@@ -22,7 +22,6 @@ import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class HashMapBackingAccounts implements BackingStore<AccountID, HederaAccount> {
     final AccountID GENESIS = IdUtils.asAccount("0.0.2");
@@ -57,11 +56,6 @@ public class HashMapBackingAccounts implements BackingStore<AccountID, HederaAcc
     @Override
     public void remove(AccountID id) {
         accounts.remove(id);
-    }
-
-    @Override
-    public Set<AccountID> idSet() {
-        return accounts.keySet();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingNfts.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingNfts.java
@@ -20,7 +20,6 @@ import com.hedera.node.app.service.mono.state.migration.UniqueTokenAdapter;
 import com.hedera.node.app.service.mono.store.models.NftId;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class HashMapBackingNfts implements BackingStore<NftId, UniqueTokenAdapter> {
     private Map<NftId, UniqueTokenAdapter> nfts = new HashMap<>();
@@ -48,11 +47,6 @@ public class HashMapBackingNfts implements BackingStore<NftId, UniqueTokenAdapte
     @Override
     public boolean contains(NftId id) {
         return nfts.containsKey(id);
-    }
-
-    @Override
-    public Set<NftId> idSet() {
-        return nfts.keySet();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokenRels.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokenRels.java
@@ -21,7 +21,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class HashMapBackingTokenRels implements BackingStore<Pair<AccountID, TokenID>, HederaTokenRel> {
@@ -45,11 +44,6 @@ public class HashMapBackingTokenRels implements BackingStore<Pair<AccountID, Tok
     @Override
     public void remove(Pair<AccountID, TokenID> id) {
         rels.remove(id);
-    }
-
-    @Override
-    public Set<Pair<AccountID, TokenID>> idSet() {
-        return rels.keySet();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokens.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokens.java
@@ -20,7 +20,6 @@ import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hederahashgraph.api.proto.java.TokenID;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class HashMapBackingTokens implements BackingStore<TokenID, MerkleToken> {
     private Map<TokenID, MerkleToken> tokens = new HashMap<>();
@@ -43,11 +42,6 @@ public class HashMapBackingTokens implements BackingStore<TokenID, MerkleToken> 
     @Override
     public void remove(TokenID id) {
         tokens.remove(id);
-    }
-
-    @Override
-    public Set<TokenID> idSet() {
-        return tokens.keySet();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapTestAccounts.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapTestAccounts.java
@@ -19,7 +19,6 @@ package com.hedera.node.app.service.mono.ledger.backing;
 import com.hedera.node.app.service.mono.ledger.accounts.TestAccount;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class HashMapTestAccounts implements BackingStore<Long, TestAccount> {
     private Map<Long, TestAccount> testAccounts = new HashMap<>();
@@ -47,11 +46,6 @@ public class HashMapTestAccounts implements BackingStore<Long, TestAccount> {
     @Override
     public boolean contains(Long id) {
         return testAccounts.containsKey(id);
-    }
-
-    @Override
-    public Set<Long> idSet() {
-        return testAccounts.keySet();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccountsTest.java
@@ -35,7 +35,6 @@ import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.merkle.map.MerkleMap;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -82,17 +81,6 @@ class PureBackingAccountsTest {
         assertTrue(subject.contains(b));
         // and:
         verify(map, times(2)).containsKey(any());
-    }
-
-    @Test
-    void delegatesIdSet() {
-        var ids = Set.of(aKey, bKey);
-        var expectedIds = Set.of(a, b);
-
-        given(map.keySet()).willReturn(ids);
-
-        // expect:
-        assertEquals(expectedIds, subject.idSet());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -43,10 +43,7 @@ import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.utils.MiscUtils;
 import com.hedera.node.app.spi.numbers.HederaAccountNumbers;
-import com.hedera.test.extensions.LogCaptor;
-import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
-import com.hedera.test.extensions.LoggingTarget;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
@@ -57,15 +54,11 @@ import com.swirlds.common.system.address.AddressBook;
 import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
-@ExtendWith(LogCaptureExtension.class)
 class BackedSystemAccountsCreatorTest {
-
     private final long shard = 0;
     private final long realm = 0;
     private final long totalBalance = 100l;
@@ -79,9 +72,6 @@ class BackedSystemAccountsCreatorTest {
     private BackingStore<AccountID, HederaAccount> backingAccounts;
     private TreasuryCloner treasuryCloner;
     private HederaAccountNumbers accountNums;
-
-    @LoggingTarget
-    private LogCaptor logCaptor;
 
     @LoggingSubject
     private BackedSystemAccountsCreator subject;
@@ -113,8 +103,6 @@ class BackedSystemAccountsCreatorTest {
         given(book.getAddress(new NodeId(0L))).willReturn(address);
 
         backingAccounts = (BackingStore<AccountID, HederaAccount>) mock(BackingStore.class);
-        given(backingAccounts.idSet())
-                .willReturn(Set.of(accountWith(1), accountWith(2), accountWith(3), accountWith(4)));
         given(backingAccounts.getImmutableRef(accountWith(1))).willReturn(withExpectedBalance(0));
         given(backingAccounts.getImmutableRef(accountWith(2))).willReturn(withExpectedBalance(totalBalance));
         given(backingAccounts.getImmutableRef(accountWith(3))).willReturn(withExpectedBalance(0));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/TreasuryClonerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/TreasuryClonerTest.java
@@ -71,7 +71,7 @@ public class TreasuryClonerTest {
                 .given(accounts)
                 .getImmutableRef(any());
 
-        subject.ensureTreasuryClonesExist();
+        subject.ensureTreasuryClonesExist(true);
         final var created = subject.getClonesCreated();
 
         for (long i = 200; i <= 750L; i++) {
@@ -81,6 +81,27 @@ public class TreasuryClonerTest {
         }
         assertEquals(500, created.size());
         verifyNoMoreInteractions(accounts);
+
+        subject.forgetCreatedClones();
+        assertTrue(subject.getClonesCreated().isEmpty());
+    }
+
+    @Test
+    void prepsSyntheticRecordsAsExpected() {
+        willAnswer(invocationOnMock -> {
+                    final var id = (AccountID) invocationOnMock.getArgument(0);
+                    if (id.getAccountNum() == 2L || id.getAccountNum() == 666L) {
+                        return accountWith(pretendExpiry, pretendTreasuryKey);
+                    }
+                    return null;
+                })
+                .given(accounts)
+                .getImmutableRef(any());
+
+        subject.ensureTreasuryClonesExist(false);
+        final var created = subject.getClonesCreated();
+
+        assertEquals(501, created.size());
 
         subject.forgetCreatedClones();
         assertTrue(subject.getClonesCreated().isEmpty());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManagerTest.java
@@ -259,6 +259,7 @@ class MigrationRecordsManagerTest {
 
         subject.publishMigrationRecords(now);
 
+        verify(systemAccountsCreator).ensureSynthRecordsPresentOnFirstEverTransaction();
         verify(sigImpactHistorian).markEntityChanged(2L);
         verify(recordsHistorian, times(3))
                 .trackPrecedingChildRecord(eq(DEFAULT_SOURCE_ID), bodyCaptor.capture(), eq(record));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStoreTest.java
@@ -254,7 +254,6 @@ class HederaTokenStoreTest {
         given(backingTokens.getImmutableRef(tNft.tokenId())).willReturn(nonfungibleToken);
         given(backingTokens.getImmutableRef(tNft.tokenId()).treasury())
                 .willReturn(EntityId.fromGrpcAccountId(primaryTreasury));
-        given(backingTokens.idSet()).willReturn(Set.of(created));
 
         tokenRelsLedger = mock(TransactionalLedger.class);
         given(tokenRelsLedger.exists(sponsorMisc)).willReturn(true);


### PR DESCRIPTION
**Description**:
 - Closes #7971 
 - Closes #7925 
 - Adds method `SystemAccountsCreator.ensureSynthRecordsPresentOnFirstEverTransaction()`, called at the beginning of the first-ever handled transaction to ensure we externalize the same synthetic `CryptoCreate` records whether we are starting from genesis or replaying from round 1.
 - Removes `idSet()` method.