### PR TITLE
fix NettyGRPC non linux

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
@@ -253,7 +253,7 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
 
     /** Utility for setting up various shared configuration settings between both servers */
     private NettyServerBuilder builderFor(final int port, NettyConfig config) {
-        NettyServerBuilder builder;
+        NettyServerBuilder builder = null;
         try {
             builder = NettyServerBuilder.forPort(port)
                     .keepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
@@ -269,7 +269,7 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
                     .bossEventLoopGroup(new EpollEventLoopGroup())
                     .workerEventLoopGroup(new EpollEventLoopGroup());
             logger.info("Using Epoll for gRPC server");
-        } catch (final Exception ignored) {
+        } catch (final UnsatisfiedLinkError | NoClassDefFoundError ignored) {
             // If we can't use Epoll, then just use NIO
             logger.info("Epoll not available, using NIO");
             builder = NettyServerBuilder.forPort(port)
@@ -282,8 +282,9 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
                     .maxConcurrentCallsPerConnection(config.prodMaxConcurrentCalls())
                     .flowControlWindow(config.prodFlowControlWindow())
                     .directExecutor();
+        } catch (final Exception unexpected) {
+            logger.info("Unexpected exception initializing Netty", unexpected);
         }
-
         return builder;
     }
 


### PR DESCRIPTION
fix the issue sonar fix from PR 7839
that causing e2e tests to fail with that error

```
java.lang.UnsatisfiedLinkError: failed to load the required native library

	at io.netty.channel.epoll.Epoll.ensureAvailability(Epoll.java:81)
	at io.netty.channel.epoll.EpollEventLoop.<clinit>(EpollEventLoop.java:56)
	at io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:186)
	at io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:37)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:60)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:49)
	at io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:114)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:101)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:78)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:54)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:47)
	at com.hedera.node.app.grpc.impl.netty.NettyGrpcServerManager.builderFor(NettyGrpcServerManager.java:268)
	at com.hedera.node.app.grpc.impl.netty.NettyGrpcServerManager.start(NettyGrpcServerManager.java:149)
	at com.hedera.node.app.Hedera.startGrpcServer(Hedera.java:567)
	at com.hedera.node.app.Hedera.run(Hedera.java:515)

```
