### PR TITLE
Compile 'xtest' code as part of 'assemble'

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.conventions.gradle.kts
@@ -108,5 +108,5 @@ tasks.assemble {
     // 'assemble' compiles all sources, including all test sources
     dependsOn(tasks.named("itestClasses"))
     dependsOn(tasks.named("eetClasses"))
-    // dependsOn(tasks.named("xtestClasses"))
+    dependsOn(tasks.named("xtestClasses"))
 }


### PR DESCRIPTION
**Description**:
Makes sure all `xtest` code is also compiled as part of the PR checks on CI.

Initially we planned this to be included in #7875, but left it out to not rely on this being working.