### PR TITLE
enable test to work with modularize code FetchSystemFiles

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FetchSystemFiles.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FetchSystemFiles.java
@@ -19,6 +19,7 @@ package com.hedera.services.bdd.suites.file;
 import static com.hedera.services.bdd.spec.HapiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -49,6 +50,7 @@ public class FetchSystemFiles extends HapiSuite {
     }
 
     /** Fetches the system files from a running network and saves them to the local file system. */
+    @HapiTest
     private HapiSpec fetchFiles() {
         return customHapiSpec("FetchFiles")
                 .withProperties(Map.of(


### PR DESCRIPTION
enable test to work with modularize code FetchSystemFiles

**Related issue(s)**:

Fixes #8053 

