### PR TITLE
Update network details dashboard to map all values for platform status

### DIFF
--- a/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/network-details-prom.json
+++ b/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/network-details-prom.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 36,
+  "id": 63,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -51,20 +51,40 @@
                   "index": 1,
                   "text": "ACTIVE"
                 },
-                "3": {
-                  "color": "orange",
-                  "index": 2,
-                  "text": "DISCONNECTED"
-                },
                 "4": {
                   "color": "yellow",
-                  "index": 3,
+                  "index": 2,
                   "text": "BEHIND"
                 },
                 "5": {
                   "color": "purple",
+                  "index": 3,
+                  "text": "FREEZING"
+                },
+                "6": {
+                  "color": "yellow",
                   "index": 4,
-                  "text": "MAINTENANCE"
+                  "text": "FREEZE COMPLETE"
+                },
+                "7": {
+                  "color": "yellow",
+                  "index": 5,
+                  "text": "OBSERVING"
+                },
+                "9": {
+                  "color": "yellow",
+                  "index": 6,
+                  "text": "CHECKING"
+                },
+                "10": {
+                  "color": "yellow",
+                  "index": 7,
+                  "text": "RECONNECT COMPLETE"
+                },
+                "11": {
+                  "color": "dark-red",
+                  "index": 8,
+                  "text": "CATASTROPHIC FAILURE"
                 }
               },
               "type": "value"
@@ -74,7 +94,7 @@
                 "match": "null+nan",
                 "result": {
                   "color": "yellow",
-                  "index": 5,
+                  "index": 9,
                   "text": "UNKNOWN"
                 }
               },
@@ -85,7 +105,7 @@
                 "match": "empty",
                 "result": {
                   "color": "dark-yellow",
-                  "index": 6,
+                  "index": 10,
                   "text": "EMPTY"
                 }
               },
@@ -125,7 +145,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -214,7 +234,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -712,7 +732,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -776,7 +796,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -840,7 +860,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -901,7 +921,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -965,7 +985,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2-67a213dc85",
+      "pluginVersion": "10.2.0-59542pre",
       "targets": [
         {
           "datasource": {
@@ -1640,8 +1660,8 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 37,
+  "refresh": "",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/network-details-prom.json
+++ b/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/network-details-prom.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 63,
+  "id": 66,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -62,22 +62,22 @@
                   "text": "FREEZING"
                 },
                 "6": {
-                  "color": "yellow",
+                  "color": "dark-purple",
                   "index": 4,
                   "text": "FREEZE COMPLETE"
                 },
                 "7": {
-                  "color": "yellow",
+                  "color": "blue",
                   "index": 5,
                   "text": "OBSERVING"
                 },
                 "9": {
-                  "color": "yellow",
+                  "color": "dark-blue",
                   "index": 6,
                   "text": "CHECKING"
                 },
                 "10": {
-                  "color": "yellow",
+                  "color": "dark-green",
                   "index": 7,
                   "text": "RECONNECT COMPLETE"
                 },
@@ -93,7 +93,7 @@
               "options": {
                 "match": "null+nan",
                 "result": {
-                  "color": "yellow",
+                  "color": "orange",
                   "index": 9,
                   "text": "UNKNOWN"
                 }
@@ -104,7 +104,7 @@
               "options": {
                 "match": "empty",
                 "result": {
-                  "color": "dark-yellow",
+                  "color": "dark-orange",
                   "index": 10,
                   "text": "EMPTY"
                 }


### PR DESCRIPTION
This PR updates the network details dashboard to add all platform statuses as defined in https://github.com/hashgraph/hedera-services/blob/develop/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/status/PlatformStatus.java

Previously the dashboard only covered statuses 1-5, and not any of the new statuses added in the last couple months.

![Screenshot 2023-08-22 at 13 48 52](https://github.com/hashgraph/hedera-services/assets/294617/a642d7d5-f07f-4b71-b895-347e16d21249)
