### PR TITLE
Dump unique NFTs from a signed state file

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -225,13 +225,13 @@ public class DumpStateCommand extends AbstractCommand {
     }
 
     @Command(name = "tokens", description = "Dump fungible token types")
-    void fungible(
+    void tokens(
             @Option(
                             names = {"--token"},
                             arity = "1",
                             description = "Output file for fungibles dump")
                     @NonNull
-                    Path tokensPath,
+                    final Path tokensPath,
             @Option(
                             names = {"--keys"},
                             arity = "0..*",
@@ -256,6 +256,26 @@ public class DumpStateCommand extends AbstractCommand {
                 doFeeSummary ? WithFeeSummary.YES : WithFeeSummary.NO,
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 parent.verbosity);
+        finish();
+    }
+
+    @Command(name = "uniques", description = "Dump unique (serial-numbered) tokens")
+    void uniques(
+            @Option(
+                            names = {"--unique"},
+                            arity = "1",
+                            description = "Output file for unique tokens dump")
+                    @NonNull
+                    final Path uniquesPath,
+            @Option(
+                            names = {"-s", "--summary"},
+                            description = "Emit a summary line")
+                    final boolean emitSummary) {
+        Objects.requireNonNull(uniquesPath);
+        init();
+        System.out.println("=== unique NFTs ===");
+        DumpUniqueTokensSubcommand.doit(
+                parent.signedState, uniquesPath, emitSummary ? EmitSummary.YES : EmitSummary.NO, parent.verbosity);
         finish();
     }
 

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -176,7 +176,6 @@ public class DumpStateCommand extends AbstractCommand {
                             description = "How to dump key summaries")
                     final EnumSet<KeyDetails> keyDetails) {
         Objects.requireNonNull(accountPath);
-        Objects.requireNonNull(keyDetails);
         if (lowLimit > highLimit)
             throw new CommandLine.ParameterException(
                     parent.getSpec().commandLine(), "--highLimit must be >= --lowLimit");
@@ -188,7 +187,7 @@ public class DumpStateCommand extends AbstractCommand {
                 accountPath,
                 lowLimit,
                 highLimit,
-                keyDetails,
+                null != keyDetails ? keyDetails : EnumSet.noneOf(KeyDetails.class),
                 doCsv ? Format.CSV : Format.ELIDED_DEFAULT_FIELDS,
                 parent.verbosity);
         finish();
@@ -212,13 +211,12 @@ public class DumpStateCommand extends AbstractCommand {
                             description = "Emit a summary line")
                     final boolean emitSummary) {
         Objects.requireNonNull(filesPath);
-        Objects.requireNonNull(keyDetails);
         init();
         System.out.println("=== files ===");
         DumpFilesSubcommand.doit(
                 parent.signedState,
                 filesPath,
-                keyDetails,
+                null != keyDetails ? keyDetails : EnumSet.noneOf(KeyDetails.class),
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 parent.verbosity);
         finish();
@@ -246,13 +244,12 @@ public class DumpStateCommand extends AbstractCommand {
                             description = "Emit a summary line")
                     final boolean emitSummary) {
         Objects.requireNonNull(tokensPath);
-        Objects.requireNonNull(keyDetails);
         init();
         System.out.println("=== tokens ===");
         DumpTokensSubcommand.doit(
                 parent.signedState,
                 tokensPath,
-                keyDetails,
+                null != keyDetails ? keyDetails : EnumSet.noneOf(KeyDetails.class),
                 doFeeSummary ? WithFeeSummary.YES : WithFeeSummary.NO,
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 parent.verbosity);

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokensSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokensSubcommand.java
@@ -50,7 +50,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/** Dump all fungible token types, from a signed state file, to a text file, in deterministic order. */
+/** Dump all fungible and non-fungible token types, from a signed state file, to a text file, in deterministic order. */
 @SuppressWarnings({"java:S106", "java:S5411", "java:S4276", "java:S1192"})
 // S106: "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 // S5411: "Avoid using boxed "Boolean" types directly in boolean expressions" - this rule is almost always undesirable
@@ -385,7 +385,7 @@ public class DumpTokensSubcommand {
 
     @NonNull
     String formatHeader() {
-        return fieldFormatters.stream().map(Pair::left).collect(Collectors.joining(","));
+        return fieldFormatters.stream().map(Pair::left).collect(Collectors.joining(FIELD_SEPARATOR));
     }
 
     void reportOnTokens(
@@ -460,7 +460,7 @@ public class DumpTokensSubcommand {
             final var feeProfile = fees.stream()
                     .map(ThingsToStrings::toSketchyStringOfFcCustomFee)
                     .sorted()
-                    .collect(Collectors.joining(","));
+                    .collect(Collectors.joining(SUBFIELD_SEPARATOR));
             histogram.merge(feeProfile, 1, Integer::sum);
         }
 

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpUniqueTokensSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpUniqueTokensSubcommand.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import static com.hedera.services.cli.utils.ThingsToStrings.getMaybeStringifyByteString;
+import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+
+import com.google.common.collect.ComparisonChain;
+import com.hedera.node.app.service.mono.state.merkle.MerkleUniqueToken;
+import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
+import com.hedera.node.app.service.mono.state.submerkle.EntityId;
+import com.hedera.node.app.service.mono.state.submerkle.RichInstant;
+import com.hedera.node.app.service.mono.state.virtual.UniqueTokenKey;
+import com.hedera.node.app.service.mono.state.virtual.UniqueTokenValue;
+import com.hedera.node.app.service.mono.utils.EntityNumPair;
+import com.hedera.node.app.service.mono.utils.NftNumPair;
+import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.utils.ThingsToStrings;
+import com.hedera.services.cli.utils.Writer;
+import com.swirlds.base.utility.Pair;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Dump all unique (serial-numbered) tokens, from a signed state file, to a text file, in deterministic order. */
+@SuppressWarnings({"java:S106"})
+// S106: "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+public class DumpUniqueTokensSubcommand {
+    static void doit(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path uniquesPath,
+            @NonNull final DumpStateCommand.EmitSummary emitSummary,
+            @NonNull final SignedStateCommand.Verbosity verbosity) {
+        new DumpUniqueTokensSubcommand(state, uniquesPath, emitSummary, verbosity).doit();
+    }
+
+    @NonNull
+    final SignedStateHolder state;
+
+    @NonNull
+    final Path uniquesPath;
+
+    @NonNull
+    final SignedStateCommand.Verbosity verbosity;
+
+    @NonNull
+    final DumpStateCommand.EmitSummary emitSummary;
+
+    DumpUniqueTokensSubcommand(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path uniquesPath,
+            @NonNull final DumpStateCommand.EmitSummary emitSummary,
+            @NonNull final SignedStateCommand.Verbosity verbosity) {
+        this.state = state;
+        this.uniquesPath = uniquesPath;
+        this.emitSummary = emitSummary;
+        this.verbosity = verbosity;
+    }
+
+    void doit() {
+        final var uniquesStore = state.getUniqueNFTTokens();
+        System.out.printf(
+                "=== %d unique tokens (%s) ===%n",
+                uniquesStore.size(), uniquesStore.isVirtual() ? "virtual" : "merkle");
+        final var uniques = gatherUniques(uniquesStore);
+        System.out.printf("    %d unique tokens gathered%n", uniques.size());
+
+        int reportSize;
+        try (@NonNull final var writer = new Writer(uniquesPath)) {
+            if (emitSummary == EmitSummary.YES) reportSummary(writer, uniques);
+            reportOnUniques(writer, uniques);
+            reportSize = writer.getSize();
+        }
+
+        System.out.printf("=== uniques report is %d bytes%n", reportSize);
+    }
+
+    record UniqueNFTId(long id, long serial) implements Comparable<UniqueNFTId> {
+
+        static UniqueNFTId from(@NonNull final UniqueTokenKey ukey) {
+            return new UniqueNFTId(ukey.getNum(), ukey.getTokenSerial());
+        }
+
+        static UniqueNFTId from(@NonNull final EntityNumPair enp) {
+            return new UniqueNFTId(enp.getHiOrderAsLong(), enp.getLowOrderAsLong());
+        }
+
+        @Override
+        public String toString() {
+            return "%d%s%d".formatted(id, FIELD_SEPARATOR, serial);
+        }
+
+        @Override
+        public int compareTo(UniqueNFTId o) {
+            return ComparisonChain.start()
+                    .compare(this.id, o.id)
+                    .compare(this.serial, o.serial)
+                    .result();
+        }
+    }
+
+    @SuppressWarnings(
+            "java:S6218") // "Equals/hashcode method should be overridden in records containing array fields" - this
+    // record will never be compared or used as a key
+    record UniqueNFT(
+            EntityId owner,
+            EntityId spender,
+            @NonNull RichInstant creationTime,
+            @NonNull byte[] metadata,
+            @NonNull NftNumPair previous,
+            @NonNull NftNumPair next) {
+
+        static final byte[] EMPTY_BYTES = new byte[0];
+
+        static UniqueNFT from(@NonNull final UniqueTokenValue utv) {
+            return new UniqueNFT(
+                    utv.getOwner(),
+                    utv.getSpender(),
+                    utv.getCreationTime(),
+                    null != utv.getMetadata() ? utv.getMetadata() : EMPTY_BYTES,
+                    utv.getPrev(),
+                    utv.getNext());
+        }
+
+        static UniqueNFT from(@NonNull final MerkleUniqueToken mut) {
+            return new UniqueNFT(
+                    mut.getOwner(),
+                    mut.getSpender(),
+                    mut.getCreationTime(),
+                    null != mut.getMetadata() ? mut.getMetadata() : EMPTY_BYTES,
+                    mut.getPrev(),
+                    mut.getNext());
+        }
+    }
+
+    void reportSummary(@NonNull final Writer writer, @NonNull final Map<UniqueNFTId, UniqueNFT> uniques) {
+        final var relatedEntityCounts = RelatedEntities.countRelatedEntities(uniques);
+        writer.writeln("=== %7d unique tokens".formatted(uniques.size()));
+        writer.writeln("    %7d null or missing owners, %7d null or missing spenders"
+                .formatted(
+                        uniques.size() - relatedEntityCounts.owners(),
+                        uniques.size() - relatedEntityCounts.spenders()));
+        writer.writeln("");
+    }
+
+    record RelatedEntities(long owners, long spenders) {
+        @NonNull
+        static RelatedEntities countRelatedEntities(@NonNull final Map<UniqueNFTId, UniqueNFT> uniques) {
+            final var cs = new long[2];
+            uniques.values().forEach(unique -> {
+                if (null != unique.owner && !unique.owner.equals(EntityId.MISSING_ENTITY_ID)) cs[0]++;
+                if (null != unique.spender && !unique.spender.equals(EntityId.MISSING_ENTITY_ID)) cs[1]++;
+            });
+            return new RelatedEntities(cs[0], cs[1]);
+        }
+    }
+
+    /** String that separates all fields in the CSV format */
+    static final String FIELD_SEPARATOR = ";";
+
+    // Need to move this to a common location (copied here from DumpTokensSubcommand)
+    static class FieldBuilder {
+        final StringBuilder sb;
+        final String fieldSeparator;
+
+        FieldBuilder(@NonNull final String fieldSeparator) {
+            this.sb = new StringBuilder();
+            this.fieldSeparator = fieldSeparator;
+        }
+
+        void append(@NonNull final String v) {
+            sb.append(v);
+            sb.append(fieldSeparator);
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            if (sb.length() > fieldSeparator.length()) sb.setLength(sb.length() - fieldSeparator.length());
+            return sb.toString();
+        }
+    }
+
+    void reportOnUniques(@NonNull final Writer writer, @NonNull final Map<UniqueNFTId, UniqueNFT> uniques) {
+        writer.writeln(formatHeader());
+        uniques.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(e -> formatUnique(writer, e.getKey(), e.getValue()));
+        writer.writeln("");
+    }
+
+    @NonNull
+    String formatHeader() {
+        return "nftId,nftSerial,"
+                + fieldFormatters.stream().map(Pair::left).collect(Collectors.joining(FIELD_SEPARATOR));
+    }
+
+    // spotless:off
+    @NonNull static List<Pair<String,BiConsumer<FieldBuilder,UniqueNFT>>> fieldFormatters = List.of(
+            Pair.of("owner", getFieldFormatter(UniqueNFT::owner, ThingsToStrings::toStringOfEntityId)),
+            Pair.of("spender",getFieldFormatter(UniqueNFT::spender, ThingsToStrings::toStringOfEntityId)),
+            Pair.of("creationTime", getFieldFormatter(UniqueNFT::creationTime, ThingsToStrings::toStringOfRichInstant)),
+            Pair.of("metadata", getFieldFormatter(UniqueNFT::metadata, getMaybeStringifyByteString(FIELD_SEPARATOR))),
+            Pair.of("prev", getFieldFormatter(UniqueNFT::previous, Object::toString)),
+            Pair.of("next", getFieldFormatter(UniqueNFT::next, Object::toString))
+    );
+    // spotless:on
+
+    @NonNull
+    static <T> BiConsumer<FieldBuilder, UniqueNFT> getFieldFormatter(
+            @NonNull final Function<UniqueNFT, T> fun, @NonNull final Function<T, String> formatter) {
+        return (fb, u) -> formatField(fb, u, fun, formatter);
+    }
+
+    static <T> void formatField(
+            @NonNull final FieldBuilder fb,
+            @NonNull final UniqueNFT unique,
+            @NonNull final Function<UniqueNFT, T> fun,
+            @NonNull final Function<T, String> formatter) {
+        fb.append(formatter.apply(fun.apply(unique)));
+    }
+
+    void formatUnique(@NonNull final Writer writer, @NonNull final UniqueNFTId id, @NonNull final UniqueNFT unique) {
+        final var fb = new FieldBuilder(FIELD_SEPARATOR);
+        fb.append(id.toString());
+        fieldFormatters.stream().map(Pair::right).forEach(ff -> ff.accept(fb, unique));
+        writer.writeln(fb);
+    }
+
+    @NonNull
+    Map<UniqueNFTId, UniqueNFT> gatherUniques(@NonNull final UniqueTokenMapAdapter uniquesStore) {
+        final var r = new HashMap<UniqueNFTId, UniqueNFT>();
+        if (uniquesStore.isVirtual()) {
+            // world of VirtualMapLike<UniqueTokenKey, UniqueTokenValue>
+            final var threadCount = 8; // Good enough for my laptop, why not?
+            final var keys = new ConcurrentLinkedQueue<UniqueNFTId>();
+            final var values = new ConcurrentLinkedQueue<UniqueNFT>();
+            try {
+                uniquesStore
+                        .virtualMap()
+                        .extractVirtualMapDataC(
+                                getStaticThreadManager(),
+                                p -> {
+                                    keys.add(UniqueNFTId.from(p.left()));
+                                    values.add(UniqueNFT.from(p.right()));
+                                },
+                                threadCount);
+            } catch (final InterruptedException ex) {
+                System.err.println("*** Traversal of uniques virtual map interrupted!");
+                Thread.currentThread().interrupt();
+            }
+            // Consider in the future: Use another thread to pull things off the queue as they're put on by the
+            // virtual map traversal
+            while (!keys.isEmpty()) {
+                r.put(keys.poll(), values.poll());
+            }
+        } else {
+            // world of MerkleMap<EntityNumPair, MerkleUniqueToken>
+            uniquesStore
+                    .merkleMap()
+                    .getIndex()
+                    .forEach((key, value) -> r.put(UniqueNFTId.from(key), UniqueNFT.from(value)));
+        }
+        return r;
+    }
+}


### PR DESCRIPTION
**Description**:

Dumps unique NFTs from a signed state file.

**Related issue(s)**:

Fixes #8255 

**Notes for reviewer**:

You can use the following command line (except providing your own signed state file):

```bash
./platform-sdk/swirlds-cli/pcli.sh \
   --memory 40 \
   --ignore-jars \
   --load hedera-node/data/lib \
   --load hedera-node/cli-clients/build/libs \
   --cli com.hedera.services.cli.signedstate \
   signed-state  -f /Users/davidbakin/StatesStreams/mainnet-2023-07-19/state/2023-07-19.00.00/144535932/SignedState.swh --verbose \
   dump \
      uniques --unique ./unique.lst --summary
```

This produced a 262MB file from a mainnet state of 2023-07, >2M unique NFTs.

Start of the file looked like this:
```
=== 2155205 unique tokens (863628 owned by treasury accounts)
          0 null owners, 2094718 null or missing spenders

nftId,nftSerial,owner;spender;creationTime;metadata;prev;next
410224;1;0.0.410226;;1630615611.855620000;5E192EB3;0.0.0.0;0.0.0.0
428976;1;0.0.309540;;1631258839.930284000;"{""name"":""Xact Logo V1"",""creator"":""Xact Team"",""category"":""Art"",""supply"":2}";0.0.428976.2;0.0.0.0
428976;2;0.0.309540;;1631258839.930284000;"{""name"":""Xact Logo V1"",""creator"":""Xact Team"",""category"":""Art"",""supply"":2}";0.0.446449.10;0.0.428976.1
439270;1;0.0.439272;;1631634298.625166000;5D16BC75;0.0.0.0;0.0.0.0
439393;1;0.0.439395;;1631636441.91550000;28BC0F90;0.0.0.0;0.0.0.0
446388;1;;;1631803925.656168000;"{""name"":""Xact Lines"",""creator"":""Xact Team"",""category"":""Art"",""supply"":10}";0.0.0.0;0.0.0.0
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (manual)

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>