### PR TITLE
6475: com.swirlds.merkledb.files.DataFileCollectionTest test flake

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -39,7 +39,6 @@ import com.swirlds.merkledb.collections.LongListHeap;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -394,7 +393,7 @@ class DataFileCollectionTest {
                             assertNotNull(dataItem, "DataItem should never be null");
                         }
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        fail("Exception should not be thrown", e);
                     }
                 }
             } else if (thread < (NUM_OF_THREADS - 1)) { // check reading item at index 100 as fast as
@@ -405,11 +404,8 @@ class DataFileCollectionTest {
                     try {
                         final long[] dataItem = fileCollection.readDataItemUsingIndex(storedOffsets, 100);
                         assertNotNull(dataItem, "DataItem should never be null");
-                    } catch (ClosedChannelException e) {
-                        e.printStackTrace();
-                        fail("Exception should not be thrown");
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        fail("Exception should not be thrown", e);
                     }
                 }
             } else if (thread == (NUM_OF_THREADS - 1)) { // move thread
@@ -461,16 +457,15 @@ class DataFileCollectionTest {
                                     DataFileCommon.fileIndexFromDataLocation(location),
                                     "Expect all data to be" + " correct"));
                     System.out.println("============= CHECK DONE ===========================");
+                    final KeyRange validKeyRange = fileCollection.getValidKeyRange();
+                    assertEquals(new KeyRange(0, NUM_OF_KEYS), validKeyRange, "Should still have values");
+                    mergeComplete.set(true);
+                    // all files should have been merged into 1.
+                    assertNotNull(mergedFiles, "null merged files list");
+                    assertEquals(1, mergedFiles.size(), "unexpected # of post-merge files");
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    fail("Exception should not be thrown");
+                    fail("Exception should not be thrown", e);
                 }
-                final KeyRange validKeyRange = fileCollection.getValidKeyRange();
-                assertEquals(new KeyRange(0, NUM_OF_KEYS), validKeyRange, "Should still have values");
-                mergeComplete.set(true);
-                // all files should have been merged into 1.
-                assertNotNull(mergedFiles, "null merged files list");
-                assertEquals(1, mergedFiles.size(), "unexpected # of post-merge files");
             }
         });
         // check we only have 1 file left


### PR DESCRIPTION
I still can't reproduce the exception from the bug description. So this PR is to improve exception reporting in the test, so if it fails next time, a good stack trace is available for further investigation.

Fixes: https://github.com/hashgraph/hedera-services/issues/6475
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
