### PR TITLE
fixed code to pass CryptoUpdateSuite test

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -307,7 +307,8 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
 
         final var stakedNode = account.stakedNodeId();
         final var stakedAccount = account.stakedAccountId();
-        if (stakedNode != null) {
+        if (stakedNode != null && stakedNode != -1) {
+            // -1 is a special value to remove the account's staked node ID.
             stakingInfo.stakedNodeId(stakedNode);
             addNodeStakeMeta(stakingInfo, account, stakingInfoStore, stakingRewardsStore);
         } else if (stakedAccount != null) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -27,6 +27,7 @@ import static com.hedera.hapi.node.base.TokenKycStatus.GRANTED;
 import static com.hedera.hapi.node.base.TokenKycStatus.KYC_NOT_APPLICABLE;
 import static com.hedera.node.app.hapi.utils.CommonUtils.asEvmAddress;
 import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.EVM_ADDRESS_LEN;
+import static com.hedera.node.app.service.token.impl.handlers.staking.StakeInfoHelper.SENTINEL_NODE_ID;
 import static com.hedera.node.app.spi.key.KeyUtils.ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH;
 import static com.hedera.node.app.spi.key.KeyUtils.isEmpty;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
@@ -307,7 +308,7 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
 
         final var stakedNode = account.stakedNodeId();
         final var stakedAccount = account.stakedAccountId();
-        if (stakedNode != null && stakedNode != -1) {
+        if (stakedNode != null && stakedNode != SENTINEL_NODE_ID) {
             // -1 is a special value to remove the account's staked node ID.
             stakingInfo.stakedNodeId(stakedNode);
             addNodeStakeMeta(stakingInfo, account, stakingInfoStore, stakingRewardsStore);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -23,6 +23,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
+import static com.hedera.node.app.service.token.impl.handlers.staking.StakeInfoHelper.SENTINEL_ACCOUNT_ID;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
@@ -182,7 +183,7 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
             builder.declineReward(op.declineReward().booleanValue());
         }
         if (op.hasStakedAccountId()) {
-            if (AccountID.newBuilder().accountNum(0).build().equals(op.stakedAccountId())) {
+            if (SENTINEL_ACCOUNT_ID.equals(op.stakedAccountId())) {
                 builder.stakedAccountId((AccountID) null);
             } else {
                 builder.stakedAccountId(op.stakedAccountId());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
@@ -90,15 +90,19 @@ public class StakeInfoHelper {
         final var isDeclineReward = account.declineReward();
 
         final var stakingInfo = stakingInfoStore.get(nodeId);
-        final var copy = stakingInfo.copyBuilder();
-        if (isDeclineReward) {
-            final var stakedToNotReward = stakingInfo.stakeToNotReward() + stakeToAward;
-            copy.stakeToNotReward(stakedToNotReward);
+        if (stakingInfo != null) {
+            final var copy = stakingInfo.copyBuilder();
+            if (isDeclineReward) {
+                final var stakedToNotReward = stakingInfo.stakeToNotReward() + stakeToAward;
+                copy.stakeToNotReward(stakedToNotReward);
+            } else {
+                final var stakedToReward = stakingInfo.stakeToReward() + stakeToAward;
+                copy.stakeToReward(stakedToReward);
+            }
+            stakingInfoStore.put(nodeId, copy.build());
         } else {
-            final var stakedToReward = stakingInfo.stakeToReward() + stakeToAward;
-            copy.stakeToReward(stakedToReward);
+            log.error("Staking info is null for node {}", nodeId);
         }
-        stakingInfoStore.put(nodeId, copy.build());
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
@@ -20,6 +20,7 @@ import static com.hedera.node.app.service.token.impl.handlers.staking.StakingUti
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingUtilities.totalStake;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,6 +35,9 @@ import org.apache.logging.log4j.Logger;
 @Singleton
 public class StakeInfoHelper {
     private static final Logger log = LogManager.getLogger(StakeInfoHelper.class);
+    public static final int SENTINEL_NODE_ID = -1;
+    public static final AccountID SENTINEL_ACCOUNT_ID =
+            AccountID.newBuilder().accountNum(0).build();
 
     @Inject
     public StakeInfoHelper() {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.token.impl.handlers.staking;
 import static com.hedera.node.app.service.mono.ledger.accounts.staking.StakingUtils.NOT_REWARDED_SINCE_LAST_STAKING_META_CHANGE;
 import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.asAccount;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakeIdChangeType.FROM_ACCOUNT_TO_ACCOUNT;
+import static com.hedera.node.app.service.token.impl.handlers.staking.StakeInfoHelper.SENTINEL_NODE_ID;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.getPossibleRewardReceivers;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingUtilities.hasStakeMetaChanges;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingUtilities.roundedToHbar;
@@ -244,8 +245,8 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
             final Instant consensusNow) {
         if (scenario.withdrawsFromNode()) {
             final var currentStakedNodeId = originalAccount.stakedNodeId();
-            // -1 is a special value to remove the account's staked node ID.
-            if (currentStakedNodeId != -1) {
+            // SENTINEL_NODE_ID is a special value to remove the account's staked node ID.
+            if (currentStakedNodeId != SENTINEL_NODE_ID) {
                 stakeInfoHelper.withdrawStake(currentStakedNodeId, originalAccount, stakingInfoStore);
                 if (containStakeMetaChanges) {
                     // Pending rewards are calculated midnight each day for every account.
@@ -267,7 +268,7 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
             final var modifiedStakedNodeId = modifiedAccount.stakedNodeId();
             // We need the latest updates to balance and stakedToMe for the account in modifications also
             // to be reflected in stake awarded. So use the modifiedAccount instead of originalAccount
-            if (modifiedStakedNodeId != -1)
+            if (modifiedStakedNodeId != SENTINEL_NODE_ID)
                 stakeInfoHelper.awardStake(modifiedStakedNodeId, modifiedAccount, stakingInfoStore);
         }
     }
@@ -372,7 +373,7 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
             @NonNull final AccountID stakee,
             final long roundedFinalBalance,
             @NonNull final WritableAccountStore writableStore) {
-        // stakee is null when 0.0.0 sent as staked_account_id in update crypto transaction
+        // stakee is null when SENTINEL_ACCOUNT_ID sent as staked_account_id in update crypto transaction
         if (stakee != null) {
             final var account = writableStore.get(stakee);
             final var initialStakedToMe = account.stakedToMe();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -51,6 +51,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_B
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
@@ -131,6 +132,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                 updateStakingFieldsWorks());
     }
 
+    @HapiTest
     private HapiSpec updateStakingFieldsWorks() {
         return defaultHapiSpec("updateStakingFieldsWorks")
                 .given(
@@ -180,6 +182,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                                 .logged());
     }
 
+    // @HapiTest recheck after TransactionRecord.getTranscationFee() is implemented
     private HapiSpec usdFeeAsExpectedCryptoUpdate() {
         double autoAssocSlotPrice = 0.0018;
         double baseFee = 0.00022;
@@ -234,6 +237,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                                 .skippedIfAutoScheduling(Set.of(CryptoUpdate)));
     }
 
+    @HapiTest
     private HapiSpec updateFailsWithOverlyLongLifetime() {
         final var smallBuffer = 12_345L;
         final var excessiveExpiry = DEFAULT_MAX_LIFETIME + Instant.now().getEpochSecond() + smallBuffer;
@@ -243,6 +247,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                 .then(cryptoUpdate(TARGET_ACCOUNT).expiring(excessiveExpiry).hasKnownStatus(INVALID_EXPIRATION_TIME));
     }
 
+    @HapiTest
     private HapiSpec sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign() {
         String sysAccount = "0.0.99";
         String randomAccount = "randomAccount";
@@ -268,6 +273,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                                 .hasPrecheck(INVALID_SIGNATURE));
     }
 
+    @HapiTest
     private HapiSpec canUpdateMemo() {
         String firstMemo = "First";
         String secondMemo = "Second";
@@ -283,6 +289,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                         .has(accountDetailsWith().memo(secondMemo)));
     }
 
+    @HapiTest
     private HapiSpec updateWithUniqueSigs() {
         return defaultHapiSpec("UpdateWithUniqueSigs")
                 .given(
@@ -294,6 +301,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                         .receiverSigRequired(true));
     }
 
+    @HapiTest
     private HapiSpec updateWithOneEffectiveSig() {
         KeyLabel oneUniqueKey =
                 complex(complex("X", "X", "X", "X", "X", "X", "X"), complex("X", "X", "X", "X", "X", "X", "X"));
@@ -313,6 +321,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                         .hasKnownStatus(SUCCESS));
     }
 
+    @HapiTest
     private HapiSpec updateWithOverlappingSigs() {
         return defaultHapiSpec("UpdateWithOverlappingSigs")
                 .given(
@@ -325,6 +334,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                         .hasKnownStatus(SUCCESS));
     }
 
+    @HapiTest
     private HapiSpec updateFailsWithContractKey() {
         return defaultHapiSpec("UpdateFailsWithContractKey")
                 .given(cryptoCreate(TARGET_ACCOUNT))
@@ -332,6 +342,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                 .then(cryptoUpdate(TARGET_ACCOUNT).usingContractKey().hasKnownStatus(INVALID_SIGNATURE));
     }
 
+    @HapiTest
     private HapiSpec updateFailsWithInsufficientSigs() {
         return defaultHapiSpec("UpdateFailsWithInsufficientSigs")
                 .given(
@@ -344,6 +355,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                         .hasKnownStatus(INVALID_SIGNATURE));
     }
 
+    @HapiTest
     private HapiSpec cannotSetThresholdNegative() {
         return defaultHapiSpec("CannotSetThresholdNegative")
                 .given(cryptoCreate(TEST_ACCOUNT))
@@ -351,6 +363,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                 .then(cryptoUpdate(TEST_ACCOUNT).sendThreshold(-1L));
     }
 
+    @HapiTest
     private HapiSpec updateFailsIfMissingSigs() {
         SigControl origKeySigs = SigControl.threshSigs(3, ON, ON, SigControl.threshSigs(1, OFF, ON));
         SigControl updKeySigs = SigControl.listSigs(ON, OFF, SigControl.threshSigs(1, ON, OFF, OFF, OFF));
@@ -369,6 +382,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                         .hasKnownStatus(INVALID_SIGNATURE));
     }
 
+    @HapiTest
     private HapiSpec updateWithEmptyKeyFails() {
         SigControl updKeySigs = threshOf(0, 0);
 
@@ -380,6 +394,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                 .then(cryptoUpdate(TEST_ACCOUNT).key(UPD_KEY).hasPrecheck(INVALID_ADMIN_KEY));
     }
 
+    // @HapiTest recheck after MichaelT complete the parseStrict() #96 fix
     private HapiSpec updateMaxAutoAssociationsWorks() {
         final int maxAllowedAssociations = 5000;
         final int originalMax = 2;


### PR DESCRIPTION
Fixed code to pass CryptoUpdateSuite test.
Added stakednode = -1 and stakedaccount = null handling in rewards calculation 
Added unit test for payerAccount=deleted in PreHandleWorkflowImplTest

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #8329 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
