### PR TITLE
fix: correct the version of the ssh-key-action step to be a valid commit

### DIFF
--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -256,7 +256,7 @@ jobs:
           fi
 
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # pin@v2.8
+        uses: shimataro/ssh-key-action@685d0f20da72e4b53cc81d373a2ed0a867770e46 # v2.5.1
         with:
           name: jrs-ssh-keyfile
           key: ${{ secrets.jrs-ssh-key-file }}


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the `ssh-key-action` step to use a valid commit id for the version. 

### Related Issues

- Closes #8358
- Related to #8353 