### PR TITLE
Remove no longer existing property 

### DIFF
--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -12,7 +12,6 @@ sync.syncProtocolPermitCount,                  2                            # di
 
 merkleDb.iteratorInputBufferBytes,             16777216
 merkleDb.hashesRamToDiskThreshold,             8388608
-state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         300                          # differs from mainnet
 state.signedStateDisk,                         3                            # differs from mainnet
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -12,7 +12,6 @@ sync.syncProtocolPermitCount,                  2                            # di
 
 merkleDb.iteratorInputBufferBytes,             16777216
 merkleDb.hashesRamToDiskThreshold,             8388608
-state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         300                          # differs from mainnet
 state.signedStateDisk,                         5
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -12,7 +12,6 @@ sync.syncProtocolPermitCount,                  17
 
 merkleDb.iteratorInputBufferBytes,             16777216
 merkleDb.hashesRamToDiskThreshold,             8388608
-state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -12,7 +12,6 @@ sync.syncProtocolPermitCount,                  4                            # di
 
 merkleDb.iteratorInputBufferBytes,             16777216
 merkleDb.hashesRamToDiskThreshold,             8388608
-state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -12,7 +12,6 @@ sync.syncProtocolPermitCount,                  4                            # di
 
 merkleDb.iteratorInputBufferBytes,             16777216
 merkleDb.hashesRamToDiskThreshold,             8388608
-state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -12,7 +12,6 @@ sync.syncProtocolPermitCount,                  4                            # di
 
 merkleDb.iteratorInputBufferBytes,             16777216
 merkleDb.hashesRamToDiskThreshold,             8388608
-state.checkSignedStateFromDisk,                true
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/platform-sdk/swirlds-platform-core/src/test/resources/com/swirlds/platform/settings4.txt
+++ b/platform-sdk/swirlds-platform-core/src/test/resources/com/swirlds/platform/settings4.txt
@@ -42,7 +42,6 @@ benchmark.csvWriteFrequency, 4000
 benchmark.csvAppend, true
 event.eventIntakeQueueThrottleSize, 2000
 event.eventIntakeQueueSize, 15000
-state.checkSignedStateFromDisk, true
 event.randomEventProbability, 1
 event.staleEventPreventionThreshold, 10
 event.rescueChildlessInverseProbability, 15


### PR DESCRIPTION
**Description**:

All services tests are failing because property `state.checkSignedStateFromDisk` has been removed
from platform but still used in settings.txt

