### PR TITLE
Added key structure summary reports to account and file signed state dumpers

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
@@ -16,22 +16,24 @@
 
 package com.hedera.services.cli.signedstate;
 
+import static com.hedera.services.cli.utils.ThingsToStrings.toStructureSummaryOfJKey;
+import static java.util.function.Predicate.not;
+
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.services.cli.signedstate.DumpStateCommand.Format;
+import com.hedera.services.cli.signedstate.DumpStateCommand.KeyDetails;
 import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
 import com.hedera.services.cli.utils.ThingsToStrings;
+import com.hedera.services.cli.utils.Writer;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Proxy;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +51,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 
 /** Dump all Hedera account objects, from a signed state file, to a text file, in deterministic order.
- * Can output in either CSV format (actually: semicolon-separated) or in a "elided field" format where fields are
+ * Can output in either CSV format (actually: semicolon-separated) or in an "elided field" format where fields are
  * dumped in "name:value" pairs and missing fields or fields with default values are skipped.
  */
 @SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
@@ -60,9 +62,10 @@ public class DumpAccountsSubcommand {
             @NonNull final Path accountPath,
             final int lowLimit,
             final int highLimit,
+            @NonNull final EnumSet<KeyDetails> keyDetails,
             @NonNull final Format format,
             @NonNull final Verbosity verbosity) {
-        new DumpAccountsSubcommand(state, accountPath, lowLimit, highLimit, format, verbosity).doit();
+        new DumpAccountsSubcommand(state, accountPath, lowLimit, highLimit, keyDetails, format, verbosity).doit();
     }
 
     @NonNull
@@ -81,17 +84,22 @@ public class DumpAccountsSubcommand {
 
     final int highLimit;
 
+    @NonNull
+    final EnumSet<KeyDetails> keyDetails;
+
     DumpAccountsSubcommand(
             @NonNull final SignedStateHolder state,
             @NonNull final Path accountPath,
             final int lowLimit,
             final int highLimit,
+            @NonNull final EnumSet<KeyDetails> keyDetails,
             @NonNull final Format format,
             @NonNull final Verbosity verbosity) {
         this.state = state;
         this.accountPath = accountPath;
         this.lowLimit = Math.max(lowLimit, 0);
         this.highLimit = Math.max(highLimit, 0);
+        this.keyDetails = keyDetails;
         this.format = format;
         this.verbosity = verbosity;
     }
@@ -103,36 +111,72 @@ public class DumpAccountsSubcommand {
 
         final var accountsArr = gatherAccounts(accountsStore);
 
-        final var sb = new StringBuilder(1000);
         final var reportSize = new int[1];
-
-        try (final var fileWriter = new FileWriter(accountPath.toFile(), StandardCharsets.UTF_8);
-                final var writer = new BufferedWriter(fileWriter)) {
-
-            if (format == Format.CSV) {
-                writer.write("account#");
-                writer.write(FIELD_SEPARATOR);
-                writer.write(formatCsvHeader(allFieldNamesInOrder()));
-                writer.newLine();
-            }
-
-            Arrays.stream(accountsArr).map(a -> formatAccount(sb, a)).forEachOrdered(s -> {
-                try {
-                    writer.write(s);
-                    writer.newLine();
-                } catch (final IOException ex) {
-                    System.err.printf("Error writing to '%s':%n", accountPath);
-                    throw new UncheckedIOException(ex);
-                }
-                reportSize[0] += s.length() + 1;
-            });
-        } catch (final IOException ex) {
-            System.err.printf("Error creating or closing '%s'%n", accountPath);
-            throw new UncheckedIOException(ex); // CLI program: Java will print the exception + stacktrace
+        try (@NonNull final var writer = new Writer(accountPath)) {
+            reportOnAccounts(writer, accountsArr, reportSize);
+            if (keyDetails.contains(KeyDetails.STRUCTURE) || keyDetails.contains(KeyDetails.STRUCTURE_WITH_IDS))
+                reportOnKeyStructure(writer, accountsArr);
         }
 
         System.out.printf("=== accounts report is %d bytes%n", reportSize[0]);
         System.out.printf("=== fields with exceptions: %s%n", String.join(",", fieldsWithExceptions));
+    }
+
+    void reportOnAccounts(
+            @NonNull final Writer writer, @NonNull final HederaAccount[] accountsArr, @NonNull final int[] reportSize) {
+        if (format == Format.CSV) {
+            writer.write("account#");
+            writer.write(FIELD_SEPARATOR);
+            writer.write(formatCsvHeader(allFieldNamesInOrder()));
+            writer.newLine();
+        }
+
+        final var sb = new StringBuilder();
+        Arrays.stream(accountsArr).map(a -> formatAccount(sb, a)).forEachOrdered(s -> {
+            writer.write(s);
+            writer.newLine();
+            reportSize[0] += s.length() + 1;
+        });
+    }
+
+    void reportOnKeyStructure(@NonNull final Writer writer, @NonNull final HederaAccount[] accountsArr) {
+        final var eoaKeySummary = new HashMap<String, Integer>();
+        accumulateSummaries(not(HederaAccount::isSmartContract), eoaKeySummary, accountsArr);
+        writeKeySummaryReport(writer, "EOA", eoaKeySummary);
+
+        final var scKeySummary = new HashMap<String, Integer>();
+        accumulateSummaries(HederaAccount::isSmartContract, scKeySummary, accountsArr);
+        writeKeySummaryReport(writer, "Smart Contract", scKeySummary);
+    }
+
+    @SuppressWarnings(
+            "java:S135") // Loops should not contain more than a single "break" or "continue" statement - disagree it
+    // would make things clearer here
+    void accumulateSummaries(
+            @NonNull final Predicate<HederaAccount> filter,
+            @NonNull final HashMap<String, Integer> structureSummary,
+            @NonNull final HederaAccount[] accountsArr) {
+        for (@NonNull final var ha : accountsArr) {
+            if (ha.isDeleted()) continue;
+            if (!filter.test(ha)) continue;
+            final var jkey = ha.getAccountKey();
+            final var sb = new StringBuilder();
+            final var b = toStructureSummaryOfJKey(sb, jkey);
+            if (!b) {
+                sb.setLength(0);
+                sb.append("NULL-KEY");
+            }
+            structureSummary.merge(sb.toString(), 1, Integer::sum);
+        }
+    }
+
+    void writeKeySummaryReport(
+            @NonNull final Writer writer, @NonNull final String kind, @NonNull final Map<String, Integer> keySummary) {
+
+        writer.write("=== %s Key Summary ===%n".formatted(kind));
+        keySummary.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEachOrdered(e -> writer.write("%7d: %s%n".formatted(e.getValue(), e.getKey())));
     }
 
     /** Traverses the dehydrated signed state file to pull out all the accounts for later processing.
@@ -337,7 +381,7 @@ public class DumpAccountsSubcommand {
             Pair.of("TSL", coerceMinus1ToBeDefault(HederaAccount::totalStakeAtStartOfLastRewardedPeriod)));
 
     /** Unfortunately this is a hack to handle the two long-valued fields where `-1` is used as the "missing" marker.
-     * Probably all of the primitive-valued fields should be changed to use `Field` descriptors, which would then be
+     * Probably all the primitive-valued fields should be changed to use `Field` descriptors, which would then be
      * enhanced to have a per-field "is default value?" predicate.  But not now.)
      */
     @SuppressWarnings(

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -21,6 +21,7 @@ import com.swirlds.cli.utility.AbstractCommand;
 import com.swirlds.cli.utility.SubcommandOf;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
 import picocli.CommandLine;
@@ -66,8 +67,9 @@ public class DumpStateCommand extends AbstractCommand {
     }
 
     enum KeyDetails {
-        DEEP,
-        SHALLOW
+        STRUCTURE,
+        STRUCTURE_WITH_IDS,
+        NONE
     }
 
     // We want to open the signed state file only once but run a bunch of dumps against it
@@ -162,7 +164,12 @@ public class DumpStateCommand extends AbstractCommand {
                             arity = "0..1",
                             defaultValue = "2147483647",
                             description = "highest account number (inclusive) to dump")
-                    int highLimit) {
+                    int highLimit,
+            @Option(
+                            names = {"--keys"},
+                            arity = "0..*",
+                            description = "How to dump key summaries")
+                    final EnumSet<KeyDetails> keyDetails) {
         Objects.requireNonNull(accountPath);
         if (lowLimit > highLimit)
             throw new CommandLine.ParameterException(
@@ -175,6 +182,7 @@ public class DumpStateCommand extends AbstractCommand {
                 accountPath,
                 lowLimit,
                 highLimit,
+                keyDetails,
                 doCsv ? Format.CSV : Format.ELIDED_DEFAULT_FIELDS,
                 parent.verbosity);
         finish();
@@ -189,10 +197,10 @@ public class DumpStateCommand extends AbstractCommand {
                     @NonNull
                     final Path filesPath,
             @Option(
-                            names = {"--deep-keys"},
-                            arity = "0..1",
-                            description = "Whether to fully dump keys or not")
-                    final boolean doDeepKeys,
+                            names = {"--keys"},
+                            arity = "0..*",
+                            description = "How to dump key summaries")
+                    final EnumSet<KeyDetails> keyDetails,
             @Option(
                             names = {"-s", "--summary"},
                             description = "Emit a summary line")
@@ -203,7 +211,7 @@ public class DumpStateCommand extends AbstractCommand {
         DumpFilesSubcommand.doit(
                 parent.signedState,
                 filesPath,
-                doDeepKeys ? KeyDetails.DEEP : KeyDetails.SHALLOW,
+                keyDetails,
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 parent.verbosity);
         finish();


### PR DESCRIPTION
**Description**:
Added key structure summary reports to account and file signed state dumpers

Displays a histogram showing for each key structure how many {files, accounts} have that structure.

Example output is something like:

```
=== EOA Key Summary ===
 811711: Key[EC]
2155557: Key[ED]
   2511: Key[KL[#1,ED]]
      1: Key[KL[#1,TH[1-of-1,ED]]]
     41: Key[KL[#1,TH[1-of-2,ED,ED]]]
      1: Key[KL[#1,TH[1-of-3,ED,ED,ED]]]
      2: Key[KL[#1,TH[2-of-2,TH[1-of-2,ED,ED],TH[2-of-4,ED,ED,ED,ED]]]]
   1499: Key[KL[#1,TH[2-of-2,TH[1-of-7,ED,ED,ED,ED,ED,ED,ED],TH[3-of-7,ED,ED,ED,ED,ED,ED,ED]]]]
      1: Key[KL[#1,TH[2-of-3,ED,ED,ED]]]
    215: Key[KL[#1,TH[2-of-4,ED,ED,ED,ED]]]
    490: Key[KL[#1,TH[3-of-5,ED,ED,ED,ED,ED]]]
```

**Related issue(s)**:

Fixes #8227 

**Notes for reviewer**:

Use `--keys=STRUCTURE` with both file+account dumper, and/or `--keys=STRUCTURE_WITH_IDS` for the file dumper.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
