### PR TITLE
8380: a memory leak in `SwirldsPlatform.components`

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -654,10 +654,9 @@ public class SwirldsPlatform implements Platform, Startable {
             eventLinker.loadFromSignedState(initialState);
 
             // We don't want to invoke these callbacks until after we are starting up.
+            final long round = initialState.getRound();
+            final Hash hash = initialState.getState().getHash();
             components.add((Startable) () -> {
-                final long round = initialState.getRound();
-                final Hash hash = initialState.getState().getHash();
-
                 // If we loaded from disk then call the appropriate dispatch.
                 // It is important that this is sent after the ConsensusHashManager
                 // is initialized.


### PR DESCRIPTION
**Description**:
A lambda with references to `initialState` is added to `components`. That prevents the state from ever be garbage collected.

**Related issue(s)**:

Fixes #8380

**Notes for reviewer**:
Are `components` needed beyond `components.start()`? They could be cleared to avoid leaking temporary components in the future. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ x] Tested (unit, integration, etc.)
