### PR TITLE
Enable HandleContextImpl to work with unknown payer

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeManager.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -137,11 +138,15 @@ public final class FeeManager {
      */
     @NonNull
     public FeeCalculator createFeeCalculator(
-            @NonNull final TransactionInfo txInfo,
-            @NonNull final Key payerKey,
+            @Nullable final TransactionInfo txInfo,
+            @Nullable final Key payerKey,
             final int numVerifications,
             @NonNull final Instant consensusTime,
             @NonNull final SubType subType) {
+
+        if (txInfo == null || payerKey == null) {
+            return NoOpFeeCalculator.INSTANCE;
+        }
 
         // Determine which fee schedule to use, based on the consensus time
         final var feeData = getFeeData(txInfo.functionality(), consensusTime, subType);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeAccumulator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.fees;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.app.spi.fees.FeeAccumulator;
+import com.hedera.node.app.spi.fees.Fees;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A no-op implementation of {@link FeeAccumulator} that can be used if no fees are to be charged.
+ */
+public class NoOpFeeAccumulator implements FeeAccumulator {
+
+    public static final NoOpFeeAccumulator INSTANCE = new NoOpFeeAccumulator();
+
+    @Override
+    public void charge(@NonNull AccountID payer, @NonNull Fees fees) {}
+
+    @Override
+    public void refund(@NonNull AccountID receiver, @NonNull Fees fees) {}
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeCalculator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeCalculator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.fees;
+
+import com.hedera.node.app.hapi.utils.fee.SigValueObj;
+import com.hedera.node.app.spi.fees.FeeCalculator;
+import com.hedera.node.app.spi.fees.Fees;
+import com.hederahashgraph.api.proto.java.FeeData;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.function.Function;
+
+/**
+ * A no-op implementation of {@link FeeCalculator} that always returns {@link Fees#FREE}.
+ */
+public class NoOpFeeCalculator implements FeeCalculator {
+
+    public static final NoOpFeeCalculator INSTANCE = new NoOpFeeCalculator();
+
+    @NonNull
+    @Override
+    public FeeCalculator withResourceUsagePercent(double percent) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public FeeCalculator addBytesPerTransaction(long bytes) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public FeeCalculator addStorageBytesSeconds(long seconds) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public FeeCalculator addNetworkRamByteSeconds(long amount) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public FeeCalculator addRamByteSeconds(long amount) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public Fees legacyCalculate(@NonNull Function<SigValueObj, FeeData> callback) {
+        return Fees.FREE;
+    }
+
+    @NonNull
+    @Override
+    public Fees calculate() {
+        return Fees.FREE;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
@@ -119,6 +119,7 @@ public class HandleContextImpl implements HandleContext, FeeContext {
      * Constructs a {@link HandleContextImpl}.
      *
      * @param txBody                The {@link TransactionBody} of the transaction
+     * @param txInfo                The {@link TransactionInfo} of the transaction
      * @param payer                 The {@link AccountID} of the payer
      * @param payerKey              The {@link Key} of the payer
      * @param networkInfo           The {@link NetworkInfo} of the network
@@ -155,7 +156,7 @@ public class HandleContextImpl implements HandleContext, FeeContext {
             @NonNull final FeeManager feeManager,
             @NonNull final ExchangeRateManager exchangeRateManager,
             @NonNull final Instant userTransactionConsensusTime) {
-        this.txBody = requireNonNull(txBody, "txInfo must not be null");
+        this.txBody = requireNonNull(txBody, "txBody must not be null");
         this.payer = requireNonNull(payer, "payer must not be null");
         this.payerKey = payerKey;
         this.networkInfo = requireNonNull(networkInfo, "networkInfo must not be null");

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
@@ -31,7 +31,10 @@ import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.fees.ExchangeRateManager;
+import com.hedera.node.app.fees.FeeAccumulatorImpl;
 import com.hedera.node.app.fees.FeeManager;
+import com.hedera.node.app.fees.NoOpFeeAccumulator;
+import com.hedera.node.app.fees.NoOpFeeCalculator;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.ids.WritableEntityIdStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
@@ -41,7 +44,6 @@ import com.hedera.node.app.spi.fees.ExchangeRateInfo;
 import com.hedera.node.app.spi.fees.FeeAccumulator;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.records.BlockRecordInfo;
 import com.hedera.node.app.spi.records.RecordCache;
@@ -82,6 +84,7 @@ import org.apache.logging.log4j.Logger;
  * The default implementation of {@link HandleContext}.
  */
 public class HandleContextImpl implements HandleContext, FeeContext {
+
     private static final Logger logger = LogManager.getLogger(HandleContextImpl.class);
 
     private final TransactionBody txBody;
@@ -115,7 +118,7 @@ public class HandleContextImpl implements HandleContext, FeeContext {
     /**
      * Constructs a {@link HandleContextImpl}.
      *
-     * @param txInfo                The {@link TransactionInfo} of the transaction
+     * @param txBody                The {@link TransactionBody} of the transaction
      * @param payer                 The {@link AccountID} of the payer
      * @param payerKey              The {@link Key} of the payer
      * @param networkInfo           The {@link NetworkInfo} of the network
@@ -133,9 +136,10 @@ public class HandleContextImpl implements HandleContext, FeeContext {
      * @param userTransactionConsensusTime The consensus time of the user transaction, not any child transactions
      */
     public HandleContextImpl(
-            @NonNull final TransactionInfo txInfo,
+            @NonNull final TransactionBody txBody,
+            @Nullable final TransactionInfo txInfo,
             @NonNull final AccountID payer,
-            @NonNull final Key payerKey,
+            @Nullable final Key payerKey,
             @NonNull final NetworkInfo networkInfo,
             @NonNull final TransactionCategory category,
             @NonNull final SingleTransactionRecordBuilderImpl recordBuilder,
@@ -151,9 +155,9 @@ public class HandleContextImpl implements HandleContext, FeeContext {
             @NonNull final FeeManager feeManager,
             @NonNull final ExchangeRateManager exchangeRateManager,
             @NonNull final Instant userTransactionConsensusTime) {
-        this.txBody = requireNonNull(txInfo, "txInfo must not be null").txBody();
+        this.txBody = requireNonNull(txBody, "txInfo must not be null");
         this.payer = requireNonNull(payer, "payer must not be null");
-        this.payerKey = requireNonNull(payerKey, "payerKey must not be null");
+        this.payerKey = payerKey;
         this.networkInfo = requireNonNull(networkInfo, "networkInfo must not be null");
         this.category = requireNonNull(category, "category must not be null");
         this.recordBuilder = requireNonNull(recordBuilder, "recordBuilder must not be null");
@@ -169,25 +173,21 @@ public class HandleContextImpl implements HandleContext, FeeContext {
         this.feeManager = requireNonNull(feeManager, "feeManager must not be null");
         this.userTransactionConsensusTime =
                 requireNonNull(userTransactionConsensusTime, "userTransactionConsensusTime must not be null");
-        this.feeCalculatorCreator = subType -> feeManager.createFeeCalculator(
-                txInfo, payerKey, verifier.numSignaturesVerified(), userTransactionConsensusTime, subType);
 
         final var serviceScope = serviceScopeLookup.getServiceName(txBody);
         this.writableStoreFactory = new WritableStoreFactory(stack, serviceScope);
         this.serviceApiFactory = new ServiceApiFactory(stack, configuration);
 
-        final var tokenApi = this.serviceApiFactory.getApi(TokenServiceApi.class);
-        this.feeAccumulator = new FeeAccumulator() {
-            @Override
-            public void charge(@NonNull AccountID payer, @NonNull Fees fees) {
-                tokenApi.chargeFees(payer, fees, recordBuilder);
-            }
+        if (txInfo == null || payerKey == null) {
+            this.feeCalculatorCreator = ignore -> NoOpFeeCalculator.INSTANCE;
+            this.feeAccumulator = NoOpFeeAccumulator.INSTANCE;
+        } else {
+            this.feeCalculatorCreator = subType -> feeManager.createFeeCalculator(
+                    txInfo, payerKey, verifier.numSignaturesVerified(), userTransactionConsensusTime, subType);
+            final var tokenApi = serviceApiFactory.getApi(TokenServiceApi.class);
+            this.feeAccumulator = new FeeAccumulatorImpl(tokenApi, recordBuilder);
+        }
 
-            @Override
-            public void refund(@NonNull AccountID receiver, @NonNull Fees fees) {
-                tokenApi.refundFees(receiver, fees, recordBuilder);
-            }
-        };
         this.exchangeRateManager = requireNonNull(exchangeRateManager, "exchangeRateManager must not be null");
     }
 
@@ -493,8 +493,13 @@ public class HandleContextImpl implements HandleContext, FeeContext {
 
         final var childVerifier = new DelegateHandleContextVerifier(callback);
 
+        TransactionInfo txInfo = null;
+        if (transactionID != null) {
+            txInfo = new TransactionInfo(transaction, txBody, SignatureMap.DEFAULT, bodyBytes, function);
+        }
         final var childContext = new HandleContextImpl(
-                new TransactionInfo(Transaction.DEFAULT, txBody, SignatureMap.DEFAULT, Bytes.EMPTY, function),
+                txBody,
+                txInfo,
                 payer,
                 payerKey,
                 networkInfo,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -295,6 +295,7 @@ public class HandleWorkflow {
 
             // Setup context
             final var context = new HandleContextImpl(
+                    txBody,
                     transactionInfo,
                     payer,
                     preHandleResult.payerKey(),

--- a/hedera-node/hedera-app/src/xtest/java/contract/ScaffoldingModule.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ScaffoldingModule.java
@@ -238,6 +238,7 @@ public interface ScaffoldingModule {
             final var txInfo =
                     new TransactionInfo(Transaction.DEFAULT, body, SignatureMap.DEFAULT, Bytes.EMPTY, function);
             return new HandleContextImpl(
+                    body,
                     txInfo,
                     body.transactionIDOrThrow().accountIDOrThrow(),
                     Key.DEFAULT,


### PR DESCRIPTION
Some child transactions are executed without a known `TransactionID`. Also, we create the `HandleContext` before validating the input. Therefore it has to work with an unknown `payerKey`.

This "solution" is pretty messy, but at least it fixes the failing tests. We should probably revisit the creation of `HandleContext` at some point.

Closes #8493 