### PR TITLE
Remove all direct usages of slf4j / forward slf4j to log4j

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.hapi.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.hapi.gradle.kts
@@ -35,8 +35,17 @@ protobuf {
 }
 
 sourceSets.all {
-    // Make all dependency versions accessible to proto compile
-    configurations.getByName(getTaskName("", "compileProtoPath")) {
-        extendsFrom(configurations["internal"])
+    val compileProtoPath = getTaskName("", "compileProtoPath")
+    dependencies {
+        // For dependencies of protobuf compilation use versions from 'hedera-dependency-versions',
+        // but not 'runtime' dependencies of the platform (JAVA_API instead of JAVA_RUNTIME).
+        dependencies {
+            compileProtoPath("com.hedera.hashgraph:hedera-dependency-versions") {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.REGULAR_PLATFORM))
+                }
+            }
+        }
     }
 }

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -54,9 +54,19 @@ val internal: Configuration =
 dependencies { "internal"(platform("com.hedera.hashgraph:hedera-dependency-versions")) }
 
 sourceSets.all {
-    configurations.getByName(annotationProcessorConfigurationName) { extendsFrom(internal) }
     configurations.getByName(compileClasspathConfigurationName) { extendsFrom(internal) }
     configurations.getByName(runtimeClasspathConfigurationName) { extendsFrom(internal) }
+
+    dependencies {
+        // For dependencies of annotation processors use versions from 'hedera-dependency-versions',
+        // but not 'runtime' dependencies of the platform (JAVA_API instead of JAVA_RUNTIME).
+        annotationProcessorConfigurationName("com.hedera.hashgraph:hedera-dependency-versions") {
+            attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.REGULAR_PLATFORM))
+            }
+        }
+    }
 }
 
 tasks.withType<AbstractArchiveTask>().configureEach {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-module-dependencies.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-module-dependencies.gradle.kts
@@ -53,7 +53,7 @@ javaModuleDependencies {
     moduleNameToGA.put("io.perfmark", "io.perfmark:perfmark-api")
     moduleNameToGA.put(
         "org.apache.logging.log4j.slf4j",
-        "org.apache.logging.log4j:log4j-slf4j-impl"
+        "org.apache.logging.log4j:log4j-slf4j2-impl"
     )
     moduleNameToGA.put("org.bouncycastle.util", "org.bouncycastle:bcutil-jdk15on")
     moduleNameToGA.put(

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -196,8 +196,6 @@ extraJavaModuleInfo {
     knownModule("junit:junit", "junit")
     knownModule("org.apache.logging.log4j:log4j-api", "org.apache.logging.log4j")
     knownModule("org.apache.logging.log4j:log4j-core", "org.apache.logging.log4j.core")
-    knownModule("org.apache.logging.log4j:log4j-slf4j", "org.apache.logging.log4j.slf4j")
-    knownModule("org.apache.logging.log4j:log4j-jul", "org.apache.logging.log4j.jul")
     knownModule("org.jetbrains.kotlin:kotlin-stdlib-jdk8", "kotlin.stdlib.jdk8")
     knownModule("org.slf4j:slf4j-api", "org.slf4j")
     knownModule("jakarta.inject:jakarta.inject-api", "jakarta.inject")

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -26,7 +26,7 @@ val eclipseCollectionsVersion = "10.4.0"
 val grpcVersion = "1.54.1"
 val helidonVersion = "3.2.1"
 val jacksonVersion = "2.13.5"
-val log4jVersion = "2.17.2"
+val log4jVersion = "2.20.0"
 val mockitoVersion = "4.11.0"
 val nettyVersion = "4.1.87.Final"
 val prometheusVersion = "0.16.0"
@@ -37,6 +37,9 @@ val tuweniVersion = "2.3.1"
 
 dependencies {
     api(enforcedPlatform("io.netty:netty-bom:$nettyVersion"))
+
+    // forward logging from modules using SLF4J (e.g. 'org.hyperledger.besu.evm') to Log4J
+    runtime(javaModuleDependencies.gav("org.apache.logging.log4j.slf4j"))
 }
 
 moduleInfo {
@@ -82,7 +85,7 @@ moduleInfo {
     version("org.apache.commons.math3", "3.2")
     version("org.apache.logging.log4j", log4jVersion)
     version("org.apache.logging.log4j.core", log4jVersion)
-    version("org.apache.logging.log4j.jul", log4jVersion)
+    version("org.apache.logging.log4j.slf4j", log4jVersion)
     version("org.assertj.core", "3.23.1")
     version("org.bouncycastle.pkix", bouncycastleVersion)
     version("org.bouncycastle.provider", bouncycastleVersion)
@@ -101,7 +104,6 @@ moduleInfo {
     version("org.mockito.inline", mockitoVersion)
     version("org.mockito.junit.jupiter", mockitoVersion)
     version("org.opentest4j", "1.2.0")
-    version("org.slf4j", "2.0.3")
     version("org.testcontainers", testContainersVersion)
     version("org.testcontainers.junit.jupiter", testContainersVersion)
     version("org.yaml.snakeyaml", "1.33")

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LogCaptor.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LogCaptor.java
@@ -114,7 +114,7 @@ public class LogCaptor {
             }
             // now check if the current match is the level we're looking for
             String matchLevel = m.group(0);
-            if (level.equals(Level.getLevel(matchLevel))) {
+            if (!matchLevel.isEmpty() && level.equals(Level.getLevel(matchLevel))) {
                 prevLevelMatch = true;
             }
             // move the start index for the next search to the end of the current match

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/GrpcServiceBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/GrpcServiceBuilder.java
@@ -41,8 +41,8 @@ import io.grpc.stub.StreamObserver;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Convenient builder API for constructing gRPC Service definitions. The {@link GrpcServiceBuilder}
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 /*@NotThreadSafe*/
 final class GrpcServiceBuilder {
     /** Logger */
-    private static final Logger logger = LoggerFactory.getLogger(GrpcServiceBuilder.class);
+    private static final Logger logger = LogManager.getLogger(GrpcServiceBuilder.class);
 
     /**
      * Create a single JVM-wide Marshaller instance that simply reads/writes byte arrays to/from

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -67,8 +67,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Checks transactions for internal consistency and validity.
@@ -82,7 +82,7 @@ import org.slf4j.LoggerFactory;
  */
 @Singleton
 public class TransactionChecker {
-    private static final Logger logger = LoggerFactory.getLogger(TransactionChecker.class);
+    private static final Logger logger = LogManager.getLogger(TransactionChecker.class);
 
     private static final int USER_TRANSACTION_NONCE = 0;
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/verifier/BaseHandleContextVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/verifier/BaseHandleContextVerifier.java
@@ -38,15 +38,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Base implementation of {@link HandleContextVerifier}
  */
 public class BaseHandleContextVerifier implements HandleContextVerifier {
 
-    private static final Logger logger = LoggerFactory.getLogger(BaseHandleContextVerifier.class);
+    private static final Logger logger = LogManager.getLogger(BaseHandleContextVerifier.class);
 
     private final long timeout;
     private final Map<Key, SignatureVerificationFuture> keyVerifications;

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -41,7 +41,6 @@ module com.hedera.node.app {
     requires io.netty.transport.classes.epoll;
     requires io.netty.transport;
     requires org.apache.logging.log4j;
-    requires org.slf4j;
     requires static com.github.spotbugs.annotations;
 
     exports com.hedera.node.app to

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
@@ -44,9 +44,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.util.encoders.Hex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A proto-duction implementation of cache warming for {@link VirtualMap}, i.e. a quick-and-dirty
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class EntityMapWarmer {
 
-    private static final Logger log = LoggerFactory.getLogger(EntityMapWarmer.class);
+    private static final Logger log = LogManager.getLogger(EntityMapWarmer.class);
     // Note: these suppliers need to be stored here as they are (instead of storing what
     // the supplier references) in order for this class to get the latest copies of the
     // underlying data structures

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -281,6 +281,5 @@ module com.hedera.node.app.service.mono {
     requires org.hyperledger.besu.secp256k1;
     requires com.sun.jna;
     requires org.eclipse.collections.impl;
-    requires org.slf4j;
     requires static com.github.spotbugs.annotations;
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -51,11 +51,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class BaseTokenHandler {
-    private static final Logger log = LoggerFactory.getLogger(BaseTokenHandler.class);
+    private static final Logger log = LogManager.getLogger(BaseTokenHandler.class);
     /**
      * Mints fungible tokens. This method is called in both token create and mint.
      * @param token the new or existing token to mint

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenRelListCalculator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenRelListCalculator.java
@@ -30,7 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Class that computes the expected results of a token relation operation. That is to say, given a
@@ -39,7 +40,7 @@ import org.slf4j.Logger;
  * relationships in some way
  */
 public class TokenRelListCalculator {
-    private static final Logger log = org.slf4j.LoggerFactory.getLogger(TokenRelListCalculator.class);
+    private static final Logger log = LogManager.getLogger(TokenRelListCalculator.class);
 
     private final ReadableTokenRelationStore tokenRelStore;
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/module-info.java
@@ -15,7 +15,6 @@ module com.hedera.node.app.service.token.impl {
     requires com.swirlds.common;
     requires org.apache.commons.lang3;
     requires org.apache.logging.log4j;
-    requires org.slf4j;
     requires static com.github.spotbugs.annotations;
 
     provides com.hedera.node.app.service.token.TokenService with


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Some SLF4J usages sneaked in through transitive dependencies I suppose. In the dependency "cleanup" (e.g. #7875) this was not yet addressed. Instead now you sometimes see:

```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
```

This problem was suppressed [before](https://github.com/hashgraph/hedera-services/blob/3893445245b2c290beafe776ea26cb414c8fc53f/platform-sdk/settings.gradle.kts#L143) by adding `slf4j-nop` which swallowed the logging. This is already gone on develop (hence the message above).

This PR does two things:
1. Exchange all usages of "slf4j" in the code with "log4j"
2. Add the `org.apache.logging.log4j.slf4` bridge as a central "runtime only" dependency that is added to the runtime classpath of all tests/applications. This forwards the slf4j logs to log4j.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
