### PR TITLE
Fix 'swirlds-platform' vs 'platform-sdk' build identity

### DIFF
--- a/platform-sdk/settings.gradle.kts
+++ b/platform-sdk/settings.gradle.kts
@@ -18,8 +18,6 @@ pluginManagement { includeBuild("../build-logic") }
 
 plugins { id("com.hedera.hashgraph.settings") }
 
-rootProject.name = "swirlds-platform"
-
 includeBuild("../hedera-dependency-versions")
 
 include(":swirlds")


### PR DESCRIPTION


**Description**:
Gradle's include mechanism uses different names in the build/project path if the name is not already corrected here. This leads to some functionality in IntelliJ - like test debugging - to not work as expected.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
