### PR TITLE
Create upgrade special files during genesis with empty file contents

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -620,40 +620,6 @@ public final class Hedera implements SwirldMain {
         initializeThrottleManager(state);
     }
 
-    // The last throttle-exempt account is configurable to make it easy to start dev networks
-    // without throttling
-
-    // Only called during genesis
-    private void createUpdateFilesIfMissing() {
-        /*
-        final var firstUpdateNum = fileNumbers.firstSoftwareUpdateFile();
-        final var lastUpdateNum = fileNumbers.lastSoftwareUpdateFile();
-        final var specialFiles = hfs.specialFiles();
-        for (var updateNum = firstUpdateNum; updateNum <= lastUpdateNum; updateNum++) {
-            final var disFid = fileNumbers.toFid(updateNum);
-            if (!hfs.exists(disFid)) {
-                materialize(disFid, systemFileInfo(), new byte[0]);
-            } else if (!specialFiles.contains(disFid)) {
-                // This can be the case for file 0.0.150, whose metadata had
-                // been created for the legacy MerkleDiskFs. But whatever its
-                // contents were doesn't matter now. Just make sure it exists
-                // in the MerkleSpecialFiles!
-                specialFiles.update(disFid, new byte[0]);
-            }
-        }
-         */
-    }
-
-    private void doGenesisHousekeeping() {
-        /*
-        // List the node ids in the address book at genesis
-        final List<Long> genesisNodeIds = idsFromAddressBook(addressBook);
-
-        // Prepare the stake info manager for managing the new node ids
-        stakeInfoManager.prepForManaging(genesisNodeIds);
-         */
-    }
-
     private void initializeFeeManager(@NonNull final HederaState state) {
         logger.info("Initializing fee schedules");
         final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
@@ -107,7 +107,7 @@ public class GenesisSchema extends Schema {
         createGenesisNetworkProperties(bootstrapConfig, hederaConfig, filesConfig, files, ctx.configuration());
         createGenesisHapiPermissions(bootstrapConfig, hederaConfig, filesConfig, files);
         createGenesisThrottleDefinitions(bootstrapConfig, hederaConfig, filesConfig, files);
-        createGenesisSoftwareUpdateZip(bootstrapConfig, filesConfig, files);
+        createGenesisSoftwareUpdateFiles(bootstrapConfig, hederaConfig, filesConfig, files);
     }
 
     // ================================================================================================================
@@ -525,13 +525,37 @@ public class GenesisSchema extends Schema {
     }
 
     // ================================================================================================================
-    // Creates and loads the software update file into state (may be empty? NOT SURE)
+    // Creates and loads the software update file into state
 
-    private void createGenesisSoftwareUpdateZip(
+    private void createGenesisSoftwareUpdateFiles(
             @NonNull final BootstrapConfig bootstrapConfig,
+            @NonNull final HederaConfig hederaConfig,
             @NonNull final FilesConfig filesConfig,
             @NonNull final WritableKVState<FileID, File> files) {
-        logger.debug("Creating genesis software update zip file");
-        // TBD Implement this method
+
+        // These files all start off as an empty byte array. Only file 150 is actually used, the others are not, but
+        // may be used in the future.
+        logger.debug("Creating genesis software update files");
+        final var fileNums = filesConfig.softwareUpdateRange();
+        final var firstUpdateNum = fileNums.left();
+        final var lastUpdateNum = fileNums.right();
+        final var masterKey =
+                Key.newBuilder().ed25519(bootstrapConfig.genesisPublicKey()).build();
+        for (var updateNum = firstUpdateNum; updateNum <= lastUpdateNum; updateNum++) {
+            final var fileId = FileID.newBuilder()
+                    .shardNum(hederaConfig.shard())
+                    .realmNum(hederaConfig.realm())
+                    .fileNum(updateNum)
+                    .build();
+            logger.debug("Putting update file {} into state", updateNum);
+            files.put(
+                    fileId,
+                    File.newBuilder()
+                            .contents(Bytes.EMPTY)
+                            .fileId(fileId)
+                            .keys(KeyList.newBuilder().keys(masterKey))
+                            .expirationSecond(bootstrapConfig.systemEntityExpiry())
+                            .build());
+        }
     }
 }

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/schemas/GenesisSchemaTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/schemas/GenesisSchemaTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.file.impl.test.schemas;
+
+import static com.swirlds.common.utility.CommonUtils.unhex;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.state.file.File;
+import com.hedera.node.app.service.file.impl.FileServiceImpl;
+import com.hedera.node.app.service.file.impl.schemas.GenesisSchema;
+import com.hedera.node.app.spi.fixtures.info.FakeNetworkInfo;
+import com.hedera.node.app.spi.fixtures.state.MapWritableKVState;
+import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
+import com.hedera.node.app.spi.info.NetworkInfo;
+import com.hedera.node.app.spi.state.EmptyReadableStates;
+import com.hedera.node.app.spi.state.ReadableStates;
+import com.hedera.node.app.state.merkle.MigrationContextImpl;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+final class GenesisSchemaTest {
+    private final ReadableStates prevStates = EmptyReadableStates.INSTANCE;
+    private MapWritableStates newStates;
+    private final NetworkInfo networkInfo = new FakeNetworkInfo();
+
+    @BeforeEach
+    void setUp() {
+        newStates = MapWritableStates.builder()
+                .state(MapWritableKVState.builder(FileServiceImpl.BLOBS_KEY).build())
+                .build();
+    }
+
+    @DisplayName("Special update files are created with empty contents")
+    @Test
+    void emptyFilesCreatedForUpdateFiles() {
+        // Given a file GenesisSchema, and a configuration setting for the range that is unique, so we can make
+        // sure to verify that the code in question is using the config values, (and same for key and expiry)
+        final var schema = new GenesisSchema();
+        final var expiry = 1000;
+        final var keyString = "0123456789012345678901234567890123456789012345678901234567890123";
+        final var key = Key.newBuilder().ed25519(Bytes.wrap(unhex(keyString))).build();
+        final var config = HederaTestConfigBuilder.create()
+                .withValue("files.softwareUpdateRange", "151-158")
+                .withValue("bootstrap.system.entityExpiry", expiry)
+                .withValue("bootstrap.genesisPublicKey", keyString)
+                .getOrCreateConfig();
+
+        // When we migrate
+        schema.migrate(new MigrationContextImpl(prevStates, newStates, config, networkInfo));
+
+        // Then the new state has empty bytes for files 151-158 and proper values
+        final var files = newStates.<FileID, File>get(FileServiceImpl.BLOBS_KEY);
+        for (int i = 151; i <= 158; i++) {
+            final var fileID = FileID.newBuilder().fileNum(i).build();
+            final var file = files.get(fileID);
+            assertThat(file).as("file %d is null", i).isNotNull();
+            assertThat(file.contents()).as("file %d has non-empty contents", i).isEqualTo(Bytes.EMPTY);
+            assertThat(file.deleted()).isFalse();
+            assertThat(file.expirationSecond()).isEqualTo(expiry);
+            assertThat(file.memo()).isEmpty();
+            assertThat(file.hasKeys()).isTrue();
+            assertThat(file.keysOrThrow().keysOrThrow()).containsExactly(key);
+        }
+
+        // And files outside of that range (but within the normal, default range!) do not exist
+        assertThat(files.get(FileID.newBuilder().fileNum(150).build())).isNull();
+        assertThat(files.get(FileID.newBuilder().fileNum(159).build())).isNull();
+    }
+}


### PR DESCRIPTION
**Description**:
In `GenesisSchema` of the file service, creates the special files (by default, 150-159) for upgrade, all with empty bytes.

**Related issue(s)**:

Closes #8316

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
