### PR TITLE
Cherry-pick : Remove deprecated Stake update field on restart

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -24,7 +24,6 @@ import static com.hedera.node.app.service.mono.state.migration.StateVersions.MIN
 import static com.hedera.node.app.service.mono.state.migration.UniqueTokensMigrator.migrateFromUniqueTokenMerkleMap;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.parseAccount;
 import static com.swirlds.common.system.InitTrigger.GENESIS;
-import static com.swirlds.common.system.InitTrigger.RECONNECT;
 import static com.swirlds.common.system.InitTrigger.RESTART;
 import static java.util.Objects.requireNonNull;
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -468,10 +468,6 @@ public class ServicesState extends PartialNaryMerkleInternal
                 app.sysFilesManager().createManagedFilesIfMissing();
                 app.stakeStartupHelper().doGenesisHousekeeping(addressBook());
             }
-            if (trigger != RECONNECT) {
-                // Once we have a dynamic address book, this will run unconditionally
-                app.sysFilesManager().updateStakeDetails();
-            }
         }
         return app;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemFilesManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemFilesManager.java
@@ -21,8 +21,6 @@ public interface SystemFilesManager {
 
     void createNodeDetailsIfMissing();
 
-    void updateStakeDetails();
-
     void createUpdateFilesIfMissing();
 
     default void createManagedFilesIfMissing() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -421,7 +421,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.hashLogger()).willReturn(hashLogger);
         given(app.initializationFlow()).willReturn(initFlow);
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(platform.getSelfId()).willReturn(selfId);
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
 
@@ -618,7 +618,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.initializationFlow()).willReturn(initFlow);
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -654,7 +654,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.initializationFlow()).willReturn(initFlow);
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -683,7 +683,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.initializationFlow()).willReturn(initFlow);
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -715,7 +715,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.initializationFlow()).willReturn(initFlow);
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -786,7 +786,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
         given(platform.getAddressBook()).willReturn(addressBook);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -829,7 +829,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
         given(platform.getAddressBook()).willReturn(addressBook);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -882,7 +882,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(app.dualStateAccessor()).willReturn(dualStateAccessor);
         given(platform.getSelfId()).willReturn(selfId);
         given(platform.getAddressBook()).willReturn(addressBook);
-        given(app.sysFilesManager()).willReturn(systemFilesManager);
+
         given(app.stakeStartupHelper()).willReturn(stakeStartupHelper);
         // and:
         APPS.save(selfId, app);
@@ -984,7 +984,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
         // This signed state should be auto-closed by the try block
         try (ReservedSignedState state = loadSignedState(relocatedSignedState.toString())) {
             final var mockPlatform = createMockPlatformWithCrypto();
-            given(addressBook.getAddress(new NodeId(0L))).willReturn(address);
+
             given(mockPlatform.getAddressBook()).willReturn(addressBook);
             ServicesState swirldState = (ServicesState) state.get().getSwirldState();
             swirldState.init(mockPlatform, new DualStateImpl(), RESTART, forHapiAndHedera("0.30.0", "0.30.5"));


### PR DESCRIPTION
Fixes #8106 

Cherry-pick https://github.com/hashgraph/hedera-services/pull/8095

The stake field on file 102 is deprecated and need not be updated on restart.