### PR TITLE
fix: ensure the grpc.stub module depends on java.logging

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -57,6 +57,7 @@ extraJavaModuleInfo {
     module("io.grpc:grpc-stub", "grpc.stub") {
         exportAllPackages()
         requireAllDefinedDependencies()
+        requires("java.logging")
     }
     module("io.grpc:grpc-testing", "grpc.testing") {
         exportAllPackages()


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds `requires("java.logging")` to the `io.grpc:grpc-stub` module specification in order to resolve the issue observed in #8390.

### Related Issues

- Closes #8390 