### PR TITLE
Call ExchangeRateManager.update in SystemFileUpdateFacility

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -962,7 +962,8 @@ public final class Hedera implements SwirldMain {
                     .configuration(configProvider)
                     .throttleManager(throttleManager)
                     .exchangeRateManager(exchangeRateManager)
-                    .systemFileUpdateFacility(new SystemFileUpdateFacility(configProvider, throttleManager, exchangeRateManager))
+                    .systemFileUpdateFacility(
+                            new SystemFileUpdateFacility(configProvider, throttleManager, exchangeRateManager))
                     .self(SelfNodeInfoImpl.of(nodeAddress, version))
                     .initialHash(initialHash)
                     .platform(platform)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
@@ -150,6 +150,9 @@ public interface HederaInjectionComponent {
         Builder systemFileUpdateFacility(SystemFileUpdateFacility systemFileUpdateFacility);
 
         @BindsInstance
+        Builder exchangeRateManager(ExchangeRateManager exchangeRateManager);
+
+        @BindsInstance
         Builder maxSignedTxnSize(@MaxSignedTxnSize final int maxSignedTxnSize);
 
         @BindsInstance

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacility.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacility.java
@@ -55,7 +55,7 @@ public class SystemFileUpdateFacility {
      * @param configProvider the configuration provider
      */
     public SystemFileUpdateFacility(
-            @NonNull final ConfigProviderImpl configProvider, 
+            @NonNull final ConfigProviderImpl configProvider,
             @NonNull final ThrottleManager throttleManager,
             @NonNull final ExchangeRateManager exchangeRateManager) {
         this.configProvider = requireNonNull(configProvider, "configProvider must not be null");

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -89,7 +89,8 @@ class IngestComponentTest {
                 .crypto(CryptographyHolder.get())
                 .bootstrapProps(new BootstrapProperties())
                 .configuration(configProvider)
-                .systemFileUpdateFacility(new SystemFileUpdateFacility(configProvider, throttleManager, exchangeRateManager))
+                .systemFileUpdateFacility(
+                        new SystemFileUpdateFacility(configProvider, throttleManager, exchangeRateManager))
                 .throttleManager(throttleManager)
                 .self(selfNodeInfo)
                 .initialHash(new Hash())

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -27,6 +27,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.DaggerHederaInjectionComponent;
 import com.hedera.node.app.HederaInjectionComponent;
 import com.hedera.node.app.config.ConfigProviderImpl;
+import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.info.SelfNodeInfoImpl;
 import com.hedera.node.app.service.mono.context.properties.BootstrapProperties;
 import com.hedera.node.app.spi.info.SelfNodeInfo;
@@ -86,19 +87,21 @@ class IngestComponentTest {
                         SemanticVersion.newBuilder().major(2).build()));
 
         final var configProvider = new ConfigProviderImpl(false);
+        final var exchangeRateManager = new ExchangeRateManager();
         app = DaggerHederaInjectionComponent.builder()
                 .initTrigger(InitTrigger.GENESIS)
                 .platform(platform)
                 .crypto(CryptographyHolder.get())
                 .bootstrapProps(new BootstrapProperties())
                 .configuration(configProvider)
-                .systemFileUpdateFacility(new SystemFileUpdateFacility(configProvider))
+                .systemFileUpdateFacility(new SystemFileUpdateFacility(configProvider, exchangeRateManager))
                 .self(selfNodeInfo)
                 .initialHash(new Hash())
                 .maxSignedTxnSize(1024)
                 .currentPlatformStatus(() -> PlatformStatus.ACTIVE)
                 .servicesRegistry(Set::of)
                 .instantSource(InstantSource.system())
+                .exchangeRateManager(exchangeRateManager)
                 .build();
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
@@ -94,7 +94,11 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
         final var txBody = simpleCryptoTransfer().body();
 
         // then
-        assertThatThrownBy(() -> new SystemFileUpdateFacility(null, null, null))
+        assertThatThrownBy(() -> new SystemFileUpdateFacility(null, throttleManager, exchangeRateManager))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SystemFileUpdateFacility(configProvider, null, exchangeRateManager))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SystemFileUpdateFacility(configProvider, throttleManager, null))
                 .isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> subject.handleTxBody(null, txBody)).isInstanceOf(NullPointerException.class);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.workflows.handle;
 
 import static com.hedera.node.app.service.file.impl.FileServiceImpl.BLOBS_KEY;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,7 @@ import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.config.VersionedConfigImpl;
+import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fixtures.state.FakeHederaState;
 import com.hedera.node.app.service.file.FileService;
 import com.hedera.node.app.spi.fixtures.TransactionFactory;
@@ -62,6 +64,9 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
 
     private SystemFileUpdateFacility subject;
 
+    @Mock
+    private ExchangeRateManager exchangeRateManager;
+
     @BeforeEach
     void setUp() {
         files = new HashMap<>();
@@ -75,7 +80,7 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1L));
 
-        subject = new SystemFileUpdateFacility(configProvider);
+        subject = new SystemFileUpdateFacility(configProvider, exchangeRateManager);
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -85,7 +90,7 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
         final var txBody = simpleCryptoTransfer().body();
 
         // then
-        assertThatThrownBy(() -> new SystemFileUpdateFacility(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SystemFileUpdateFacility(null, null)).isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> subject.handleTxBody(null, txBody)).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> subject.handleTxBody(state, null)).isInstanceOf(NullPointerException.class);
@@ -130,5 +135,24 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
 
         // then
         verify(configProvider).update(FILE_BYTES);
+    }
+
+    @Test
+    void exchangeRateManagerUpdatedOnFileUpdate() {
+        // given
+        final var configuration = configProvider.getConfiguration();
+        final var config = configuration.getConfigData(FilesConfig.class);
+
+        final var fileNum = config.exchangeRates();
+        final var fileID = FileID.newBuilder().fileNum(fileNum).build();
+        final var txBody = TransactionBody.newBuilder()
+                .fileAppend(FileAppendTransactionBody.newBuilder().fileID(fileID));
+        files.put(fileID, File.newBuilder().contents(FILE_BYTES).build());
+
+        // when
+        subject.handleTxBody(state, txBody.build());
+
+        // then
+        verify(exchangeRateManager, times(1)).update(SystemFileUpdateFacility.getFileContent(state, fileID));
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
@@ -94,7 +94,8 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
         final var txBody = simpleCryptoTransfer().body();
 
         // then
-        assertThatThrownBy(() -> new SystemFileUpdateFacility(null, null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SystemFileUpdateFacility(null, null, null))
+                .isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> subject.handleTxBody(null, txBody)).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> subject.handleTxBody(state, null)).isInstanceOf(NullPointerException.class);
@@ -169,7 +170,7 @@ class SystemFileUpdateFacilityTest implements TransactionFactory {
         final var fileNum = config.exchangeRates();
         final var fileID = FileID.newBuilder().fileNum(fileNum).build();
         final var txBody = TransactionBody.newBuilder()
-            .fileAppend(FileAppendTransactionBody.newBuilder().fileID(fileID));
+                .fileAppend(FileAppendTransactionBody.newBuilder().fileID(fileID));
         files.put(fileID, File.newBuilder().contents(FILE_BYTES).build());
 
         // when


### PR DESCRIPTION
**Description**:
Calling the ExchangeRateManager.update method from SystemFileUpdateFacility

Additional: fixing two comments from https://github.com/hashgraph/hedera-services/pull/8072:
- https://github.com/hashgraph/hedera-services/pull/8072#discussion_r1301615877
- https://github.com/hashgraph/hedera-services/pull/8072#discussion_r1301621458

**Note:** The sonar coverage is so low because of the changes in Hedera.java class. Currently, there are no tests written for that and it will be very time-consuming if I start writing them from the beginning(I'm guessing we have future stories for that). I've marked what needs to be tested in HederaTest

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/8120

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
