### PR TITLE
Load the address book info at genesis into files 101 and 102

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
@@ -61,11 +61,28 @@ public interface NodeInfo {
      */
     String memo();
 
+    /**
+     * The host name of this node, as known by the external world. This is an IP address.
+     *
+     * @return The host name (IP Address) of this node
+     */
     String externalHostName();
 
+    /**
+     * The port the node is listening on.
+     * @return the port. Non-negative.
+     */
     int externalPort();
 
+    /**
+     * The public key of this node, as a hex-encoded string.
+     * @return the public key
+     */
     String hexEncodedPublicKey();
 
+    /**
+     * The stake weight of this node.
+     * @return the stake weight
+     */
     long stake();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
@@ -31,7 +31,9 @@ public interface NodeInfo {
      *
      * @return whether this node has zero stake.
      */
-    boolean zeroStake();
+    default boolean zeroStake() {
+        return stake() == 0;
+    }
 
     /**
      * Gets the node ID. This is a separate identifier from the node's account. This IS NOT IN ANY WAY related to the
@@ -58,4 +60,12 @@ public interface NodeInfo {
      * @return this node's account memo
      */
     String memo();
+
+    String externalHostName();
+
+    int externalPort();
+
+    String hexEncodedPublicKey();
+
+    long stake();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.spi.state;
 
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -52,4 +53,12 @@ public interface MigrationContext {
      */
     @NonNull
     Configuration configuration();
+
+    /**
+     * Information about the network itself. Generally, this is not useful information for migrations, but is used at
+     * genesis for the file service. In the future, this may no longer be required.
+     *
+     * @return The {@link NetworkInfo} of the network at the time of migration.
+     */
+    NetworkInfo networkInfo();
 }

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/info/FakeNetworkInfo.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/info/FakeNetworkInfo.java
@@ -34,10 +34,29 @@ public class FakeNetworkInfo implements NetworkInfo {
 
     private static final List<NodeInfo> FAKE_NODE_INFOS = List.of(
             fakeInfoWith(
-                    false, 2L, "Alpha", AccountID.newBuilder().accountNum(3).build()),
-            fakeInfoWith(true, 4L, "Bravo", AccountID.newBuilder().accountNum(4).build()),
+                    2L,
+                    AccountID.newBuilder().accountNum(3).build(),
+                    30,
+                    "333.333.333.333",
+                    50233,
+                    "3333333333333333333333333333333333333333333333333333333333333333",
+                    "Alpha"),
             fakeInfoWith(
-                    false, 8L, "Charlie", AccountID.newBuilder().accountNum(5).build()));
+                    4L,
+                    AccountID.newBuilder().accountNum(4).build(),
+                    40,
+                    "444.444.444.444",
+                    50244,
+                    "444444444444444444444444444444444444444444444444444444444444444",
+                    "Bravo"),
+            fakeInfoWith(
+                    8L,
+                    AccountID.newBuilder().accountNum(5).build(),
+                    50,
+                    "555.555.555.555",
+                    50255,
+                    "555555555555555555555555555555555555555555555555555555555555555",
+                    "Charlie"));
 
     @NonNull
     @Override
@@ -80,6 +99,26 @@ public class FakeNetworkInfo implements NetworkInfo {
             public String memo() {
                 return FAKE_NODE_INFOS.get(0).memo();
             }
+
+            @Override
+            public String externalHostName() {
+                return FAKE_NODE_INFOS.get(0).externalHostName();
+            }
+
+            @Override
+            public int externalPort() {
+                return FAKE_NODE_INFOS.get(0).externalPort();
+            }
+
+            @Override
+            public String hexEncodedPublicKey() {
+                return FAKE_NODE_INFOS.get(0).hexEncodedPublicKey();
+            }
+
+            @Override
+            public long stake() {
+                return FAKE_NODE_INFOS.get(0).stake();
+            }
         };
     }
 
@@ -96,10 +135,13 @@ public class FakeNetworkInfo implements NetworkInfo {
     }
 
     private static NodeInfo fakeInfoWith(
-            final boolean zeroStake,
             final long nodeId,
-            @NonNull final String memo,
-            @NonNull final AccountID nodeAccountId) {
+            @NonNull final AccountID nodeAccountId,
+            long stake,
+            @NonNull String externalHostName,
+            int externalPort,
+            @NonNull String hexEncodedPublicKey,
+            @NonNull String memo) {
         return new NodeInfo() {
             @Override
             public long nodeId() {
@@ -112,13 +154,28 @@ public class FakeNetworkInfo implements NetworkInfo {
             }
 
             @Override
-            public boolean zeroStake() {
-                return zeroStake;
+            public AccountID accountId() {
+                return nodeAccountId;
             }
 
             @Override
-            public AccountID accountId() {
-                return nodeAccountId;
+            public String externalHostName() {
+                return externalHostName;
+            }
+
+            @Override
+            public int externalPort() {
+                return externalPort;
+            }
+
+            @Override
+            public String hexEncodedPublicKey() {
+                return hexEncodedPublicKey;
+            }
+
+            @Override
+            public long stake() {
+                return stake;
             }
         };
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -143,6 +143,8 @@ public final class Hedera implements SwirldMain {
     private final ServicesRegistry servicesRegistry;
     /** The current version of THIS software */
     private final HederaSoftwareVersion version;
+    /** The configuration at the time of bootstrapping the node */
+    private final ConfigProvider bootstrapConfigProvider;
     /** The Hashgraph Platform. This is set during state initialization. */
     private Platform platform;
     /** The configuration for this node */
@@ -151,8 +153,6 @@ public final class Hedera implements SwirldMain {
     private ThrottleManager throttleManager;
     /** The exchange rate manager */
     private ExchangeRateManager exchangeRateManager;
-    /** The configuration at the time of bootstrapping the node */
-    private ConfigProvider bootstrapConfigProvider;
     /**
      * Dependencies managed by Dagger. Set during state initialization. The mono-service requires this object, but none
      * of the rest of the system (and particularly the modular implementation) uses it directly. Rather, it is created

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.info.CurrentPlatformStatusImpl;
+import com.hedera.node.app.info.NetworkInfoImpl;
 import com.hedera.node.app.info.SelfNodeInfoImpl;
 import com.hedera.node.app.records.BlockRecordService;
 import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
@@ -59,6 +60,7 @@ import com.hedera.node.app.throttle.ThrottleManager;
 import com.hedera.node.app.version.HederaSoftwareVersion;
 import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.app.workflows.handle.SystemFileUpdateFacility;
+import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.Utils;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
@@ -149,6 +151,8 @@ public final class Hedera implements SwirldMain {
     private ThrottleManager throttleManager;
     /** The exchange rate manager */
     private ExchangeRateManager exchangeRateManager;
+    /** The configuration at the time of bootstrapping the node */
+    private ConfigProvider bootstrapConfigProvider;
     /**
      * Dependencies managed by Dagger. Set during state initialization. The mono-service requires this object, but none
      * of the rest of the system (and particularly the modular implementation) uses it directly. Rather, it is created
@@ -191,7 +195,8 @@ public final class Hedera implements SwirldMain {
 
         // Load the bootstrap configuration. These config values are NOT stored in state, so we don't need to have
         // state up and running for getting their values. We use this bootstrap config only in this constructor.
-        final var bootstrapConfig = new BootstrapConfigProviderImpl().configuration();
+        this.bootstrapConfigProvider = new BootstrapConfigProviderImpl();
+        final var bootstrapConfig = bootstrapConfigProvider.getConfiguration();
 
         // Let the user know which mode they are starting in (DEV vs. TEST vs. PROD).
         // NOTE: This bootstrapConfig is not entirely satisfactory. We probably need an alternative...
@@ -366,7 +371,10 @@ public final class Hedera implements SwirldMain {
                 () -> previousVersion == null ? "<NONE>" : HapiUtils.toString(previousVersion),
                 () -> HapiUtils.toString(currentVersion));
 
-        final var networkInfo = daggerApp.networkInfo();
+        final var selfId = platform.getSelfId();
+        final var nodeAddress = platform.getAddressBook().getAddress(selfId);
+        final var selfNodeInfo = SelfNodeInfoImpl.of(nodeAddress, version);
+        final var networkInfo = new NetworkInfoImpl(selfNodeInfo, platform, bootstrapConfigProvider);
         for (final var service : servicesRegistry.services()) {
             // FUTURE We should have metrics here to keep track of how long it takes to migrate each service
             final var serviceName = service.getServiceName();
@@ -546,9 +554,17 @@ public final class Hedera implements SwirldMain {
      * Called for an orderly shutdown.
      */
     public void shutdown() {
+        logger.info("Shutting down Hedera node");
         shutdownGrpcServer();
 
         if (daggerApp != null) {
+            logger.debug("Shutting down the state");
+            final var state = daggerApp.workingStateAccessor().getHederaState();
+            if (state instanceof MerkleHederaState mhs) {
+                mhs.close();
+            }
+
+            logger.debug("Shutting down the block manager");
             daggerApp.blockRecordManager().close();
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -366,6 +366,7 @@ public final class Hedera implements SwirldMain {
                 () -> previousVersion == null ? "<NONE>" : HapiUtils.toString(previousVersion),
                 () -> HapiUtils.toString(currentVersion));
 
+        final var networkInfo = daggerApp.networkInfo();
         for (final var service : servicesRegistry.services()) {
             // FUTURE We should have metrics here to keep track of how long it takes to migrate each service
             final var serviceName = service.getServiceName();
@@ -373,7 +374,7 @@ public final class Hedera implements SwirldMain {
             logger.debug("Registering schemas for service {}", serviceName);
             service.registerSchemas(registry);
             logger.info("Migrating Service {}", serviceName);
-            registry.migrate(state, previousVersion, currentVersion, configProvider.getConfiguration());
+            registry.migrate(state, previousVersion, currentVersion, configProvider.getConfiguration(), networkInfo);
         }
         logger.info("Migration complete");
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
@@ -16,8 +16,11 @@
 
 package com.hedera.node.app.config;
 
+import com.hedera.node.config.VersionedConfiguration;
+import com.hedera.node.config.converter.BytesConverter;
 import com.hedera.node.config.converter.SemanticVersionConverter;
 import com.hedera.node.config.data.HederaConfig;
+import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.VersionConfig;
 import com.hedera.node.config.sources.PropertyConfigSource;
 import com.swirlds.common.config.sources.SystemEnvironmentConfigSource;
@@ -49,6 +52,8 @@ public class BootstrapConfigProviderImpl extends ConfigProviderBase {
                 .withSource(new PropertyConfigSource(SEMANTIC_VERSION_PROPERTIES_DEFAULT_PATH, 500))
                 .withConfigDataType(HederaConfig.class)
                 .withConfigDataType(VersionConfig.class)
+                .withConfigDataType(LedgerConfig.class)
+                .withConverter(new BytesConverter())
                 .withConverter(new SemanticVersionConverter());
 
         try {
@@ -68,5 +73,11 @@ public class BootstrapConfigProviderImpl extends ConfigProviderBase {
     @NonNull
     public Configuration configuration() {
         return bootstrapConfig;
+    }
+
+    @NonNull
+    @Override
+    public VersionedConfiguration getConfiguration() {
+        return new VersionedConfigImpl(bootstrapConfig, 0);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderBase.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.config;
 
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.node.config.ConfigProvider;
 import com.swirlds.common.config.sources.PropertyFileConfigSource;
 import com.swirlds.config.api.ConfigurationBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -31,7 +32,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * A convenient base class for implementing configuration providers. Not intended to be used outside of this package.
  */
-public abstract class ConfigProviderBase {
+public abstract class ConfigProviderBase implements ConfigProvider {
     /**
      * Name of an environment variable that can be used to override the default path to the genesis.properties file (see
      * {@link #GENESIS_PROPERTIES_DEFAULT_PATH}).

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
@@ -95,7 +95,7 @@ import org.apache.logging.log4j.Logger;
  * Implementation of the {@link ConfigProvider} interface.
  */
 @Singleton
-public class ConfigProviderImpl extends ConfigProviderBase implements ConfigProvider {
+public class ConfigProviderImpl extends ConfigProviderBase {
     private static final Logger logger = LogManager.getLogger(ConfigProviderImpl.class);
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NodeInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NodeInfoImpl.java
@@ -17,17 +17,32 @@
 package com.hedera.node.app.info;
 
 import static com.hedera.node.app.spi.HapiUtils.parseAccount;
+import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.node.app.spi.info.NodeInfo;
 import com.swirlds.common.system.address.Address;
+import com.swirlds.common.utility.CommonUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public record NodeInfoImpl(long nodeId, @NonNull AccountID accountId, boolean zeroStake, @NonNull String memo)
+public record NodeInfoImpl(
+        long nodeId,
+        @NonNull AccountID accountId,
+        long stake,
+        @NonNull String externalHostName,
+        int externalPort,
+        @NonNull String hexEncodedPublicKey,
+        @NonNull String memo)
         implements NodeInfo {
     @NonNull
     static NodeInfo fromAddress(@NonNull final Address address) {
         return new NodeInfoImpl(
-                address.getNodeId().id(), parseAccount(address.getMemo()), address.getWeight() <= 0, address.getMemo());
+                address.getNodeId().id(),
+                parseAccount(address.getMemo()),
+                address.getWeight(),
+                requireNonNull(address.getHostnameExternal()),
+                address.getPortExternal(),
+                CommonUtils.hex(requireNonNull(address.getSigPublicKey()).getEncoded()),
+                address.getMemo());
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/SelfNodeInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/SelfNodeInfoImpl.java
@@ -24,12 +24,16 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.info.SelfNodeInfo;
 import com.hedera.node.app.version.HederaSoftwareVersion;
 import com.swirlds.common.system.address.Address;
+import com.swirlds.common.utility.CommonUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public record SelfNodeInfoImpl(
         long nodeId,
         @NonNull AccountID accountId,
-        boolean zeroStake,
+        long stake,
+        @NonNull String externalHostName,
+        int externalPort,
+        @NonNull String hexEncodedPublicKey,
         @NonNull String memo,
         @NonNull HederaSoftwareVersion version)
         implements SelfNodeInfo {
@@ -48,7 +52,10 @@ public record SelfNodeInfoImpl(
         return new SelfNodeInfoImpl(
                 address.getNodeId().id(),
                 parseAccount(address.getMemo()),
-                address.getWeight() <= 0,
+                address.getWeight(),
+                requireNonNull(address.getHostnameExternal()),
+                address.getPortExternal(),
+                CommonUtils.hex(requireNonNull(address.getSigPublicKey()).getEncoded()),
                 address.getMemo(),
                 version);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -60,11 +60,14 @@ import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * An implementation of {@link SwirldState} and {@link HederaState}. The Hashgraph Platform
@@ -85,6 +88,7 @@ import java.util.Set;
  * consider nesting service nodes in a MerkleMap, or some other such approach to get a binary tree.
  */
 public class MerkleHederaState extends PartialNaryMerkleInternal implements MerkleInternal, SwirldState, HederaState {
+    private static final Logger logger = LogManager.getLogger(MerkleHederaState.class);
 
     /** Used when asked for a service's readable states that we don't have */
     private static final ReadableStates EMPTY_READABLE_STATES = new EmptyReadableStates();
@@ -236,6 +240,30 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     @Override
     public int getVersion() {
         return CURRENT_VERSION;
+    }
+
+    /**
+     * To be called ONLY at node shutdown. Attempts to gracefully close any virtual maps. This method is a bit of a
+     * hack, ideally there would be something more generic at the platform level that virtual maps could hook into
+     * to get shutdown in an orderly way.
+     */
+    public void close() {
+        logger.info("Closing MerkleHederaState");
+        for (final var svc : services.values()) {
+            for (final var md : svc.values()) {
+                final var index = findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
+                if (index >= 0) {
+                    final var node = getChild(index);
+                    if (node instanceof VirtualMap<?, ?>) {
+                        try {
+                            ((VirtualMap<?, ?>) node).getDataSource().close();
+                        } catch (IOException e) {
+                            logger.warn("Unable to close data source for virtual map {}", md.serviceName(), e);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -255,9 +255,9 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
                         findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
                 if (index >= 0) {
                     final var node = getChild(index);
-                    if (node instanceof VirtualMap<?, ?>) {
+                    if (node instanceof VirtualMap<?, ?> virtualMap) {
                         try {
-                            ((VirtualMap<?, ?>) node).getDataSource().close();
+                            virtualMap.getDataSource().close();
                         } catch (IOException e) {
                             logger.warn("Unable to close data source for virtual map {}", md.serviceName(), e);
                         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -251,7 +251,8 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
         logger.info("Closing MerkleHederaState");
         for (final var svc : services.values()) {
             for (final var md : svc.values()) {
-                final var index = findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
+                final var index =
+                        findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
                 if (index >= 0) {
                     final var node = getChild(index);
                     if (node instanceof VirtualMap<?, ?>) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -201,7 +201,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                 } else {
                     // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
                     // PREFER_DISK_BASED_INDICES = false
-                    final MerkleDbTableConfig tableConfig = new MerkleDbTableConfig<>(
+                    final var tableConfig = new MerkleDbTableConfig<>(
                                     (short) 1,
                                     DigestType.SHA_384,
                                     (short) 1,
@@ -210,7 +210,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                                     new OnDiskValueSerializer<>(md))
                             .maxNumberOfKeys(def.maxKeysHint());
                     final var label = StateUtils.computeLabel(serviceName, stateKey);
-                    final MerkleDbDataSourceBuilder dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
+                    final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
                     hederaState.putServiceStateIfAbsent(md, new VirtualMap<>(label, dsBuilder));
                 }
             });

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MigrationContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MigrationContextImpl.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.state.merkle;
 
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.WritableStates;
@@ -30,5 +33,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param configuration The configuration to use
  */
 public record MigrationContextImpl(
-        @NonNull ReadableStates previousStates, @NonNull WritableStates newStates, @NonNull Configuration configuration)
-        implements MigrationContext {}
+        @NonNull ReadableStates previousStates,
+        @NonNull WritableStates newStates,
+        @NonNull Configuration configuration,
+        @NonNull NetworkInfo networkInfo)
+        implements MigrationContext {
+
+    public MigrationContextImpl {
+        requireNonNull(previousStates);
+        requireNonNull(newStates);
+        requireNonNull(configuration);
+        requireNonNull(networkInfo);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/AppTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/AppTestBase.java
@@ -141,8 +141,15 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
     protected final AccountID nodeSelfAccountId =
             AccountID.newBuilder().shardNum(0).realmNum(0).accountNum(8).build();
 
-    protected final SelfNodeInfo selfNodeInfo =
-            new SelfNodeInfoImpl(7, nodeSelfAccountId, false, "Node7", softwareVersion);
+    protected final SelfNodeInfo selfNodeInfo = new SelfNodeInfoImpl(
+            7,
+            nodeSelfAccountId,
+            10,
+            "127.0.0.1",
+            50211,
+            "0123456789012345678901234567890123456789012345678901234567890123",
+            "Node7",
+            softwareVersion);
 
     /**
      * The gRPC system has extensive metrics. This object allows us to inspect them and make sure they are being set
@@ -303,30 +310,33 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
 
             final SelfNodeInfo realSelfNodeInfo;
             if (this.selfNodeInfo == null) {
-                final var nodeSelfId = new NodeId(7);
                 final var nodeSelfAccountId = AccountID.newBuilder()
                         .shardNum(0)
                         .realmNum(0)
                         .accountNum(8)
                         .build();
-                realSelfNodeInfo = new SelfNodeInfoImpl(7, nodeSelfAccountId, false, "Node7", hederaSoftwareVersion);
+                realSelfNodeInfo = new SelfNodeInfoImpl(
+                        7,
+                        nodeSelfAccountId,
+                        10,
+                        "127.0.0.1",
+                        50211,
+                        "0123456789012345678901234567890123456789012345678901234567890123",
+                        "Node7",
+                        hederaSoftwareVersion);
             } else {
                 realSelfNodeInfo = new SelfNodeInfoImpl(
                         selfNodeInfo.nodeId(),
                         selfNodeInfo.accountId(),
-                        selfNodeInfo.zeroStake(),
+                        selfNodeInfo.stake(),
+                        selfNodeInfo.externalHostName(),
+                        selfNodeInfo.externalPort(),
+                        selfNodeInfo.hexEncodedPublicKey(),
                         selfNodeInfo.memo(),
                         hederaSoftwareVersion);
             }
 
-            final var initialState = new FakeHederaState();
             final var workingStateAccessor = new WorkingStateAccessor();
-            services.forEach(svc -> {
-                final var reg = new FakeSchemaRegistry();
-                svc.registerSchemas(reg);
-                reg.migrate(svc.getServiceName(), initialState);
-            });
-            workingStateAccessor.setHederaState(initialState);
 
             final ConfigProvider configProvider = () -> new VersionedConfigImpl(configBuilder.getOrCreateConfig(), 1);
             final var addresses = nodes.stream()
@@ -338,6 +348,14 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
 
             final var platform = new FakePlatform(realSelfNodeInfo.nodeId(), new AddressBook(addresses));
             final var networkInfo = new NetworkInfoImpl(realSelfNodeInfo, platform, configProvider);
+
+            final var initialState = new FakeHederaState();
+            services.forEach(svc -> {
+                final var reg = new FakeSchemaRegistry();
+                svc.registerSchemas(reg);
+                reg.migrate(svc.getServiceName(), initialState, networkInfo);
+            });
+            workingStateAccessor.setHederaState(initialState);
 
             return new App() {
                 @NonNull

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -74,7 +74,10 @@ class IngestComponentTest {
         final var selfNodeInfo = new SelfNodeInfoImpl(
                 1L,
                 AccountID.newBuilder().accountNum(1001).build(),
-                false,
+                10,
+                "127.0.0.1",
+                50211,
+                "0123456789012345678901234567890123456789012345678901234567890123",
                 "memo",
                 new HederaSoftwareVersion(
                         SemanticVersion.newBuilder().major(1).build(),

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.lenient;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.fixtures.state.TestSchema;
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import com.hedera.node.app.spi.state.ReadableSingletonState;
@@ -53,6 +54,7 @@ import org.mockito.Mockito;
 class MerkleSchemaRegistryTest extends MerkleTestBase {
     private MerkleSchemaRegistry schemaRegistry;
     private Configuration config;
+    private NetworkInfo networkInfo;
 
     @BeforeEach
     void setUp() {
@@ -61,6 +63,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         registry = Mockito.mock(ConstructableRegistry.class);
         schemaRegistry = new MerkleSchemaRegistry(registry, FIRST_SERVICE);
         config = Mockito.mock(Configuration.class);
+        networkInfo = Mockito.mock(NetworkInfo.class);
         final var hederaConfig = Mockito.mock(HederaConfig.class);
         lenient().when(config.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);
     }
@@ -147,7 +150,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             (tree, state) -> {}, (e, m, s) -> {}, (state, platform, dualState, trigger, version) -> {}),
                     version(9, 0, 0),
                     version(10, 0, 0),
-                    config);
+                    config,
+                    networkInfo);
         }
     }
 
@@ -172,7 +176,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a null hederaState throws NPE")
         void nullMerkleThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(null, versions[0], versions[1], config))
+            assertThatThrownBy(() -> schemaRegistry.migrate(null, versions[0], versions[1], config, networkInfo))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -180,7 +184,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a null currentVersion throws NPE")
         void nullCurrentVersionThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], null, config))
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], null, config, networkInfo))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -188,7 +192,15 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a null config throws NPE")
         void nullConfigVersionThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[1], null))
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[1], null, networkInfo))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Calling migrate with a null networkInfo throws NPE")
+        void nullNetworkInfoThrows() {
+            //noinspection ConstantConditions
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[1], config, null))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -196,7 +208,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("Calling migrate with a currentVersion < previousVersion throws IAE")
         void currentVersionLessThanPreviousVersionThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[5], versions[4], config))
+            assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[5], versions[4], config, networkInfo))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -208,7 +220,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
             // When it is registered twice and migrate is called
             schemaRegistry.register(schema);
-            schemaRegistry.migrate(merkleTree, versions[1], versions[1], config);
+            schemaRegistry.migrate(merkleTree, versions[1], versions[1], config, networkInfo);
 
             // Then nothing happens
             Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
@@ -247,7 +259,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
             }
 
             // When we migrate
-            schemaRegistry.migrate(merkleTree, versions[firstVersion], versions[lastVersion], config);
+            schemaRegistry.migrate(merkleTree, versions[firstVersion], versions[lastVersion], config, networkInfo);
 
             // Then each schema less than or equal to firstVersion are not called
             for (int i = 1; i <= firstVersion; i++) {
@@ -290,7 +302,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
             schemaRegistry.register(schemaV6);
 
             // When we migrate from v0 to v7
-            schemaRegistry.migrate(merkleTree, null, versions[7], config);
+            schemaRegistry.migrate(merkleTree, null, versions[7], config, networkInfo);
 
             // Then each of v1, v4, and v6 are called
             assertThat(called).hasSize(3);
@@ -446,7 +458,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
 
                 // When we migrate
                 schemaRegistry.register(schemaV1);
-                schemaRegistry.migrate(merkleTree, versions[0], versions[1], config);
+                schemaRegistry.migrate(merkleTree, versions[0], versions[1], config, networkInfo);
 
                 // Then we see that the values for A, B, and C are available
                 final var readableStates = merkleTree.createReadableStates(FIRST_SERVICE);
@@ -465,7 +477,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                 // When we migrate
                 schemaRegistry.register(schemaV1);
                 schemaRegistry.register(schemaV2);
-                schemaRegistry.migrate(merkleTree, versions[0], versions[2], config);
+                schemaRegistry.migrate(merkleTree, versions[0], versions[2], config, networkInfo);
 
                 // We should see the v2 state (the delta from v2 after applied atop v1)
                 final var readableStates = merkleTree.createReadableStates(FIRST_SERVICE);
@@ -495,7 +507,7 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                 schemaRegistry.register(schemaV1);
                 schemaRegistry.register(schemaV2);
                 schemaRegistry.register(schemaV3);
-                schemaRegistry.migrate(merkleTree, versions[0], versions[3], config);
+                schemaRegistry.migrate(merkleTree, versions[0], versions[3], config, networkInfo);
 
                 // We should see the v3 state (the delta from v3 after applied atop v2 and v1)
                 final var readableStates = merkleTree.createReadableStates(FIRST_SERVICE);
@@ -530,7 +542,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                 schemaRegistry.register(schemaV2);
 
                 // We should see that the migration failed
-                assertThatThrownBy(() -> schemaRegistry.migrate(merkleTree, versions[0], versions[2], config))
+                assertThatThrownBy(
+                                () -> schemaRegistry.migrate(merkleTree, versions[0], versions[2], config, networkInfo))
                         .isInstanceOf(RuntimeException.class)
                         .hasMessage("Bad");
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -35,6 +35,7 @@ import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.fixtures.state.FakeHederaState;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
 import com.hedera.node.app.spi.fixtures.state.ListWritableQueueState;
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.WritableQueueState;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.WorkingStateAccessor;
@@ -81,13 +82,14 @@ final class RecordCacheImplTest {
     void setUp(
             @Mock final VersionedConfiguration versionedConfig,
             @Mock final HederaConfig hederaConfig,
-            @Mock final LedgerConfig ledgerConfig) {
+            @Mock final LedgerConfig ledgerConfig,
+            @Mock final NetworkInfo networkInfo) {
         dedupeCache = new DeduplicationCacheImpl(props);
         final var registry = new FakeSchemaRegistry();
         final var state = new FakeHederaState();
         final var svc = new RecordCacheService();
         svc.registerSchemas(registry);
-        registry.migrate(svc.getServiceName(), state);
+        registry.migrate(svc.getServiceName(), state, networkInfo);
         lenient().when(wsa.getHederaState()).thenReturn(state);
         lenient().when(props.getConfiguration()).thenReturn(versionedConfig);
         lenient().when(versionedConfig.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.fixtures.state;
 import com.hedera.node.app.spi.fixtures.state.ListWritableQueueState;
 import com.hedera.node.app.spi.fixtures.state.MapWritableKVState;
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.EmptyReadableStates;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.ReadableStates;
@@ -39,7 +40,10 @@ public class FakeSchemaRegistry implements SchemaRegistry {
     private final List<Schema> schemas = new LinkedList<>();
 
     @SuppressWarnings("rawtypes")
-    public void migrate(@NonNull final String serviceName, @NonNull final FakeHederaState state) {
+    public void migrate(
+            @NonNull final String serviceName,
+            @NonNull final FakeHederaState state,
+            @NonNull final NetworkInfo networkInfo) {
         // For each schema, create the underlying raw data sources (maps, or lists) and the writable states that
         // will wrap them. Then call the schema's migrate method to populate those states, and commit each of them
         // to the underlying data sources. At that point, we have properly migrated the state.
@@ -85,6 +89,11 @@ public class FakeSchemaRegistry implements SchemaRegistry {
                 @Override
                 public Configuration configuration() {
                     return ConfigurationBuilder.create().build();
+                }
+
+                @Override
+                public NetworkInfo networkInfo() {
+                    return networkInfo;
                 }
             });
 

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LedgerConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LedgerConfig.java
@@ -29,9 +29,9 @@ import com.swirlds.config.api.validation.annotation.Min;
 @ConfigData("ledger")
 public record LedgerConfig(
         @ConfigProperty(defaultValue = "5000") @NetworkProperty int maxAutoAssociations,
-        @ConfigProperty(defaultValue = "100") @NetworkProperty int numSystemAccounts,
-        @ConfigProperty(defaultValue = "5000000000000000000") @Min(0) @NetworkProperty long totalTinyBarFloat,
-        @ConfigProperty(defaultValue = "0x03") @NetworkProperty Bytes id,
+        @ConfigProperty(defaultValue = "100") int numSystemAccounts,
+        @ConfigProperty(defaultValue = "5000000000000000000") @Min(0) long totalTinyBarFloat,
+        @ConfigProperty(defaultValue = "0x03") Bytes id,
         @ConfigProperty(value = "changeHistorian.memorySecs", defaultValue = "20") @NetworkProperty
                 int changeHistorianMemorySecs,
         @ConfigProperty(value = "autoRenewPeriod.maxDuration", defaultValue = "8000001") @NetworkProperty

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
@@ -31,7 +31,10 @@ import com.hedera.hapi.node.base.FeeSchedule;
 import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.ServiceEndpoint;
 import com.hedera.hapi.node.base.ServicesConfigurationList;
 import com.hedera.hapi.node.base.Setting;
 import com.hedera.hapi.node.base.SubType;
@@ -41,6 +44,7 @@ import com.hedera.hapi.node.state.file.File;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.StateDefinition;
@@ -97,8 +101,7 @@ public class GenesisSchema extends Schema {
         final var filesConfig = ctx.configuration().getConfigData(FilesConfig.class);
         final var hederaConfig = ctx.configuration().getConfigData(HederaConfig.class);
         final WritableKVState<FileID, File> files = ctx.newStates().get(BLOBS_KEY);
-        createGenesisAddressBook(bootstrapConfig, filesConfig, files);
-        createGenesisNodeDetails(bootstrapConfig, filesConfig, files);
+        createGenesisAddressBookAndNodeDetails(bootstrapConfig, hederaConfig, filesConfig, files, ctx.networkInfo());
         createGenesisFeeSchedule(bootstrapConfig, hederaConfig, filesConfig, files);
         createGenesisExchangeRate(bootstrapConfig, hederaConfig, filesConfig, files);
         createGenesisNetworkProperties(bootstrapConfig, hederaConfig, filesConfig, files, ctx.configuration());
@@ -110,23 +113,78 @@ public class GenesisSchema extends Schema {
     // ================================================================================================================
     // Creates and loads the Address Book into state
 
-    private void createGenesisAddressBook(
+    private void createGenesisAddressBookAndNodeDetails(
             @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final HederaConfig hederaConfig,
             @NonNull final FilesConfig filesConfig,
-            @NonNull final WritableKVState<FileID, File> files) {
-        logger.debug("Creating genesis address book file");
-        // TBD Implement this method
-    }
+            @NonNull final WritableKVState<FileID, File> files,
+            @NonNull final NetworkInfo networkInfo) {
 
-    // ================================================================================================================
-    // Creates and loads the Node Details into state
+        logger.debug("Creating genesis address book and node details files");
 
-    private void createGenesisNodeDetails(
-            @NonNull final BootstrapConfig bootstrapConfig,
-            @NonNull final FilesConfig filesConfig,
-            @NonNull final WritableKVState<FileID, File> files) {
-        logger.debug("Creating genesis node details file");
-        // TBD Implement this method
+        logger.trace("Converting NetworkInfo to NodeAddressBook");
+        final var nodeAddresses = new ArrayList<NodeAddress>();
+        for (final var nodeInfo : networkInfo.addressBook()) {
+            nodeAddresses.add(NodeAddress.newBuilder()
+                    .ipAddress(Bytes.wrap(nodeInfo.externalHostName()))
+                    .rsaPubKey(nodeInfo.hexEncodedPublicKey())
+                    .nodeId(nodeInfo.nodeId())
+                    .stake(nodeInfo.stake())
+                    .memo(Bytes.wrap(nodeInfo.memo()))
+                    .serviceEndpoint(ServiceEndpoint.newBuilder()
+                            .ipAddressV4(Bytes.wrap(nodeInfo.externalHostName()))
+                            .port(nodeInfo.externalPort())
+                            .build())
+                    .nodeAccountId(nodeInfo.accountId())
+                    .build());
+        }
+
+        final var nodeAddressBook =
+                NodeAddressBook.newBuilder().nodeAddress(nodeAddresses).build();
+        final var nodeAddressBookProto = NodeAddressBook.PROTOBUF.toBytes(nodeAddressBook);
+
+        // Create the master key that will own both of these special files
+        final var masterKey = KeyList.newBuilder()
+                .keys(Key.newBuilder()
+                        .ed25519(bootstrapConfig.genesisPublicKey())
+                        .build())
+                .build();
+
+        // Create the address book file
+        final var addressBookFileNum = filesConfig.addressBook();
+        final var addressBookFileId = FileID.newBuilder()
+                .shardNum(hederaConfig.shard())
+                .realmNum(hederaConfig.realm())
+                .fileNum(addressBookFileNum)
+                .build();
+
+        logger.trace("Add address book into {}", addressBookFileNum);
+        files.put(
+                addressBookFileId,
+                File.newBuilder()
+                        .contents(nodeAddressBookProto)
+                        .fileId(addressBookFileId)
+                        .keys(masterKey)
+                        .expirationSecond(bootstrapConfig.systemEntityExpiry())
+                        .build());
+
+        // Create the node details
+        final var nodeInfoFileNum = filesConfig.nodeDetails();
+        final var nodeInfoFileId = FileID.newBuilder()
+                .shardNum(hederaConfig.shard())
+                .realmNum(hederaConfig.realm())
+                .fileNum(nodeInfoFileNum)
+                .build();
+
+        logger.trace("Add node info into {}", nodeInfoFileNum);
+        files.put(
+                nodeInfoFileId,
+                File.newBuilder()
+                        .contents(nodeAddressBookProto)
+                        .fileId(nodeInfoFileId)
+                        .keys(masterKey)
+                        .expirationSecond(bootstrapConfig.systemEntityExpiry())
+                        .build());
     }
 
     // ================================================================================================================

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
@@ -25,6 +25,7 @@ import com.hedera.node.app.fixtures.state.FakeHederaState;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
 import com.hedera.node.app.service.networkadmin.FreezeService;
 import com.hedera.node.app.service.networkadmin.impl.FreezeServiceImpl;
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
@@ -39,6 +40,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FreezeServiceImplTest {
     @Mock
     private SchemaRegistry registry;
+
+    @Mock
+    private NetworkInfo networkInfo;
 
     @Test
     void testSpi() {
@@ -76,7 +80,7 @@ class FreezeServiceImplTest {
         final var state = new FakeHederaState();
 
         subject.registerSchemas(registry);
-        registry.migrate(FreezeService.NAME, state);
+        registry.migrate(FreezeService.NAME, state, networkInfo);
         final var upgradeFileHashKeyState =
                 state.createReadableStates(FreezeService.NAME).getSingleton(UPGRADE_FILE_HASH_KEY);
         assertNotNull(upgradeFileHashKeyState.get());

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -47,6 +47,7 @@ import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenRelationStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
 import com.hedera.node.app.spi.fixtures.state.MapReadableKVState;
+import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.WorkingStateAccessor;
@@ -163,6 +164,9 @@ public class NetworkAdminHandlerTestBase {
     @Mock
     private LedgerConfig ledgerConfig;
 
+    @Mock
+    private NetworkInfo networkInfo;
+
     @BeforeEach
     void commonSetUp() {
         givenValidAccount(false, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
@@ -181,7 +185,7 @@ public class NetworkAdminHandlerTestBase {
         final var registry = new FakeSchemaRegistry();
         final var svc = new RecordCacheService();
         svc.registerSchemas(registry);
-        registry.migrate(svc.getServiceName(), state);
+        registry.migrate(svc.getServiceName(), state, networkInfo);
         lenient().when(wsa.getHederaState()).thenReturn(state);
         lenient().when(props.getConfiguration()).thenReturn(versionedConfig);
         lenient().when(versionedConfig.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -216,6 +216,11 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
 
         @Override
         public HapiTestEngineExecutionContext before(HapiTestEngineExecutionContext context) {
+            // If there are no children, then there is nothing to do.
+            if (super.getChildren().isEmpty()) {
+                return context;
+            }
+
             try {
                 // Deleting the test data. Currently, we are deleting the data/saved and the eventstreams folders.
                 // We need to do that in order to be able to run all tests at the same time. Without that the tests


### PR DESCRIPTION
Closes #8267

- Enhance MigrationContext to expose NetworkInfo, so the file service can build files 101 and 102. This involves extending the API on NodeInfo with missing items
- Fix bootstrap configuration in `Hedera`, and create a `NetworkInfo` for migration. Migration needs this, but the dagger app cannot be initialized until after the migration has happened. Also needed to add LedgerConfig to bootstrap
- Add to shutdown the ability to shutdown virtual map databases. Kind of a hack, need a better way to do shutdown from the platform.
- Fix the JUnit HAPI Engine so it starts a single server at the start of all tests and shuts them down at the end