### PR TITLE
08212 - Fix Migrated State Event Validation

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -539,7 +539,7 @@ public class SwirldsPlatform implements Platform, Startable {
         validators.add(new TransactionSizeValidator(transactionConfig.maxTransactionBytesPerEvent()));
         // some events in the PCES might have been created by nodes that are no longer in the current
         // address book but are in the previous one, so we need both for signature validation
-        final List<AddressBook> validationAddressBooks = Stream.of(currentAddressBook, previousAddressBook)
+        final List<AddressBook> validationAddressBooks = Stream.of(previousAddressBook, currentAddressBook)
                 .filter(Objects::nonNull)
                 .toList();
         if (basicConfig.verifyEventSigs()) {


### PR DESCRIPTION
**Description**:
For nodes that were shared between the state address book and the config.txt address book, signature validation was using the public keys of the state address book.  Swapped the order to default to the public keys generated from the nodes in current address book (which may be the state address book if the initializer decided that was the AB to use). 

**Related issue(s)**:

Fixes #8212 
