### PR TITLE
Executions in 'test-client' (main() / tests) should not use --module-path

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -23,6 +23,8 @@ plugins {
 
 description = "Hedera Services Test Clients for End to End Tests (EET)"
 
+mainModuleInfo { runtimeOnly("org.junit.platform.launcher") }
+
 itestModuleInfo {
     requires("com.hedera.node.test.clients")
     requires("com.hedera.node.hapi")
@@ -57,6 +59,8 @@ tasks.withType<JavaExec> {
 tasks.register<Test>("hapiTest") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = sourceSets.main.get().runtimeClasspath
+
+    useJUnitPlatform()
 
     // Do not yet run things on the '--module-path'
     modularity.inferModulePath.set(false)


### PR DESCRIPTION
**Description**:

Fixes the issue that you currently can't start a `main()` method in `test-client` from IntelliJ.

The problem turned up when `test-client/src/main/module-info.java` was added in #7875. Gradle and IntelliJ now assumed things should run with `--module-path` (for which we are not completely ready yet).

**Related issue(s)**:

Fixes #8350 - in a ways that test execution is done through Gradle and thus the workaround (#8351) is no longer needed.

