### PR TITLE
08237 Fixed validation of multiple rounds in VirtualMerkleLeafHasher

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleTestBase.java
@@ -16,9 +16,6 @@
 
 package com.hedera.node.app.state.merkle;
 
-import static com.swirlds.common.io.utility.FileUtils.deleteDirectory;
-import static com.swirlds.common.io.utility.TemporaryFileBuilder.getTemporaryFileLocation;
-
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.fixtures.state.StateTestBase;
 import com.hedera.node.app.spi.fixtures.state.TestSchema;
@@ -52,9 +49,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 
 /**
@@ -313,12 +308,7 @@ public class MerkleTestBase extends StateTestBase {
     }
 
     @AfterEach
-    void cleanUp() throws IOException, NoSuchFieldException, IllegalAccessException {
-        // We need to make sure that the test cleans up after itself to prevent interference with the other tests
-        Field field = MerkleDb.class.getDeclaredField("instances");
-        field.setAccessible(true);
-        ((Map<?, ?>) field.get(null)).clear();
-
-        deleteDirectory(getTemporaryFileLocation());
+    void cleanUp() {
+        MerkleDb.resetDefaultInstancePath();
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -138,13 +138,15 @@ public class ServicesState extends PartialNaryMerkleInternal
     public ServicesState() {
         // RuntimeConstructable
         bootstrapProperties = null;
-        resetDefaultMerkleDbPathIfNeeded();
+
+        MerkleDb.resetDefaultInstancePath();
     }
 
     @VisibleForTesting
     ServicesState(final BootstrapProperties bootstrapProperties) {
         this.bootstrapProperties = bootstrapProperties;
-        resetDefaultMerkleDbPathIfNeeded();
+
+        MerkleDb.resetDefaultInstancePath();
     }
 
     private ServicesState(final ServicesState that) {
@@ -321,16 +323,6 @@ public class ServicesState extends PartialNaryMerkleInternal
         // irrespective of the weight provided in config.txt
         configNodeIds.forEach(nodeId -> configAddressBook.updateWeight(nodeId, 0));
         return configAddressBook;
-    }
-
-    private void resetDefaultMerkleDbPathIfNeeded() {
-        // This is a workaround to support multiple nodes running in a single process for testing
-        // purposes. When a node is restored from a saved state, all virtual maps are restored to
-        // the default MerkleDb instance. There is no way yet to provide node config to MerkleDb,
-        // it's a singleton. It leads to nodes to overwrite each other's data. To work it around,
-        // let's reset the default MerkleDb path. It has to be done before the state is loaded
-        // from disk, so I'm putting this code right into the constructor
-        MerkleDb.setDefaultPath(null);
     }
 
     private ServicesApp deserializedInit(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/UniqueTokensLinkManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/UniqueTokensLinkManagerTest.java
@@ -93,7 +93,7 @@ class UniqueTokensLinkManagerTest extends ResponsibleVMapUser {
     @AfterEach
     void shutDown() {
         // Use a different data source for each test. Assume MerkleDb is used by default for tests
-        MerkleDb.setDefaultPath(null);
+        MerkleDb.resetDefaultInstancePath();
     }
 
     @Test

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
@@ -34,6 +34,7 @@ import com.swirlds.demo.virtualmerkle.map.smartcontracts.bytecode.SmartContractB
 import com.swirlds.demo.virtualmerkle.map.smartcontracts.bytecode.SmartContractByteCodeMapValue;
 import com.swirlds.demo.virtualmerkle.map.smartcontracts.data.SmartContractMapKey;
 import com.swirlds.demo.virtualmerkle.map.smartcontracts.data.SmartContractMapValue;
+import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualMap;
 import com.swirlds.virtualmap.VirtualValue;
@@ -162,6 +163,9 @@ public class VirtualMerkleLeafHasher<K extends VirtualKey, V extends VirtualValu
         TemporaryFileBuilder.overrideTemporaryFileLocation(classFolder.resolve("tmp"));
 
         for (final Path roundFolder : roundsFolders) {
+            // reset the default instance path to force creation of a new MerkleDB instance
+            // https://github.com/hashgraph/hedera-services/pull/8534
+            MerkleDb.resetDefaultInstancePath();
             Hash accountsHash;
             Hash scHash;
             Hash byteCodeHash;

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -25,6 +25,7 @@ import com.swirlds.common.io.utility.TemporaryFileBuilder;
 import com.swirlds.merkledb.files.DataFileCommon;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -179,11 +180,24 @@ public final class MerkleDb {
      *
      * @param value The new default database path
      */
-    public static void setDefaultPath(Path value) {
+    public static void setDefaultPath(@NonNull Path value) {
+        Objects.requireNonNull(value);
         // It probably makes sense to let change default instance path only before the first call
         // to getDefaultInstance(). Update: in the tests, this method may be called multiple times,
         // if a test needs to create multiple maps with the same name
         defaultInstancePath.set(value);
+    }
+
+    /**
+     * This method resets the path to a default instance to force the next {@link #getDefaultInstance()} to
+     * create another instance. This method is used in tests to load multiple MerkleDb instances within one process.
+     * When a node is restored from a saved state, all virtual maps are restored to the default MerkleDb instance.
+     * There is no way yet to provide node config to MerkleDb, it's a singleton. It leads to nodes to attempt overwriting each other's data,
+     * which ultimately results in exceptions on load. To work it around, call this method.
+     * It has to be done before the state is loaded from disk.
+     */
+    public static void resetDefaultInstancePath() {
+        defaultInstancePath.set(null);
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
@@ -127,7 +127,7 @@ class MerkleDbSnapshotTest {
         }
         lastRoot.set(stateRoot);
 
-        MerkleDb.setDefaultPath(null);
+        MerkleDb.resetDefaultInstancePath();
         final MerkleDataInputStream in =
                 new MerkleDataInputStream(Files.newInputStream(snapshotFile, StandardOpenOption.READ));
         final MerkleInternal restoredStateRoot = in.readMerkleTree(snapshotDir, Integer.MAX_VALUE);
@@ -193,7 +193,7 @@ class MerkleDbSnapshotTest {
         out.writeMerkleTree(snapshotDir, rootToSnapshot.get());
         rootToSnapshot.get().release();
 
-        MerkleDb.setDefaultPath(null);
+        MerkleDb.resetDefaultInstancePath();
         final MerkleDataInputStream in =
                 new MerkleDataInputStream(Files.newInputStream(snapshotFile, StandardOpenOption.READ));
         final MerkleInternal restoredStateRoot = in.readMerkleTree(snapshotDir, Integer.MAX_VALUE);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
@@ -38,6 +38,7 @@ public class MerkleDbTest {
 
     @BeforeAll
     public static void setup() throws Exception {
+        MerkleDb.resetDefaultInstancePath();
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
     }
 


### PR DESCRIPTION
**Description**:

This fix resets MerkleDb static state to prevent usage of incorrect metadata during the validation of the state files. 
Here is the explanation of why it's happening. `VirtualMerkleLeafHasher#main` loads rounds to validate. To do so it creates a virtual map which, in it's turn, creates a _default instance_ of MerkleDB (see `com.swirlds.virtualmap.VirtualMap#loadFromFile`) if it doesn't exist. To check if it exists or not, it checks if the path for a default instance is set or not. If the path is `null`, it creates a new instance. 

Also, `VirtualMap#loadFromFile` loads `virtualMapState` from the disk. This state, among other things, contains `firstLeafPath` and `lastLeafPath`. These parameters are defining a valid range of the keys we can use to get leaf values from the map. 

It all works perfectly fine if `VirtualMerkleLeafHasher` needs to validate a single round. The issue comes into play whenever it tries to validate more than one round. To validate the next round it creates another virtual map, and another call to  `VirtualMap#loadFromFile` updates `virtualMapState` and, therefore, `firstLeafPath` and `lastLeafPath`. However, it doesn't create another instance of `MerkleDb` because it was previously created. And this previously created instance has different valid `firstLeafPath` and `lastLeafPath`. 


**Related issue(s)**:

Fixes #8237 
