### PR TITLE
08103 Changed the way ClosedByInterruptException handled in DataFileCollection

### DIFF
--- a/platform-sdk/settings.gradle.kts
+++ b/platform-sdk/settings.gradle.kts
@@ -253,7 +253,7 @@ dependencyResolutionManagement {
             // List of bundles provided for us. When applicable, favor using these over individual
             // libraries.
             bundle("junit", listOf("junit-jupiter", "junit-jupiter-api", "junit-jupiter-params"))
-            bundle("mocking", listOf("mockito-core", "mockito-junit"))
+            bundle("mocking", listOf("mockito-core", "mockito-junit", "mockito-inline"))
             bundle("utils", listOf("awaitility", "assertj-core", "truth"))
 
             // Define the individual libraries
@@ -267,6 +267,8 @@ dependencyResolutionManagement {
 
             // Mocking Bundle
             library("mockito-core", "org.mockito", "mockito-core").versionRef("mockito-version")
+            // to enable mocking of final classes
+            library("mockito-inline", "org.mockito", "mockito-inline").versionRef("mockito-version")
             library("mockito-junit", "org.mockito", "mockito-junit-jupiter")
                 .versionRef("mockito-version")
 

--- a/platform-sdk/swirlds-jasperdb/build.gradle.kts
+++ b/platform-sdk/swirlds-jasperdb/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(testFixtures(project(":swirlds-common")))
     testImplementation(testLibs.bundles.junit)
     testImplementation(testLibs.bundles.mocking)
+    // to enable mocking of final classes
     testImplementation(testFixtures(project(":swirlds-config-api")))
     testImplementation(libs.log4j.core)
 }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -1418,7 +1418,7 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
             logger.info(MERKLE_DB.getMarker(), "[{}] Finished compaction", tableName);
             return true;
         } catch (final InterruptedException | ClosedByInterruptException e) {
-            logger.info(MERKLE_DB.getMarker(), "Interrupted while merging, this is allowed.");
+            logger.info(MERKLE_DB.getMarker(), "Interrupted while merging, this is allowed.", e);
             Thread.currentThread().interrupt();
             return false;
         } catch (final Throwable e) {

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -37,6 +37,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -447,6 +448,14 @@ public class DataFileCollection<D> implements Snapshotable {
                             serializationVersion, reader.readDataItemBytes(fileOffset));
                     // update the index
                     index.putIfEqual(path, dataLocation, newLocation);
+                } catch (final ClosedByInterruptException e) {
+                    logger.info(
+                            EXCEPTION.getMarker(),
+                            "Failed to copy data item {} / {} due to thread interruption",
+                            fileIndex,
+                            fileOffset,
+                            e);
+                    throw e;
                 } catch (final IOException z) {
                     logger.error(EXCEPTION.getMarker(), "Failed to copy data item {} / {}", fileIndex, fileOffset, z);
                     throw z;

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -450,7 +450,7 @@ public class DataFileCollection<D> implements Snapshotable {
                     index.putIfEqual(path, dataLocation, newLocation);
                 } catch (final ClosedByInterruptException e) {
                     logger.info(
-                            EXCEPTION.getMarker(),
+                            MERKLE_DB.getMarker(),
                             "Failed to copy data item {} / {} due to thread interruption",
                             fileIndex,
                             fileOffset,

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.merkledb.files;
 
+import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyTrue;
 import static com.swirlds.merkledb.MerkleDbTestUtils.checkDirectMemoryIsCleanedUpToLessThanBaseUsage;
 import static com.swirlds.merkledb.MerkleDbTestUtils.getDirectMemoryUsedBytes;
 import static com.swirlds.merkledb.files.DataFileCommon.FOOTER_SIZE;
@@ -29,7 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
+import com.swirlds.common.test.logging.MockAppender;
 import com.swirlds.common.units.UnitConstants;
 import com.swirlds.merkledb.KeyRange;
 import com.swirlds.merkledb.collections.CASableLongIndex;
@@ -42,7 +46,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,6 +59,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -62,6 +70,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
 
 @SuppressWarnings("SameParameterValue")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -653,27 +662,7 @@ class DataFileCollectionTest {
         final LongListHeap storedOffsets = new LongListHeap(5000);
         storedOffsetsMap.put(testType, storedOffsets);
         // create 10x 100 item files
-        int count = 0;
-        for (int f = 0; f < 10; f++) {
-            fileCollection.startWriting();
-            // put in 1000 items
-            for (int i = count; i < count + 100; i++) {
-                long[] dataValue;
-                switch (testType) {
-                    default:
-                    case fixed:
-                        dataValue = new long[] {i, i + 10_000};
-                        break;
-                    case variable:
-                        dataValue = getVariableSizeDataForI(i, 10_000);
-                        break;
-                }
-                // store in file
-                storedOffsets.put(i, fileCollection.storeDataItem(dataValue));
-            }
-            fileCollection.endWriting(0, count + 100).setFileCompleted();
-            count += 100;
-        }
+        populateDataFileCollection(testType, fileCollection, storedOffsets);
         // check 10 files were created and data is correct
         assertEquals(
                 10,
@@ -711,6 +700,108 @@ class DataFileCollectionTest {
         checkData(testType, 0, 1000, 10_000);
         // close db
         fileCollection2.close();
+    }
+
+    private static void populateDataFileCollection(
+            FilesTestType testType, DataFileCollection<long[]> fileCollection, LongListHeap storedOffsets)
+            throws IOException {
+        int count = 0;
+        for (int f = 0; f < 10; f++) {
+            fileCollection.startWriting();
+            // put in 1000 items
+            for (int i = count; i < count + 100; i++) {
+                long[] dataValue;
+                switch (testType) {
+                    default:
+                    case fixed:
+                        dataValue = new long[] {i, i + 10_000};
+                        break;
+                    case variable:
+                        dataValue = getVariableSizeDataForI(i, 10_000);
+                        break;
+                }
+                // store in file
+                storedOffsets.put(i, fileCollection.storeDataItem(dataValue));
+            }
+            fileCollection.endWriting(0, count + 100).setFileCompleted();
+            count += 100;
+        }
+    }
+
+    /**
+     * This test emulates scenario in which compaction is interrupted by thread interruption. This event shouldn't be
+     * reported as an error in the logs.
+     */
+    @Test
+    public void testClosedByInterruptException() throws IOException {
+        // mock appender to capture the log statements
+        final MockAppender mockAppender = new MockAppender("testClosedByInterruptException");
+        Logger logger = (Logger) LogManager.getLogger(DataFileCollection.class);
+        mockAppender.start();
+        logger.addAppender(mockAppender);
+        final Path dbDir = tempFileDir.resolve("testClosedByInterruptException");
+        final String storeName = "testClosedByInterruptException";
+
+        // init file collection with some content to compact
+        final DataFileCollection<long[]> fileCollection =
+                new DataFileCollection<>(dbDir, storeName, FilesTestType.fixed.dataItemSerializer, null);
+        final LongListHeap storedOffsets = new LongListHeap(5000);
+        populateDataFileCollection(FilesTestType.fixed, fileCollection, storedOffsets);
+
+        // a flag to make sure that `compactFiles` th
+        AtomicBoolean closedByInterruptFromCompaction = new AtomicBoolean(false);
+
+        final Thread thread = new Thread(() -> {
+            List<DataFileReader<long[]>> allCompletedFiles = fileCollection.getAllCompletedFiles();
+            DataFileReader<long[]> spy = Mockito.spy(allCompletedFiles.get(0));
+            try {
+                AtomicInteger count = new AtomicInteger(0);
+                when(spy.getMetadata()).thenAnswer(invocation -> {
+                    // on the second call to getMetadata, we interrupt the thread
+                    if (count.getAndIncrement() == 1) {
+                        Thread.currentThread().interrupt();
+                    }
+
+                    return invocation.callRealMethod();
+                });
+
+                List<DataFileReader<long[]>> allCompletedFilesUpdated = new ArrayList<>(allCompletedFiles);
+                allCompletedFilesUpdated.set(0, spy);
+                fileCollection.compactFiles(storedOffsets, allCompletedFilesUpdated);
+            } catch (InterruptedException e) {
+                // we expect interrupted exception here
+                closedByInterruptFromCompaction.set(true);
+            } catch (IOException e) {
+                fail("Exception should not be thrown");
+            }
+            reset(spy);
+        });
+        thread.start();
+        try {
+            assertEventuallyTrue(
+                    () -> {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        if (!closedByInterruptFromCompaction.get()) {
+                            return false;
+                        }
+
+                        if (mockAppender.size() == 0) {
+                            return false;
+                        }
+                        assertEquals(
+                                "INFO - Failed to copy data item 0 / 0 due to thread interruption",
+                                mockAppender.get(0));
+                        return true;
+                    },
+                    Duration.ofMillis(5000),
+                    "Compaction should not throw exception when interrupted");
+        } finally {
+            mockAppender.stop();
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -780,11 +780,6 @@ class DataFileCollectionTest {
         try {
             assertEventuallyTrue(
                     () -> {
-                        try {
-                            Thread.sleep(100);
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
                         if (!closedByInterruptFromCompaction.get()) {
                             return false;
                         }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -788,7 +788,7 @@ class DataFileCollectionTest {
                             return false;
                         }
                         assertEquals(
-                                "INFO - Failed to copy data item 0 / 0 due to thread interruption",
+                                "MERKLE_DB - INFO - Failed to copy data item 0 / 0 due to thread interruption",
                                 mockAppender.get(0));
                         return true;
                     },

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     // These should not be implementation() based deps, but this requires refactoring to eliminate.
     implementation(project(":swirlds-unit-tests:common:swirlds-test-framework"))
     implementation(testFixtures(project(":swirlds-common")))
+    implementation(libs.log4j.core)
 
     testImplementation(libs.bundles.logging.impl)
     testImplementation(testLibs.bundles.junit)

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.test.logging;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+
+/**
+ * This class intended to be used in unit tests to capture log messages. It is thread-safe.
+ * To make it work, add the following to your test:
+ * <pre>{@code
+ *         final MockAppender mockAppender = new MockAppender(<test name>);
+ *         Logger logger = (Logger) LogManager.getLogger(DataFileCollection.class);
+ *         mockAppender.start();
+ *         logger.addAppender(mockAppender);
+ *  } </pre>
+ *  Then call {@code mockAppender.get(<index>)} to get the log message.
+ *  After the test, call {@code mockAppender.stop()} to clean up.
+ *
+ */
+public class MockAppender extends AbstractAppender {
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    public MockAppender(String name) {
+        super("MockAppender-" + name, null, null, true, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (isStarted()) {
+            messages.add(String.format(
+                    "%s - %s", event.getLevel(), event.getMessage().getFormattedMessage()));
+        }
+    }
+
+    public int size() {
+        return messages.size();
+    }
+
+    public void clear() {
+        messages.clear();
+    }
+
+    public String get(int index) {
+        return messages.get(index);
+    }
+
+    @Override
+    public void stop() {
+        messages.clear();
+        super.stop();
+    }
+}

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
@@ -45,7 +45,10 @@ public class MockAppender extends AbstractAppender {
     public void append(LogEvent event) {
         if (isStarted()) {
             messages.add(String.format(
-                    "%s - %s", event.getLevel(), event.getMessage().getFormattedMessage()));
+                    "%s - %s - %s",
+                    event.getMarker().getName(),
+                    event.getLevel(),
+                    event.getMessage().getFormattedMessage()));
         }
     }
 

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.common.test.logging;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.logging.log4j.core.LogEvent;
@@ -37,12 +38,15 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 public class MockAppender extends AbstractAppender {
     private final List<String> messages = new CopyOnWriteArrayList<>();
 
-    public MockAppender(String name) {
+    public MockAppender(@NonNull final String name) {
         super("MockAppender-" + name, null, null, true, null);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void append(LogEvent event) {
+    public void append(@NonNull final LogEvent event) {
         if (isStarted()) {
             messages.add(String.format(
                     "%s - %s - %s",
@@ -52,18 +56,33 @@ public class MockAppender extends AbstractAppender {
         }
     }
 
+    /**
+     * Get the number of captured log messages.
+     * @return the number of captured log messages
+     */
     public int size() {
         return messages.size();
     }
 
+    /**
+     * Clear previously captured the log messages.
+     */
     public void clear() {
         messages.clear();
     }
 
-    public String get(int index) {
+    /**
+     * Get the log message at the specified index.
+     * @param index the index of the message
+     * @return the log message
+     */
+    public String get(final int index) {
         return messages.get(index);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void stop() {
         messages.clear();

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/module-info.java
@@ -18,4 +18,5 @@ open module com.swirlds.common.test {
     requires lazysodium.java;
     requires static com.github.spotbugs.annotations;
     requires com.swirlds.common.test.fixtures;
+    requires org.apache.logging.log4j.core;
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -91,6 +91,7 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("ALL")
 class VirtualMapTests extends VirtualTestBase {
 
+    public static final String ATTACH_LISTENER_THREAD_NAME = "Attach Listener";
     /**
      * Temporary directory provided by JUnit
      */
@@ -152,7 +153,7 @@ class VirtualMapTests extends VirtualTestBase {
         }
 
         for (final String threadName : currentThreadNames) {
-            if (!threadNames.contains(threadName)) {
+            if (!threadNames.contains(threadName) && !threadName.equals(ATTACH_LISTENER_THREAD_NAME)) {
                 createdThreads.add(threadName);
             }
         }


### PR DESCRIPTION
This PR changs the way `ClosedByInterruptException` handled in `DataFileCollection`. It's no longer resulted in a message of `ERROR` level.

To capture log entries for further verification I added `MockAppender` to `swirlds-common-test` module. 


**Related issue(s)**:

Fixes #8103 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
