### PR TITLE
Add the modular restart support

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/Schema.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/Schema.java
@@ -96,6 +96,18 @@ public abstract class Schema implements Comparable<Schema> {
         return Collections.emptySet();
     }
 
+    /**
+     * Called on this schema if, and only if, this schema is the most recent schema that is not newer than the
+     * version of software in use, and if the node is being restarted. Most services have nothing to do in this
+     * case, but some services may need to re-read configuration, or files on disk, or something similar. They
+     * are free to modify the state as needed in the same way that {@link #migrate(MigrationContext)} does.
+     *
+     * @param ctx {@link MigrationContext} for this schema restart operation
+     */
+    public void restart(@NonNull final MigrationContext ctx) {
+        Objects.requireNonNull(ctx);
+    }
+
     /** {@inheritDoc} */
     @Override
     public int compareTo(Schema o) {

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestService.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.spi.fixtures;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.spi.Service;
+import com.hedera.node.app.spi.fixtures.state.TestSchema;
+import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.spi.state.SchemaRegistry;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestService implements Service {
+    private final String name;
+    private final List<Schema> schemas;
+
+    public TestService(@NonNull final String name) {
+        this.name = requireNonNull(name);
+        this.schemas = List.of();
+    }
+
+    public TestService(@NonNull final String name, @NonNull final List<Schema> schemas) {
+        this.name = requireNonNull(name);
+        this.schemas = requireNonNull(schemas);
+    }
+
+    @NonNull
+    @Override
+    public String getServiceName() {
+        return name;
+    }
+
+    @Override
+    public void registerSchemas(@NonNull SchemaRegistry registry) {
+        schemas.forEach(registry::register);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String name;
+        private final List<Schema> schemas = new ArrayList<>();
+
+        private Builder() {}
+
+        public Builder name(@NonNull final String name) {
+            this.name = requireNonNull(name);
+            return this;
+        }
+
+        public Builder schema(@NonNull final TestSchema.Builder schemaBuilder) {
+            this.schemas.add(schemaBuilder.build());
+            return this;
+        }
+
+        public Builder schema(@NonNull final Schema schema) {
+            this.schemas.add(schema);
+            return this;
+        }
+
+        public TestService build() {
+            return new TestService(name, schemas);
+        }
+    }
+}

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/TestSchema.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/TestSchema.java
@@ -19,7 +19,11 @@ package com.hedera.node.app.spi.fixtures.state;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.spi.state.StateDefinition;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * An implementation of {@link Schema} that takes an integer as the version and has no
@@ -27,11 +31,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * like to test with.
  */
 public class TestSchema extends Schema {
-    private Runnable onMigrate;
-
-    public TestSchema(SemanticVersion version) {
-        super(version);
-    }
+    private final Runnable onMigrate;
+    private final Runnable onRestart;
+    private final Set<StateDefinition> statesToCreate;
+    private final Set<String> statesToRemove;
 
     public TestSchema(int version) {
         this(SemanticVersion.newBuilder().major(version).build());
@@ -41,9 +44,25 @@ public class TestSchema extends Schema {
         this(SemanticVersion.newBuilder().major(major).minor(minor).patch(patch).build());
     }
 
+    public TestSchema(SemanticVersion version) {
+        this(version, null);
+    }
+
     public TestSchema(SemanticVersion version, Runnable onMigrate) {
-        this(version);
+        this(version, Set.of(), Set.of(), onMigrate, null);
+    }
+
+    public TestSchema(
+            @NonNull final SemanticVersion version,
+            @NonNull final Set<StateDefinition> statesToCreate,
+            @NonNull final Set<String> statesToRemove,
+            @Nullable Runnable onMigrate,
+            @Nullable Runnable onRestart) {
+        super(version);
         this.onMigrate = onMigrate;
+        this.onRestart = onRestart;
+        this.statesToCreate = statesToCreate;
+        this.statesToRemove = statesToRemove;
     }
 
     @Override
@@ -51,6 +70,82 @@ public class TestSchema extends Schema {
         super.migrate(ctx);
         if (onMigrate != null) {
             onMigrate.run();
+        }
+    }
+
+    @NonNull
+    @Override
+    public Set<StateDefinition> statesToCreate() {
+        return statesToCreate;
+    }
+
+    @NonNull
+    @Override
+    public Set<String> statesToRemove() {
+        return statesToRemove;
+    }
+
+    @Override
+    public void restart(@NonNull MigrationContext ctx) {
+        super.restart(ctx);
+        if (onRestart != null) {
+            onRestart.run();
+        }
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private SemanticVersion version = SemanticVersion.DEFAULT;
+        private Runnable onMigrate;
+        private Runnable onRestart;
+        private final Set<StateDefinition> statesToCreate = new HashSet<>();
+        private final Set<String> statesToRemove = new HashSet<>();
+
+        public Builder version(SemanticVersion version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder majorVersion(int major) {
+            this.version = version.copyBuilder().major(major).build();
+            return this;
+        }
+
+        public Builder minorVersion(int minor) {
+            this.version = version.copyBuilder().minor(minor).build();
+            return this;
+        }
+
+        public Builder patchVersion(int patch) {
+            this.version = version.copyBuilder().patch(patch).build();
+            return this;
+        }
+
+        public Builder onMigrate(Runnable onMigrate) {
+            this.onMigrate = onMigrate;
+            return this;
+        }
+
+        public Builder onRestart(Runnable onRestart) {
+            this.onRestart = onRestart;
+            return this;
+        }
+
+        public Builder stateToCreate(StateDefinition state) {
+            this.statesToCreate.add(state);
+            return this;
+        }
+
+        public Builder stateToRemove(String state) {
+            this.statesToRemove.add(state);
+            return this;
+        }
+
+        public TestSchema build() {
+            return new TestSchema(version, statesToCreate, statesToRemove, onMigrate, onRestart);
         }
     }
 }

--- a/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
@@ -21,8 +21,10 @@ import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.hapi.node.transaction.TransactionResponse;
 import com.hedera.node.app.grpc.impl.netty.NettyGrpcServerManager;
+import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.spi.Service;
 import com.hedera.node.app.spi.fixtures.TestBase;
+import com.hedera.node.app.state.merkle.MerkleSchemaRegistry;
 import com.hedera.node.app.workflows.ingest.IngestWorkflow;
 import com.hedera.node.app.workflows.query.QueryWorkflow;
 import com.hedera.node.config.VersionedConfigImpl;
@@ -30,6 +32,7 @@ import com.hedera.node.config.data.GrpcConfig;
 import com.hedera.node.config.data.NettyConfig;
 import com.hedera.pbj.runtime.RpcMethodDefinition;
 import com.hedera.pbj.runtime.RpcServiceDefinition;
+import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.DefaultMetrics;
@@ -171,10 +174,13 @@ abstract class GrpcTestBase extends TestBase {
             }
         };
 
+        final var cr = ConstructableRegistry.getInstance();
+        final var registry = new MerkleSchemaRegistry(cr, "TestService");
+        final var registration = new ServicesRegistry.Registration(testService, registry);
         final var config = createConfig(new TestSource());
         this.grpcServer = new NettyGrpcServerManager(
                 () -> new VersionedConfigImpl(config, 1),
-                () -> Set.of(testService),
+                () -> Set.of(registration),
                 ingestWorkflow,
                 queryWorkflow,
                 metrics);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -661,7 +661,7 @@ public final class Hedera implements SwirldMain {
         this.throttleManager = new ThrottleManager();
 
         logger.info("Initializing ExchangeRateManager");
-        exchangeRateManager = new ExchangeRateManager();
+        exchangeRateManager = new ExchangeRateManager(configProvider);
 
         // Create all the nodes in the merkle tree for all the services
         // TODO: Actually, we should reinitialize the config on each step along the migration path, so we should pass

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -45,7 +45,6 @@ import com.hedera.node.app.service.networkadmin.impl.NetworkServiceImpl;
 import com.hedera.node.app.service.schedule.impl.ScheduleServiceImpl;
 import com.hedera.node.app.service.token.impl.TokenServiceImpl;
 import com.hedera.node.app.service.util.impl.UtilServiceImpl;
-import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.services.ServicesRegistryImpl;
 import com.hedera.node.app.spi.HapiUtils;
 import com.hedera.node.app.spi.Service;
@@ -136,7 +135,7 @@ public final class Hedera implements SwirldMain {
     /** Required for state management. Used by platform for deserialization of state. */
     private final ConstructableRegistry constructableRegistry;
     /** The registry of all known services */
-    private final ServicesRegistry servicesRegistry;
+    private final ServicesRegistryImpl servicesRegistry;
     /** The current version of THIS software */
     private final HederaSoftwareVersion version;
     /** The configuration at the time of bootstrapping the node */
@@ -186,7 +185,7 @@ public final class Hedera implements SwirldMain {
                             -----------------------
                                 ---------------
                         """);
-        logger.info("Welcome to Hedera! Developed with love by the Open Source Community. "
+        logger.info("Welcome to Hedera! Developed with ❤\uFE0F by the Open Source Community. "
                 + "https://github.com/hashgraph/hedera-services");
 
         // Load the bootstrap configuration. These config values are NOT stored in state, so we don't need to have
@@ -213,19 +212,21 @@ public final class Hedera implements SwirldMain {
         // Create all the service implementations
         logger.info("Registering services");
         // FUTURE: Use the service loader framework to load these services!
-        this.servicesRegistry = new ServicesRegistryImpl(Set.of(
-                new ConsensusServiceImpl(),
-                CONTRACT_SERVICE,
-                new FileServiceImpl(),
-                new FreezeServiceImpl(),
-                new NetworkServiceImpl(),
-                new ScheduleServiceImpl(),
-                new TokenServiceImpl(),
-                new UtilServiceImpl(),
-                new RecordCacheService(),
-                new BlockRecordService(),
-                new EntityIdService(),
-                new FeeService()));
+        this.servicesRegistry = new ServicesRegistryImpl(constructableRegistry);
+        Set.of(
+                        new ConsensusServiceImpl(),
+                        CONTRACT_SERVICE,
+                        new FileServiceImpl(),
+                        new FreezeServiceImpl(),
+                        new NetworkServiceImpl(),
+                        new ScheduleServiceImpl(),
+                        new TokenServiceImpl(),
+                        new UtilServiceImpl(),
+                        new RecordCacheService(),
+                        new BlockRecordService(),
+                        new EntityIdService(),
+                        new FeeService())
+                .forEach(servicesRegistry::register);
 
         // Register MerkleHederaState with the ConstructableRegistry, so we can use a constructor OTHER THAN the default
         // constructor to make sure it has the config and other info it needs to be created correctly.
@@ -346,14 +347,21 @@ public final class Hedera implements SwirldMain {
         // assertion will hold true.
         assert configProvider != null : "Config Provider *must* have been set by now!";
 
-        // Since we now have an "app" instance, we can update the dual state accessor. This is *ONLY* used by the app to
-        // produce a log summary after a freeze. We should refactor to not have a global reference to this.
-        updateDualState(dualState);
+        // Some logging on what we found about freeze in the dual state
+        logger.info(
+                "Dual state includes freeze time={} and last frozen={}",
+                dualState.getFreezeTime(),
+                dualState.getLastFrozenTime());
     }
 
     /**
-     * Called by this class when we detect it is time to do migration. This is only used as part of genesis or restart,
-     * not as a result of reconnect.
+     * Called by this class when we detect it is time to do migration. The {@code deserializedVersion} must not be
+     * newer than the current software version. If it is prior to the current version, then each migration between
+     * the {@code deserializedVersion} and the current version, including the current version, will be executed, thus
+     * bringing the state up to date.
+     *
+     * <p>If the {@code deserializedVersion} is {@code null}, then this is the first time the node has been started,
+     * and thus all schemas will be executed.
      */
     private void onMigrate(
             @NonNull final MerkleHederaState state, @Nullable final HederaSoftwareVersion deserializedVersion) {
@@ -368,13 +376,12 @@ public final class Hedera implements SwirldMain {
         final var nodeAddress = platform.getAddressBook().getAddress(selfId);
         final var selfNodeInfo = SelfNodeInfoImpl.of(nodeAddress, version);
         final var networkInfo = new NetworkInfoImpl(selfNodeInfo, platform, bootstrapConfigProvider);
-        for (final var service : servicesRegistry.services()) {
+        for (final var registration : servicesRegistry.registrations()) {
             // FUTURE We should have metrics here to keep track of how long it takes to migrate each service
+            final var service = registration.service();
             final var serviceName = service.getServiceName();
-            final var registry = new MerkleSchemaRegistry(constructableRegistry, serviceName);
-            logger.debug("Registering schemas for service {}", serviceName);
-            service.registerSchemas(registry);
             logger.info("Migrating Service {}", serviceName);
+            final var registry = (MerkleSchemaRegistry) registration.registry();
             registry.migrate(state, previousVersion, currentVersion, configProvider.getConfiguration(), networkInfo);
         }
         logger.info("Migration complete");
@@ -462,6 +469,9 @@ public final class Hedera implements SwirldMain {
             // tempted to say that each service has lifecycle methods we can invoke (optional methods on the Service
             // interface), but I worry about the order of invocation on different services. Which service gets called
             // before which other service? Does it matter?
+            // ANSWER: We need to look and see if there is an update to the upgrade file that happened on other nodes
+            // that we reconnected with. In that case, we need to save the file to disk. Similar to how we have to hook
+            // for all the other special files on restart / genesis / reconnect.
 
             // TBD: notifications.register(StateWriteToDiskCompleteListener.class,
             // It looks like this notification is handled by
@@ -622,53 +632,6 @@ public final class Hedera implements SwirldMain {
         initializeThrottleManager(state);
     }
 
-    private void initializeFeeManager(@NonNull final HederaState state) {
-        logger.info("Initializing fee schedules");
-        final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
-        final var fileNum = filesConfig.feeSchedules();
-        final File file = getFileFromStorage(state, fileNum);
-        if (file != null) {
-            final var fileData = file.contents();
-            daggerApp.feeManager().update(fileData);
-        }
-        logger.info("Fee schedule initialized");
-    }
-
-    private void initializeExchangeRateManager(@NonNull final HederaState state) {
-        logger.info("Initializing exchange rates");
-        final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
-        final var fileNum = filesConfig.exchangeRates();
-        final var file = getFileFromStorage(state, fileNum);
-        if (file != null) {
-            final var fileData = file.contents();
-            daggerApp.exchangeRateManager().init(state, fileData);
-        }
-        logger.info("Exchange rates initialized");
-    }
-
-    private void initializeThrottleManager(@NonNull final HederaState state) {
-        logger.info("Initializing throttles");
-        final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
-        final var fileNum = filesConfig.throttleDefinitions();
-        final var file = getFileFromStorage(state, fileNum);
-        if (file != null) {
-            final var fileData = file.contents();
-            daggerApp.throttleManager().update(fileData);
-        }
-        logger.info("Throttles initialized");
-    }
-
-    private File getFileFromStorage(HederaState state, long fileNum) {
-        final var readableFileStore = new ReadableStoreFactory(state).getStore(ReadableFileStore.class);
-        final var hederaConfig = configProvider.getConfiguration().getConfigData(HederaConfig.class);
-        final var fileId = FileID.newBuilder()
-                .fileNum(fileNum)
-                .shardNum(hederaConfig.shard())
-                .realmNum(hederaConfig.realm())
-                .build();
-        return readableFileStore.getFileLeaf(fileId);
-    }
-
     /*==================================================================================================================
     *
     * Restart Initialization
@@ -688,50 +651,33 @@ public final class Hedera implements SwirldMain {
             System.exit(1);
         }
 
-        // This configuration is based on what is in state *RIGHT NOW*, before any possible upgrade. This is the config
-        // that must be passed to the migration methods.
+        // Initialize the configuration from disk (restart case). We must do this BEFORE we run migration, because
+        // the various migration methods may depend on configuration to do their work
+        logger.info("Initializing restart configuration");
+        this.configProvider = new ConfigProviderImpl(false);
+        logConfiguration();
+
+        logger.info("Initializing ThrottleManager");
+        this.throttleManager = new ThrottleManager();
+
+        logger.info("Initializing ExchangeRateManager");
+        exchangeRateManager = new ExchangeRateManager();
+
+        // Create all the nodes in the merkle tree for all the services
         // TODO: Actually, we should reinitialize the config on each step along the migration path, so we should pass
         //       the config provider to the migration code and let it get the right version of config as it goes.
-        logger.info("Initializing Configuration");
-        this.configProvider = new ConfigProviderImpl(false);
+        onMigrate(state, deserializedVersion);
 
-        // Migrate to the most recent state, if needed
-        final boolean upgrade = isUpgrade(version, deserializedVersion);
-        if (upgrade) {
-            logger.debug("Upgrade detected");
-            onMigrate(state, deserializedVersion);
-        }
-
-        // TODO Update the configuration with whatever is the new latest version in state. In reality, we shouldn't
-        //      be messing with configuration during migration, but it could happen (by the file service), so we should
-        //      be defensive about it so the software is always correct, even in that very unlikely scenario.
-        //        this.configProvider.update(null);
-
-        // Now that we have the state created, we are ready to create the all the dagger dependencies
+        // Now that we have the state created, we are ready to create the dependency graph with Dagger
         initializeDagger(state, RESTART);
 
-        // We may still want to change the address book without an upgrade. But note
-        // that without a dynamic address book, this MUST be a no-op during reconnect.
-        //        final var stakingInfo = stateChildren.stakingInfo();
-        //        final var networkCtx = stateChildren.networkCtx();
-        //        daggerApp.stakeStartupHelper().doRestartHousekeeping(stateChildren.addressBook(), stakingInfo);
-        //        if (upgrade) {
-        //            dualState.setFreezeTime(null);
-        //            networkCtx.discardPreparedUpgradeMeta();
-        ////            if (version.hasMigrationRecordsFrom(deserializedVersion)) {
-        ////                networkCtx.markMigrationRecordsNotYetStreamed();
-        ////            }
-        //        }
-
-        // This updates the working state accessor with our children
-        //        daggerApp.initializationFlow().runWith(stateChildren, configProvider);
-        //        if (upgrade) {
-        //            daggerApp.stakeStartupHelper().doUpgradeHousekeeping(networkCtx, stateChildren.accounts(),
-        // stakingInfo);
-        //        }
-
-        // Once we have a dynamic address book, this will run unconditionally
-        //        daggerApp.sysFilesManager().updateStakeDetails();
+        // And now that the entire dependency graph has been initialized, and we have config, and all migration has
+        // been completed, we are prepared to initialize in-memory data structures. These specifically are loaded
+        // from information held in state (especially those in special files).
+        initializeFeeManager(state);
+        initializeExchangeRateManager(state);
+        initializeThrottleManager(state);
+        // TODO We may need to update the config with the latest version in file 121
     }
 
     /*==================================================================================================================
@@ -780,18 +726,6 @@ public final class Hedera implements SwirldMain {
         }
     }
 
-    private void updateDualState(final SwirldDualState dualState) {
-        //        daggerApp.dualStateAccessor().setDualState(dualState);
-        logger.info(
-                "Dual state includes freeze time={} and last frozen={}",
-                dualState.getFreezeTime(),
-                dualState.getLastFrozenTime());
-    }
-
-    private boolean isUpgrade(final HederaSoftwareVersion deployedVersion, final SoftwareVersion deserializedVersion) {
-        return deployedVersion.isAfter(deserializedVersion);
-    }
-
     private boolean isDowngrade(
             final HederaSoftwareVersion deployedVersion, final SoftwareVersion deserializedVersion) {
         return deployedVersion.isBefore(deserializedVersion);
@@ -805,5 +739,52 @@ public final class Hedera implements SwirldMain {
             Utils.allProperties(config).forEach((key, value) -> lines.add(key + " = " + value));
             logger.info(String.join("\n", lines));
         }
+    }
+
+    private void initializeFeeManager(@NonNull final HederaState state) {
+        logger.info("Initializing fee schedules");
+        final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileNum = filesConfig.feeSchedules();
+        final File file = getFileFromStorage(state, fileNum);
+        if (file != null) {
+            final var fileData = file.contents();
+            daggerApp.feeManager().update(fileData);
+        }
+        logger.info("Fee schedule initialized");
+    }
+
+    private void initializeExchangeRateManager(@NonNull final HederaState state) {
+        logger.info("Initializing exchange rates");
+        final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileNum = filesConfig.exchangeRates();
+        final var file = getFileFromStorage(state, fileNum);
+        if (file != null) {
+            final var fileData = file.contents();
+            daggerApp.exchangeRateManager().init(state, fileData);
+        }
+        logger.info("Exchange rates initialized");
+    }
+
+    private void initializeThrottleManager(@NonNull final HederaState state) {
+        logger.info("Initializing throttles");
+        final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileNum = filesConfig.throttleDefinitions();
+        final var file = getFileFromStorage(state, fileNum);
+        if (file != null) {
+            final var fileData = file.contents();
+            daggerApp.throttleManager().update(fileData);
+        }
+        logger.info("Throttles initialized");
+    }
+
+    private File getFileFromStorage(HederaState state, long fileNum) {
+        final var readableFileStore = new ReadableStoreFactory(state).getStore(ReadableFileStore.class);
+        final var hederaConfig = configProvider.getConfiguration().getConfigData(HederaConfig.class);
+        final var fileId = FileID.newBuilder()
+                .fileNum(fileNum)
+                .shardNum(hederaConfig.shard())
+                .realmNum(hederaConfig.realm())
+                .build();
+        return readableFileStore.getFileLeaf(fileId);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
@@ -99,7 +99,8 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
         requireNonNull(metrics);
 
         // Convert the various RPC service definitions into transaction or query endpoints using the GrpcServiceBuilder.
-        services = servicesRegistry.services().stream()
+        services = servicesRegistry.registrations().stream()
+                .map(ServicesRegistry.Registration::service)
                 .flatMap(s -> s.rpcDefinitions().stream())
                 .map(d -> {
                     final var builder = new GrpcServiceBuilder(d.basePath(), ingestWorkflow, queryWorkflow);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistry.java
@@ -16,7 +16,10 @@
 
 package com.hedera.node.app.services;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.node.app.spi.Service;
+import com.hedera.node.app.spi.state.SchemaRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 import javax.inject.Singleton;
@@ -27,10 +30,23 @@ import javax.inject.Singleton;
 @Singleton
 public interface ServicesRegistry {
     /**
-     * Gets the full set of services registered.
+     * A record of a service registration.
+     *
+     * @param service The service that was registered
+     * @param registry The schema registry for the service
+     */
+    record Registration(@NonNull Service service, @NonNull SchemaRegistry registry) {
+        public Registration {
+            requireNonNull(service);
+            requireNonNull(registry);
+        }
+    }
+
+    /**
+     * Gets the full set of services registered, sorted deterministically.
      *
      * @return The set of services. May be empty.
      */
     @NonNull
-    Set<Service> services();
+    Set<Registration> registrations();
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistryImpl.java
@@ -16,26 +16,58 @@
 
 package com.hedera.node.app.services;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.node.app.spi.Service;
+import com.hedera.node.app.state.merkle.MerkleSchemaRegistry;
+import com.swirlds.common.constructable.ConstructableRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
-import java.util.Set;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import javax.inject.Singleton;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
  * A simple implementation of {@link ServicesRegistry}.
- *
- * @param services The services that are registered
  */
 @Singleton
-public record ServicesRegistryImpl(@NonNull Set<Service> services) implements ServicesRegistry {
+public final class ServicesRegistryImpl implements ServicesRegistry {
     private static final Logger logger = LogManager.getLogger(ServicesRegistryImpl.class);
+    /** We have to register with the {@link ConstructableRegistry} based on the schemas of the services */
+    private final ConstructableRegistry constructableRegistry;
+    /** The set of registered services */
+    private final SortedSet<Registration> entries;
 
-    public ServicesRegistryImpl(@NonNull final Set<Service> services) {
-        this.services = Collections.unmodifiableSet(services);
-        this.services.forEach(service -> logger.info(
-                "Registered service {} with implementation {}", service.getServiceName(), service.getClass()));
+    /**
+     * Creates a new registry.
+     */
+    public ServicesRegistryImpl(@NonNull final ConstructableRegistry constructableRegistry) {
+        this.constructableRegistry = requireNonNull(constructableRegistry);
+        this.entries = new TreeSet<>(Comparator.comparing(r -> r.service().getServiceName()));
+    }
+
+    /**
+     * Register the given service.
+     *
+     * @param service The service to register
+     */
+    public void register(@NonNull final Service service) {
+        final var serviceName = service.getServiceName();
+
+        logger.debug("Registering schemas for service {}", serviceName);
+        final var registry = new MerkleSchemaRegistry(constructableRegistry, serviceName);
+        service.registerSchemas(registry);
+
+        entries.add(new Registration(service, registry));
+        logger.info("Registered service {} with implementation {}", service.getServiceName(), service.getClass());
+    }
+
+    @NonNull
+    @Override
+    public SortedSet<Registration> registrations() {
+        return Collections.unmodifiableSortedSet(entries);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -16,8 +16,9 @@
 
 package com.hedera.node.app.state.merkle;
 
-import com.google.protobuf.ByteString;
-import com.hedera.node.app.service.mono.utils.EntityNum;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.Hedera;
 import com.hedera.node.app.spi.state.CommittableWritableStates;
 import com.hedera.node.app.spi.state.EmptyReadableStates;
 import com.hedera.node.app.spi.state.EmptyWritableStates;
@@ -45,6 +46,7 @@ import com.hedera.node.app.state.merkle.queue.WritableQueueStateImpl;
 import com.hedera.node.app.state.merkle.singleton.ReadableSingletonStateImpl;
 import com.hedera.node.app.state.merkle.singleton.SingletonNode;
 import com.hedera.node.app.state.merkle.singleton.WritableSingletonStateImpl;
+import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
@@ -56,7 +58,6 @@ import com.swirlds.common.system.SwirldDualState;
 import com.swirlds.common.system.SwirldState;
 import com.swirlds.common.system.events.Event;
 import com.swirlds.common.utility.Labeled;
-import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -64,8 +65,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -96,9 +97,23 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     private static final WritableStates EMPTY_WRITABLE_STATES = new EmptyWritableStates();
 
     // For serialization
+    /**
+     * This class ID is returned IF the default constructor was used. This is a nasty workaround for
+     * {@link ConstructableRegistry}. The registry does classpath scanning, and finds this class. It then invokes
+     * the default constructor and then asks for the class ID, and then throws away the object. It sticks this
+     * mapping of class ID to class name into a map. Later (in {@link Hedera}) we define an actual mapping for the
+     * {@link ConstructableRegistry} that maps {@link #CLASS_ID} to {@link MerkleHederaState} using a lambda that will
+     * create the instancing using the non-default constructor. But the {@link ConstructableRegistry} doesn't
+     * actually register the second mapping! So we will trick it. We will return this bogus class ID if the default
+     * constructor is used, or {@link #CLASS_ID} otherwise.
+     */
+    private static final long DO_NOT_USE_IN_REAL_LIFE_CLASS_ID = 0x0000deadbeef0000L;
+
     private static final long CLASS_ID = 0x2de3ead3caf06392L;
     private static final int VERSION_1 = 1;
     private static final int CURRENT_VERSION = VERSION_1;
+
+    private long classId;
 
     /**
      * This callback is invoked whenever the consensus round happens. The Hashgraph Platform, today,
@@ -134,15 +149,6 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     private final Map<String, Map<String, StateMetadata<?, ?>>> services = new HashMap<>();
 
     /**
-     * A rebuilt-map of all aliases.
-     *
-     * <p>NOTE: This field is TEMPORARY. Once we have eliminated mono-service, this alias map will
-     * move to being a normal part of state using a VirtualMap, and we will no longer have it as a
-     * separate in-memory data structure.</p>
-     */
-    private final FCHashMap<ByteString, EntityNum> aliases;
-
-    /**
      * Create a new instance. This constructor must be used for all creations of this class.
      *
      * @param onPreHandle            The callback to invoke when an event is ready for pre-handle
@@ -153,10 +159,10 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
             @NonNull final PreHandleListener onPreHandle,
             @NonNull final HandleConsensusRoundListener onHandleConsensusRound,
             @NonNull final OnStateInitialized onInit) {
-        this.onPreHandle = Objects.requireNonNull(onPreHandle);
-        this.onHandleConsensusRound = Objects.requireNonNull(onHandleConsensusRound);
-        this.onInit = Objects.requireNonNull(onInit);
-        this.aliases = new FCHashMap<>();
+        this.onPreHandle = requireNonNull(onPreHandle);
+        this.onHandleConsensusRound = requireNonNull(onHandleConsensusRound);
+        this.onInit = requireNonNull(onInit);
+        this.classId = CLASS_ID;
     }
 
     /**
@@ -170,8 +176,8 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     @Deprecated(forRemoval = true)
     public MerkleHederaState() {
         // ConstructableRegistry requires a "working" no-arg constructor
-        aliases = null;
         onPreHandle = null;
+        this.classId = DO_NOT_USE_IN_REAL_LIFE_CLASS_ID;
     }
 
     /**
@@ -202,8 +208,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
         // Copy the Merkle route from the source instance
         super(from);
 
-        // Make a copy of the aliases map
-        this.aliases = from.aliases.copy();
+        this.classId = from.classId;
 
         // Copy over the metadata
         for (final var entry : from.services.entrySet()) {
@@ -234,7 +239,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
 
     @Override
     public long getClassId() {
-        return CLASS_ID;
+        return classId;
     }
 
     @Override
@@ -327,53 +332,26 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
         return this;
     }
 
-    <K, V> void putServiceStateIfAbsent(@NonNull final StateMetadata<K, V> md) {
-        throwIfImmutable();
-        Objects.requireNonNull(md);
-        final var stateMetadata = services.computeIfAbsent(md.serviceName(), k -> new HashMap<>());
-        stateMetadata.put(md.stateDefinition().stateKey(), md);
-    }
-
     /**
      * Puts the defined service state and its associated node into the merkle tree. The precondition
      * for calling this method is that node MUST be a {@link MerkleMap} or {@link VirtualMap} and
      * MUST have a correct label applied.
      *
      * @param md   The metadata associated with the state
-     * @param node The node to add. Cannot be null.
+     * @param nodeSupplier Returns the node to add. Cannot be null. Can be used to create the node on-the-fly.
      * @throws IllegalArgumentException if the node is neither a merkle map nor virtual map, or if
      *                                  it doesn't have a label, or if the label isn't right.
      */
-    <K, V> void putServiceStateIfAbsent(@NonNull final StateMetadata<K, V> md, @NonNull final MerkleNode node) {
+    <K, V> void putServiceStateIfAbsent(
+            @NonNull final StateMetadata<K, V> md, @NonNull final Supplier<MerkleNode> nodeSupplier) {
 
         // Validate the inputs
         throwIfImmutable();
-        Objects.requireNonNull(md);
-        Objects.requireNonNull(node);
-
-        final var label = node instanceof Labeled labeled ? labeled.getLabel() : null;
-        if (label == null) {
-            throw new IllegalArgumentException("`node` must be a Labeled and have a label");
-        }
-
-        final var def = md.stateDefinition();
-        if (def.onDisk() && !(node instanceof VirtualMap<?, ?>)) {
-            throw new IllegalArgumentException(
-                    "Mismatch: state definition claims on-disk, but " + "the merkle node is not a VirtualMap");
-        }
-
-        if (label.isEmpty()) {
-            // It looks like both MerkleMap and VirtualMap do not allow for a null label.
-            // But I want to leave this check in here anyway, in case that is ever changed.
-            throw new IllegalArgumentException("A label must be specified on the node");
-        }
-
-        if (!label.equals(StateUtils.computeLabel(md.serviceName(), def.stateKey()))) {
-            throw new IllegalArgumentException(
-                    "A label must be computed based on the same " + "service name and state key in the metadata!");
-        }
+        requireNonNull(md);
+        requireNonNull(nodeSupplier);
 
         // Put this metadata into the map
+        final var def = md.stateDefinition();
         final var stateMetadata = services.computeIfAbsent(md.serviceName(), k -> new HashMap<>());
         stateMetadata.put(def.stateKey(), md);
 
@@ -382,6 +360,28 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
         // because it may have been loaded from state on disk, and the node provided here in this
         // call is always for genesis. So we may just ignore it.
         if (findNodeIndex(md.serviceName(), def.stateKey()) == -1) {
+            final var node = requireNonNull(nodeSupplier.get());
+            final var label = node instanceof Labeled labeled ? labeled.getLabel() : null;
+            if (label == null) {
+                throw new IllegalArgumentException("`node` must be a Labeled and have a label");
+            }
+
+            if (def.onDisk() && !(node instanceof VirtualMap<?, ?>)) {
+                throw new IllegalArgumentException(
+                        "Mismatch: state definition claims on-disk, but " + "the merkle node is not a VirtualMap");
+            }
+
+            if (label.isEmpty()) {
+                // It looks like both MerkleMap and VirtualMap do not allow for a null label.
+                // But I want to leave this check in here anyway, in case that is ever changed.
+                throw new IllegalArgumentException("A label must be specified on the node");
+            }
+
+            if (!label.equals(StateUtils.computeLabel(md.serviceName(), def.stateKey()))) {
+                throw new IllegalArgumentException(
+                        "A label must be computed based on the same " + "service name and state key in the metadata!");
+            }
+
             setChild(getNumberOfChildren(), node);
         }
     }
@@ -394,8 +394,8 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      */
     void removeServiceState(@NonNull final String serviceName, @NonNull final String stateKey) {
         throwIfImmutable();
-        Objects.requireNonNull(serviceName);
-        Objects.requireNonNull(stateKey);
+        requireNonNull(serviceName);
+        requireNonNull(stateKey);
 
         // Remove the metadata entry
         final var stateMetadata = services.get(serviceName);
@@ -446,7 +446,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
          * @param stateMetadata cannot be null
          */
         MerkleStates(@NonNull final Map<String, StateMetadata<?, ?>> stateMetadata) {
-            this.stateMetadata = Objects.requireNonNull(stateMetadata);
+            this.stateMetadata = requireNonNull(stateMetadata);
             this.stateKeys = Collections.unmodifiableSet(stateMetadata.keySet());
             this.kvInstances = new HashMap<>();
             this.singletonInstances = new HashMap<>();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.state.merkle;
 
 import static com.hedera.node.app.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
+import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.HapiUtils;
@@ -24,9 +25,10 @@ import com.hedera.node.app.spi.Service;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.FilteredReadableStates;
 import com.hedera.node.app.spi.state.FilteredWritableStates;
+import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
-import com.hedera.node.app.state.merkle.MerkleHederaState.MerkleWritableStates;
+import com.hedera.node.app.spi.state.StateDefinition;
 import com.hedera.node.app.state.merkle.disk.OnDiskKey;
 import com.hedera.node.app.state.merkle.disk.OnDiskKeySerializer;
 import com.hedera.node.app.state.merkle.disk.OnDiskValue;
@@ -49,12 +51,9 @@ import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.logging.log4j.LogManager;
@@ -93,8 +92,8 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      */
     public MerkleSchemaRegistry(
             @NonNull final ConstructableRegistry constructableRegistry, @NonNull final String serviceName) {
-        this.constructableRegistry = Objects.requireNonNull(constructableRegistry);
-        this.serviceName = StateUtils.validateStateKey(Objects.requireNonNull(serviceName));
+        this.constructableRegistry = requireNonNull(constructableRegistry);
+        this.serviceName = StateUtils.validateStateKey(requireNonNull(serviceName));
     }
 
     /**
@@ -105,7 +104,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
     @Override
     public SchemaRegistry register(@NonNull Schema schema) {
         schemas.remove(schema);
-        schemas.add(Objects.requireNonNull(schema));
+        schemas.add(requireNonNull(schema));
         logger.debug(
                 "Registering schema {} for service {} ",
                 () -> HapiUtils.toString(schema.getVersion()),
@@ -126,6 +125,11 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      * the supplied versions, applies all necessary migrations for every {@link Schema} newer than
      * {@code previousVersion} and no newer than {@code currentVersion}.
      *
+     * <p>If the {@code previousVersion} and {@code currentVersion} are the same, then we do not need
+     * to migrate, but instead we just call {@link Schema#restart(MigrationContext)} to allow the schema
+     * to perform any necessary logic on restart. Most services have nothing to do, but some may need
+     * to read files from disk, and could potentially change their state as a result.
+     *
      * @param hederaState The {@link MerkleHederaState} instance for this registry to use.
      * @param previousVersion The version of state loaded from disk. Possibly null.
      * @param currentVersion The current version. Never null. Must be newer than {@code
@@ -139,37 +143,15 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             @NonNull final SemanticVersion currentVersion,
             @NonNull final Configuration config,
             @NonNull final NetworkInfo networkInfo) {
-        Objects.requireNonNull(hederaState);
-        Objects.requireNonNull(currentVersion);
-        Objects.requireNonNull(config);
-        Objects.requireNonNull(networkInfo);
-
-        // If the previous and current versions are the same, then we have no need to migrate
-        // to achieve the correct merkle tree version. All we need to do is register with
-        // the MerkleHederaState the metadata for this version
-        if (isSameVersion(previousVersion, currentVersion)) {
-            final var schemasToApply = computeApplicableSchemas(null, currentVersion);
-            final Map<String, StateMetadata<?, ?>> metadata = new HashMap<>();
-            for (Schema schema : schemasToApply) {
-                for (var def : schema.statesToCreate()) {
-                    final var md = new StateMetadata<>(serviceName, schema, def);
-                    metadata.put(def.stateKey(), md);
-                }
-                for (var stateKey : schema.statesToRemove()) {
-                    metadata.remove(stateKey);
-                }
-            }
-
-            for (final var md : metadata.values()) {
-                hederaState.putServiceStateIfAbsent((StateMetadata) md);
-            }
-
-            return;
-        }
+        requireNonNull(hederaState);
+        requireNonNull(currentVersion);
+        requireNonNull(config);
+        requireNonNull(networkInfo);
 
         // Figure out which schemas need to be applied based on the previous and current versions, and then for each
         // of those schemas, create the new states and remove the old states and migrate the data.
         final var schemasToApply = computeApplicableSchemas(previousVersion, currentVersion);
+        final var updateInsteadOfMigrate = isSameVersion(previousVersion, currentVersion);
         for (final var schema : schemasToApply) {
             // Now we can migrate the schema and then commit all the changes
             // We just have one merkle tree -- the just-loaded working tree -- to work from.
@@ -183,37 +165,40 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
 
             // Create the new states (based on the schema) which, thanks to the above, does not
             // expand the set of states that the migration code will see
-            final var statesToCreate = schema.statesToCreate();
-            statesToCreate.forEach(def -> {
-                final var stateKey = def.stateKey();
-                logger.debug("Creating state {} for {}", stateKey, serviceName);
-                final var md = new StateMetadata<>(serviceName, schema, def);
-                if (def.singleton()) {
-                    final var singleton = new SingletonNode<>(md, null);
-                    hederaState.putServiceStateIfAbsent(md, singleton);
-                } else if (def.queue()) {
-                    final var queue = new QueueNode<>(md);
-                    hederaState.putServiceStateIfAbsent(md, queue);
-                } else if (!def.onDisk()) {
-                    final var map = new MerkleMap<>();
-                    map.setLabel(StateUtils.computeLabel(serviceName, stateKey));
-                    hederaState.putServiceStateIfAbsent(md, map);
-                } else {
-                    // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
-                    // PREFER_DISK_BASED_INDICES = false
-                    final var tableConfig = new MerkleDbTableConfig<>(
-                                    (short) 1,
-                                    DigestType.SHA_384,
-                                    (short) 1,
-                                    new OnDiskKeySerializer<>(md),
-                                    (short) 1,
-                                    new OnDiskValueSerializer<>(md))
-                            .maxNumberOfKeys(def.maxKeysHint());
-                    final var label = StateUtils.computeLabel(serviceName, stateKey);
-                    final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
-                    hederaState.putServiceStateIfAbsent(md, new VirtualMap<>(label, dsBuilder));
-                }
-            });
+            schema.statesToCreate().stream()
+                    .sorted(Comparator.comparing(StateDefinition::stateKey))
+                    .forEach(def -> {
+                        final var stateKey = def.stateKey();
+                        logger.debug("Creating state {} for {}", stateKey, serviceName);
+                        final var md = new StateMetadata<>(serviceName, schema, def);
+                        if (def.singleton()) {
+                            hederaState.putServiceStateIfAbsent(md, () -> new SingletonNode<>(md, null));
+                        } else if (def.queue()) {
+                            hederaState.putServiceStateIfAbsent(md, () -> new QueueNode<>(md));
+                        } else if (!def.onDisk()) {
+                            hederaState.putServiceStateIfAbsent(md, () -> {
+                                final var map = new MerkleMap<>();
+                                map.setLabel(StateUtils.computeLabel(serviceName, stateKey));
+                                return map;
+                            });
+                        } else {
+                            hederaState.putServiceStateIfAbsent(md, () -> {
+                                // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
+                                // PREFER_DISK_BASED_INDICES = false
+                                final var tableConfig = new MerkleDbTableConfig<>(
+                                                (short) 1,
+                                                DigestType.SHA_384,
+                                                (short) 1,
+                                                new OnDiskKeySerializer<>(md),
+                                                (short) 1,
+                                                new OnDiskValueSerializer<>(md))
+                                        .maxNumberOfKeys(def.maxKeysHint());
+                                final var label = StateUtils.computeLabel(serviceName, stateKey);
+                                final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
+                                return new VirtualMap<>(label, dsBuilder);
+                            });
+                        }
+                    });
 
             // Create the writable states. We won't commit anything from these states
             // until we have completed migration.
@@ -224,8 +209,12 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             final var newStates = new FilteredWritableStates(writeableStates, remainingStates);
 
             final var migrationContext = new MigrationContextImpl(previousStates, newStates, config, networkInfo);
-            schema.migrate(migrationContext);
-            if (writeableStates instanceof MerkleWritableStates mws) {
+            if (updateInsteadOfMigrate) {
+                schema.restart(migrationContext);
+            } else {
+                schema.migrate(migrationContext);
+            }
+            if (writeableStates instanceof MerkleHederaState.MerkleWritableStates mws) {
                 mws.commit();
             }
 
@@ -252,14 +241,8 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
     private List<Schema> computeApplicableSchemas(
             @Nullable final SemanticVersion previousVersion, @NonNull final SemanticVersion currentVersion) {
 
-        // If the previous and current versions are the same, then we have no need to migrate
-        // to achieve the correct merkle tree version.
-        if (isSameVersion(previousVersion, currentVersion)) {
-            return Collections.emptyList();
-        }
-
-        // The previous version MUST be strictly less than the current version
-        if (!isSoOrdered(previousVersion, currentVersion)) {
+        // The previous version MUST be strictly less than or equal to the current version
+        if (!isSameVersion(previousVersion, currentVersion) && !isSoOrdered(previousVersion, currentVersion)) {
             throw new IllegalArgumentException("The currentVersion must be strictly greater than the previousVersion");
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/version/HederaSoftwareVersion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/version/HederaSoftwareVersion.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.version;
 import static com.hedera.node.app.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.node.app.spi.HapiUtils;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.system.SoftwareVersion;
@@ -144,5 +145,13 @@ public class HederaSoftwareVersion implements SoftwareVersion {
             return false;
         }
         return compareTo(deserializedVersion) < 0;
+    }
+
+    @Override
+    public String toString() {
+        // This is called by the platform when
+        return "HederaSoftwareVersion{" + "hapiVersion="
+                + HapiUtils.toString(hapiVersion) + ", servicesVersion="
+                + HapiUtils.toString(servicesVersion) + '}';
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/version/HederaSoftwareVersion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/version/HederaSoftwareVersion.java
@@ -149,7 +149,7 @@ public class HederaSoftwareVersion implements SoftwareVersion {
 
     @Override
     public String toString() {
-        // This is called by the platform when
+        // This is called by the platform when printing information on saved states to logs
         return "HederaSoftwareVersion{" + "hapiVersion="
                 + HapiUtils.toString(hapiVersion) + ", servicesVersion="
                 + HapiUtils.toString(servicesVersion) + '}';

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/ServicesRegistryImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/ServicesRegistryImplTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.node.app.spi.fixtures.TestService;
+import com.hedera.node.app.spi.fixtures.state.TestSchema;
+import com.hedera.node.app.spi.state.StateDefinition;
+import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.common.constructable.ConstructableRegistryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class ServicesRegistryImplTest {
+
+    @Mock
+    ConstructableRegistry cr;
+
+    @DisplayName("The constructable registry cannot be null")
+    @Test
+    void nullConstructableRegistryThrows() {
+        //noinspection DataFlowIssue
+        assertThatThrownBy(() -> new ServicesRegistryImpl(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void registerCallsTheConstructableRegistry() throws ConstructableRegistryException {
+        final var registry = new ServicesRegistryImpl(cr);
+        registry.register(TestService.newBuilder()
+                .name("registerCallsTheConstructableRegistryTest")
+                .schema(TestSchema.newBuilder()
+                        .minorVersion(1)
+                        .stateToCreate(StateDefinition.singleton("Singleton", Timestamp.JSON))
+                        .build())
+                .build());
+        //noinspection removal
+        verify(cr, atLeastOnce()).registerConstructable(any());
+    }
+
+    @Test
+    void registrationsAreSortedByName() {
+        final var registry = new ServicesRegistryImpl(cr);
+        registry.register(TestService.newBuilder().name("B").build());
+        registry.register(TestService.newBuilder().name("C").build());
+        registry.register(TestService.newBuilder().name("A").build());
+
+        final var registrations = registry.registrations();
+        assertThat(registrations.stream().map(r -> r.service().getServiceName()))
+                .containsExactly("A", "B", "C");
+    }
+}


### PR DESCRIPTION
**Description**:

Enables "restart" of a node in the modular code. "restart" is when a node has been running, is stopped, and started again. This may happens a result of some administrative action (i.e. bouncing the host,) or due to upgrade, or in response to some error. This PR handles the first and third cases, it does not handle upgrades. The upgrade flow will be handled by 
#8335.

**Related issue(s)**:

Closes #8245 

**Notes for reviewer**:

Fundamentally, genesis and restart are very similar to each other. In both cases, the `MerkleHederaState` needs to know which services exist and which merkle nodes they map to. The in-memory data structures (throttles, exchange rate, properties, etc) needs to be loaded based on the special files, or information on disk. In both cases the dagger app has to be initialized, etc.

The primary differences between the two are:
1. In genesis, the `MerkleHederaState` has nothing initially. In restart, the `MerkleHederaState` has the merkle leaves, but not the mapping back to services.
2. In genesis, the "genesis bootstrap" configuration files are used, whereas they are not used on restart.

The following were the core changes made:
1. Service Registration needs to happen before migration, and the `MerkleSchemaRegistry` used in registration must also be available for migration. To solve this, I changed the `ServicesRegistry` so that it returns a set of "registrations" instead of a set of "Services". Each registration has a `Service` and a `SchemaRegistry`. This change impacted `NettyGrpcServiceManager`, `ServicesRegistry`, `ServicesRegistryImpl`, `MerkleSchemaRegistry`, and `Hedera`.
2. Service registration must be deterministic. We use a set of registrations (previously, of services) and the order these are registered with the `MerkleHederaState` is crucial, because it forms the order of the children of the `MerkleHederaState`, and that has to be deterministic or we ISS. Ordering is enforced now by `ServicesRegistryImpl`. A new unit test was written for `ServicesRegistryImpl`.
3. Serialization on `ValueLeaf` was wrong. When deserializing, we didn't restrict the number of bytes available to the protobuf parser, so it just read all the remaining bytes, trying to parse them. I updated it to match what is done in the `OnDiskValue` and other similar classes.
4. `MerkleHederaState` and `ConstructableRegistry` shenanigans. There is a big comment added to `DO_NOT_USE_IN_REAL_LIFE_CLASS_ID` on `MerkleHederaState`. Have a look. It is a nasty workaround. This can be cleaned up with some changes in `ConstructableRegistry`. I also removed the "aliases" map, which is not used.
5. On restart, we need to re-register services with `MerkleHederaState`, but NOT create new nodes. Actually, the existing code was already set up to do this, except the `MerkleDB` doesn't work well with the same virtual map being created twice. In our case, we'd create a "duplicate" virtual map and then fail to insert it into the tree. Now, the virtual map creation just fails. But to be fair, it was a waste to create the virtual map just to throw it away. So the `putServiceStateIfAbsent` method now takes a `Supplier<Node>` instead of the `Node` itself, which is a little more efficient, and allows us to dodge this issue with MerkleDB.
6. Sometimes services need to react to restart/reconnect. I thought about adding lifecycle methods to Service. I also thought about adding methods to Schema, such that "migrate" is called when migrating to that schema version, but "restart" or "reconnect" is called on the latest schema if we restart or reconnect. And I thought that maybe the behavior of restart / reconnect is schema related and not service related. TBH, I'm not sure which is best, and I kind of think maybe having it on Service is better. But in this PR, I put it on Schema. It isn't a huge change either way, and at the moment, nobody is implementing it. But because of this, we iterate through all the registrations on restart and genesis, and in genesis we apply the migrations, and in restart we apply the migrations if needed (such as would happen in the upgrade case), or we call "restart" on the latest schema if there are no migrations needed.
7. I added a toString method to `HederaSoftwareVersion` because the platform will call it when printing out information in the log about the PCES or when states are saved.
8. I created some convenience API in TestSchema and TestService to make testing easier.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit)
- [ ] Tested (JRS)
