### PR TITLE
Do not preload file 121 with all network properties

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
@@ -49,7 +49,6 @@ import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.StateDefinition;
 import com.hedera.node.app.spi.state.WritableKVState;
-import com.hedera.node.config.Utils;
 import com.hedera.node.config.data.BootstrapConfig;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/GenesisSchema.java
@@ -353,11 +353,8 @@ public class GenesisSchema extends Schema {
 
         // Get the set of network properties from configuration, and generate the file content to store in state.
         List<Setting> settings = new ArrayList<>();
-        Utils.networkProperties(configuration)
-                .forEach((propertyName, propertyValue) -> settings.add(Setting.newBuilder()
-                        .name(propertyName)
-                        .value(propertyValue.toString())
-                        .build()));
+        // FUTURE: We would like to preload all network properties. If we actually do that, then we would do that here.
+        //         using some kind of reflection on the configuration system.
 
         final var servicesConfigList =
                 ServicesConfigurationList.newBuilder().nameValue(settings).build();


### PR DESCRIPTION
**Description**:
Restores behavior of to match mono, where file 121 is created but not populated at Genesis.

**Related issue(s)**:

Fixes #8450 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
