### PR TITLE
08105 Make DataFileWriter gracefully handle interrupts.

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCommon.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCommon.java
@@ -157,11 +157,6 @@ public final class DataFileCommon {
                 + FILE_EXTENSION);
     }
 
-    /** Get the path for a lock file for a given data file path */
-    static Path getLockFilePath(final Path dataFilePath) {
-        return dataFilePath.resolveSibling(dataFilePath.getFileName().toString() + ".lock");
-    }
-
     /**
      * Get the packed data location from file index and byte offset.
      *
@@ -223,11 +218,7 @@ public final class DataFileCommon {
             return false;
         }
         final String fileName = path.getFileName().toString();
-        final boolean validFile = fileName.startsWith(filePrefix) && fileName.endsWith(FILE_EXTENSION);
-        if (!validFile) {
-            return false;
-        }
-        return !Files.exists(getLockFilePath(path));
+        return fileName.startsWith(filePrefix) && fileName.endsWith(FILE_EXTENSION);
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -366,8 +366,8 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
             BUFFER_CACHE.set(buffer);
         }
         // Try a few times. It's very unlikely (other than in tests) that a thread is
-        // interrupted more than once in short period of time, so 2 retries should be enough
-        for (int retries = 2; retries > 0; retries--) {
+        // interrupted more than once in short period of time, so 3 retries should be enough
+        for (int retries = 3; retries > 0; retries--) {
             final int fcIndex = leaseFileChannel();
             final FileChannel fileChannel = fileChannels.get(fcIndex);
             try {

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -19,7 +19,6 @@ package com.swirlds.merkledb.files;
 import static com.swirlds.merkledb.files.DataFileCommon.FOOTER_SIZE;
 import static com.swirlds.merkledb.files.DataFileCommon.PAGE_SIZE;
 import static com.swirlds.merkledb.files.DataFileCommon.createDataFilePath;
-import static com.swirlds.merkledb.files.DataFileCommon.getLockFilePath;
 
 import com.swirlds.merkledb.serialize.DataItemSerializer;
 import java.io.IOException;
@@ -54,11 +53,6 @@ public final class DataFileWriter<D> {
     private static final int MMAP_BUF_SIZE = PAGE_SIZE * 1024 * 4;
 
     /**
-     * The file channel we are writing to. The channel isn't used directly to write bytes, but to
-     * create mapped byte buffers.
-     */
-    private FileChannel writingChannel;
-    /**
      * The current mapped byte buffer used for writing. When overflowed, it is released, and another
      * buffer is mapped from the file channel.
      */
@@ -79,8 +73,6 @@ public final class DataFileWriter<D> {
     private final Instant creationInstant;
     /** The path to the data file we are writing */
     private final Path path;
-    /** The path to the lock file for data file we are writing */
-    private final Path lockFilePath;
     /** File metadata */
     private final DataFileMetadata metadata;
     /**
@@ -124,10 +116,6 @@ public final class DataFileWriter<D> {
         this.dataItemSerializer = dataItemSerializer;
         this.creationInstant = creationTime;
         this.path = createDataFilePath(filePrefix, dataFileDir, index, creationInstant);
-        this.lockFilePath = getLockFilePath(path);
-        if (Files.exists(lockFilePath)) {
-            throw new IOException("Tried to start writing to data file [" + path + "] when lock file already existed");
-        }
         metadata = new DataFileMetadata(
                 DataFileCommon.FILE_FORMAT_VERSION,
                 dataItemSerializer.getSerializedSize(),
@@ -135,10 +123,8 @@ public final class DataFileWriter<D> {
                 index,
                 creationInstant,
                 dataItemSerializer.getCurrentDataVersion());
-        writingChannel = FileChannel.open(
-                path, StandardOpenOption.CREATE_NEW, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        Files.createFile(path);
         moveMmapBuffer(0);
-        Files.createFile(lockFilePath);
     }
 
     /**
@@ -149,9 +135,15 @@ public final class DataFileWriter<D> {
      * @throws IOException if I/O error(s) occurred
      */
     private void moveMmapBuffer(final int currentMmapPos) throws IOException {
-        mmapPositionInFile += currentMmapPos;
-        closeMmapBuffer();
-        writingMmap = writingChannel.map(MapMode.READ_WRITE, mmapPositionInFile, MMAP_BUF_SIZE);
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            MappedByteBuffer newMap =
+                    channel.map(MapMode.READ_WRITE, mmapPositionInFile + currentMmapPos, MMAP_BUF_SIZE);
+            if (newMap != null) {
+                closeMmapBuffer();
+                writingMmap = newMap;
+                mmapPositionInFile += currentMmapPos;
+            }
+        }
     }
 
     /** Closes (unmaps) the current mapped byte buffer used to write bytes, if not null. */
@@ -301,14 +293,12 @@ public final class DataFileWriter<D> {
         final long totalFileSize = mmapPositionInFile + writingMmap.position();
         // release all the resources
         closeMmapBuffer();
-        writingChannel.truncate(totalFileSize);
-        // after finishWriting(), mmapPositionInFile should be equal to the file size
-        mmapPositionInFile = totalFileSize;
-        writingChannel.force(true);
-        writingChannel.close();
-        writingChannel = null;
-        // delete lock file
-        Files.delete(lockFilePath);
+
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            channel.truncate(totalFileSize);
+            // after finishWriting(), mmapPositionInFile should be equal to the file size
+            mmapPositionInFile = totalFileSize;
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -135,8 +135,8 @@ public final class DataFileWriter<D> {
      * @throws IOException if I/O error(s) occurred
      */
     private void moveMmapBuffer(final int currentMmapPos) throws IOException {
-        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            MappedByteBuffer newMap =
+        try (final FileChannel channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            final MappedByteBuffer newMap =
                     channel.map(MapMode.READ_WRITE, mmapPositionInFile + currentMmapPos, MMAP_BUF_SIZE);
             verifyMmapCorrectness(newMap);
             closeMmapBuffer();
@@ -152,7 +152,7 @@ public final class DataFileWriter<D> {
      *
      * @param newMap the mapped byte buffer to verify
      */
-    private static void verifyMmapCorrectness(MappedByteBuffer newMap) throws IOException {
+    private static void verifyMmapCorrectness(final MappedByteBuffer newMap) throws IOException {
         // theoretically it's possible, we should check it
         if(newMap == null) {
             throw new IOException("Failed to map file channel to memory");
@@ -161,7 +161,7 @@ public final class DataFileWriter<D> {
         try {
             newMap.put(MMAP_BUF_SIZE - 1, (byte) -1);
             if (newMap.get(MMAP_BUF_SIZE - 1) != -1) throw new IOException("Fatal error when creating mmap. Possibly,  out of disk memory.");
-        } catch (Error e) {
+        } catch (final Error e) {
             throw new IOException(e);
         }
     }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -51,6 +51,8 @@ public final class DataFileWriter<D> {
 
     /** Mapped buffer size */
     private static final int MMAP_BUF_SIZE = PAGE_SIZE * 1024 * 4;
+    /** A value to write to verify a newly created mapped buffer */
+    public static final int PROBE_VALUE = 42;
 
     /**
      * The current mapped byte buffer used for writing. When overflowed, it is released, and another
@@ -154,13 +156,15 @@ public final class DataFileWriter<D> {
      */
     private static void verifyMmapCorrectness(final MappedByteBuffer newMap) throws IOException {
         // theoretically it's possible, we should check it
-        if(newMap == null) {
+        if (newMap == null) {
             throw new IOException("Failed to map file channel to memory");
         }
         // The idea is to force this mapping to happen. By default, actual mapping happens lazily.
         try {
-            newMap.put(MMAP_BUF_SIZE - 1, (byte) -1);
-            if (newMap.get(MMAP_BUF_SIZE - 1) != -1) throw new IOException("Fatal error when creating mmap. Possibly,  out of disk memory.");
+            newMap.put(MMAP_BUF_SIZE - 1, (byte) PROBE_VALUE);
+            if (newMap.get(MMAP_BUF_SIZE - 1) != PROBE_VALUE) {
+                throw new IOException("Fatal error when creating mmap. Possibly, out of disk memory.");
+            }
         } catch (final Error e) {
             throw new IOException(e);
         }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -51,9 +51,6 @@ public final class DataFileWriter<D> {
 
     /** Mapped buffer size */
     private static final int MMAP_BUF_SIZE = PAGE_SIZE * 1024 * 4;
-    /** A value to write to verify a newly created mapped buffer */
-    public static final int PROBE_VALUE = 42;
-
     /**
      * The current mapped byte buffer used for writing. When overflowed, it is released, and another
      * buffer is mapped from the file channel.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileWriterTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileWriterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.merkledb.files;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.swirlds.merkledb.serialize.DataItemSerializer;
+import java.io.IOException;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+
+class DataFileWriterTest {
+
+    private DataFileWriter<Object> dataFileWriter;
+
+    @Mock
+    private DataItemSerializer<Object> dataItemSerializer;
+
+    private final CountDownLatch serializeLatch = new CountDownLatch(1);
+    private final AtomicInteger callCount = new AtomicInteger(0);
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        when(dataItemSerializer.getSerializedSize()).thenReturn(1);
+        when(dataItemSerializer.getCurrentDataVersion()).thenReturn(1L);
+        when(dataItemSerializer.copyItem(anyLong(), anyInt(), any(), any()))
+                .thenAnswer((Answer<Integer>) invocation -> {
+                    int i = callCount.incrementAndGet();
+                    if (i == 1) {
+                        // on the first call it throws an exception to get to `moveMmapBuffer` method in the catch block
+                        throw new BufferOverflowException();
+                    } else {
+                        try {
+                            // here it waits to be interrupted
+                            serializeLatch.await();
+                        } catch (InterruptedException e) {
+                            // interrupted exception is expected
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+
+                    return 1;
+                });
+
+        Path dataFileWriterPath = Files.createTempDirectory("dataFileWriter");
+        dataFileWriter = new DataFileWriter<>("test", dataFileWriterPath, 1, dataItemSerializer, Instant.now());
+    }
+
+    /**
+     * This test reproduces rare scenario when `moveMmapBuffer` method is called on interrupted thread.
+     * It will result in writingChannel.map(MapMode.READ_WRITE, mmapPositionInFile, MMAP_BUF_SIZE) call returning null.
+     * DataFileWriter has to handle this case gracefully.
+     */
+    @RepeatedTest(100) // it takes several iterations to reproduce the issue
+    public void testMoveMmapBufferOnInterruptedThread() {
+        ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
+        Future<?> writeFuture = writeExecutor.submit(() -> {
+            try {
+                ByteBuffer allocate = ByteBuffer.allocate(4);
+                allocate.put("test".getBytes());
+                dataFileWriter.writeCopiedDataItem(1, allocate);
+            } catch (IOException e) {
+                throw new RuntimeException();
+            }
+        });
+
+        // at this point a thread in writeExecutor is blocked on serializeLatch.await()
+
+        ExecutorService finishExecutor = Executors.newSingleThreadExecutor();
+        Future<?> finishWritingFuture = finishExecutor.submit(() -> {
+            try {
+                dataFileWriter.finishWriting();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // At this point a thread in finishExecutor is blocked on finishWriting because a thread from
+        // writeExecutor holds the lock.
+
+        // Releasing the latch by interrupting the thread in writeExecutor
+        writeFuture.cancel(true);
+
+        assertDoesNotThrow(() -> finishWritingFuture.get());
+    }
+}


### PR DESCRIPTION
**Description**:

This PR fixes possible reconnect failure which may happen due to unfortunate timing of a compaction pause. 
Also, it simplifies `DataFileWriter` by removing lock file because it's not necessary. `Files.createFile(path);` provides guarantees of atomic disk operation. 
Also, this PR reproduces the failure scenario in `DataFileWriterTest`.


**Related issue(s)**:

Fixes #8105 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
