### PR TITLE
revert hapi proto branch

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -106,9 +106,7 @@ gradleEnterprise {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-// val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
-val hapiProtoBranchOrTag =
-    "7684-protobuf-cleanup" // revert this change after associated protobuf PR is merged
+val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
**Description**:
Following the merge of https://github.com/hashgraph/hedera-protobufs/pull/298 in hedera-protobufs repo, we can repoint hedera-services back to using add-pbj-types-for-state.

**Related issue(s)**:
Fixes #8037
Related to https://github.com/hashgraph/hedera-protobufs/pull/298
Related to https://github.com/hashgraph/hedera-services/pull/7986
