### PR TITLE
fix: ensure the ephemeral files created during a release workflow are not committed

### DIFF
--- a/.github/workflows/platform-zxc-release-maven-central.yaml
+++ b/.github/workflows/platform-zxc-release-maven-central.yaml
@@ -234,6 +234,7 @@ jobs:
           author_email: ${{ secrets.git-user-email }}
           commit: --signoff --gpg-sign
           message: "[Automated Maven Central Release] Platform SDK v${{ inputs.new-version }}"
+          remove: ${{ steps.google-auth.outputs.credentials_file_path }}
 
 #      - name: Cache SDK Release Archives
 #        id: archive-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1075,3 +1075,6 @@ hedera-node/hapi/checkouts.bin
 !platform-sdk/**/src/test/resources/**/*.evts_sig
 *.dtmp
 *.bkp
+
+### CI Pipeline Created Files
+gha-creds-*.json


### PR DESCRIPTION
## Description

This pull request ensures certain files generated during a CI pipeline execution are never committed. 

### Related Issues

- Closes #8114 