### PR TITLE
Revert hapi-proto-branch

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -106,9 +106,7 @@ gradleEnterprise {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-// val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
-val hapiProtoBranchOrTag =
-    "7684-protobuf-cleanup" // revert this change after associated protobuf PR is merged
+val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
**Description**:
PR https://github.com/hashgraph/hedera-services/pull/7986 temporarily changed the hapi proto branch in use. Now that https://github.com/hashgraph/hedera-protobufs/pull/298 has been merged, it's time to revert the hapi proto branch to what it was before.

**Related issue(s)**:

Fixes #8037
