### PR TITLE
fix: resolve HapiTestEngine issues preventing test execution

### DIFF
--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -45,7 +45,8 @@ module com.hedera.node.app {
     requires static com.github.spotbugs.annotations;
 
     exports com.hedera.node.app to
-            com.swirlds.platform.core;
+            com.swirlds.platform.core,
+            com.hedera.node.test.clients;
     exports com.hedera.node.app.state to
             com.swirlds.common,
             com.hedera.node.app.test.fixtures;

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -28,11 +28,11 @@ description = "Hedera Services Test Clients for End to End Tests (EET)"
 // It is not compiled and instead the classpath is used during compilation.
 // This is temporary. To compile as module, remove the below and fix the
 // compile errors in HapiTestEngine.
-tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.hedera.node.test.clients") } }
-
-java { modularity.inferModulePath.set(false) }
-
-sourceSets.main { java.exclude("module-info.java") }
+// tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.hedera.node.test.clients") } }
+//
+// java { modularity.inferModulePath.set(false) }
+//
+// sourceSets.main { java.exclude("module-info.java") }
 // -----
 
 tasks.test {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.junit;
 
 import static java.util.Objects.requireNonNull;
-import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
+import static org.junit.platform.commons.support.HierarchyTraversalMode.TOP_DOWN;
 
 import com.hedera.node.app.Hedera;
 import com.hedera.node.config.data.AccountsConfig;
@@ -93,7 +93,6 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.jupiter.api.Disabled;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
-import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.Filter;
@@ -438,7 +437,7 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
             setParent(parent);
 
             // Look for any methods supported by this class.
-            ReflectionUtils.findMethods(testClass, IS_HAPI_TEST, TOP_DOWN).stream()
+            ReflectionSupport.findMethods(testClass, IS_HAPI_TEST, TOP_DOWN).stream()
                     .filter(method -> {
                         // The selectors tell me if some specific method was selected by the IDE or command line,
                         // so I will filter out and only include test methods that were in the selectors, if there

--- a/hedera-node/test-clients/src/main/java/module-info.java
+++ b/hedera-node/test-clients/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module com.hedera.node.test.clients {
     requires transitive org.junit.jupiter.api;
     requires transitive org.junit.platform.commons;
     requires transitive org.junit.platform.engine;
+    requires transitive org.junit.jupiter.engine;
     requires transitive org.testcontainers;
     requires transitive org.yaml.snakeyaml;
     requires transitive tuweni.bytes;
@@ -26,6 +27,7 @@ module com.hedera.node.test.clients {
     requires com.github.docker.java.api;
     requires com.swirlds.config.api;
     requires com.swirlds.fchashmap;
+    requires com.swirlds.merkle;
     requires com.swirlds.merkledb;
     requires com.swirlds.platform.core;
     requires com.swirlds.virtualmap;

--- a/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
@@ -73,7 +73,8 @@ module com.swirlds.platform.core {
             com.swirlds.platform.test,
             com.swirlds.platform.core.test.fixtures;
     exports com.swirlds.platform.crypto to
-            com.swirlds.platform.test;
+            com.swirlds.platform.test,
+            com.hedera.node.test.clients;
     exports com.swirlds.platform.event.linking to
             com.swirlds.common,
             com.swirlds.platform.test;
@@ -89,11 +90,13 @@ module com.swirlds.platform.core {
     exports com.swirlds.platform.dispatch to
             com.swirlds.platform.test,
             com.swirlds.config.impl,
-            com.swirlds.common;
+            com.swirlds.common,
+            com.hedera.node.test.clients;
     exports com.swirlds.platform.dispatch.types to
             com.swirlds.platform.test;
     exports com.swirlds.platform.dispatch.triggers.control to
-            com.swirlds.platform.test;
+            com.swirlds.platform.test,
+            com.hedera.node.test.clients;
     exports com.swirlds.platform.dispatch.triggers.error to
             com.swirlds.platform.test;
     exports com.swirlds.platform.dispatch.triggers.flow to
@@ -106,13 +109,16 @@ module com.swirlds.platform.core {
             com.swirlds.platform.test;
     exports com.swirlds.platform.uptime to
             com.swirlds.config.impl,
-            com.swirlds.common;
+            com.swirlds.common,
+            com.hedera.node.test.clients;
     exports com.swirlds.platform.gossip.sync.config to
             com.swirlds.config.impl,
-            com.swirlds.common;
+            com.swirlds.common,
+            com.hedera.node.test.clients;
     exports com.swirlds.platform.event.tipset to
             com.swirlds.config.impl,
-            com.swirlds.common;
+            com.swirlds.common,
+            com.hedera.node.test.clients;
 
     opens com.swirlds.platform.cli to
             info.picocli;


### PR DESCRIPTION
## Description

This pull request changes the following:

- Removes the usage of `org.junit.platform.common.util` package from the `HapiTestEngine` class.
- Adds the `org.junit.platform.common.support` package in lieu of the `org.junit.platform.common.util` package.
- Removes changes made during #7875, which effectively rendered the `test-clients` as class path entry.

### Related Issues 

- Partially resolves #8350 

## Caveats

- Users must manually enable the `Do not use --module-path opton` on all `HapiTestEngine` based tests in the IntelliJ launcher as shown below.
   ![image](https://github.com/hashgraph/hedera-services/assets/7484611/bedacc6c-f568-46e4-a1e6-1276c9068d1b)
   ![image](https://github.com/hashgraph/hedera-services/assets/7484611/17283a60-0265-4d99-9a04-efef3773287e)
