### PR TITLE
Check transaction node account matches on ingest not on pre-handle

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -309,11 +309,6 @@ public class TransactionChecker {
      * @throws NullPointerException if any of the parameters is {@code null}
      */
     public void checkTransactionBody(@NonNull final TransactionBody txBody) throws PreCheckException {
-        // The transaction MUST have been sent to *this* node
-        if (!nodeAccount.equals(txBody.nodeAccountID())) {
-            throw new PreCheckException(INVALID_NODE_ACCOUNT);
-        }
-
         final var config = props.getConfiguration().getConfigData(HederaConfig.class);
         checkTransactionID(txBody.transactionID());
         checkMemo(txBody.memo(), config.transactionMaxMemoUtf8Bytes());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.workflows;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_DURATION;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.workflows.prehandle;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PAYER_ACCOUNT_DELETED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
@@ -151,6 +152,11 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
         final TransactionInfo txInfo;
         try {
             txInfo = transactionChecker.parseAndCheck(txBytes);
+
+            // The transaction account ID MUST have matched the creator!
+            if (!creator.equals(txInfo.txBody().nodeAccountID())) {
+                throw new PreCheckException(INVALID_NODE_ACCOUNT);
+            }
         } catch (PreCheckException preCheck) {
             // The node SHOULD have verified the transaction before it was submitted to the network.
             // Since it didn't, it has failed in its due diligence and will be charged accordingly.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -154,6 +154,7 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
         } catch (PreCheckException preCheck) {
             // The node SHOULD have verified the transaction before it was submitted to the network.
             // Since it didn't, it has failed in its due diligence and will be charged accordingly.
+            logger.debug("Transaction failed pre-check", preCheck);
             return nodeDueDiligenceFailure(creator, preCheck.responseCode(), null);
         }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -728,22 +728,6 @@ final class TransactionCheckerTest extends AppTestBase {
             }
 
             @Test
-            @DisplayName("A wrong nodeId in transaction fails")
-            void testWrongNodeIdFails() {
-                // Given a transaction with an unknown node ID
-                final var unknownNodeId = AccountID.newBuilder()
-                        .accountNum(nodeSelfAccountId.accountNumOrElse(0L) + 1L)
-                        .build();
-                final var body = bodyBuilder(txIdBuilder()).nodeAccountID(unknownNodeId);
-                final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
-
-                // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
-                        .isInstanceOf(PreCheckException.class)
-                        .has(responseCode(INVALID_NODE_ACCOUNT));
-            }
-
-            @Test
             @DisplayName("A scheduled transaction should fail")
             void testScheduledTransactionFails() {
                 final var body = bodyBuilder(txIdBuilder().scheduled(true));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.workflows;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONSENSUS_CREATE_TOPIC;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_DURATION;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
@@ -60,6 +60,11 @@ public class TransactionScenarioBuilder implements Scenarios {
         return this;
     }
 
+    public TransactionScenarioBuilder withNodeAccount(@Nullable final AccountID nodeAccount) {
+        body = body.copyBuilder().nodeAccountID(nodeAccount).build();
+        return this;
+    }
+
     public TransactionScenarioBuilder withPayer(@Nullable final AccountID payer) {
         final var oldId = body.transactionID();
         final var id = oldId == null
@@ -117,6 +122,7 @@ public class TransactionScenarioBuilder implements Scenarios {
 
     public static TransactionBody goodDefaultBody() {
         return TransactionBody.newBuilder()
+                .nodeAccountID(NODE_1.nodeAccountID())
                 .transactionID(TransactionID.newBuilder()
                         .accountID(ALICE.accountID())
                         .transactionValidStart(Timestamp.newBuilder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.workflows.prehandle;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
@@ -392,7 +391,8 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
         void preHandleCreatorAccountNotTxNodeAccount() throws PreCheckException {
             // Given a transactionID that refers to an account OTHER THAN the creator node account.
             // The creator in this scenario is NODE_1.
-            final var txInfo = scenario().withNodeAccount(NODE_2.nodeAccountID()).txInfo();
+            final var txInfo =
+                    scenario().withNodeAccount(NODE_2.nodeAccountID()).txInfo();
 
             final Transaction platformTx = new SwirldTransaction(asByteArray(txInfo.transaction()));
             when(transactionChecker.parseAndCheck(any(Bytes.class))).thenReturn(txInfo);


### PR DESCRIPTION
**Description**:
We should only check the node account ID, in the transaction, matches **this** node during transaction ingest. We should check during pre-handle that the node account ID matches the node that sent the event.

**Related issue(s)**:

Fixes #8451

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
