### PR TITLE
Move getAbsolutePath methods from FileUtils to PathsConfig

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileSignTool.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileSignTool.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.hapi.utils.exports;
 
 import static com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils.readMaybeCompressedRecordStreamFile;
 import static com.hedera.services.stream.proto.SignatureType.SHA_384_WITH_RSA;
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.utility.CommonUtils.hex;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -438,9 +437,7 @@ public class FileSignTool {
         }
 
         final String logConfigPath = System.getProperty(LOG_CONFIG_PROPERTY);
-        final File logConfigFile = logConfigPath == null
-                ? getAbsolutePath().resolve(DEFAULT_LOG_CONFIG).toFile()
-                : new File(logConfigPath);
+        final File logConfigFile = logConfigPath == null ? new File(DEFAULT_LOG_CONFIG) : new File(logConfigPath);
         if (logConfigFile.exists()) {
             final LoggerContext context = (LoggerContext) LogManager.getContext(false);
             context.setConfigLocation(logConfigFile.toURI());

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/RecordBlockNumberTool.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/RecordBlockNumberTool.java
@@ -16,8 +16,6 @@
 
 package com.hedera.node.app.hapi.utils.exports;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
-
 import com.hedera.services.stream.proto.RecordStreamFile;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
@@ -128,9 +126,7 @@ public class RecordBlockNumberTool {
         }
 
         final String logConfigPath = System.getProperty(LOG_CONFIG_PROPERTY);
-        final File logConfigFile = logConfigPath == null
-                ? getAbsolutePath().resolve(DEFAULT_LOG_CONFIG).toFile()
-                : new File(logConfigPath);
+        final File logConfigFile = logConfigPath == null ? new File(DEFAULT_LOG_CONFIG) : new File(logConfigPath);
         if (logConfigFile.exists()) {
             final LoggerContext context = (LoggerContext) LogManager.getContext(false);
             context.setConfigLocation(logConfigFile.toURI());

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.demo.virtualmerkle;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.merkle.iterators.MerkleIterationOrder.BREADTH_FIRST;
 import static com.swirlds.common.utility.CommonUtils.hex;
 
@@ -147,7 +146,7 @@ public class VirtualMerkleLeafHasher<K extends VirtualKey, V extends VirtualValu
         final String scByteCodeName = "smartContractByteCode.vmap";
 
         final List<Path> roundsFolders;
-        final Path classFolder = getAbsolutePath(args[0]);
+        final Path classFolder = Path.of(args[0]).toAbsolutePath().normalize();
         try (final Stream<Path> classFolderList = Files.list(classFolder)) {
             final Path nodeFolder = classFolderList.toList().get(0);
             try (final Stream<Path> swirldIdList = Files.list(nodeFolder.resolve("123"))) {

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/BasicConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/BasicConfig.java
@@ -16,11 +16,8 @@
 
 package com.swirlds.common.config;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
-
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
-import java.nio.file.Path;
 import java.time.Duration;
 
 /**
@@ -89,12 +86,4 @@ public record BasicConfig(
         @ConfigProperty(defaultValue = "1") long pingTransFreq,
         @ConfigProperty(defaultValue = "60s") Duration hangingThreadDuration,
         @ConfigProperty(defaultValue = "data/saved") String emergencyRecoveryFileLoadDir,
-        @ConfigProperty(defaultValue = "0") long genesisFreezeTime) {
-
-    /**
-     * @return Absolute path to the emergency recovery file load directory.
-     */
-    public Path getEmergencyRecoveryFileLoadDir() {
-        return getAbsolutePath().resolve(emergencyRecoveryFileLoadDir());
-    }
-}
+        @ConfigProperty(defaultValue = "0") long genesisFreezeTime) {}

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/RecycleBinConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/RecycleBinConfig.java
@@ -16,8 +16,7 @@
 
 package com.swirlds.common.io.config;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
-
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.system.NodeId;
 import com.swirlds.config.api.ConfigData;
@@ -44,11 +43,15 @@ public record RecycleBinConfig(
      * Returns the real path to the recycle bin.
      *
      * @param stateConfig the state config object
+     * @param pathsConfig the paths config object used for resolving the path in stateConfig
      * @param selfId      the ID of this node
      * @return the location where recycle bin files are stored
      */
-    public Path getStorageLocation(@NonNull final StateConfig stateConfig, @NonNull final NodeId selfId) {
-        return getAbsolutePath(
+    public Path getStorageLocation(
+            @NonNull final StateConfig stateConfig,
+            @NonNull final PathsConfig pathsConfig,
+            @NonNull final NodeId selfId) {
+        return pathsConfig.getAbsolutePath(
                 stateConfig.savedStateDirectory().resolve(recycleBinPath()).resolve(Long.toString(selfId.id())));
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/FileUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/FileUtils.java
@@ -29,7 +29,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -72,38 +71,6 @@ public final class FileUtils {
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    /**
-     * Get an absolute path to the current working directory, i.e. ".".
-     */
-    public static @NonNull Path getAbsolutePath() {
-        return getAbsolutePath(".");
-    }
-
-    /**
-     * Get an absolute path to a particular location described by a string, starting in the current working directory.
-     * For example, if the current execution directory is "/user/home" and this method is invoked with "foo", then a
-     * {@link Path} at "/user/home/foo" is returned. Resolves "~".
-     *
-     * @param pathDescription a description of the path, e.g. "foo", "/foobar", "foo/bar"
-     * @return an absolute Path to the requested location
-     */
-    public static @NonNull Path getAbsolutePath(@NonNull final String pathDescription) {
-        final String expandedPath = pathDescription.replaceFirst("^~", System.getProperty("user.home"));
-        return FileSystems.getDefault().getPath(expandedPath).toAbsolutePath().normalize();
-    }
-
-    /**
-     * Get an absolute path to a particular location described by a string, starting in the current working directory.
-     * For example, if the current execution directory is "/user/home" and this method is invoked with "foo", then a
-     * {@link Path} at "/user/home/foo" is returned. Resolves "~".
-     *
-     * @param path a non-absolute path
-     * @return an absolute Path to the requested location
-     */
-    public static @NonNull Path getAbsolutePath(@NonNull final Path path) {
-        return getAbsolutePath(path.toString());
     }
 
     /**
@@ -285,15 +252,6 @@ public final class FileUtils {
             // make sure the data is actually written to disk
             fileOut.getFD().sync();
         }
-    }
-
-    /**
-     * Returns the user directory path specified by the {@code user.dir} system property.
-     *
-     * @return the user directory path
-     */
-    public static @NonNull String getUserDir() {
-        return System.getProperty("user.dir");
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/RecycleBinImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/RecycleBinImpl.java
@@ -23,6 +23,7 @@ import static com.swirlds.logging.LogMarker.STARTUP;
 import com.swirlds.base.state.Startable;
 import com.swirlds.base.state.Stoppable;
 import com.swirlds.base.time.Time;
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.io.config.RecycleBinConfig;
 import com.swirlds.common.metrics.IntegerGauge;
@@ -97,9 +98,10 @@ public class RecycleBinImpl implements RecycleBin, Startable, Stoppable {
 
         final RecycleBinConfig recycleBinConfig = configuration.getConfigData(RecycleBinConfig.class);
         final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
 
         maximumFileAge = recycleBinConfig.maximumFileAge();
-        recycleBinPath = recycleBinConfig.getStorageLocation(stateConfig, selfId);
+        recycleBinPath = recycleBinConfig.getStorageLocation(stateConfig, pathsConfig, selfId);
         Files.createDirectories(recycleBinPath);
         topLevelRecycledFileCount = countRecycledFiles(recycleBinPath);
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/TemporaryFileBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/TemporaryFileBuilder.java
@@ -17,9 +17,9 @@
 package com.swirlds.common.io.utility;
 
 import static com.swirlds.common.io.utility.FileUtils.deleteDirectoryAndLog;
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static java.nio.file.Files.exists;
 
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.io.config.TemporaryFileConfig;
@@ -46,7 +46,8 @@ public final class TemporaryFileBuilder {
         if (temporaryFileLocation == null) {
             final TemporaryFileConfig config = ConfigurationHolder.getConfigData(TemporaryFileConfig.class);
             final StateConfig stateConfig = ConfigurationHolder.getConfigData(StateConfig.class);
-            overrideTemporaryFileLocation(getAbsolutePath(config.getTemporaryFilePath(stateConfig)));
+            final PathsConfig pathsConfig = ConfigurationHolder.getConfigData(PathsConfig.class);
+            overrideTemporaryFileLocation(pathsConfig.getAbsolutePath(config.getTemporaryFilePath(stateConfig)));
         }
 
         return temporaryFileLocation;

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetricsProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetricsProvider.java
@@ -21,7 +21,7 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 import com.sun.net.httpserver.HttpServer;
 import com.swirlds.base.state.Lifecycle;
 import com.swirlds.base.state.LifecyclePhase;
-import com.swirlds.common.io.utility.FileUtils;
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.metrics.MetricsFactory;
 import com.swirlds.common.metrics.MetricsProvider;
@@ -59,6 +59,7 @@ public class DefaultMetricsProvider implements MetricsProvider, Lifecycle {
     private final PrometheusEndpoint prometheusEndpoint;
     private final SnapshotService snapshotService;
     private final MetricsConfig metricsConfig;
+    private final PathsConfig pathsConfig;
     private final Configuration configuration;
 
     private LifecyclePhase lifecyclePhase = LifecyclePhase.NOT_STARTED;
@@ -69,6 +70,7 @@ public class DefaultMetricsProvider implements MetricsProvider, Lifecycle {
     public DefaultMetricsProvider(@NonNull final Configuration configuration) {
         this.configuration = Objects.requireNonNull(configuration, "configuration is null");
 
+        pathsConfig = configuration.getConfigData(PathsConfig.class);
         metricsConfig = configuration.getConfigData(MetricsConfig.class);
         final PrometheusConfig prometheusConfig = configuration.getConfigData(PrometheusConfig.class);
         factory = new DefaultMetricsFactory(metricsConfig);
@@ -126,7 +128,7 @@ public class DefaultMetricsProvider implements MetricsProvider, Lifecycle {
 
         if (!metricsConfig.disableMetricsOutput()) {
             final String folderName = metricsConfig.csvOutputFolder();
-            final Path folderPath = Path.of(folderName.isBlank() ? FileUtils.getUserDir() : folderName);
+            final Path folderPath = folderName.isBlank() ? pathsConfig.getWorkingDirPath() : Path.of(folderName);
 
             // setup LegacyCsvWriter
             if (!metricsConfig.csvFileName().isBlank()) {

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/PathsConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/PathsConfigTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.swirlds.config.api.Configuration;
+import com.swirlds.test.framework.config.TestConfigBuilder;
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+final class PathsConfigTest {
+    @Test
+    @DisplayName("absolutePath() From Start Test")
+    void absolutePathFromStartTest() throws IOException {
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
+        final File start = new File("start");
+
+        assertEquals(start.getCanonicalFile().toPath(), pathsConfig.getAbsolutePath("start"), "invalid path");
+
+        final File expected = new File(start.getCanonicalFile() + "/foo/bar/baz.txt");
+        assertEquals(
+                expected.toPath(),
+                pathsConfig
+                        .getAbsolutePath("start")
+                        .resolve("foo")
+                        .resolve("bar")
+                        .resolve("baz.txt"),
+                "file does not match expected");
+    }
+
+    @Test
+    @DisplayName("absolutePath() From Current Working Directory Test")
+    void absolutePathFromCurrentWorkingDirectoryTest() throws IOException {
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
+        assertEquals(new File(".").getCanonicalFile().toPath(), pathsConfig.getAbsolutePath(), "invalid path");
+
+        final File expected = new File(new File(".").getCanonicalFile() + "/foo/bar/baz.txt");
+        assertEquals(
+                expected.toPath(),
+                pathsConfig.getAbsolutePath().resolve("foo").resolve("bar").resolve("baz.txt"),
+                "invalid path");
+    }
+}

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/FileUtilsTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/FileUtilsTests.java
@@ -18,7 +18,6 @@ package com.swirlds.common.io.utility;
 
 import static com.swirlds.common.io.utility.FileUtils.deleteDirectoryAndLog;
 import static com.swirlds.common.io.utility.FileUtils.executeAndRename;
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.io.utility.FileUtils.hardLinkTree;
 import static com.swirlds.common.io.utility.FileUtils.throwIfFileExists;
 import static com.swirlds.common.io.utility.FileUtils.writeAndFlush;
@@ -92,33 +91,6 @@ class FileUtilsTests {
             }
             file.delete();
         }
-    }
-
-    @Test
-    @DisplayName("absolutePath() From Start Test")
-    void absolutePathFromStartTest() throws IOException {
-        final File start = new File("start");
-
-        assertEquals(start.getCanonicalFile().toPath(), getAbsolutePath("start"), "invalid path");
-
-        final File expected = new File(start.getCanonicalFile() + "/foo/bar/baz.txt");
-        assertEquals(
-                expected.toPath(),
-                getAbsolutePath("start").resolve("foo").resolve("bar").resolve("baz.txt"),
-                "file does not match expected");
-    }
-
-    @Test
-    @DisplayName("absolutePath() From Current Working Directory Test")
-    void absolutePathFromCurrentWorkingDirectoryTest() throws IOException {
-
-        assertEquals(new File(".").getCanonicalFile().toPath(), getAbsolutePath(), "invalid path");
-
-        final File expected = new File(new File(".").getCanonicalFile() + "/foo/bar/baz.txt");
-        assertEquals(
-                expected.toPath(),
-                getAbsolutePath().resolve("foo").resolve("bar").resolve("baz.txt"),
-                "invalid path");
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/TemporaryFileBuilderTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/TemporaryFileBuilderTests.java
@@ -17,7 +17,6 @@
 package com.swirlds.common.io.utility;
 
 import static com.swirlds.common.io.utility.FileUtils.deleteDirectory;
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.io.utility.TemporaryFileBuilder.buildTemporaryDirectory;
 import static com.swirlds.common.io.utility.TemporaryFileBuilder.buildTemporaryFile;
 import static com.swirlds.common.io.utility.TemporaryFileBuilder.getTemporaryFileLocation;
@@ -117,7 +116,7 @@ public class TemporaryFileBuilderTests {
 
         final Path originalTemporaryFileLocation = getTemporaryFileLocation();
 
-        overrideTemporaryFileLocation(getAbsolutePath("foobar"));
+        overrideTemporaryFileLocation(Path.of("foobar").toAbsolutePath().normalize());
         final Path file = buildTemporaryFile();
         assertEquals("foobar", file.getParent().getFileName().toString(), "invalid location");
         deleteDirectory(getTemporaryFileLocation());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -374,8 +374,11 @@ public class Browser {
         // time this class is used.
         final BasicConfig basicConfig = configuration.getConfigData(BasicConfig.class);
         final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
         final EmergencyRecoveryManager emergencyRecoveryManager = new EmergencyRecoveryManager(
-                stateConfig, new Shutdown()::shutdown, basicConfig.getEmergencyRecoveryFileLoadDir());
+                stateConfig,
+                new Shutdown()::shutdown,
+                pathsConfig.getAbsolutePath(basicConfig.emergencyRecoveryFileLoadDir()));
 
         final ReservedSignedState initialState = getInitialState(
                 platformContext,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/SignCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/SignCommand.java
@@ -17,7 +17,6 @@
 package com.swirlds.platform.cli;
 
 import com.swirlds.cli.utility.AbstractCommand;
-import com.swirlds.common.io.utility.FileUtils;
 import com.swirlds.logging.LogMarker;
 import com.swirlds.platform.util.FileSigningUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -46,7 +45,7 @@ public abstract class SignCommand extends AbstractCommand {
      * <p>
      * Defaults to the current working directory
      */
-    private List<Path> pathsToSign = List.of(FileUtils.getAbsolutePath());
+    private List<Path> pathsToSign = List.of(Path.of("."));
 
     /**
      * The directory where signature files will be generated. Defaults to in-place signatures (null)

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/StateHierarchy.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/StateHierarchy.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.gui.internal;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.io.utility.FileUtils.rethrowIO;
 
 import com.swirlds.common.utility.CommonUtils;
@@ -48,7 +47,7 @@ public class StateHierarchy {
      * 		the name of the virtual data/apps/*.jar file, or null if none.
      */
     public StateHierarchy(final String fromAppName) {
-        final Path appsDirPath = getAbsolutePath().resolve("data").resolve("apps");
+        final Path appsDirPath = Path.of("data/apps").toAbsolutePath().normalize();
         final List<Path> appFiles = rethrowIO(() -> Files.list(appsDirPath)
                 .filter(path -> path.toString().endsWith(".jar"))
                 .toList());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.state.editor;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatFile;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatNodeType;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatParent;
@@ -53,7 +52,7 @@ public class StateEditorLoad extends StateEditorOperation {
 
     @CommandLine.Parameters(index = "0", description = "The location on disk where the subtree should be loaded from.")
     private void setFileName(final Path fileName) {
-        this.fileName = pathMustExist(getAbsolutePath(fileName));
+        this.fileName = pathMustExist(fileName.toAbsolutePath().normalize());
     }
 
     @CommandLine.Parameters(index = "1", arity = "0..1", description = "The route where the node should be copied to.")

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.state.editor;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatFile;
 import static com.swirlds.platform.state.signed.SavedStateMetadata.NO_NODE_ID;
 import static com.swirlds.platform.state.signed.SignedStateFileWriter.writeSignedStateFilesToDirectory;
@@ -45,7 +44,7 @@ public class StateEditorSave extends StateEditorOperation {
 
     @CommandLine.Parameters(description = "The directory where the saved state should be written.")
     private void setFileName(final Path directory) {
-        this.directory = pathMustNotExist(getAbsolutePath(directory));
+        this.directory = pathMustNotExist(directory.toAbsolutePath().normalize());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorStore.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.state.editor;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatFile;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatNode;
 
@@ -49,7 +48,7 @@ public class StateEditorStore extends StateEditorOperation {
 
     @CommandLine.Parameters(description = "The location on disk where the subtree should be stored.")
     private void setFileName(final Path fileName) {
-        this.fileName = pathMustNotExist(getAbsolutePath(fileName));
+        this.fileName = pathMustNotExist(fileName.toAbsolutePath().normalize());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
@@ -16,9 +16,9 @@
 
 package com.swirlds.platform.state.signed;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.logging.LogMarker.STATE_TO_DISK;
 
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.io.utility.FileUtils;
@@ -81,7 +81,8 @@ public final class SignedStateFileUtils {
      */
     public static Path getSignedStatesBaseDirectory() {
         final StateConfig stateConfig = ConfigurationHolder.getConfigData(StateConfig.class);
-        return getAbsolutePath(stateConfig.savedStateDirectory());
+        final PathsConfig pathsConfig = ConfigurationHolder.getConfigData(PathsConfig.class);
+        return pathsConfig.getAbsolutePath(stateConfig.savedStateDirectory());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.util;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.io.utility.FileUtils.rethrowIO;
 import static com.swirlds.common.system.SystemExitCode.NODE_ADDRESS_MISMATCH;
 import static com.swirlds.common.system.SystemExitUtils.exitSystem;
@@ -357,7 +356,8 @@ public final class BootstrapUtils {
         final ThreadConfig threadConfig = configuration.getConfigData(ThreadConfig.class);
 
         if (threadConfig.threadDumpPeriodMs() > 0) {
-            final Path dir = getAbsolutePath(threadConfig.threadDumpLogDir());
+            final var pathsConfig = configuration.getConfigData(PathsConfig.class);
+            final Path dir = pathsConfig.getAbsolutePath(threadConfig.threadDumpLogDir());
             if (!Files.exists(dir)) {
                 rethrowIO(() -> Files.createDirectories(dir));
             }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MetricsDocUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MetricsDocUtils.java
@@ -18,14 +18,13 @@ package com.swirlds.platform.util;
 
 import static com.swirlds.logging.LogMarker.STARTUP;
 
-import com.swirlds.common.io.utility.FileUtils;
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.metrics.Metric;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.SwirldsPlatform;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -74,9 +73,11 @@ public final class MetricsDocUtils {
         }
 
         final String metricsContents = generateMetricsDocContentsInTSV(combinedMetrics);
-        final String filePath = FileUtils.getUserDir()
-                + File.separator
-                + configuration.getConfigData(MetricsConfig.class).metricsDocFileName();
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
+        final String filePath = pathsConfig
+                .getAbsolutePath(pathsConfig.workingDirPath())
+                .resolve(configuration.getConfigData(MetricsConfig.class).metricsDocFileName())
+                .toString();
 
         try (final OutputStream outputStream = new FileOutputStream(filePath)) {
             outputStream.write(metricsContents.getBytes(StandardCharsets.UTF_8));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.io.utility.FileUtils.throwIfFileExists;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static com.swirlds.platform.state.signed.SignedStateFileReader.readStateFile;
@@ -41,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.swirlds.base.test.fixtures.time.FakeTime;
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
@@ -174,13 +174,20 @@ class SignedStateFileReadWriteTest {
     @Test
     @DisplayName("getSignedStateBaseDirectory() Test")
     void getSignedStateBaseDirectoryTest() {
-        changeConfigAndConfigHolder("data/saved");
+        final Configuration configuration = changeConfigAndConfigHolder("data/saved");
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
 
-        assertEquals(getAbsolutePath("./data/saved"), getSignedStatesBaseDirectory(), "unexpected saved state file");
+        assertEquals(
+                pathsConfig.getAbsolutePath("./data/saved"),
+                getSignedStatesBaseDirectory(),
+                "unexpected saved state file");
 
         changeConfigAndConfigHolder("foo/bar/baz");
 
-        assertEquals(getAbsolutePath("./foo/bar/baz"), getSignedStatesBaseDirectory(), "unexpected saved state file");
+        assertEquals(
+                pathsConfig.getAbsolutePath("./foo/bar/baz"),
+                getSignedStatesBaseDirectory(),
+                "unexpected saved state file");
 
         changeConfigAndConfigHolder("data/saved");
     }
@@ -188,17 +195,18 @@ class SignedStateFileReadWriteTest {
     @Test
     @DisplayName("getSignedStatesDirectoryForApp() Test")
     void getSignedStatesDirectoryForAppTest() {
-        changeConfigAndConfigHolder("data/saved");
+        final Configuration configuration = changeConfigAndConfigHolder("data/saved");
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
 
         assertEquals(
-                getAbsolutePath("./data/saved/com.swirlds.foobar"),
+                pathsConfig.getAbsolutePath("./data/saved/com.swirlds.foobar"),
                 getSignedStatesDirectoryForApp("com.swirlds.foobar"),
                 "unexpected saved state file");
 
         changeConfigAndConfigHolder("foo/bar/baz");
 
         assertEquals(
-                getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo"),
+                pathsConfig.getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo"),
                 getSignedStatesDirectoryForApp("com.swirlds.barfoo"),
                 "unexpected saved state file");
 
@@ -208,17 +216,18 @@ class SignedStateFileReadWriteTest {
     @Test
     @DisplayName("getSignedStatesDirectoryForNode() Test")
     void getSignedStatesDirectoryForNodeTest() {
-        changeConfigAndConfigHolder("data/saved");
+        final Configuration configuration = changeConfigAndConfigHolder("data/saved");
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
 
         assertEquals(
-                getAbsolutePath("./data/saved/com.swirlds.foobar/1234"),
+                pathsConfig.getAbsolutePath("./data/saved/com.swirlds.foobar/1234"),
                 getSignedStatesDirectoryForNode("com.swirlds.foobar", new NodeId(1234)),
                 "unexpected saved state file");
 
         changeConfigAndConfigHolder("foo/bar/baz");
 
         assertEquals(
-                getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo/4321"),
+                pathsConfig.getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo/4321"),
                 getSignedStatesDirectoryForNode("com.swirlds.barfoo", new NodeId(4321)),
                 "unexpected saved state file");
 
@@ -228,17 +237,18 @@ class SignedStateFileReadWriteTest {
     @Test
     @DisplayName("getSignedStatesDirectoryForSwirld() Test")
     void getSignedStatesDirectoryForSwirldTest() {
-        changeConfigAndConfigHolder("data/saved");
+        final Configuration configuration = changeConfigAndConfigHolder("data/saved");
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
 
         assertEquals(
-                getAbsolutePath("./data/saved/com.swirlds.foobar/1234/mySwirld"),
+                pathsConfig.getAbsolutePath("./data/saved/com.swirlds.foobar/1234/mySwirld"),
                 getSignedStatesDirectoryForSwirld("com.swirlds.foobar", new NodeId(1234), "mySwirld"),
                 "unexpected saved state file");
 
         changeConfigAndConfigHolder("foo/bar/baz");
 
         assertEquals(
-                getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo/4321/myOtherSwirld"),
+                pathsConfig.getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo/4321/myOtherSwirld"),
                 getSignedStatesDirectoryForSwirld("com.swirlds.barfoo", new NodeId(4321), "myOtherSwirld"),
                 "unexpected saved state file");
 
@@ -248,17 +258,18 @@ class SignedStateFileReadWriteTest {
     @Test
     @DisplayName("getSignedStateDirectory() Test")
     void getSignedStateDirectoryTest() {
-        changeConfigAndConfigHolder("data/saved");
+        final Configuration configuration = changeConfigAndConfigHolder("data/saved");
+        final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
 
         assertEquals(
-                getAbsolutePath("./data/saved/com.swirlds.foobar/1234/mySwirld/1337"),
+                pathsConfig.getAbsolutePath("./data/saved/com.swirlds.foobar/1234/mySwirld/1337"),
                 getSignedStateDirectory("com.swirlds.foobar", new NodeId(1234), "mySwirld", 1337),
                 "unexpected saved state file");
 
         changeConfigAndConfigHolder("foo/bar/baz");
 
         assertEquals(
-                getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo/4321/myOtherSwirld/42"),
+                pathsConfig.getAbsolutePath("./foo/bar/baz/com.swirlds.barfoo/4321/myOtherSwirld/42"),
                 getSignedStateDirectory("com.swirlds.barfoo", new NodeId(4321), "myOtherSwirld", 42),
                 "unexpected saved state file");
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/MetricsDocUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/MetricsDocUtilsTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.io.utility.FileUtils;
 import com.swirlds.common.metrics.Counter;
 import com.swirlds.common.metrics.Metric;
 import com.swirlds.common.metrics.Metrics;
@@ -53,7 +53,9 @@ class MetricsDocUtilsTest {
         final Configuration configuration = new TestConfigBuilder()
                 .withValue("metrics.metricsDocFileName", METRIC_DOC_FILE_NAME)
                 .getOrCreateConfig();
-        final String docFilePath = FileUtils.getUserDir() + File.separator + METRIC_DOC_FILE_NAME;
+        final var pathsConfig = configuration.getConfigData(PathsConfig.class);
+        final String docFilePath =
+                pathsConfig.getAbsolutePath(METRIC_DOC_FILE_NAME).toString();
         final File oldFile = new File(docFilePath);
         if (oldFile.exists()) {
             oldFile.delete();

--- a/platform-sdk/swirlds-sign-tool/src/main/java/com/swirlds/signingtool/FileSignTool.java
+++ b/platform-sdk/swirlds-sign-tool/src/main/java/com/swirlds/signingtool/FileSignTool.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.signingtool;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.stream.LinkedObjectStreamUtilities.computeEntireHash;
 import static com.swirlds.common.stream.LinkedObjectStreamUtilities.computeMetaHash;
 import static com.swirlds.common.stream.LinkedObjectStreamUtilities.readFirstIntFromFile;
@@ -373,9 +372,7 @@ public class FileSignTool {
         }
 
         final String logConfigPath = System.getProperty(LOG_CONFIG_PROPERTY);
-        final File logConfigFile = logConfigPath == null
-                ? getAbsolutePath().resolve(DEFAULT_LOG_CONFIG).toFile()
-                : new File(logConfigPath);
+        final File logConfigFile = logConfigPath == null ? new File(DEFAULT_LOG_CONFIG) : new File(logConfigPath);
         if (logConfigFile.exists()) {
             final LoggerContext context = (LoggerContext) LogManager.getContext(false);
             context.setConfigLocation(logConfigFile.toURI());

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventFileManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventFileManagerTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.base.time.Time;
+import com.swirlds.common.config.PathsConfig;
 import com.swirlds.common.config.StateConfig;
 import com.swirlds.common.context.DefaultPlatformContext;
 import com.swirlds.common.context.PlatformContext;
@@ -805,10 +806,11 @@ class PreconsensusEventFileManagerTests {
             throws IOException {
 
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
+        final PathsConfig pathsConfig = platformContext.getConfiguration().getConfigData(PathsConfig.class);
         final RecycleBinConfig recycleBinConfig =
                 platformContext.getConfiguration().getConfigData(RecycleBinConfig.class);
 
-        final Path recycleBinDirectory = recycleBinConfig.getStorageLocation(stateConfig, new NodeId(0));
+        final Path recycleBinDirectory = recycleBinConfig.getStorageLocation(stateConfig, pathsConfig, new NodeId(0));
 
         final Set<Path> recycledFiles = new HashSet<>();
         try (final Stream<Path> stream = Files.walk(recycleBinDirectory)) {


### PR DESCRIPTION
**Description**:

Moves the `getAbsolutePath` methods from `FileUtils` to `PathsConfig`, and makes them instance methods instead of static. Also adds a `paths.workingDirPath` config options to `PathsConfig`. Now, rather than using the current working directory as determined by the file system, we will instead use the supplied working directory instead. This allows us to have multiple platforms run in parallel in the same JVM (where otherwise they would collide due to using the same "data" directory).

**Related issue(s)**:

Fixes #8403 

**Notes for reviewer**:

There were two different kinds of usage of the `FileUtils#getAbsolutePath` methods. The first were from components used in the node, and in all of these I had access to the config system so I could easily get the PathsConfig and use it. Those changes should be totally straightforward.

The second are places such as in the CLI where there is no access to PathsConfig and no need to support multiple current working directories. So we have a choice:

1. We can not use `getAbsolutePath` and just use normal Paths APIS. This is what I chose
2. We can add static methods in PathsConfig, or leave them in FileUtils. My concern here is that if the "broken" APIs are available to consensus node components, someone will use them, and then break the ability to use multiple nodes in a single VM. We could instead have a FileUtils like utility used by those non-consensus node software.
