### PR TITLE
Dump files from signed state file

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
@@ -99,7 +99,7 @@ public class DumpAccountsSubcommand {
     void doit() {
         final var accountsStore = state.getAccounts();
         System.out.printf(
-                "=== %d accounts %s%n", accountsStore.size(), accountsStore.areOnDisk() ? "on disk" : "in memory");
+                "=== %d accounts (%s)%n", accountsStore.size(), accountsStore.areOnDisk() ? "on disk" : "in memory");
 
         final var accountsArr = gatherAccounts(accountsStore);
 
@@ -131,7 +131,7 @@ public class DumpAccountsSubcommand {
             throw new UncheckedIOException(ex); // CLI program: Java will print the exception + stacktrace
         }
 
-        System.out.printf("=== report is %d bytes%n", reportSize[0]);
+        System.out.printf("=== accounts report is %d bytes%n", reportSize[0]);
         System.out.printf("=== fields with exceptions: %s%n", String.join(",", fieldsWithExceptions));
     }
 
@@ -378,7 +378,7 @@ public class DumpAccountsSubcommand {
                 Field.of("fungibleTokenAllowances", a::getFungibleTokenAllowances, doWithBuilder(sb, ThingsToStrings::toStringOfMapFcLong)),
                 Field.of("headNftKey", a::getHeadNftKey, doWithBuilder(sb, ThingsToStrings::toStringOfEntityNumPair)),
                 Field.of("latestAssociation", a::getLatestAssociation, doWithBuilder(sb, ThingsToStrings::toStringOfEntityNumPair)),
-                Field.of("memo", a::getMemo, s -> { if (s.isEmpty()) return false; sb.append(ThingsToStrings.quoteForCsv(s)); return true; }),
+                Field.of("memo", a::getMemo, s -> { if (s.isEmpty()) return false; sb.append(ThingsToStrings.quoteForCsv(FIELD_SEPARATOR,  s)); return true; }),
                 Field.of("proxy", a::getProxy, doWithBuilder(sb, ThingsToStrings::toStringOfEntityId))
         ).sorted(Comparator.comparing(Field::name)).toList();
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
@@ -104,12 +104,20 @@ public class DumpContractBytecodesSubcommand {
                 contractsWithBytecode.contracts().size();
         int totalUniqueContractsPresentInFileStore = totalContractsPresentInFileStore;
 
-        if (uniqify == DumpStateCommand.Uniqify.YES) {
+        if (uniqify == Uniqify.YES) {
             r = uniqifyContracts(contractsWithBytecode, zeroLengthContracts);
             contractsWithBytecode = r.getLeft();
             zeroLengthContracts = r.getRight();
             totalUniqueContractsPresentInFileStore =
                     contractsWithBytecode.contracts().size();
+        }
+
+        if (verbosity == Verbosity.VERBOSE) {
+            if (uniqify == Uniqify.YES)
+                System.out.printf(
+                        "=== %d contracts (%d unique) ===%n",
+                        totalContractsRegisteredWithAccounts, totalUniqueContractsPresentInFileStore);
+            else System.out.printf("=== %d contracts ===%n", totalContractsRegisteredWithAccounts);
         }
 
         final var sb = new StringBuilder(estimateReportSize(contractsWithBytecode));
@@ -126,7 +134,8 @@ public class DumpContractBytecodesSubcommand {
         }
         appendFormattedContractLines(sb, contractsWithBytecode);
 
-        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Have %d byte report%n", sb.length());
+        if (verbosity == Verbosity.VERBOSE)
+            System.out.printf("=== contract bytecode report is %d bytes%n", sb.length());
 
         writeReportToFile(sb.toString());
     }
@@ -139,9 +148,7 @@ public class DumpContractBytecodesSubcommand {
         // Make a swag based on how many contracts there are plus bytecode size - each line has not just the bytecode
         // but the list of contract ids, so the estimated size of the file accounts for the bytecodes (as hex) and the
         // contract ids (as decimal)
-        int reportSizeEstimate = contracts.registeredContractsCount() * 20 + totalBytecodeSize * 2;
-        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Estimating %d byte report%n", reportSizeEstimate);
-        return reportSizeEstimate;
+        return contracts.registeredContractsCount() * 20 + totalBytecodeSize * 2;
     }
 
     void writeReportToFile(@NonNull String report) {

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -122,8 +122,6 @@ public class DumpContractStoresSubcommand {
 
             long reportSizeEstimate = (nDistinctContractIds * 20)
                     + (nContractStateValues * 2 /*K/V*/ * (32 /*bytes*/ * 2 /*hexits/byte*/ + 3 /*whitespace+slop*/));
-            if (verbosity == Verbosity.VERBOSE)
-                System.out.printf("=== Estimating %d byte report%n", reportSizeEstimate);
             final var sb = new StringBuilder((int) reportSizeEstimate);
 
             if (verbosity == Verbosity.VERBOSE)
@@ -131,8 +129,8 @@ public class DumpContractStoresSubcommand {
                         "=== %d contract stores found, %d k/v pairs%n", nDistinctContractIds, nContractStateValues);
 
             if (emitSummary == EmitSummary.YES)
-                sb.append("*** %d contract stores found, %d k/v pairs%n"
-                        .formatted(nDistinctContractIds, nContractStateValues));
+                sb.append(
+                        "*** %d contract stores, %d k/v pairs%n".formatted(nDistinctContractIds, nContractStateValues));
 
             // This list is generated in contract id order so that it is deterministic; also all the slot#/value pairs
             // are sorted by slot# for the same reason
@@ -156,7 +154,8 @@ public class DumpContractStoresSubcommand {
             if (withSlots == WithSlots.YES)
                 for (final var aContractState : contractStates) appendSerializedContractStore(sb, aContractState);
 
-            if (verbosity == Verbosity.VERBOSE) System.out.printf("=== Accual report size %d bytes%n", sb.length());
+            if (verbosity == Verbosity.VERBOSE)
+                System.out.printf("=== Contract store report is %d bytes%n", sb.length());
 
             writeReportToFile(sb.toString());
         } else {

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import static com.hedera.services.cli.utils.ThingsToStrings.quoteForCsv;
+import static com.hedera.services.cli.utils.ThingsToStrings.toStringOfByteArray;
+import static com.hedera.services.cli.utils.ThingsToStrings.toStructureSummaryOfJKey;
+import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+
+import com.hedera.node.app.service.mono.files.HFileMeta;
+import com.hedera.node.app.service.mono.files.MetadataMapFactory;
+import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
+import com.hedera.node.app.service.mono.utils.MiscUtils;
+import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.signedstate.DumpStateCommand.KeyDetails;
+import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import com.hedera.services.cli.utils.Writer;
+import com.swirlds.base.utility.Pair;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Dump all the data files in a signed state file in textual format.  Output is deterministic for a signed
+ * state - sorted by file entity number, etc. - so that
+ * comparisons can be made between two signed states that are similar (e.g., mono-service vs modularized service when
+ * the same events are run through them).
+ */
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+public class DumpFilesSubcommand {
+
+    static void doit(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path filesPath,
+            @NonNull final KeyDetails keyDetails,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final Verbosity verbosity) {
+        new DumpFilesSubcommand(state, filesPath, keyDetails, emitSummary, verbosity).doit();
+    }
+
+    @NonNull
+    final SignedStateHolder state;
+
+    @NonNull
+    final Path filesPath;
+
+    @NonNull
+    final KeyDetails keyDetails;
+
+    @NonNull
+    final EmitSummary emitSummary;
+
+    @NonNull
+    final Verbosity verbosity;
+
+    DumpFilesSubcommand(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path filesPath,
+            @NonNull final KeyDetails keyDetails,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final Verbosity verbosity) {
+        this.state = state;
+        this.filesPath = filesPath;
+        this.keyDetails = keyDetails;
+        this.emitSummary = emitSummary;
+        this.verbosity = verbosity;
+    }
+
+    void doit() {
+        final var fileStore = state.getFileStore();
+
+        final var collectedFiles = collectFiles(fileStore);
+        final var fileSummary = collectedFiles.left();
+        final var allFiles = collectedFiles.right();
+
+        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== %d data files ===%n", allFiles.size());
+
+        final var reportSize = new int[1];
+        try (@NonNull final var writer = new Writer(filesPath)) {
+            if (EmitSummary.YES == emitSummary) reportSummary(writer, fileSummary, allFiles);
+            if (EmitSummary.YES == emitSummary) reportFileSizes(writer, allFiles);
+            reportFileContents(writer, allFiles);
+            if (KeyDetails.DEEP == keyDetails) reportOnKeys(writer, allFiles);
+            reportSize[0] = writer.getSize();
+        } catch (final RuntimeException ex) {
+            System.err.printf("*** Exception when writing to '%s':%n", filesPath);
+            throw ex;
+        }
+
+        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== files report is %d bytes%n", reportSize[0]);
+    }
+
+    /** Holds summaries of how many files of each type there are in the store, also how many are missing content. */
+    record FileSummary(
+            @NonNull Map<VirtualBlobKey.Type, Integer> typeOccurrences,
+            @NonNull Map<VirtualBlobKey.Type, Integer> nullValueOccurrences,
+            @NonNull Integer nNullMetadataValues) {}
+
+    /** Holds the content and the metadata for a single data file in the store */
+    @SuppressWarnings("java:S6218") // "Equals/hashcode methods should be overridden in records containing array fields"
+    // not using this with equals
+    record HederaFile(@NonNull Integer contractId, @NonNull byte[] contents, @Nullable HFileMeta metadata) {
+
+        @NonNull
+        static HederaFile of(@NonNull Integer contractId, @NonNull byte[] contents) {
+            return new HederaFile(contractId, contents, null);
+        }
+
+        @NonNull
+        static HederaFile of(@NonNull Integer contractId, @NonNull byte[] contents, @NonNull HFileMeta metadata) {
+            return new HederaFile(contractId, contents, metadata);
+        }
+
+        boolean isActive() {
+            return null != metadata && !metadata.isDeleted();
+        }
+
+        boolean isDeleted() {
+            return !isActive();
+        }
+    }
+
+    /** Emits the summary of the files in the store */
+    void reportSummary(
+            @NonNull final Writer writer,
+            @NonNull final FileSummary fileSummary,
+            @NonNull final Map<Integer, HederaFile> allFiles) {
+        final var nTotalFiles = fileSummary.typeOccurrences().values().stream().reduce(0, Integer::sum);
+
+        final var nDataFiles = fileSummary.typeOccurrences().get(VirtualBlobKey.Type.FILE_DATA);
+        final var nDeletedDataFiles =
+                allFiles.values().stream().filter(HederaFile::isDeleted).count();
+
+        final var nMetadataFiles = fileSummary.typeOccurrences().get(VirtualBlobKey.Type.FILE_METADATA);
+        final var nActiveDataFiles =
+                allFiles.values().stream().filter(HederaFile::isActive).count();
+        final var nActiveDataFilesWithMetadata =
+                allFiles.values().stream().filter(HederaFile::isActive).count();
+        final var nActiveDataFilesMissingMetadata = nActiveDataFiles - nActiveDataFilesWithMetadata;
+
+        Function<VirtualBlobKey.Type, String> wereNull = t -> {
+            final var n = fileSummary.nullValueOccurrences().get(t);
+            return 0 != n ? " (%d had missing content)".formatted(n) : "";
+        };
+
+        final var sb = new StringBuilder(1000);
+
+        sb.append("#   === Summary ===%n".formatted());
+        sb.append("#   %7d total files%n".formatted(nTotalFiles));
+        sb.append("#   %7d were contract bytecodes%s%n"
+                .formatted(
+                        fileSummary.typeOccurrences().get(VirtualBlobKey.Type.CONTRACT_BYTECODE),
+                        wereNull.apply(VirtualBlobKey.Type.CONTRACT_BYTECODE)));
+        sb.append("#   %7d were data, of which %d were deleted, leaving %d live data files%s%s%n"
+                .formatted(
+                        nDataFiles,
+                        nDeletedDataFiles,
+                        nDataFiles - nDeletedDataFiles,
+                        wereNull.apply(VirtualBlobKey.Type.FILE_DATA),
+                        nActiveDataFilesMissingMetadata != 0
+                                ? " (%d of those missing metadata)".formatted(nActiveDataFilesMissingMetadata)
+                                : ""));
+        sb.append("#   %7d were metadata%s%s%n"
+                .formatted(
+                        nMetadataFiles,
+                        wereNull.apply(VirtualBlobKey.Type.FILE_METADATA),
+                        0 != fileSummary.nNullMetadataValues
+                                ? " (%d, not counted here, had null metadata)"
+                                        .formatted(fileSummary.nNullMetadataValues)
+                                : ""));
+        sb.append("#   %7d were system deleted/entity expiry%s%n"
+                .formatted(
+                        fileSummary.typeOccurrences().get(VirtualBlobKey.Type.SYSTEM_DELETED_ENTITY_EXPIRY),
+                        wereNull.apply(VirtualBlobKey.Type.SYSTEM_DELETED_ENTITY_EXPIRY)));
+
+        writer.write(sb);
+    }
+
+    /** Emits a histogram of file content sizes */
+    void reportFileSizes(@NonNull final Writer writer, @NonNull final Map<Integer, HederaFile> allFiles) {
+        final var histogram = allFiles.values().stream()
+                .filter(HederaFile::isActive)
+                .map(hf -> hf.contents().length)
+                .collect(Collectors.groupingBy(n -> 0 == n ? 0 : (int) Math.log10(n), Collectors.counting()));
+        final var maxDigits =
+                histogram.keySet().stream().max(Comparator.naturalOrder()).orElse(0);
+
+        final var sb = new StringBuilder(1000);
+
+        sb.append("#   === Content Size Histogram ===%n".formatted());
+        sb.append("#        =0: %6d%n".formatted(histogram.getOrDefault(0, 0L)));
+        for (int i = 1; i <= maxDigits; i++) {
+            sb.append("# %9s: %6d%n".formatted("<=" + (int) Math.pow(10, i), histogram.getOrDefault(i, 0L)));
+        }
+
+        writer.write(sb);
+    }
+
+    /** Emits the actual content (hexified) for each file), and it's full key */
+    void reportFileContents(@NonNull final Writer writer, @NonNull final Map<Integer, HederaFile> allFiles) {
+        for (@NonNull
+        final var file :
+                allFiles.entrySet().stream().sorted(Map.Entry.comparingByKey()).toList()) {
+            // Is it correct to _skip_ files without metadata?  Or print them (none currently exist)
+
+            final var contractId = file.getKey();
+            final var hf = file.getValue();
+            if (hf.isActive()) {
+                assert hf.metadata() != null;
+                final var sb = new StringBuilder();
+                toStringOfByteArray(sb, hf.contents());
+                writer.write(
+                        "%d,PRESENT,%d,%s,%d,%s,%s%n",
+                        contractId,
+                        hf.metadata().getExpiry(),
+                        quoteForCsv(",", hf.metadata().getMemo()),
+                        hf.contents().length,
+                        sb,
+                        quoteForCsv(",", MiscUtils.describe(hf.metadata().getWacl())));
+            } else {
+                writer.write("%d,DELETED%n", contractId);
+            }
+        }
+    }
+
+    /** Emits a summary of the _structures_ of the keys securing the data files. */
+    void reportOnKeys(@NonNull final Writer writer, @NonNull final Map<Integer, HederaFile> allFiles) {
+        final var keySummary = new HashMap<String, Integer>();
+        for (@NonNull final var hf : allFiles.values()) {
+            if (hf.isDeleted()) continue;
+            final var jkey = hf.metadata().getWacl();
+            final var sb = new StringBuilder();
+            final var b = toStructureSummaryOfJKey(sb, jkey);
+            if (!b) {
+                sb.setLength(0);
+                sb.append("NULL-KEY");
+            }
+            keySummary.merge(sb.toString(), 1, Integer::sum);
+        }
+
+        writer.writeln("=== Key Summary ===");
+        keySummary.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEachOrdered(e -> writer.write("%7d: %s%n", e.getValue(), e.getKey()));
+    }
+
+    /** Collects the information for each data file in the file store, also the summaries of all files of all types. */
+    @SuppressWarnings("java:S108") // "Nested blocks of code should not be left empty" - not for switches on an enum
+    @NonNull
+    Pair<FileSummary, Map<Integer, HederaFile>> collectFiles(
+            @NonNull final VirtualMapLike<VirtualBlobKey, VirtualBlobValue> fileStore) {
+        final var foundFiles = new ConcurrentHashMap<Integer, byte[]>();
+        final var foundMetadata = new ConcurrentHashMap<Integer, HFileMeta>();
+
+        final var nType = new ConcurrentHashMap<VirtualBlobKey.Type, Integer>();
+        final var nNullValues = new ConcurrentHashMap<VirtualBlobKey.Type, Integer>();
+        final var nNulLMetadataValues = new AtomicInteger();
+
+        Stream.of(nType, nNullValues)
+                .forEach(m -> EnumSet.allOf(VirtualBlobKey.Type.class).forEach(t -> m.put(t, 0)));
+
+        final int THREAD_COUNT = 8; // size it for a laptop, why not?
+        boolean didRunToCompletion = true;
+        try {
+            fileStore.extractVirtualMapDataC(
+                    getStaticThreadManager(),
+                    entry -> {
+                        final var contractId = entry.key().getEntityNumCode();
+
+                        final var type = entry.key().getType();
+                        nType.merge(type, 1, Integer::sum);
+
+                        final var value = entry.value().getData();
+                        if (null != value) {
+                            switch (type) {
+                                case FILE_DATA -> foundFiles.put(contractId, value);
+
+                                case FILE_METADATA -> {
+                                    final var metadata = MetadataMapFactory.toAttr(value);
+                                    if (null != metadata) {
+                                        foundMetadata.put(contractId, metadata);
+                                    } else {
+                                        nNulLMetadataValues.incrementAndGet();
+
+                                        System.err.printf(
+                                                "*** collectFiles file metadata (HFileMeta) null for contract id %d, type %s%n",
+                                                contractId, type);
+                                    }
+                                }
+                                case CONTRACT_BYTECODE, SYSTEM_DELETED_ENTITY_EXPIRY -> {}
+                            }
+                        } else {
+                            nNullValues.merge(type, 1, Integer::sum);
+
+                            System.err.printf(
+                                    "*** collectFiles file value (bytes) null for contract id %d, type %s%n",
+                                    contractId, type);
+                        }
+                    },
+                    THREAD_COUNT);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            didRunToCompletion = false;
+        }
+
+        if (!didRunToCompletion) {
+            System.err.printf("*** collectFiles interrupted (did not run to completion)%n");
+        }
+
+        final var r = new HashMap<Integer, HederaFile>();
+        for (@NonNull final var e : foundFiles.entrySet()) {
+            final var contractId = e.getKey();
+            final var contents = e.getValue();
+            final var metadata = foundMetadata.getOrDefault(contractId, null);
+            r.put(
+                    contractId,
+                    null != metadata
+                            ? HederaFile.of(contractId, contents, metadata)
+                            : HederaFile.of(contractId, contents));
+        }
+
+        final var fileSummary = new FileSummary(Map.copyOf(nType), Map.copyOf(nNullValues), nNulLMetadataValues.get());
+        return Pair.of(fileSummary, r);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -65,6 +65,11 @@ public class DumpStateCommand extends AbstractCommand {
         ELIDED_DEFAULT_FIELDS
     }
 
+    enum KeyDetails {
+        DEEP,
+        SHALLOW
+    }
+
     // We want to open the signed state file only once but run a bunch of dumps against it
     // (because it takes a long time to open the signed state file).  So we can specify
     // more than one of these subcommands on the single command line.  But we don't get
@@ -171,6 +176,35 @@ public class DumpStateCommand extends AbstractCommand {
                 lowLimit,
                 highLimit,
                 doCsv ? Format.CSV : Format.ELIDED_DEFAULT_FIELDS,
+                parent.verbosity);
+        finish();
+    }
+
+    @Command(name = "files")
+    void files(
+            @Option(
+                            names = {"--files"},
+                            arity = "1",
+                            description = "Output file for files dump")
+                    @NonNull
+                    final Path filesPath,
+            @Option(
+                            names = {"--deep-keys"},
+                            arity = "0..1",
+                            description = "Whether to fully dump keys or not")
+                    final boolean doDeepKeys,
+            @Option(
+                            names = {"-s", "--summary"},
+                            description = "Emit a summary line")
+                    final boolean emitSummary) {
+        Objects.requireNonNull(filesPath);
+        init();
+        System.out.println("=== files ===");
+        DumpFilesSubcommand.doit(
+                parent.signedState,
+                filesPath,
+                doDeepKeys ? KeyDetails.DEEP : KeyDetails.SHALLOW,
+                emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 parent.verbosity);
         finish();
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Writer.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Writer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.utils;
+
+import com.swirlds.common.AutoCloseableNonThrowing;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+/** Holds a file that you can write to, and implements obvious writing methods.  Key features are 1) throws
+ * `UncheckedIOException` instead of `IOException` and 2) keeps track of how many characters are written.
+ */
+public class Writer implements AutoCloseableNonThrowing {
+    private final FileWriter fw;
+    private final BufferedWriter bw;
+    private int size;
+
+    public Writer(@NonNull final Path path) {
+        try {
+            fw = new FileWriter(path.toFile(), StandardCharsets.UTF_8);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        bw = new BufferedWriter(fw);
+    }
+
+    public void write(@NonNull final Object o) {
+        final var s = o.toString();
+        try {
+            bw.write(s);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        size += s.length();
+    }
+
+    public void write(@NonNull final String format, @NonNull final Object... os) {
+        final var s = format.formatted(os);
+        try {
+            bw.write(s);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        size += s.length();
+    }
+
+    public void writeln(@NonNull final Object o) {
+        write(o);
+        newLine();
+    }
+
+    public void newLine() {
+        write(System.lineSeparator());
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    @Override
+    public void close() {
+        try {
+            bw.close();
+            fw.close();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -74,6 +74,7 @@ module com.hedera.node.app.service.mono {
             com.hedera.node.app.service.mono.test.fixtures,
             com.hedera.node.app;
     exports com.hedera.node.app.service.mono.files to
+            com.hedera.node.services.cli,
             com.hedera.node.app.service.mono.test.fixtures,
             com.hedera.node.app,
             com.hedera.node.app.service.file.impl;


### PR DESCRIPTION
**Description**:

Dumps all _data_ files from a signed state file.  Includes their content and their full key.  Also has a histogram of file sizes, and a list of all the different key structures.

Given a signed state file from 2023-07-19 it found ~20000 _data_ files and produced a report of ~110MB.

**Related issue(s)**:

Fixes #8143 

**Notes for reviewer**:

Sample command line (you'll have to provide your own signed state file:

```bash
./platform-sdk/swirlds-cli/pcli.sh \
    --memory 40 \
    --ignore-jars \
    --load hedera-node/data/lib \
    --load hedera-node/cli-clients/build/libs \
    --cli com.hedera.services.cli.signedstate \
    signed-state  -f /Users/davidbakin/StatesStreams/mainnet-2023-07-19/state/2023-07-19.00.00/144535932/SignedState.swh --verbose \
    dump \
       files --files ./files.lst --deep-keys
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (manual)
