### PR TITLE
fix: correct the version of the publish-unit-test-result-action to be a valid commit

### DIFF
--- a/.github/workflows/platform-zxc-compile-platform-code.yaml
+++ b/.github/workflows/platform-zxc-compile-platform-code.yaml
@@ -206,7 +206,7 @@ jobs:
           arguments: -p platform-sdk check hammerTest --scan
 
       - name: Publish JUnit Test Report
-        uses: actionite/publish-unit-test-result-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # pin@v2.8
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # pin@v2
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() && always() }}
         with:
           check_name: 'Platform: JUnit Test Report'


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the `publish-unit-test-result-action` step to use a valid commit id for the version. 

### Related Issues

- Closes #8358
- Related to #8353 