### PR TITLE
08034 Fixed index validation after compaction

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCommon.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCommon.java
@@ -253,7 +253,10 @@ public final class DataFileCommon {
         final ConcurrentMap<Integer, Long> missingFileCounts = LongStream.range(
                         validKeyRange.getMinValidKey(), validKeyRange.getMaxValidKey() + 1)
                 .parallel()
-                .map(key -> index.get(key, -1))
+                .map(key -> index.get(key, NON_EXISTENT_DATA_LOCATION))
+                // the index could've been modified while we were iterating over it, so non-existent data locations
+                // possible
+                .filter(location -> location != NON_EXISTENT_DATA_LOCATION)
                 .filter(location -> {
                     final int fileIndex = DataFileCommon.fileIndexFromDataLocation(location);
                     return !(validFileIds.contains(fileIndex)


### PR DESCRIPTION
**Description**:

This PR fixes validation that didn't take into account the fact that the index could've changed, and the snapshot of `validKeyRange`  it uses may no longer correspond to the index state. So, if the value it checks is not not the index, the value is simply ignored.


**Related issue(s)**:

Fixes #8034
