### PR TITLE
Implement frontend throttle

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/MonoThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/MonoThrottleAccumulator.java
@@ -21,6 +21,7 @@ import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.ThrottleDefinitions;
 import com.hedera.node.app.service.mono.pbj.PbjConverter;
 import com.hedera.node.app.service.mono.throttling.FunctionalityThrottling;
 import com.hedera.node.app.service.mono.throttling.annotations.HapiThrottle;
@@ -38,11 +39,16 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class MonoThrottleAccumulator implements ThrottleAccumulator {
+
     private final FunctionalityThrottling hapiThrottling;
 
     @Inject
-    public MonoThrottleAccumulator(@HapiThrottle final FunctionalityThrottling hapiThrottling) {
+    public MonoThrottleAccumulator(
+            @HapiThrottle final FunctionalityThrottling hapiThrottling, ThrottleManager throttleManager) {
         this.hapiThrottling = hapiThrottling;
+
+        // adding the throttle definition configuration
+        this.hapiThrottling.rebuildFor(ThrottleDefinitions.fromProto(throttleManager.throttleDefinitionsProto()));
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleManager.java
@@ -36,6 +36,7 @@ public class ThrottleManager {
     private static final ThrottleDefinitions DEFAULT_THROTTLE_DEFINITIONS = ThrottleDefinitions.DEFAULT;
 
     private ThrottleDefinitions throttleDefinitions;
+    private com.hederahashgraph.api.proto.java.ThrottleDefinitions throttleDefinitionsProto;
     private List<ThrottleBucket> throttleBuckets;
 
     public ThrottleManager() {
@@ -53,6 +54,8 @@ public class ThrottleManager {
         // Parse the throttle file. If we cannot parse it, we just continue with whatever our previous rate was.
         try {
             throttleDefinitions = ThrottleDefinitions.PROTOBUF.parse(bytes.toReadableSequentialData());
+            throttleDefinitionsProto =
+                    com.hederahashgraph.api.proto.java.ThrottleDefinitions.parseFrom(bytes.toByteArray());
         } catch (final Exception e) {
             // Not being able to parse the throttle file is not fatal, and may happen if the throttle file
             // was too big for a single file update for example.
@@ -84,5 +87,9 @@ public class ThrottleManager {
     @NonNull
     public ThrottleDefinitions throttleDefinitions() {
         return throttleDefinitions;
+    }
+
+    public com.hederahashgraph.api.proto.java.ThrottleDefinitions throttleDefinitionsProto() {
+        return throttleDefinitionsProto;
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/MonoThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/MonoThrottleAccumulatorTest.java
@@ -59,26 +59,26 @@ class MonoThrottleAccumulatorTest {
     private ThrottleManager throttleManager;
 
     ThrottleGroup throttleGroup = ThrottleGroup.newBuilder()
-        .operations(List.of(HederaFunctionality.CRYPTO_CREATE, HederaFunctionality.FREEZE))
-        .milliOpsPerSec(100)
-        .build();
+            .operations(List.of(HederaFunctionality.CRYPTO_CREATE, HederaFunctionality.FREEZE))
+            .milliOpsPerSec(100)
+            .build();
 
     ThrottleBucket throttleBucket = ThrottleBucket.newBuilder()
-        .name("throttle1")
-        .burstPeriodMs(100L)
-        .throttleGroups(throttleGroup)
-        .build();
+            .name("throttle1")
+            .burstPeriodMs(100L)
+            .throttleGroups(throttleGroup)
+            .build();
 
     ThrottleDefinitions throttleDefinitions = com.hedera.hapi.node.transaction.ThrottleDefinitions.newBuilder()
-        .throttleBuckets(throttleBucket)
-        .build();
+            .throttleBuckets(throttleBucket)
+            .build();
     Bytes throttleDefinitionsByes =
-        com.hedera.hapi.node.transaction.ThrottleDefinitions.PROTOBUF.toBytes(throttleDefinitions);
+            com.hedera.hapi.node.transaction.ThrottleDefinitions.PROTOBUF.toBytes(throttleDefinitions);
 
     @BeforeEach
     void setUp() throws InvalidProtocolBufferException {
         com.hederahashgraph.api.proto.java.ThrottleDefinitions throttleDefinitionsProto =
-            com.hederahashgraph.api.proto.java.ThrottleDefinitions.parseFrom(throttleDefinitionsByes.toByteArray());
+                com.hederahashgraph.api.proto.java.ThrottleDefinitions.parseFrom(throttleDefinitionsByes.toByteArray());
         when(throttleManager.throttleDefinitionsProto()).thenReturn(throttleDefinitionsProto);
 
         subject = new MonoThrottleAccumulator(hapiThrottling, throttleManager);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/MonoThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/MonoThrottleAccumulatorTest.java
@@ -18,19 +18,28 @@ package com.hedera.node.app.throttle;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_TRANSFER;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.ThrottleBucket;
+import com.hedera.hapi.node.transaction.ThrottleDefinitions;
+import com.hedera.hapi.node.transaction.ThrottleGroup;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.mono.throttling.FunctionalityThrottling;
 import com.hedera.node.app.service.mono.utils.accessors.TxnAccessor;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,28 +49,58 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MonoThrottleAccumulatorTest {
+
     @Mock
     private FunctionalityThrottling hapiThrottling;
 
     private MonoThrottleAccumulator subject;
 
+    @Mock
+    private ThrottleManager throttleManager;
+
+    ThrottleGroup throttleGroup = ThrottleGroup.newBuilder()
+        .operations(List.of(HederaFunctionality.CRYPTO_CREATE, HederaFunctionality.FREEZE))
+        .milliOpsPerSec(100)
+        .build();
+
+    ThrottleBucket throttleBucket = ThrottleBucket.newBuilder()
+        .name("throttle1")
+        .burstPeriodMs(100L)
+        .throttleGroups(throttleGroup)
+        .build();
+
+    ThrottleDefinitions throttleDefinitions = com.hedera.hapi.node.transaction.ThrottleDefinitions.newBuilder()
+        .throttleBuckets(throttleBucket)
+        .build();
+    Bytes throttleDefinitionsByes =
+        com.hedera.hapi.node.transaction.ThrottleDefinitions.PROTOBUF.toBytes(throttleDefinitions);
+
     @BeforeEach
-    void setUp() {
-        subject = new MonoThrottleAccumulator(hapiThrottling);
+    void setUp() throws InvalidProtocolBufferException {
+        com.hederahashgraph.api.proto.java.ThrottleDefinitions throttleDefinitionsProto =
+            com.hederahashgraph.api.proto.java.ThrottleDefinitions.parseFrom(throttleDefinitionsByes.toByteArray());
+        when(throttleManager.throttleDefinitionsProto()).thenReturn(throttleDefinitionsProto);
+
+        subject = new MonoThrottleAccumulator(hapiThrottling, throttleManager);
+    }
+
+    @Test
+    void verifyTheConstructorIsConfiguringTheThrottleDefinitions() {
+        verify(throttleManager, times(1)).throttleDefinitionsProto();
+        verify(hapiThrottling, times(1)).rebuildFor(any());
     }
 
     @Test
     void delegatesToMonoThrottlingForTransactions() {
         final ArgumentCaptor<TxnAccessor> captor = ArgumentCaptor.forClass(TxnAccessor.class);
 
-        final var txnFunction = CRYPTO_TRANSFER;
         given(hapiThrottling.shouldThrottleTxn(any())).willReturn(true);
 
         assertTrue(subject.shouldThrottle(TRANSACTION_BODY));
 
         verify(hapiThrottling).shouldThrottleTxn(captor.capture());
         final var throttledFunction = captor.getValue().getFunction();
-        assertEquals(fromPbj(txnFunction), throttledFunction);
+        assertEquals(fromPbj(CRYPTO_TRANSFER), throttledFunction);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
We have the modularization FE throttling implementation in place. Currently, it's deligating to the mono implementation(I'm guessing this will change in the future). The only thing that's left, as far as I can see, is to make it use the throttle definition file configuration implemented here https://github.com/hashgraph/hedera-services/pull/8072.

We do have throttle suite tests but they are failing. As far as I can see they are failing due to not related errors(I'm guessing errors related to the modularization efforts).

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/7961

**Notes for reviewer**:
- In `ThrottleManager` we are exposing the proto object
- In `MonoThrottleAccumulator` we are getting the throttle definitions from the `ThrottleManager` and we are using the `hapiThrottling.rebuildFor` method to configure the throttle definitions

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
