### PR TITLE
8436: Backport the fix for #8260 to release 0.42

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -516,7 +516,11 @@ public final class MerkleDb {
         final String tableName = dataSource.getTableName();
         final boolean isPrimary = primaryTables.contains(dataSource.getTableId());
         if (!isPrimary) {
-            throw new IllegalArgumentException("Cannot snapshot a secondary table, " + tableName);
+            logger.info(
+                    MERKLE_DB.getMarker(),
+                    "A snapshot is taken for a secondary table, it may happen"
+                            + " during reconnect or ISS reporting. Table name={}",
+                    tableName);
         }
         final MerkleDb targetDb = getInstance(destination);
         if (targetDb.tableExists(tableName)) {

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
@@ -28,6 +28,7 @@ import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
 import com.swirlds.merkledb.serialize.KeySerializer;
 import com.swirlds.merkledb.serialize.ValueSerializer;
 import com.swirlds.virtualmap.VirtualMap;
+import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapState;
 import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
 import java.nio.file.Files;
@@ -201,6 +202,34 @@ class MerkleDbSnapshotTest {
 
         lastRoot.get().release();
         restoredStateRoot.release();
+    }
+
+    /*
+     * This test simulates the following scenario. First, a signed state for round N is selected
+     * to be flushed to disk (periodic snapshot). Before it's done, the node is disconnected from
+     * network and starts a reconnect. Reconnect is successful for a different round M (M > N),
+     * and snapshot for round M is written to disk. Now the node has all signatures for the old
+     * round N, and that old signed state is finally written to disk.
+     */
+    @Test
+    void testSnapshotAfterReconnect() throws Exception {
+        final MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> tableConfig = fixedConfig();
+        final MerkleDbDataSourceBuilder<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> dsBuilder =
+                new MerkleDbDataSourceBuilder<>(tableConfig);
+        final VirtualDataSource<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> original =
+                dsBuilder.build("vm", false);
+        // Simulate reconnect as a learner
+        final VirtualDataSource<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> copy =
+                dsBuilder.copy(original, true);
+
+        final Path snapshotDir = TemporaryFileBuilder.buildTemporaryDirectory("snapshot");
+        dsBuilder.snapshot(snapshotDir, copy);
+
+        final Path oldSnapshotDir = TemporaryFileBuilder.buildTemporaryDirectory("oldSnapshot");
+        Assertions.assertDoesNotThrow(() -> dsBuilder.snapshot(oldSnapshotDir, original));
+
+        original.close();
+        copy.close();
     }
 
     public static class TestInternalNode extends PartialNaryMerkleInternal implements MerkleInternal {

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
@@ -334,18 +334,33 @@ public class MerkleDbTest {
                 instance.copyDataSource(dataSource2, true);
 
         final Path snapshotDir = TemporaryFileBuilder.buildTemporaryFile("testSnapshotCopiedTables");
-        // Check primary tables can be snapshotted
+        // Make a snapshot of original table 1
         instance.snapshot(snapshotDir, dataSource1);
+        // Table with this name already exists in the target dir, so exception
+        Assertions.assertThrows(IllegalStateException.class, () -> instance.snapshot(snapshotDir, inactiveCopy1));
+        // Make a snapshot of a copy of table 1
         instance.snapshot(snapshotDir, activeCopy2);
-        // Should not be able to snapshot non-primary tables
-        Assertions.assertThrows(IllegalArgumentException.class, () -> instance.snapshot(snapshotDir, dataSource2));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> instance.snapshot(snapshotDir, inactiveCopy1));
+        // This one will result in a name conflict, too
+        Assertions.assertThrows(IllegalStateException.class, () -> instance.snapshot(snapshotDir, dataSource2));
+
+        // Now try in a different order
+        final Path snapshotDir2 = TemporaryFileBuilder.buildTemporaryFile("testSnapshotCopiedTables2");
+        instance.snapshot(snapshotDir2, inactiveCopy1);
+        Assertions.assertThrows(IllegalStateException.class, () -> instance.snapshot(snapshotDir2, dataSource1));
+        instance.snapshot(snapshotDir2, dataSource2);
+        Assertions.assertThrows(IllegalStateException.class, () -> instance.snapshot(snapshotDir2, activeCopy2));
 
         final MerkleDb snapshotInstance = MerkleDb.getInstance(snapshotDir);
         Assertions.assertTrue(Files.exists(snapshotInstance.getTableDir(tableName1, dataSource1.getTableId())));
         Assertions.assertTrue(Files.exists(snapshotInstance.getTableDir(tableName2, activeCopy2.getTableId())));
         Assertions.assertFalse(Files.exists(snapshotInstance.getTableDir(tableName1, inactiveCopy1.getTableId())));
         Assertions.assertFalse(Files.exists(snapshotInstance.getTableDir(tableName2, dataSource2.getTableId())));
+
+        final MerkleDb snapshotInstance2 = MerkleDb.getInstance(snapshotDir2);
+        Assertions.assertTrue(Files.exists(snapshotInstance2.getTableDir(tableName1, inactiveCopy1.getTableId())));
+        Assertions.assertTrue(Files.exists(snapshotInstance2.getTableDir(tableName2, dataSource2.getTableId())));
+        Assertions.assertFalse(Files.exists(snapshotInstance2.getTableDir(tableName1, dataSource1.getTableId())));
+        Assertions.assertFalse(Files.exists(snapshotInstance2.getTableDir(tableName2, activeCopy2.getTableId())));
 
         dataSource1.close();
         dataSource2.close();


### PR DESCRIPTION
Fix summary: direct backport of #8260 to release 0.42 Original PR is #8419.

Fixes: https://github.com/hashgraph/hedera-services/issues/8436
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
