### PR TITLE
08439 Stabilized VirtualMapTests.testFlushCount

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -914,6 +914,8 @@ class VirtualMapTests extends VirtualTestBase {
         if (!(metric instanceof Counter counterMetric)) {
             throw new AssertionError("flushCount metric is not a counter");
         }
+        // There is a potential race condition here, as we release `VirtualRootNode.flushLatch`
+        // before we update the statiscs (see https://github.com/hashgraph/hedera-services/issues/8439)
         assertEventuallyEquals(
                 flushCount,
                 () -> counterMetric.get(),


### PR DESCRIPTION
**Description**:
This PR fixes a flaky test (`com.swirlds.virtualmap.VirtualMapTests#testFlushCount`)

**Related issue(s)**:

Fixes #8439 

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
