### PR TITLE
implement one key from keylist is needed in order to delete file, and delete E2E tests

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileDeleteHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileDeleteHandler.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.service.file.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNAUTHORIZED;
 import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.preValidate;
-import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.validateAndAddRequiredKeys;
+import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.validateAndAddRequiredKeysForDelete;
 import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.verifyNotSystemFile;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +69,7 @@ public class FileDeleteHandler implements TransactionHandler {
         preValidate(transactionFileId, fileStore, context, true);
 
         var file = fileStore.getFileLeaf(transactionFileId);
-        validateAndAddRequiredKeys(file, null, context);
+        validateAndAddRequiredKeysForDelete(file, context);
     }
 
     @Override

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
@@ -128,29 +128,21 @@ public class FileServiceUtils {
     /**
      * The function is unique for File delete Pre-handle validates the keys.
      * Then it wraps the file Keylist into thresholds adds them to the context.
-     * In addition, it add the transaction keys to the context.
      *
      * @param file file that will be checked for required keys
-     * @param transactionKeys transaction keys that add to context for required keys.
      * @param context the prehandle context for the transaction.
      */
     public static void validateAndAddRequiredKeysForDelete(
-            @Nullable final File file,
-            @Nullable final KeyList transactionKeys,
-            @NonNull final PreHandleContext context) {
+            @Nullable final File file, @NonNull final PreHandleContext context) {
         if (file != null) {
             KeyList fileKeyList = file.keys();
 
             if (fileKeyList != null && fileKeyList.hasKeys()) {
+                // this threshold created to solve the issue of the file delete that can be deleted using one of the
+                // keys in the keylist that's why it is wrapped in threshold key with threshold 1
                 ThresholdKey syntheticKey =
                         ThresholdKey.newBuilder().threshold(1).keys(fileKeyList).build();
                 context.requireKey(Key.newBuilder().thresholdKey(syntheticKey).build());
-            }
-        }
-
-        if (transactionKeys != null && transactionKeys.hasKeys()) {
-            for (final Key key : transactionKeys.keys()) {
-                context.requireKey(key);
             }
         }
     }

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
@@ -28,6 +28,7 @@ import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.ThresholdKey;
 import com.hedera.hapi.node.state.file.File;
 import com.hedera.node.app.service.file.FileMetadata;
 import com.hedera.node.app.service.file.ReadableFileStore;
@@ -114,6 +115,34 @@ public class FileServiceUtils {
                 for (final Key key : fileKeyList.keys()) {
                     context.requireKey(key);
                 }
+            }
+        }
+
+        if (transactionKeys != null && transactionKeys.hasKeys()) {
+            for (final Key key : transactionKeys.keys()) {
+                context.requireKey(key);
+            }
+        }
+    }
+
+    /**
+     * The function validates the keys and adds them to the context.
+     *
+     * @param file file that will be checked for required keys
+     * @param transactionKeys transaction keys that add to context for required keys.
+     * @param context the prehandle context for the transaction.
+     */
+    public static void validateAndAddRequiredKeysForDelete(
+            @Nullable final File file,
+            @Nullable final KeyList transactionKeys,
+            @NonNull final PreHandleContext context) {
+        if (file != null) {
+            KeyList fileKeyList = file.keys();
+
+            if (fileKeyList != null && fileKeyList.hasKeys()) {
+                ThresholdKey syntheticKey =
+                        ThresholdKey.newBuilder().threshold(1).keys(fileKeyList).build();
+                context.requireKey(Key.newBuilder().thresholdKey(syntheticKey).build());
             }
         }
 

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
@@ -126,7 +126,9 @@ public class FileServiceUtils {
     }
 
     /**
-     * The function validates the keys and adds them to the context.
+     * The function is unique for File delete Pre-handle validates the keys.
+     * Then it wraps the file Keylist into thresholds adds them to the context.
+     * In addition, it add the transaction keys to the context.
      *
      * @param file file that will be checked for required keys
      * @param transactionKeys transaction keys that add to context for required keys.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
@@ -159,6 +159,13 @@ class FileDeleteTest extends FileTestBase {
 
         assertTrue(realPreContext.requiredNonPayerKeys().size() > 0);
         assertEquals(1, realPreContext.requiredNonPayerKeys().size());
+        assertEquals(
+                1,
+                realPreContext
+                        .requiredNonPayerKeys()
+                        .toArray(Key[]::new)[0]
+                        .thresholdKey()
+                        .threshold());
     }
 
     @Test

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
@@ -158,7 +158,7 @@ class FileDeleteTest extends FileTestBase {
         subject.preHandle(realPreContext);
 
         assertTrue(realPreContext.requiredNonPayerKeys().size() > 0);
-        assertEquals(3, realPreContext.requiredNonPayerKeys().size());
+        assertEquals(1, realPreContext.requiredNonPayerKeys().size());
     }
 
     @Test

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.file.impl.test.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
 import static com.hedera.test.utils.KeyUtils.A_COMPLEX_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -157,15 +158,13 @@ class FileDeleteTest extends FileTestBase {
 
         subject.preHandle(realPreContext);
 
-        assertTrue(realPreContext.requiredNonPayerKeys().size() > 0);
-        assertEquals(1, realPreContext.requiredNonPayerKeys().size());
-        assertEquals(
-                1,
-                realPreContext
-                        .requiredNonPayerKeys()
-                        .toArray(Key[]::new)[0]
-                        .thresholdKey()
-                        .threshold());
+        assertThat(realPreContext.requiredNonPayerKeys().size()).isGreaterThan(0);
+        assertThat(1).isEqualTo(realPreContext.requiredNonPayerKeys().size());
+        assertThat(1).isEqualTo(realPreContext
+                .requiredNonPayerKeys()
+                .toArray(Key[]::new)[0]
+                .thresholdKey()
+                .threshold());
     }
 
     @Test

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
@@ -160,11 +160,12 @@ class FileDeleteTest extends FileTestBase {
 
         assertThat(realPreContext.requiredNonPayerKeys().size()).isGreaterThan(0);
         assertThat(1).isEqualTo(realPreContext.requiredNonPayerKeys().size());
-        assertThat(1).isEqualTo(realPreContext
-                .requiredNonPayerKeys()
-                .toArray(Key[]::new)[0]
-                .thresholdKey()
-                .threshold());
+        assertThat(1)
+                .isEqualTo(realPreContext
+                        .requiredNonPayerKeys()
+                        .toArray(Key[]::new)[0]
+                        .thresholdKey()
+                        .threshold());
     }
 
     @Test

--- a/hedera-node/test-clients/src/eet/java/EndToEndTests.java
+++ b/hedera-node/test-clients/src/eet/java/EndToEndTests.java
@@ -17,8 +17,12 @@
 import com.hedera.services.bdd.suites.autorenew.GracePeriodRestrictionsSuite;
 import com.hedera.services.bdd.suites.fees.CongestionPricingSuite;
 import com.hedera.services.bdd.suites.file.ExchangeRateControlSuite;
+import com.hedera.services.bdd.suites.file.FileAppendSuite;
+import com.hedera.services.bdd.suites.file.FileCreateSuite;
+import com.hedera.services.bdd.suites.file.FileDeleteSuite;
 import com.hedera.services.bdd.suites.file.FileUpdateSuite;
 import com.hedera.services.bdd.suites.file.ProtectedFilesUpdateSuite;
+import com.hedera.services.bdd.suites.file.negative.QueryFailuresSpec;
 import com.hedera.services.bdd.suites.leaky.FeatureFlagSuite;
 import com.hedera.services.bdd.suites.records.ContractRecordsSanityCheckSuite;
 import com.hedera.services.bdd.suites.records.CryptoRecordsSanityCheckSuite;
@@ -65,9 +69,9 @@ class EndToEndTests extends E2ETestBase {
                 //				extractSpecsFromSuite(DiverseStateValidation::new),
                 extractSpecsFromSuite(ExchangeRateControlSuite::new),
                 //              extractSpecsFromSuite(FetchSystemFiles::new),
-                //              extractSpecsFromSuite(FileAppendSuite::new),
-                //              extractSpecsFromSuite(FileCreateSuite::new),
-                //				extractSpecsFromSuite(FileDeleteSuite::new),
+                extractSpecsFromSuite(FileAppendSuite::new),
+                extractSpecsFromSuite(FileCreateSuite::new),
+                extractSpecsFromSuite(FileDeleteSuite::new),
                 extractSpecsFromSuite(FileUpdateSuite::new),
                 //              extractSpecsFromSuite(PermissionSemanticsSpec::new),
                 extractSpecsFromSuite(ProtectedFilesUpdateSuite::new)
@@ -260,7 +264,7 @@ class EndToEndTests extends E2ETestBase {
                 //				extractSpecsFromSuite(AppendFailuresSpec::new),
                 //				extractSpecsFromSuite(CreateFailuresSpec::new),
                 //				extractSpecsFromSuite(DeleteFailuresSpec::new),
-                //              extractSpecsFromSuite(QueryFailuresSpec::new),
+                extractSpecsFromSuite(QueryFailuresSpec::new)
                 //              extractSpecsFromSuite(UpdateFailuresSpec::new)
                 );
     }

--- a/hedera-node/test-clients/src/eet/java/EndToEndTests.java
+++ b/hedera-node/test-clients/src/eet/java/EndToEndTests.java
@@ -17,12 +17,8 @@
 import com.hedera.services.bdd.suites.autorenew.GracePeriodRestrictionsSuite;
 import com.hedera.services.bdd.suites.fees.CongestionPricingSuite;
 import com.hedera.services.bdd.suites.file.ExchangeRateControlSuite;
-import com.hedera.services.bdd.suites.file.FileAppendSuite;
-import com.hedera.services.bdd.suites.file.FileCreateSuite;
-import com.hedera.services.bdd.suites.file.FileDeleteSuite;
 import com.hedera.services.bdd.suites.file.FileUpdateSuite;
 import com.hedera.services.bdd.suites.file.ProtectedFilesUpdateSuite;
-import com.hedera.services.bdd.suites.file.negative.QueryFailuresSpec;
 import com.hedera.services.bdd.suites.leaky.FeatureFlagSuite;
 import com.hedera.services.bdd.suites.records.ContractRecordsSanityCheckSuite;
 import com.hedera.services.bdd.suites.records.CryptoRecordsSanityCheckSuite;
@@ -69,9 +65,9 @@ class EndToEndTests extends E2ETestBase {
                 //				extractSpecsFromSuite(DiverseStateValidation::new),
                 extractSpecsFromSuite(ExchangeRateControlSuite::new),
                 //              extractSpecsFromSuite(FetchSystemFiles::new),
-                extractSpecsFromSuite(FileAppendSuite::new),
-                extractSpecsFromSuite(FileCreateSuite::new),
-                extractSpecsFromSuite(FileDeleteSuite::new),
+                //              extractSpecsFromSuite(FileAppendSuite::new),
+                //              extractSpecsFromSuite(FileCreateSuite::new),
+                //				extractSpecsFromSuite(FileDeleteSuite::new),
                 extractSpecsFromSuite(FileUpdateSuite::new),
                 //              extractSpecsFromSuite(PermissionSemanticsSpec::new),
                 extractSpecsFromSuite(ProtectedFilesUpdateSuite::new)
@@ -264,7 +260,7 @@ class EndToEndTests extends E2ETestBase {
                 //				extractSpecsFromSuite(AppendFailuresSpec::new),
                 //				extractSpecsFromSuite(CreateFailuresSpec::new),
                 //				extractSpecsFromSuite(DeleteFailuresSpec::new),
-                extractSpecsFromSuite(QueryFailuresSpec::new)
+                //              extractSpecsFromSuite(QueryFailuresSpec::new),
                 //              extractSpecsFromSuite(UpdateFailuresSpec::new)
                 );
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileDeleteSuite.java
@@ -16,7 +16,6 @@
 
 package com.hedera.services.bdd.suites.file;
 
-import static com.hedera.services.bdd.spec.HapiSpec.defaultFailingHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
@@ -30,12 +29,12 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileDelete;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.suites.HapiSuite;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,27 +49,21 @@ public class FileDeleteSuite extends HapiSuite {
 
     @Override
     public List<HapiSpec> getSpecsInSuite() {
-        return allOf(positiveTests(), negativeTests());
+        return List.of(getDeletedFileInfo(), canDeleteWithAnyOneOfTopLevelKeyList());
     }
 
-    private List<HapiSpec> positiveTests() {
-        return Arrays.asList(getDeletedFileInfo());
-    }
-
-    private List<HapiSpec> negativeTests() {
-        return Arrays.asList(canDeleteWithAnyOneOfTopLevelKeyList());
-    }
-
+    @HapiTest
     private HapiSpec canDeleteWithAnyOneOfTopLevelKeyList() {
         KeyShape shape = listOf(SIMPLE, threshOf(1, 2), listOf(2));
         SigControl deleteSigs = shape.signedWith(sigs(ON, sigs(OFF, OFF), sigs(ON, OFF)));
 
-        return defaultFailingHapiSpec("CanDeleteWithAnyOneOfTopLevelKeyList")
+        return defaultHapiSpec("CanDeleteWithAnyOneOfTopLevelKeyList")
                 .given(fileCreate("test").waclShape(shape))
                 .when()
                 .then(fileDelete("test").sigControl(forKey("test", deleteSigs)));
     }
 
+    @HapiTest
     private HapiSpec getDeletedFileInfo() {
         return defaultHapiSpec("getDeletedFileInfo")
                 .given(fileCreate("deletedFile").logged())


### PR DESCRIPTION
implement one key from key list is needed in order to delete file using the threshold key, and  make the delete-suite working properly


**Related issue(s)**:

Fixes #8054 
