### PR TITLE
8170: MixedOps-Interrupted-2NReconnect-6k-41m failed with MerkleSynchronizationException

### DIFF
--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/StandardWorkGroupTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/StandardWorkGroupTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -152,5 +153,23 @@ class StandardWorkGroupTest {
         assertThat(subject.isTerminated()).isTrue();
         assertThat(subject.isShutdown()).isTrue();
         assertThat(abortCount.get()).isEqualTo(0);
+    }
+
+    @Test
+    void exceptionsPropagatedToListener() throws InterruptedException {
+        final AtomicReference<Throwable> caught = new AtomicReference<>();
+        subject = new StandardWorkGroup(getStaticThreadManager(), "groupName", abortCount::incrementAndGet, ex -> {
+            caught.set(ex);
+            return true;
+        });
+
+        final String exceptionMessage = "ExceptionMessage";
+        subject.execute("task", () -> {
+            throw new RuntimeException(exceptionMessage);
+        });
+        subject.waitForTermination();
+
+        assertThat(caught.get()).isNotNull();
+        assertThat(caught.get().getMessage()).endsWith(exceptionMessage);
     }
 }


### PR DESCRIPTION
Fix summary:

* Added a way to specify an exception listener for `StandardWorkGroup`
* The listener will be notified of all exceptions and will be able to tell if it can handle an exception, or default processing (to log it as an error) is needed
* `TeachingSyncronizer` will create an instance of `StandardWorkGroup` with a custom listener that ignores (logs as info) socket errors, but leaves everything else to be reported with EXCEPTION marker

Fixes: https://github.com/hashgraph/hedera-services/issues/8170
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
