### PR TITLE
"Productizing" contract disassembler at last

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/ContractCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/ContractCommand.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts;
+
+import com.hedera.services.cli.utils.HexToBytesConverter;
+import com.hedera.services.cli.utils.HexToBytesConverter.Bytes;
+import com.swirlds.cli.PlatformCli;
+import com.swirlds.cli.utility.AbstractCommand;
+import com.swirlds.cli.utility.SubcommandOf;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/** A subcommand of the `PlatformCLI`, for dealing with contract analysis */
+@SuppressWarnings({"java:S106"}) // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+@Command(name = "contract", mixinStandardHelpOptions = true, description = "Operations on contracts.")
+@SubcommandOf(PlatformCli.class)
+public class ContractCommand extends AbstractCommand {
+
+    public static String REPORT_SEPARATOR = "===";
+
+    @ParentCommand
+    PlatformCli parent;
+
+    enum Verbosity {
+        SILENT,
+        VERBOSE
+    }
+
+    @CommandLine.Option(
+            names = {"-v", "--verbose"},
+            arity = "0..1",
+            defaultValue = "false",
+            description = "Verbosity of command")
+    private void setVerbosity(final boolean doVerbose) {
+        verbosity = doVerbose ? Verbosity.VERBOSE : Verbosity.SILENT;
+    }
+
+    Verbosity verbosity;
+
+    @SuppressWarnings("java:S115") // "Constant names should comply with a naming convention" - enum names used
+    // directly as command line options by picocli
+    enum ShortOption {
+        b(DisassemblyOption.WITH_BYTECODE),
+        d(DisassemblyOption.DO_NOT_DECODE_BEFORE_METADATA),
+        f(DisassemblyOption.DISPLAY_CODE_OFFSET),
+        l(DisassemblyOption.FETCH_SELECTOR_NAMES),
+        m(DisassemblyOption.LIST_MACROS),
+        p(DisassemblyOption.DISPLAY_OPCODE_HEX),
+        q(DisassemblyOption.RECOGNIZE_CODE_SEQUENCES),
+        r(DisassemblyOption.WITH_RAW_DISASSEMBLY),
+        s(DisassemblyOption.DISPLAY_SELECTORS),
+        t(DisassemblyOption.TRACE_RECOGNIZERS),
+        x(DisassemblyOption.WITH_METRICS);
+
+        ShortOption(@NonNull DisassemblyOption option) {
+            this.option = option;
+        }
+
+        @NonNull
+        DisassemblyOption option() {
+            return option;
+        }
+
+        final DisassemblyOption option;
+    }
+
+    @Command(name = "disassemble", mixinStandardHelpOptions = true, description = "Disassembles contract bytecodes")
+    void disassemble(
+            @Option(
+                            names = {"-i", "--id"},
+                            paramLabel = "CONTRACT_ID",
+                            description = "Contract Id (decimal, optional)")
+                    @NonNull
+                    Optional<Integer> theContractId,
+            @Option(
+                            names = {"-b", "--bytecode"},
+                            required = true,
+                            arity = "1",
+                            converter = HexToBytesConverter.class,
+                            paramLabel = "HEX",
+                            description = "Contract bytecode as a hex string")
+                    @Nullable
+                    Bytes theContract,
+            @Option(
+                            names = {"-o", "--option", "--options"},
+                            split = ",",
+                            description = {
+                                "different output options:",
+                                "b    with contract bytecode header",
+                                "d    do not decode before metadata",
+                                "f    with code offsets in disassembly",
+                                "l    with selector lookups (from internet) (requires q)",
+                                "m    list macros",
+                                "p    with opcode (in hex)",
+                                "q    recognize and analyze code sequences",
+                                "r    list raw disassembly (before analyzed disassembly",
+                                "s    list selectors",
+                                "t    dump trace of recognizers",
+                                "x    with metrics"
+                            })
+                    @Nullable
+                    List<ShortOption> shortOptions,
+            @Option(
+                            names = {"-p", "--prefix"},
+                            description = "Prefix for each assembly line",
+                            defaultValue = "")
+                    @NonNull
+                    String prefix) {
+        Objects.requireNonNull(theContractId);
+        Objects.requireNonNull(theContract);
+        Objects.requireNonNull(prefix);
+        final var options = EnumSet.noneOf(DisassemblyOption.class);
+        if (null != shortOptions) shortOptions.stream().map(ShortOption::option).forEach(options::add);
+        System.out.print(formatSeparatorLine(
+                "Disassembly " + theContractId.map(Object::toString).orElse("")));
+        DisassembleContractSubcommand.doit(theContractId, theContract, options, prefix, verbosity);
+    }
+
+    @NonNull
+    public static String formatSeparatorLine(@NonNull final Object heading) {
+        return "%s %s %s%n".formatted(REPORT_SEPARATOR, heading, REPORT_SEPARATOR);
+    }
+
+    private ContractCommand() {}
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassembleContractSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassembleContractSubcommand.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts;
+
+import static com.hedera.services.cli.contracts.ContractCommand.formatSeparatorLine;
+import static com.hedera.services.cli.contracts.assembly.Constants.UPPERCASE_HEX_FORMATTER;
+
+import com.hedera.services.cli.contracts.ContractCommand.Verbosity;
+import com.hedera.services.cli.contracts.analysis.MethodAnalysis;
+import com.hedera.services.cli.contracts.analysis.VTableEntryRecognizer;
+import com.hedera.services.cli.contracts.analysis.VTableEntryRecognizer.MethodEntry;
+import com.hedera.services.cli.contracts.assembly.Code;
+import com.hedera.services.cli.contracts.assembly.CommentLine;
+import com.hedera.services.cli.contracts.assembly.DirectiveLine;
+import com.hedera.services.cli.contracts.assembly.Disassembler;
+import com.hedera.services.cli.contracts.assembly.Editor;
+import com.hedera.services.cli.contracts.assembly.LabelLine;
+import com.hedera.services.cli.contracts.assembly.Line;
+import com.hedera.services.cli.contracts.assembly.MacroLine;
+import com.hedera.services.cli.utils.HexToBytesConverter.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+public class DisassembleContractSubcommand {
+
+    static void doit(
+            @NonNull final Optional<Integer> theContractId,
+            @NonNull final Bytes theContract,
+            @NonNull final Set<DisassemblyOption> theOptions,
+            @NonNull final String prefix,
+            @NonNull final Verbosity verbosity) {
+        new DisassembleContractSubcommand(theContractId, theContract, theOptions, prefix, verbosity)
+                .disassembleContract();
+    }
+
+    @NonNull
+    final Optional<Integer> theContractId;
+
+    @NonNull
+    final Bytes theContract;
+
+    @NonNull
+    final String prefix;
+
+    @NonNull
+    final Verbosity verbosity;
+
+    DisassembleContractSubcommand(
+            @NonNull final Optional<Integer> theContractId,
+            @NonNull final Bytes theContract,
+            @NonNull final Set<DisassemblyOption> theOptions,
+            @NonNull final String prefix,
+            @NonNull final Verbosity verbosity) {
+        this.theContract = theContract;
+        this.theContractId = theContractId;
+        this.prefix = prefix;
+        this.verbosity = verbosity;
+
+        DisassemblyOption.setOptions(theOptions);
+    }
+
+    @SuppressWarnings("java:S1066") // "Collapsible "if" statements should be merged" to "increase the code's
+    // readability" - it doesn't always, and doesn't here
+    void disassembleContract() {
+
+        try {
+
+            var metrics = new HashMap</*@NonNull*/ String, /*@NonNull*/ Object>();
+            metrics.put(START_TIMESTAMP, System.nanoTime());
+
+            // Do the disassembly here ...
+            final var asm = new Disassembler(metrics);
+            final var prefixLines = getPrefixLines();
+            final var lines = asm.getInstructions(prefixLines, theContract.contents);
+
+            // Do the analysis here (if requested by command line option)
+            final var analysisResults = Optional.ofNullable(
+                    DisassemblyOption.isOn(DisassemblyOption.RECOGNIZE_CODE_SEQUENCES)
+                            ? new MethodAnalysis(lines).analyze()
+                            : null);
+
+            metrics.put(END_TIMESTAMP, System.nanoTime());
+
+            if (DisassemblyOption.isOn(DisassemblyOption.WITH_METRICS)) addMetricsToEnd(lines, metrics);
+
+            analysisResults.ifPresentOrElse(
+                    results -> {
+                        // analyzed listing
+                        if (DisassemblyOption.isOn(DisassemblyOption.TRACE_RECOGNIZERS)) {
+                            if (results.properties().containsKey(VTableEntryRecognizer.METHODS_PROPERTY)) {
+                                @SuppressWarnings("unchecked")
+                                final var traceLines =
+                                        (List<String>) results.properties().get(VTableEntryRecognizer.METHODS_TRACE);
+                                System.out.print(formatSeparatorLine("Methods trace"));
+                                for (final var t : traceLines) {
+                                    System.out.printf("   %s%n", t);
+                                }
+                                System.out.printf("%n");
+                            }
+                        }
+
+                        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_SELECTORS)) {
+                            if (results.properties().containsKey(VTableEntryRecognizer.METHODS_PROPERTY)) {
+                                @SuppressWarnings("unchecked")
+                                final var methodsTable = (List<VTableEntryRecognizer.MethodEntry>)
+                                        results.properties().get(VTableEntryRecognizer.METHODS_PROPERTY);
+                                methodsTable.sort(Comparator.comparing(MethodEntry::methodOffset));
+                                System.out.print(formatSeparatorLine("Selectors from contract vtable"));
+                                for (final var me : methodsTable) {
+                                    System.out.printf("   %04X: %08X%n", me.methodOffset(), me.selector());
+                                }
+                                System.out.printf("%n");
+                            }
+                        }
+
+                        if (DisassemblyOption.isOn(DisassemblyOption.LIST_MACROS)) {
+                            spewFormattedLines(
+                                    "Macros from VTableEntryRecognizer",
+                                    results.codeLineReplacements().stream()
+                                            .filter(MacroLine.class::isInstance)
+                                            .map(Line.class::cast)
+                                            .toList(),
+                                    3);
+                            System.out.printf("%n");
+                        }
+
+                        if (DisassemblyOption.isOn(DisassemblyOption.WITH_RAW_DISASSEMBLY)) {
+                            spewDisassembly("Raw disassembly", lines);
+                            System.out.printf("%n");
+                        }
+
+                        spewDisassembly(
+                                "Analyzed disassembly", mergeAnalyzedLines(lines, results.codeLineReplacements()));
+                    },
+                    (/*orElse*/ ) -> spewDisassembly("Raw disassembly", lines));
+        } catch (Exception ex) {
+            throw printFormattedException(theContractId, ex);
+        }
+    }
+
+    void addMetricsToEnd(@NonNull final List<Line> lines, @NonNull final Map<String, Object> metrics) {
+        // replace existing `END` directive with one that has the metrics as a comment (if there _is_ no existing
+        // `END` directive that's fine: just add one)
+        final var endDirective = new DirectiveLine(DirectiveLine.Kind.END, formatMetrics(metrics));
+        if (lines.get(lines.size() - 1) instanceof DirectiveLine directive
+                && DirectiveLine.Kind.END.name().equals(directive.directive())) lines.remove(lines.size() - 1);
+        lines.add(endDirective);
+    }
+
+    @NonNull
+    List<Line> mergeAnalyzedLines(@NonNull final List<Line> lines, @NonNull final List<Code> replacementLines) {
+        final var editor = new Editor(lines);
+        replacementLines.forEach(editor::add);
+        return editor.merge();
+    }
+
+    void spewFormattedLines(@NonNull final String heading, @NonNull final List<Line> lines, final int indent) {
+        System.out.printf(formatSeparatorLine(heading));
+        for (final var l : lines) System.out.print(l.formatLine().indent(indent));
+    }
+
+    void spewDisassembly(@NonNull final String heading, @NonNull final List<Line> lines) {
+        spewFormattedLines(heading, lines, 0);
+    }
+
+    /**
+     * Create "prefix" lines to be put ahead of disassembly
+     *
+     * <p>Put some interesting data in the form of comments and directives to be placed as a prefix
+     * in front of the disassembly.
+     */
+    List<Line> getPrefixLines() {
+        var lines = new ArrayList<Line>();
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_OPCODE_HEX)) {
+            final var comment = "contract (%d bytes): %s"
+                    .formatted(theContract.contents.length, UPPERCASE_HEX_FORMATTER.formatHex(theContract.contents));
+            lines.add(new CommentLine(comment));
+        }
+
+        final var comment = theContractId.map(i -> "contract id: " + i).orElse("");
+        lines.add(new DirectiveLine(DirectiveLine.Kind.BEGIN, comment));
+
+        lines.add(new LabelLine(0, "ENTRY"));
+        return lines;
+    }
+
+    // metrics keys:
+    static final String START_TIMESTAMP = "START_TIMESTAMP"; // long
+    static final String END_TIMESTAMP = "END_TIMESTAMP"; // long
+
+    /** Format metrics into a string suitable for a comment on the `END` directive */
+    String formatMetrics(@NonNull final Map</*@NonNull*/ String, /*@NonNull*/ Object> metrics) {
+        var sb = new StringBuilder();
+
+        // elapsed time computation
+        final var nanosElapsed = (long) metrics.get(END_TIMESTAMP) - (long) metrics.get(START_TIMESTAMP);
+        final float msElapsed = nanosElapsed / 1.e6f;
+        sb.append("%.3f ms elapsed".formatted(msElapsed));
+
+        return sb.toString();
+    }
+
+    /**
+     * Dump the contract id + exception + stacktrace to stdout
+     *
+     * <p>Do it here so each line can be formatted with a known prefix so that you can easily grep
+     * for problems in a directory full of disassembled contracts.
+     */
+    RuntimeException printFormattedException(final Optional<Integer> theContractId, final Exception ex) {
+        final var EXCEPTION_PREFIX = "***";
+
+        var sw = new StringWriter(2000);
+        var pw = new PrintWriter(sw, true /*auto-flush*/);
+        ex.printStackTrace(pw);
+        final var starredExceptionDump =
+                sw.toString().lines().map(s -> EXCEPTION_PREFIX + s).collect(Collectors.joining("\n"));
+        System.out.printf(
+                "*** EXCEPTION CAUGHT (id %s): %s%n%s%n",
+                theContractId.map(Object::toString).orElse("NOT-GIVEN"), ex, starredExceptionDump);
+        return ex instanceof RuntimeException rex ? rex : new RuntimeException(ex);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassemblyOption.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassemblyOption.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+public enum DisassemblyOption {
+    DISPLAY_CODE_OFFSET,
+    DISPLAY_OPCODE_HEX,
+    DO_NOT_DECODE_BEFORE_METADATA,
+    FETCH_SELECTOR_NAMES,
+    LIST_MACROS,
+    RECOGNIZE_CODE_SEQUENCES,
+    TRACE_RECOGNIZERS,
+    WITH_BYTECODE,
+    WITH_METRICS,
+    WITH_RAW_DISASSEMBLY,
+    DISPLAY_SELECTORS;
+
+    @NonNull
+    private static final Set<DisassemblyOption> current = EnumSet.noneOf(DisassemblyOption.class);
+
+    public static boolean isOn(@NonNull final DisassemblyOption option) {
+        Objects.requireNonNull(option);
+        return current.contains(option);
+    }
+
+    static void setOptions(@NonNull final Set<DisassemblyOption> options) {
+        Objects.requireNonNull(options);
+        current.addAll(options);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizer.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.assembly.Code;
+import com.hedera.services.cli.contracts.assembly.CodeLine;
+import com.hedera.services.cli.contracts.assembly.DataPseudoOpLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class CodeRecognizer {
+
+    // A limitation on code recognizers is that they get one pass through the code, in order.
+    // A _second_ major limitation is that Results only holds a List<Code> of replacements,
+    // it should really hold an Editor.
+
+    protected CodeRecognizer() {}
+
+    public void begin() {}
+
+    public void acceptCodeLine(@NonNull final CodeLine code) {
+        Objects.requireNonNull(code);
+        reset();
+    }
+
+    public void acceptDataLine(@NonNull final DataPseudoOpLine data) {
+        Objects.requireNonNull(data);
+        reset();
+    }
+
+    public record Results(@NonNull List<Code> codeLineReplacements, @NonNull Map<String, Object> properties) {
+        public Results {
+            Objects.requireNonNull(codeLineReplacements);
+            Objects.requireNonNull(properties);
+        }
+
+        public Results() {
+            this(new ArrayList<>(), new HashMap<>());
+        }
+
+        public @NonNull Results withReplacements(@NonNull final List<Code> replacements) {
+            Objects.requireNonNull(replacements);
+            codeLineReplacements.addAll(replacements);
+            return new Results(codeLineReplacements, properties);
+        }
+
+        public @NonNull Results withProperty(@NonNull final String property, @NonNull final Object value) {
+            Objects.requireNonNull(property);
+            Objects.requireNonNull(value);
+            properties.put(property, value);
+            return new Results(codeLineReplacements, properties);
+        }
+
+        public @NonNull Results addAll(@NonNull final Results r) {
+            Objects.requireNonNull(r);
+            codeLineReplacements.addAll(r.codeLineReplacements);
+            properties.putAll(r.properties);
+            return new Results(codeLineReplacements, properties);
+        }
+    }
+
+    public @NonNull Results end() {
+        return new Results();
+    }
+
+    protected abstract void reset();
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizerManager.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizerManager.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.assembly.CodeLine;
+import com.hedera.services.cli.contracts.assembly.DataPseudoOpLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Handles all (concurrently running) code recognizers during the disassembly. */
+@SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+public class CodeRecognizerManager {
+
+    public List<CodeRecognizer> recognizers = new ArrayList<>();
+    public static final List<Class<? extends CodeRecognizer>> recognizerClasses;
+
+    public class Distributor extends CodeRecognizer {
+
+        public Distributor() {
+            super();
+        }
+
+        public void begin() {
+            for (var recognizer : recognizers) recognizer.begin();
+        }
+
+        public void acceptCodeLine(@NonNull final CodeLine code) {
+            Objects.requireNonNull(code);
+            for (var recognizer : recognizers) recognizer.acceptCodeLine(code);
+        }
+
+        public void acceptDataLine(@NonNull final DataPseudoOpLine data) {
+            Objects.requireNonNull(data);
+            for (var recognizer : recognizers) recognizer.acceptDataLine(data);
+        }
+
+        public @NonNull CodeRecognizer.Results end() {
+            var result = new CodeRecognizer.Results();
+            for (var recognizer : recognizers) {
+                var r = recognizer.end();
+                result = result.addAll(r);
+            }
+            return result;
+        }
+
+        protected void reset() {}
+    }
+
+    public final @NonNull Distributor distributor;
+
+    public CodeRecognizerManager() {
+        for (var recognizerKlass : recognizerClasses)
+            try {
+                recognizers.add(recognizerKlass.getDeclaredConstructor().newInstance());
+            } catch (ReflectiveOperationException ex) {
+                System.out.printf(
+                        "*** yahcli signedstate CodeRecognizerManager - something's borked with"
+                                + " the code recognizer classes: %s%n",
+                        ex);
+                ex.printStackTrace(System.out);
+            }
+        distributor = new Distributor();
+    }
+
+    /**
+     * Returns a CodeRecognizer that will process each line through all the registered recognizers.
+     */
+    public @NonNull CodeRecognizer getDistributor() {
+        return distributor;
+    }
+
+    static {
+        // Register all CodeRecognizer subclasses (see
+        // https://github.com/classgraph/classgraph/wiki/Code-examples#get-class-references-for-subclasses-of-comxyzcontrol)
+        try (ScanResult scanResult = new ClassGraph()
+                .enableClassInfo()
+                .ignoreClassVisibility()
+                .initializeLoadedClasses()
+                .whitelistPackages(CodeRecognizer.class.getPackageName())
+                .scan()) {
+
+            recognizerClasses = scanResult
+                    .getSubclasses(CodeRecognizer.class.getName())
+                    .directOnly() // why direct subclasses only? why not?
+                    .loadClasses()
+                    .stream()
+                    .filter(klass -> klass != Distributor.class)
+                    .<Class<? extends CodeRecognizer>>map( // cast to a tighter bound
+                            klass -> klass.asSubclass(CodeRecognizer.class))
+                    .toList();
+            // (Explicit type for `map` above needed to make IntelliJ shut up -
+            // see https://stackoverflow.com/a/47473608/751579)
+        }
+
+        if (false)
+            System.out.printf(
+                    "Assembly: %d CodeRecognizer subclasses found: %s%n", recognizerClasses.size(), recognizerClasses);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/MethodAnalysis.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/MethodAnalysis.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.assembly.CodeLine;
+import com.hedera.services.cli.contracts.assembly.DataPseudoOpLine;
+import com.hedera.services.cli.contracts.assembly.Line;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import java.util.Objects;
+
+public class MethodAnalysis {
+
+    final List<Line> lines;
+
+    public MethodAnalysis(@NonNull final List<Line> lines) {
+        Objects.requireNonNull(lines);
+        this.lines = lines;
+    }
+
+    /** Recognize and analyze bytecode sequences related to methods */
+    public @NonNull CodeRecognizer.Results analyze() {
+        final CodeRecognizerManager codeRecognizerManager = new CodeRecognizerManager();
+        final CodeRecognizer recognizer = codeRecognizerManager.getDistributor();
+
+        recognizer.begin();
+        for (final var line : lines) {
+            if (line instanceof DataPseudoOpLine data) recognizer.acceptDataLine(data);
+            else if (line instanceof CodeLine code) recognizer.acceptCodeLine(code);
+        }
+        return recognizer.end();
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLeafNodeEnd.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLeafNodeEnd.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import com.hedera.services.cli.contracts.assembly.Columns;
+import com.hedera.services.cli.contracts.assembly.MacroLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+public final class VTSelectorLeafNodeEnd extends MacroLine {
+
+    public static final String FAIL_DESTINATION = "VTSelectorNotFound";
+    public final int failOffset;
+
+    public int getFailOffset() {
+        return failOffset;
+    }
+
+    public VTSelectorLeafNodeEnd(int codeOffset, int codeSize, int failOffset) {
+        super(codeOffset, codeSize, FAIL_DESTINATION);
+        this.failOffset = failOffset;
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET)) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append("%5X".formatted(getCodeOffset()));
+        }
+
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(mnemonic());
+
+        extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+        sb.append(formatOffset(failOffset));
+    }
+
+    @NonNull
+    String formatOffset(int offset) {
+        return hexer().toHexDigits(offset, 4);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLine.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import com.hedera.services.cli.contracts.assembly.Columns;
+import com.hedera.services.cli.contracts.assembly.LabelLine;
+import com.hedera.services.cli.contracts.assembly.MacroLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+public final class VTSelectorLine extends MacroLine {
+
+    public final long selector;
+    public final int methodOffset;
+
+    public long getSelector() {
+        return selector;
+    }
+
+    public int getMethodOffset() {
+        return methodOffset;
+    }
+
+    public VTSelectorLine(int codeOffset, int codeSize, long selector, int methodOffset) {
+        super(codeOffset, codeSize, "VTSelector");
+        this.selector = selector;
+        this.methodOffset = methodOffset;
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET)) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append("%5X".formatted(getCodeOffset()));
+        }
+
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(mnemonic());
+
+        extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+        sb.append(formatSelector());
+        sb.append("  ");
+        sb.append(formatOffset(methodOffset));
+    }
+
+    @NonNull
+    LabelLine asLabel() {
+        return new LabelLine(methodOffset, formatSelector(), "from @" + formatOffset(getCodeOffset()));
+    }
+
+    @NonNull
+    String formatSelector() {
+        return hexer().toHexDigits(selector, 8);
+    }
+
+    @NonNull
+    String formatOffset(int offset) {
+        return hexer().toHexDigits(offset, 4);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTableStart.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTableStart.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import com.hedera.services.cli.contracts.assembly.Columns;
+import com.hedera.services.cli.contracts.assembly.MacroLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+public final class VTSelectorTableStart extends MacroLine {
+
+    public VTSelectorTableStart(int codeOffset, int codeSize) {
+        super(codeOffset, codeSize, "VTStart");
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET)) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append("%5X".formatted(getCodeOffset()));
+        }
+
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(mnemonic());
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTreeInternalNode.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTreeInternalNode.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import com.hedera.services.cli.contracts.assembly.Columns;
+import com.hedera.services.cli.contracts.assembly.LabelLine;
+import com.hedera.services.cli.contracts.assembly.MacroLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+public final class VTSelectorTreeInternalNode extends MacroLine {
+
+    public final long selectorSplit;
+    public final int methodOffset;
+
+    public long getSelectorSplit() {
+        return selectorSplit;
+    }
+
+    public int getMethodOffset() {
+        return methodOffset;
+    }
+
+    public VTSelectorTreeInternalNode(int codeOffset, int codeSize, long selectorSplit, int methodOffset) {
+        super(codeOffset, codeSize, "VTTreeSwitch");
+        this.selectorSplit = selectorSplit;
+        this.methodOffset = methodOffset;
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET)) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append("%5X".formatted(getCodeOffset()));
+        }
+
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(mnemonic());
+
+        extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+        sb.append(formatSelectorSplit());
+        sb.append("  ");
+        sb.append(formatOffset(methodOffset));
+    }
+
+    @NonNull
+    LabelLine asLabel() {
+        return new LabelLine(methodOffset, formatSelectorSplit(), "from @" + formatOffset(getCodeOffset()));
+    }
+
+    @NonNull
+    String formatSelectorSplit() {
+        return "VT-" + hexer().toHexDigits(selectorSplit, 8);
+    }
+
+    @NonNull
+    String formatOffset(int offset) {
+        return hexer().toHexDigits(offset, 4);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTableEntryRecognizer.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTableEntryRecognizer.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.analysis;
+
+import static java.util.stream.Collectors.toCollection;
+
+import com.hedera.services.cli.contracts.assembly.Code;
+import com.hedera.services.cli.contracts.assembly.CodeLine;
+import com.hedera.services.cli.contracts.assembly.DataPseudoOpLine;
+import com.hedera.services.cli.contracts.assembly.LabelLine;
+import com.hedera.services.cli.contracts.assembly.MacroLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class VTableEntryRecognizer extends CodeRecognizer {
+
+    // This is an example of a recognizer for "macroizing" EVM contract assembly code.  Where
+    // "macroizing" means recognizing (reasonably) short sequences of opcodes with their operands
+    // and replacing them with a short pseudo-op with meaningful operands.
+
+    public VTableEntryRecognizer() {
+        super();
+    }
+
+    public static final String METHODS_PROPERTY = "Methods";
+    public static final String METHODS_TRACE = "Methods-Trace";
+
+    @SuppressWarnings("java:S1192") // "String literals should not be duplicated" - would impair readability here
+    public enum State {
+
+        // States named "HAVE_<mnemonic>" are (automatically) the destination states for
+        // transitions for the given opcode (by mnemonic)
+
+        START(null, "DUP1", "PUSH1", "PUSH2" /*, "JUMPDEST" */) {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                recognizer.setStartOffset(code.codeOffset());
+                return Optional.of(
+                        switch (code.mnemonic()) {
+                            case "DUP1" -> State.HAVE_DUP1;
+                            case "PUSH1" -> {
+                                recognizer.setJumpOffset(intFromBytes(code.operandBytes()));
+                                yield State.HAVE_PUSH1;
+                            }
+                            case "PUSH2" -> {
+                                if (recognizer.lastLineWasSelectorNode) {
+                                    recognizer.setJumpOffset(intFromBytes(code.operandBytes()));
+                                    yield State.HAVE_PUSH2_FAIL;
+                                } else yield State.START;
+                            }
+                            default -> State.START;
+                        });
+            }
+        },
+        HAVE_DUP1("PUSH4") {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                recognizer.setSelector(longFromBytes(code.operandBytes()));
+                return next();
+            }
+        },
+        HAVE_PUSH4(new Next("HAVE_EQ_OR_GT"), "EQ", "GT") {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                recognizer.setNodeKind(code.mnemonic());
+                return next();
+            }
+        },
+        HAVE_EQ_OR_GT("PUSH2") {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                recognizer.setJumpOffset(intFromBytes(code.operandBytes()));
+                return next();
+            }
+        },
+        HAVE_PUSH2(new Next("START"), "JUMPI") {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                recognizer.setNextOffset(code.getNextCodeOffset());
+                recognizer.gotSelectorNodeMatch();
+                return next();
+            }
+        },
+        HAVE_PUSH1(new Next("START"), "SHR") {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                if (recognizer.jumpOffset != 0xE0) return Optional.empty();
+                recognizer.setNextOffset(code.getNextCodeOffset());
+                recognizer.gotVTableStart();
+                return next();
+            }
+        },
+        HAVE_PUSH2_FAIL(new Next("START"), "JUMP") {
+            @Override
+            @NonNull
+            public Optional<State> acceptCodeLine(@NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code) {
+                recognizer.setNextOffset(code.getNextCodeOffset());
+                recognizer.gotVTableFailJump();
+                return next();
+            }
+        };
+
+        @NonNull
+        Optional<State> next() {
+            if (null == nextState)
+                throw new IllegalStateException(
+                        "attempting to go to default next state where it must be computed, %s".formatted(this));
+            return Optional.of(State.valueOf(nextState));
+        }
+
+        int intFromBytes(@NonNull final byte[] operand) {
+            return new BigInteger(1, operand).intValue();
+        }
+
+        long longFromBytes(@NonNull final byte[] operand) {
+            return new BigInteger(1, operand).longValue();
+        }
+
+        // State mechanism
+        final String nextState;
+        final @NonNull List<String> expectingMnemonic;
+
+        record Next(@NonNull String next) {}
+
+        State(@Nullable Next nextState, @NonNull final String... expectingMnemonic) {
+            Objects.requireNonNull(expectingMnemonic);
+            if (expectingMnemonic.length == 0)
+                throw new IllegalArgumentException("State must have at least one mnemonic expected");
+            this.nextState = null != nextState ? nextState.next : null;
+            this.expectingMnemonic = Arrays.asList(expectingMnemonic);
+        }
+
+        /**
+         * Compute the next state for this transition directly from the mnemonic (by prepending
+         * "HAVE_")
+         */
+        State(@NonNull String expectingMnemonic) {
+            // (Tried to "bind" the string to an enum instance by `State.valueOf` but _cannot do
+            // that because `valueOf` doesn't recognize enum instances that have not yet been
+            // constructed!_  A consequence of these being actual _instances_ rather than just
+            // "fancy" constants. So have to bind later, at "run time".  But it isn't expensive,
+            // so, whatever.)
+            this(new Next("HAVE_" + expectingMnemonic), expectingMnemonic);
+        }
+
+        public abstract @NonNull Optional<State> acceptCodeLine(
+                @NonNull VTableEntryRecognizer recognizer, @NonNull CodeLine code);
+
+        public void transition(@NonNull final VTableEntryRecognizer recognizer, @NonNull final CodeLine code) {
+            Objects.requireNonNull(recognizer);
+            Objects.requireNonNull(code);
+
+            // Tracing:
+            Optional<State> nextState;
+            if (expectingMnemonic.contains(code.mnemonic())
+                    && (nextState = acceptCodeLine(recognizer, code)).isPresent()) {
+
+                recognizer.trace("@%s: found %s, expected set %s, moving to %s"
+                        .formatted(this, code.mnemonic(), expectingMnemonic, nextState));
+                recognizer.advance(nextState.get());
+            } else {
+                recognizer.trace("@%s: found %s, did not find expected set %s, resetting"
+                        .formatted(this, code.mnemonic(), expectingMnemonic));
+                recognizer.reset();
+            }
+        }
+    }
+
+    State state;
+
+    void advance(@NonNull final State next) {
+        Objects.requireNonNull(next);
+        trace("advance: moving to %s".formatted(next));
+        state = next;
+    }
+
+    @Override
+    protected void reset() {
+        state = State.START;
+        startByteOffset = nextByteOffset = 0;
+        selector = jumpOffset = 0;
+        lastLineWasSelectorNode = false;
+        nodeKind = Kind.NONE;
+        // N.B.: Do _not_ reset failOffset - it needs to persist to end of run
+        trace("reset: state is START");
+    }
+
+    int startByteOffset;
+
+    void setStartOffset(int offset) {
+        trace("setStartOffset: %04X".formatted(offset));
+        startByteOffset = offset;
+    }
+
+    int nextByteOffset;
+
+    void setNextOffset(int offset) {
+        trace("setNextOffset: %04X".formatted(offset));
+        nextByteOffset = offset;
+    }
+
+    long selector;
+
+    void setSelector(long selector) {
+        trace("setSelector: %08X".formatted(selector));
+        this.selector = selector;
+    }
+
+    enum Kind {
+        NONE,
+        INTERNAL,
+        LEAF
+    };
+
+    Kind nodeKind;
+
+    void setNodeKind(@NonNull final String mnemonic) {
+        Objects.requireNonNull(mnemonic);
+        nodeKind = switch (mnemonic) {
+            case "EQ" -> Kind.LEAF;
+            case "GT" -> Kind.INTERNAL;
+            default -> Kind.NONE;};
+        trace("setNodeKind: %s -> %s".formatted(mnemonic, nodeKind));
+    }
+
+    int jumpOffset;
+
+    void setJumpOffset(int jumpOffset) {
+        trace("setJumpOffset: %04X".formatted(jumpOffset));
+        this.jumpOffset = jumpOffset;
+    }
+
+    // globals over entire run
+
+    boolean lastLineWasSelectorNode;
+    int failOffset;
+
+    void setFailOffset(int failOffset) {
+        trace("setFailOffset: %04X".formatted(failOffset));
+        this.failOffset = failOffset;
+    }
+
+    @NonNull
+    List<MacroLine> macros = new ArrayList<>();
+
+    @NonNull
+    List<String> trace = new ArrayList<>();
+
+    void trace(@NonNull final String t) {
+        Objects.requireNonNull(t);
+        this.trace.add(t);
+    }
+
+    void gotSelectorNodeMatch() {
+        trace("gotSelectorNodeMatch: startByteOffset %04X nextByteOffset %04X selector %08X jumpOffset %04X"
+                .formatted(startByteOffset, nextByteOffset, selector, jumpOffset));
+
+        lastLineWasSelectorNode = true;
+
+        final var macro =
+                switch (nodeKind) {
+                    case LEAF -> new VTSelectorLine(
+                            startByteOffset, nextByteOffset - startByteOffset, selector, jumpOffset);
+                    case INTERNAL -> new VTSelectorTreeInternalNode(
+                            startByteOffset, nextByteOffset - startByteOffset, selector, jumpOffset);
+                    case NONE -> throw new IllegalStateException(
+                            "Must have had EQ or GT to get here - but it's missing");
+                };
+        trace("gotSelectorNodeMatch: adding macro %s".formatted(macro.formatLine()));
+        macros.add(macro);
+    }
+
+    void gotVTableStart() {
+        trace("gotVTableStart: startByteOffset %04X nextByteOffset %04X".formatted(startByteOffset, nextByteOffset));
+
+        final var macro = new VTSelectorTableStart(startByteOffset, nextByteOffset - startByteOffset);
+        trace("gotVTableStart: adding macro %s".formatted(macro.formatLine()));
+        macros.add(macro);
+    }
+
+    void gotVTableFailJump() {
+        setFailOffset(jumpOffset);
+
+        trace("gotVTableFailJump: startByteOffset %04X nextByteOffset %04X failOffset %04X"
+                .formatted(startByteOffset, nextByteOffset, failOffset));
+
+        final var macro = new VTSelectorLeafNodeEnd(startByteOffset, nextByteOffset - startByteOffset, failOffset);
+        trace("gotVTableFailJump: adding macro %s".formatted(macro.formatLine()));
+        macros.add(macro);
+    }
+
+    @Override
+    public void begin() {
+        trace("begin");
+        setFailOffset(0);
+        reset();
+    }
+
+    @Override
+    public void acceptCodeLine(@NonNull final CodeLine code) {
+        Objects.requireNonNull(code);
+        trace("acceptCodeLine: %s".formatted(code));
+        state.transition(this, code);
+    }
+
+    @Override
+    public void acceptDataLine(@NonNull final DataPseudoOpLine data) {
+        Objects.requireNonNull(data);
+        trace("acceptDataLine: %s".formatted(data));
+        reset();
+    }
+
+    public record MethodEntry(long selector, int methodOffset) {}
+
+    @Override
+    public @NonNull CodeRecognizer.Results end() {
+        var vtLeafNodes = macros.stream()
+                .filter(VTSelectorLine.class::isInstance)
+                .map(VTSelectorLine.class::cast)
+                .toList();
+        var vtInternalNodes = macros.stream()
+                .filter(VTSelectorTreeInternalNode.class::isInstance)
+                .map(VTSelectorTreeInternalNode.class::cast)
+                .toList();
+
+        // Following idiom (stream-of-streams into "identity" flatmap) is hand-brewed stream concat
+        var replacements = Stream.of(
+                        macros.stream(),
+                        vtLeafNodes.stream().map(VTSelectorLine::asLabel),
+                        vtInternalNodes.stream().map(VTSelectorTreeInternalNode::asLabel),
+                        Stream.of(new LabelLine(
+                                failOffset, VTSelectorLeafNodeEnd.FAIL_DESTINATION, "selector not found/implemented")))
+                .flatMap(s -> s)
+                .map(Code.class::cast)
+                .toList();
+
+        var selectors = vtLeafNodes.stream()
+                .map(vtsl -> new MethodEntry(vtsl.selector, vtsl.methodOffset))
+                .collect(toCollection(ArrayList::new));
+        trace("end: %d selectors found".formatted(selectors.size()));
+
+        return new Results()
+                .withReplacements(replacements)
+                .withProperty(METHODS_PROPERTY, selectors)
+                .withProperty(METHODS_TRACE, trace);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTableEntryRecognizer.md
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTableEntryRecognizer.md
@@ -1,0 +1,34 @@
+# `VTableEntryRecognizer` - macroize contract virtual tables
+
+Multi-entry contracts (via Solidity AFAIK) use a multiway branch
+at the beginning of the contract to branch on a ["function
+selector"](https://solidity-by-example.org/function-selector/) to
+get to the right method in the code.
+- Selector is the first 4 bytes of the computed function signature
+  (details of which are unimportant here)
+- Selector is the first 4 bytes of the `calldata` passed in to the
+  contract.
+
+This is similar to the "virtual table" familiar to C++/C#/Java
+programmers.
+
+If there are just a few methods in the contract the vtable is
+simply a sequence of branches.  But if there are more than a few
+methods (not sure what the threshold is) then it is encoded as a
+binary search tree.
+
+The purpose of the `VTableEntryRecognizer` is to find the vtable
+in a contract and "macroize" it so that it becomes easy for the
+reader to grok (instead of being a long long list of tests and
+branches).  And it also labels all the function entry points with
+their selector so they can be easily found.  And the list of
+selectors with their entry points can be used for other purposes
+as well.
+
+- Not implemented: Looking up the selectors in
+  [4byte.directory](https://4byte.directory) so that actual method
+  names can be supplied as labels, when available.
+    - Which would work pretty well for some contracts (presumably)
+      those which have been ported over rather than new ones
+        - E.g., you can find the selectors for `968267` in that
+          directory

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Code.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Code.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * A line of _code_ (something with bytes from the contract)
+ *
+ * <p>A line of _code_ in the disassembly (could be an opcode, maybe a pseudo-op like `DATA`, or
+ * maybe a (discovered) macro.
+ */
+public interface Code extends Line {
+
+    /** Returns the code offset of this line of code */
+    int getCodeOffset();
+
+    /** Returns the number of bytes of this line of code */
+    int getCodeSize();
+
+    /** "name" of this line */
+    @NonNull
+    String mnemonic();
+
+    /** Easy identification of this line */
+    default boolean isA(@NonNull final String mnemonic) {
+        Objects.requireNonNull(mnemonic);
+        return mnemonic().equals(mnemonic);
+    }
+
+    default int getNextCodeOffset() {
+        return getCodeOffset() + getCodeSize();
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CodeLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CodeLine.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.EOL_COMMENT_PREFIX;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Represents an instruction line in the generated assembly
+ *
+ * <p>Instruction lines have an opcode, an optional operand (an array of bytes), an offset of where
+ * the instruction is in the bytecode, and an optional comment.
+ */
+public record CodeLine(int codeOffset, int opcode, byte[] operandBytes, String eolComment) implements Code {
+
+    public CodeLine {
+        opcode = opcode & 0xFF; // convert to unsigned (in case it's not)
+        // De-null optional arguments
+        operandBytes = null != operandBytes ? operandBytes : new byte[0];
+        eolComment = null != eolComment ? eolComment : "";
+    }
+
+    @Override
+    public @NonNull String mnemonic() {
+        return Opcodes.getOpcode(opcode).mnemonic();
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET)) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append("%5X".formatted(codeOffset));
+        }
+
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_OPCODE_HEX)) {
+            extendWithBlanksTo(sb, Columns.OPCODE.getColumn());
+            sb.append("  %02X".formatted(opcode()));
+        }
+
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(Opcodes.getOpcode(opcode()).mnemonic());
+        if (0 != operandBytes.length) {
+            extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+            sb.append(hexer().formatHex(operandBytes));
+        }
+        if (!eolComment.isEmpty()) {
+            if (Columns.EOL_COMMENT.getColumn() - 1 > sb.length()) {
+                extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            } else {
+                sb.append("  ");
+            }
+            sb.append(EOL_COMMENT_PREFIX);
+            sb.append(eolComment);
+        }
+    }
+
+    @Override
+    public int getCodeOffset() {
+        return codeOffset;
+    }
+
+    @Override
+    public int getCodeSize() {
+        return 1 + operandBytes.length;
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        return o instanceof CodeLine other
+                && codeOffset == other.codeOffset
+                && opcode == other.opcode
+                && Arrays.equals(operandBytes, other.operandBytes)
+                && eolComment.equals(other.eolComment);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = codeOffset;
+        result = 31 * result + opcode;
+        result = 31 * result + Arrays.hashCode(operandBytes);
+        result = 31 * result + eolComment.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CodeLine[codeOffset=%04X, opcode=%d (%02X), operandBytes=%s, eolComment='%s']"
+                .formatted(codeOffset, opcode, opcode(), hexer().formatHex(operandBytes), eolComment);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Columns.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Columns.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_CODE_OFFSET_COLUMN;
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_COMMENT_COLUMN;
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_EOL_COMMENT_COLUMN;
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_LABEL_COLUMN;
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_MNEMONIC_COLUMN;
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_OPCODE_COLUMN;
+import static com.hedera.services.cli.contracts.assembly.Constants.DEFAULT_OPERAND_COLUMN;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * Named enums for each "column" in the disassembly output, holding their column location
+ *
+ * <p>Each "column" in the resulting disassembly has its own enum value, which holds its column
+ * position. But the column locations depend on which variants are chosen. E.g., you may or may
+ * not be formatting with the code offset present. Thus there is a mechanism where the columns
+ * are given default values for the vanilla disassembly, and as options are selected which _add_
+ * a column to the disassembly the other columns to its right are moved over. For this purpose
+ * columns are "grouped".
+ *
+ * YUCK: This use of an enum, as singletons, to hold globals is probably not as justifiable as
+ * `DisassemblyOption`.  Do something better.
+ */
+public enum Columns {
+    CODE_OFFSET(0, DEFAULT_CODE_OFFSET_COLUMN),
+    OPCODE(1, DEFAULT_OPCODE_COLUMN),
+    COMMENT(2, DEFAULT_COMMENT_COLUMN),
+    LABEL(2, DEFAULT_LABEL_COLUMN),
+    MNEMONIC(2, DEFAULT_MNEMONIC_COLUMN),
+    OPERAND(2, DEFAULT_OPERAND_COLUMN),
+    EOL_COMMENT(2, DEFAULT_EOL_COMMENT_COLUMN);
+
+    public final int columnModificationGroup;
+    private int column;
+
+    public int getColumn() {
+        return column;
+    }
+
+    Columns(int columnModificationGroup, int column) {
+        this.columnModificationGroup = columnModificationGroup;
+        this.column = column;
+    }
+
+    /** When an option adds a column to the disassembly adjust the location of other columns */
+    static void adjustFieldColumns(@NonNull final Columns after, int byWidth) {
+        Objects.requireNonNull(after);
+        for (var e : Columns.values())
+            if (after.columnModificationGroup < e.columnModificationGroup) e.column += byWidth;
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CommentLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CommentLine.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.FULL_LINE_COMMENT_PREFIX;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/** Represents a full-line comment in the generated assembly */
+public record CommentLine(@NonNull String comment) implements Line {
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        extendWithBlanksTo(sb, Columns.COMMENT.getColumn());
+        sb.append(FULL_LINE_COMMENT_PREFIX);
+        sb.append(comment);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Constants.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Constants.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import java.util.HexFormat;
+
+public final class Constants {
+
+    public static final int DEFAULT_CODE_OFFSET_COLUMN = 0;
+    public static final int DEFAULT_OPCODE_COLUMN = 0;
+    public static final int DEFAULT_COMMENT_COLUMN = 6;
+    public static final int DEFAULT_LABEL_COLUMN = 6;
+    public static final int DEFAULT_MNEMONIC_COLUMN = 10;
+    public static final int DEFAULT_OPERAND_COLUMN = 18;
+    public static final int DEFAULT_EOL_COMMENT_COLUMN = 22;
+    public static final int MAX_EXPECTED_LINE = 80;
+
+    public static final int CODE_OFFSET_COLUMN_WIDTH = 8;
+    public static final int OPCODE_COLUMN_WIDTH = 2;
+
+    public static final String FULL_LINE_COMMENT_PREFIX = "# ";
+    public static final String EOL_COMMENT_PREFIX = "# ";
+
+    public static final HexFormat UPPERCASE_HEX_FORMATTER = HexFormat.of().withUpperCase();
+
+    private Constants() {}
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DataPseudoOpLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DataPseudoOpLine.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.EOL_COMMENT_PREFIX;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Represents a `DATA` pseudo op in the generated assembly
+ *
+ * <p>A DATA line is just a blob of bytes. It disassembles to the hex representation of that blob.
+ * Because it is actual code bytes it has a code offset.
+ */
+public record DataPseudoOpLine(int codeOffset, @NonNull Kind kind, byte[] operandBytes, String eolComment)
+        implements Code {
+
+    public enum Kind {
+        DATA,
+        METADATA,
+        DATA_OVERRUN
+    }
+
+    public DataPseudoOpLine {
+        // De-null operands
+        operandBytes = null != operandBytes ? operandBytes : new byte[0];
+        eolComment = null != eolComment ? eolComment : "";
+    }
+
+    @Override
+    public @NonNull String mnemonic() {
+        return kind.name();
+    }
+
+    // NOTTODO: There's a LOT of commonality here with CodeLine! like maybe this should be a
+    // subclass (except: can't do that because it's a record, and this doesn't seem like the
+    // kind of thing that should be a default method of the interface ...)
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET)) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append("%5X".formatted(codeOffset));
+        }
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(kind.name());
+
+        if (0 != operandBytes.length) {
+            extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+            sb.append(hexer().formatHex(operandBytes));
+        }
+        if (!eolComment.isEmpty()) {
+            if (Columns.EOL_COMMENT.getColumn() - 1 > sb.length()) {
+                extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            } else {
+                sb.append("  ");
+            }
+            sb.append(EOL_COMMENT_PREFIX);
+            sb.append(eolComment);
+        }
+    }
+
+    @Override
+    public int getCodeOffset() {
+        return codeOffset;
+    }
+
+    @Override
+    public int getCodeSize() {
+        return operandBytes.length;
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        return o instanceof DataPseudoOpLine other
+                && codeOffset == other.codeOffset
+                && Arrays.equals(operandBytes, other.operandBytes)
+                && eolComment.equals(other.eolComment)
+                && kind.equals(other.kind);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = codeOffset;
+        result = 31 * result + Arrays.hashCode(operandBytes);
+        result = 31 * result + eolComment.hashCode();
+        result = 31 * result + kind.hashCode();
+        return result;
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return "CodeLine[codeOffset=%04X, operandBytes=%s, eolComment='%s', kind=%s]"
+                .formatted(codeOffset, hexer().formatHex(operandBytes), eolComment, kind.toString());
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DirectiveLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DirectiveLine.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.EOL_COMMENT_PREFIX;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * Represents a directive in the generated assembly.
+ *
+ * <p>Directives are commands to the assembler (and notes to the reader) such as `BEGIN` and `END`.
+ */
+public record DirectiveLine(@NonNull String directive, @NonNull String operand, @NonNull String comment)
+        implements Line {
+
+    /**
+     * It isn't _necessary_ that the directives be listed here - _any_ string can be passed as the
+     * mnemonic of this Directive. But it's convenient for common/popular directives since you can
+     * control the spelling this way ...
+     */
+    public enum Kind {
+        BEGIN,
+        END
+    }
+
+    public DirectiveLine {
+        Objects.requireNonNull(directive);
+        Objects.requireNonNull(operand);
+        Objects.requireNonNull(comment);
+    }
+
+    public DirectiveLine(@NonNull final String directive) {
+        this(directive, "", "");
+    }
+
+    public DirectiveLine(@NonNull final Kind directive) {
+        this(directive.name(), "", "");
+    }
+
+    public DirectiveLine(@NonNull final String directive, @NonNull final String comment) {
+        this(directive, "", comment);
+    }
+
+    public DirectiveLine(@NonNull final Kind directive, @NonNull final String comment) {
+        this(directive.name(), "", comment);
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        if (!directive.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+            sb.append(directive);
+        }
+        if (!operand.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+            sb.append(operand);
+        }
+        if (!comment.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            sb.append(EOL_COMMENT_PREFIX);
+            sb.append(comment);
+        }
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Disassembler.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Disassembler.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.CODE_OFFSET_COLUMN_WIDTH;
+import static com.hedera.services.cli.contracts.assembly.Constants.OPCODE_COLUMN_WIDTH;
+import static com.hedera.services.cli.contracts.assembly.Constants.UPPERCASE_HEX_FORMATTER;
+
+import com.hedera.services.cli.contracts.DisassemblyOption;
+import com.hedera.services.cli.contracts.assembly.DataPseudoOpLine.Kind;
+import com.hedera.services.cli.utils.Range;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.regex.Pattern;
+
+/**
+ * Generates disassembly of an EVM contract
+ *
+ * <p>Generates the disassembly of an EVM contract. Defines the _lines_ of a disassembly as falling
+ * into two classes: `Line`s - every line in the disassembly is one of these records, and `Code` -
+ * all bytes of the bytecode go into one of these records.
+ */
+public class Disassembler {
+
+    public Disassembler(@NonNull final Map</*@NonNull*/ String, /*@NonNull*/ Object> metrics) {
+
+        this.metrics = metrics;
+
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_CODE_OFFSET))
+            Columns.adjustFieldColumns(Columns.CODE_OFFSET, CODE_OFFSET_COLUMN_WIDTH);
+        if (DisassemblyOption.isOn(DisassemblyOption.DISPLAY_OPCODE_HEX))
+            Columns.adjustFieldColumns(Columns.OPCODE, OPCODE_COLUMN_WIDTH);
+    }
+
+    /**
+     * Map for accumulating interesting metrics of disassembled code.
+     *
+     * <p>RFU.
+     */
+    private final @NonNull Map</*@NonNull*/ String, /*@NonNull*/ Object> metrics;
+
+    /** The next instruction decoded from the bytestream */
+    public record NextInstruction(@NonNull Line line, int nextOffset) {}
+
+    /**
+     * Get next instruction from bytecode stream
+     *
+     * <p>Get the next instruction from the bytecode stream, returning both the next instruction
+     * decoded (as a Code) and the _next_ offset for the _next_ next instruction. At end of bytecode
+     * it returns the "END" directive and then the _next_ time it is called it finally returns
+     * `null`, signalling the caller to stop iterating.
+     */
+    public NextInstruction getNextInstruction(@NonNull final byte[] bytecode, int codeOffset) {
+
+        // Check end conditions
+        if (codeOffset < 0 || codeOffset >= bytecode.length) return null;
+        ;
+
+        // Get the next opcode and its syntax.
+        final byte opcode = bytecode[codeOffset];
+        final Opcodes.Descr descr = Opcodes.getOpcode(opcode);
+        final boolean haveExtraBytes = descr.extraBytes() > 0;
+        final int instructionLength = 1 /*opcode itself*/ + descr.extraBytes();
+
+        // If we're decoding junk (e.g., we're decoding inside a block of code data) we might
+        // find ourselves looking at what seems to be a `PUSHn` that runs off the end of the
+        // bytecode.  That can't be right.
+        if (haveExtraBytes && codeOffset + instructionLength > bytecode.length)
+            throw new IndexOutOfBoundsException("opcode %s at offset %d overruns bytecode (of length %d)"
+                    .formatted(descr.mnemonic(), codeOffset, bytecode.length));
+
+        // Pull out the operand bytes, if any
+        final var operandBytes = haveExtraBytes
+                ? Arrays.copyOfRange(bytecode, codeOffset + 1, codeOffset + instructionLength)
+                : new byte[0];
+
+        // The comment field will be used to flag uses of unassigned opcodes.  (We're most
+        // likely decoding "instructions" in a code data block.)
+        final var comment = descr.isAssigned() ? "" : "**UNASSIGNED OPCODE**";
+
+        // Assemble the instruction and give it to the caller
+        final var line = new CodeLine(codeOffset, opcode, operandBytes, comment);
+        return new NextInstruction(line, codeOffset + instructionLength);
+    }
+
+    // Disassemble the entire bytecode
+
+    /** Disassemble the entire contract bytecode into its Lines of Code. */
+    public List</*@NonNull*/ Line> getInstructions(
+            @NonNull final List</*@NonNull*/ Line> prefixLines, @NonNull final byte[] bytecode) {
+        List<Line> lines = new ArrayList<>(prefixLines);
+
+        // First thing: find the metadata at the end of the contract - see where it starts, and
+        // how long it is
+        final var metadataByteRange = locateMetadata(bytecode);
+
+        // This comparator returns 0 if _at_ the metadata start, or >0 if _past_ the metadata start
+        final IntFunction<Integer> atMetadataOffset = metadataByteRange.isEmpty()
+                ? ofs -> -1 /* never reach the end */
+                : ofs -> Integer.compare(ofs, metadataByteRange.from());
+
+        // Main instruction decode loop, working from bytecode
+        NextInstruction nextInstruction;
+        int currentOffset = 0;
+        try {
+            while (null != (nextInstruction = getNextInstruction(bytecode, currentOffset))) {
+
+                // Check to see if we've overrun the start of the metadata
+                if (atMetadataOffset.apply(nextInstruction.nextOffset()) > 0) {
+                    // This instruction, evidently some kind of `PUSHn`, is taking us right past
+                    // where the metadata is supposed to start.  That means we're already decoding
+                    // the code data section and it is coming out as junk.  So we just replace
+                    // this current junk instruction with a DATA that sucks up everything from here
+                    // to where we know the metadata starts.  (If the junk started before this
+                    // point that's ok too, it'll get eaten up when we search backward for `INVALID`
+                    // or `STOP`.  (For an example of this see contract 1358908.))
+                    boolean sanityCheck = nextInstruction.line() instanceof Code code && code.getCodeSize() > 0;
+                    if (!sanityCheck)
+                        throw new IllegalStateException(
+                                "Have somehow run past metadata from with a single-byte" + " instruction");
+                    final var data = getBytecodeRangeAsData(
+                            bytecode,
+                            new Range<Byte>(currentOffset, metadataByteRange.from() - 1),
+                            "Backtracking data",
+                            Kind.DATA);
+                    nextInstruction = new NextInstruction(data, metadataByteRange.from());
+                }
+
+                // Ok, have an instruction to add the growing disassembly ...
+                lines.add(nextInstruction.line());
+                currentOffset = nextInstruction.nextOffset();
+
+                // If now we've reached the metadata time to suck it all up and emit it as a
+                // `METADATA` pseudo-op.
+                if (0 == atMetadataOffset.apply(currentOffset)) {
+                    final var comment = "(metadata %d (%04X) bytes)"
+                            .formatted(metadataByteRange.length(), metadataByteRange.length());
+                    final var data = getBytecodeRangeAsData(
+                            bytecode, metadataByteRange, comment, DataPseudoOpLine.Kind.METADATA);
+                    lines.add(data);
+                    break;
+                }
+            }
+
+            // At this point we've decoded everything to the end - now look for interesting cases
+            // where you can simplify/correct/improve-for-readability the assembly source.
+
+            // First interesting case: see if there's a code data block at the end that should
+            // have disassembled as DATA and not code - that would be the stuff between a final
+            // `INVALID` or `STOP` and the start of the metadata.
+
+            lines = elideCodeData(lines, bytecode);
+
+            // (At this time that turns out to be the _only_ interesting case we're looking for.)
+
+        } catch (IndexOutOfBoundsException ex) {
+            // If we've overrun the end then obviously something went wrong - is this an invalid
+            // contract?  Have we messed up by not finding the code block properly?  Whatever,
+            // we've got to emit the last bunch of bytes as a `DATA_OVERRUN` pseudo-op.
+            // (Currently happens for contract 44928, dunno why yet.)
+            if (ex.getMessage().contains("overruns bytecode")) {
+                final var data = getBytecodeRangeAsData(
+                        bytecode,
+                        new Range<Byte>(currentOffset, bytecode.length),
+                        "(*** PUSHn opcode here overruns end of bytecode)",
+                        DataPseudoOpLine.Kind.DATA_OVERRUN);
+                lines.add(data);
+            }
+        }
+
+        ensureEndIsAtEnd(lines);
+        return lines;
+    }
+
+    void ensureEndIsAtEnd(@NonNull final List<Line> lines) {
+        if (!lines.isEmpty()
+                && lines.get(lines.size() - 1) instanceof DirectiveLine directive
+                && directive.directive().equals(DirectiveLine.Kind.END.name())) return;
+        final var endDirective = new DirectiveLine(DirectiveLine.Kind.END);
+        lines.add(endDirective);
+    }
+
+    /**
+     * Elide the code block with a replacement `DATA` pseudo-op.
+     *
+     * <p>Given the lines (last one of which is probably a `METADATA` pseudo-op) find the code data
+     * block between the "last" `INVALID` or `STOP` instruction and the start of the metadata, take
+     * that bunch of data and change it into an (uninterpreted) `DATA` pseudo-op, and use it to
+     * _replace_ all the (mis-)interpreted lines of Code.
+     */
+    List<Line> elideCodeData(@NonNull final List<Line> lines, @NonNull final byte[] bytecode) {
+        if (!DisassemblyOption.isOn(DisassemblyOption.DO_NOT_DECODE_BEFORE_METADATA)) {
+
+            // This function maps a `Range<Line>` of disassembled instructions to a `Range<Byte>`
+            // of those bytecodes in the contract.  It does this by looking in the Lines to see what
+            // offsets they are at in the bytecode.  Ranges here are _exclusive_ at the "to" end.
+            final Function<Range<Line>, Range<Byte>> bytecodeRangeFromLineRange = lr -> {
+                if (lines.size() == lr.from()) return Range.empty();
+
+                final var fromLine = lines.get(lr.from());
+                final var toLine = lines.get(lr.to());
+                if (fromLine instanceof Code fromCode && toLine instanceof Code toCode) {
+                    return new Range<Byte>(fromCode.getCodeOffset(), toCode.getCodeOffset());
+                } else
+                    throw new IllegalStateException("Expected Code at line index %d or %d (%s, %s)"
+                            .formatted(lr.from(), lr.to(), fromLine, toLine));
+            };
+
+            // Search backwards from the metadata to an `INVALID` or `STOP` (if present).
+            final var lineRange = lookBackwardsForDelimiterInstruction(lines, bytecode);
+
+            if (!lineRange.isEmpty()) {
+                final var codeRange = bytecodeRangeFromLineRange.apply(lineRange);
+
+                // Eliminate junk "instructions" we've already disassembled that were, in fact,
+                // part of this code data block
+                lines.subList(lineRange.from(), lineRange.to()).clear();
+                // FYI (very) arguable Java design decision: See "Why is Java's `AbstractList`'s
+                // `removeRange()` method protected?"
+                // See
+                // https://stackoverflow.com/questions/2289183/why-is-javas-abstractlists-removerange-method-protected
+
+                // And now turn that bunch of bytecodes into a `DATA` pseudo-op.
+                final var dataLine = getBytecodeRangeAsData(bytecode, codeRange, "", DataPseudoOpLine.Kind.DATA);
+                lines.add(lineRange.from(), dataLine);
+            }
+        }
+
+        return lines;
+    }
+
+    /**
+     * Look for a code data block between an `INVALID` or `STOP` and the metadata.
+     *
+     * <p>Look for a code data block between an `INVALID` or `STOP` and the metadata. We want the
+     * _last_ `INVALID` or `STOP`. (There might be more than one.) How do we know which? We search
+     * _backwards_ from the metadata line.
+     */
+    @NonNull
+    public Range<Line> lookBackwardsForDelimiterInstruction(
+            @NonNull final List</*@NonNull*/ Line> lines, @NonNull final byte[] bytecode) {
+        // Only tricky thing here is keeping track of both Line locations and bytecode offsets.
+
+        // start with empty ranges
+        int lineRangeFrom = lines.size();
+        int lineRangeTo = lineRangeFrom;
+
+        if (lines.isEmpty() || 0 == bytecode.length) return Range.empty();
+
+        // We either have metadata at the end, or we don't
+        if (lines.get(lines.size() - 1) instanceof DataPseudoOpLine data
+                && data.kind() == DataPseudoOpLine.Kind.METADATA) {
+            lineRangeFrom--;
+            lineRangeTo--;
+        }
+
+        // Scan now for first prior `INVALID` or `STOP`
+        while (lineRangeFrom >= 0) {
+            if (lines.get(lineRangeFrom) instanceof CodeLine code) {
+                if (code.opcode() == INVALID_OPCODE || code.opcode() == STOP_OPCODE) {
+                    lineRangeFrom++;
+                    if (lineRangeFrom == lineRangeTo)
+                        return Range.empty(); // This would be if there was no data block between
+                    // INVALID/STOP and the metadata/end
+                    return new Range<>(lineRangeFrom, lineRangeTo);
+                }
+            }
+            lineRangeFrom--;
+        }
+        // Here, no INVALID or STOP found all the way to the beginning of the contract
+        return Range.empty();
+    }
+
+    record SolidityMetadata(int metadataLength, String approxVersion, Pattern metadataPattern) {
+        SolidityMetadata(int metadataLength, String approxVersion, String metadataPattern) {
+            this(metadataLength, approxVersion, Pattern.compile(metadataPattern));
+        }
+    }
+
+    /**
+     * Signatures of "known" Solidity-generated metadata.
+     *
+     * <p>Signatures of "known" Solidity-generated metadata. Probably missing some, and will need to
+     * update this in the future as the Solidity compiler evolves. Possibly this is too strict and
+     * we shouldn't care. Maybe _other_ contract language compilers put metadata at the end in the
+     * same CBOR format but containing different data. We'll see.
+     *
+     * <p>- ref: <a href="https://www.badykov.com/ethereum/solidity-bytecode-metadata/">...</a> -
+     * ref: <a
+     * href="https://docs.soliditylang.org/en/v0.8.17/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode">...</a>
+     */
+    static final SolidityMetadata[] solidityMetadataEvolution = {
+        new SolidityMetadata(0x0029, "~0.4.17", "A165627A7A72305820(..){32}0029"),
+        new SolidityMetadata(0x0032, "0.5.10", "A265627A7A72305820(..){32}64736F6C6343(..){3}0032"),
+        new SolidityMetadata(0x0032, "0.5.10", "A265627A7A72315820(..){32}64736F6C6343(..){3}0032"),
+        new SolidityMetadata(0x0033, "~0.8.17", "A264697066735822(..){34}64736F6C6343(..){3}0033")
+    };
+
+    static final int MAX_METADATA_LENGTH = 0x60; // just a guess
+
+    /**
+     * Given contract bytecode find the Solidity metadata blob at the very end of it, if present.
+     *
+     * <p>Solitity puts metadata at the end of a compiled contract. It consists of a CBOR-encoded
+     * blob followed by its length, the latter in two bytes (and the length here is that of the CBOR
+     * blob only, not the entire metadata blob including the length bytes).
+     *
+     * <p>Look for the metadata at the end - performing some sanity checks on it. We only recognize
+     * certain "known" patterns (there maybe some we're missing!) And the most obvious rigorous
+     * sanity check isn't performed: we don't decode the metadata to see if it is a valid CBOR-
+     * encoding thing. (Maybe someday.)
+     */
+    public @NonNull Range<Byte> locateMetadata(@NonNull final byte[] bytecode) {
+        if (bytecode.length < 2) return Range.empty();
+        final int metadataLength = bytecode[bytecode.length - 2] * 256 + bytecode[bytecode.length - 1];
+
+        if (MAX_METADATA_LENGTH < metadataLength) return Range.empty();
+        if (bytecode.length < metadataLength + 2) return Range.empty();
+
+        final var metadataFrom = bytecode.length - 2 - metadataLength;
+        final var tailAsHex = UPPERCASE_HEX_FORMATTER.formatHex(bytecode, metadataFrom, bytecode.length);
+        for (var sm : solidityMetadataEvolution) {
+            if (sm.metadataLength != metadataLength) continue;
+            if (sm.metadataPattern.matcher(tailAsHex).matches()) return new Range<>(metadataFrom, bytecode.length);
+        }
+
+        // Don't get persnickety about metadata matching the known signatures.  So far we
+        // have 2 that look like metadata at the end but don't match the signature.  We also
+        // have ~50 that look like data of some kind at the end but don't have metadata.
+        return new Range<>(metadataFrom, bytecode.length);
+    }
+
+    /** Given a range, return, as a `DATA` pseudo-op, the contract bytecodes in that range */
+    public @NonNull DataPseudoOpLine getBytecodeRangeAsData(
+            @NonNull final byte[] bytecode,
+            @NonNull final Range<Byte> range,
+            @NonNull final String comment,
+            @NonNull final DataPseudoOpLine.Kind kind) {
+        final var dataBytes = Arrays.copyOfRange(bytecode, range.from(), range.to());
+        return new DataPseudoOpLine(range.from(), kind, dataBytes, comment);
+    }
+
+    public static final int INVALID_OPCODE = Opcodes.getDescrFor("INVALID").opcode();
+    public static final int STOP_OPCODE = Opcodes.getDescrFor("STOP").opcode();
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Editor.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Editor.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
+import static java.util.stream.Collectors.groupingBy;
+
+import com.hedera.services.cli.utils.Range;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * Represents "edits" to an Assembly of Lines.
+ *
+ * <p>Lines can be inserted, replaced (by a different number of lines), deleted. Kept as a separate
+ * structure of Edits that can be "applied" to a list of Lines to produce a final listing.
+ */
+public class Editor {
+
+    @NonNull
+    private final List<Line> baseLines;
+
+    @NonNull
+    private final List<Edit> edits;
+
+    public Editor(@NonNull final List<Line> baseLines) {
+        Objects.requireNonNull(baseLines);
+        this.baseLines = baseLines;
+        this.edits = new ArrayList<>();
+    }
+
+    public void add(
+            @NonNull final Range<Line> lineRange,
+            @NonNull final List<Line> newLines,
+            @NonNull final Range<Byte> byteRange) {
+        Objects.requireNonNull(lineRange);
+        Objects.requireNonNull(newLines);
+        Objects.requireNonNull(byteRange);
+        if (lineRange.isEmpty() && newLines.isEmpty() && byteRange.isEmpty()) return;
+        edits.add(new Edit(this, lineRange, newLines, byteRange));
+    }
+
+    public void add(@NonNull final Range<Line> lineRange, @NonNull final List<Line> newLines) {
+        Objects.requireNonNull(lineRange);
+        Objects.requireNonNull(newLines);
+        edits.add(new Edit(this, lineRange, newLines));
+    }
+
+    public void add(@NonNull final Code replacementCode) {
+        Objects.requireNonNull(replacementCode);
+        edits.add(new Edit(this, getLineRangeFromCode(replacementCode), List.of(replacementCode)));
+    }
+
+    @NonNull
+    protected List<Edit> getEdits() {
+        return edits;
+    }
+
+    protected record Edit(
+            @NonNull Range<Line> lineRange, @NonNull List<Line> newLines, @NonNull Range<Byte> byteRange) {
+
+        public enum Kind {
+            INSERT,
+            DELETE,
+            REPLACE
+        }
+
+        public Edit {
+            Objects.requireNonNull(lineRange);
+            Objects.requireNonNull(newLines);
+            Objects.requireNonNull(byteRange);
+        }
+
+        public Edit(
+                @NonNull Editor editor,
+                @NonNull Range<Line> lineRange,
+                @NonNull List<Line> newLines,
+                @Nullable Range<Byte> byteRange) {
+            this(editor.validateLineRange(lineRange), newLines, editor.validateByteRange(lineRange, byteRange));
+        }
+
+        public Edit(@NonNull Editor editor, @NonNull Range<Line> lineRange, @NonNull List<Line> newLines) {
+            this(editor, lineRange, newLines, editor.getByteRangeFromLines(editor.validateLineRange(lineRange)));
+        }
+
+        @NonNull
+        public Kind getKind() {
+            if (!lineRange.isEmpty() && !newLines.isEmpty()) return Kind.REPLACE;
+            if (lineRange.isEmpty()) return Kind.INSERT;
+            return Kind.DELETE;
+        }
+
+        @Override
+        public String toString() {
+            return "Edit{lineRange=%s, byteRange=%s, newLines=%s}".formatted(lineRange, byteRange, newLines);
+        }
+    }
+
+    /** Merge a List<Line> with a bunch of Edits, producing a new assembly List<Line> */
+    public @NonNull List<Line> merge() {
+        var merged = new ArrayList<Line>(baseLines);
+        final Consumer<Edit> inserter = edit -> merged.addAll(edit.lineRange().from(), edit.newLines());
+        final Consumer<Edit> deleter = edit ->
+                merged.subList(edit.lineRange().from(), edit.lineRange().to()).clear();
+
+        // Edits are specified in terms of the line ranges they affect ... so a little thought
+        // reveals that for best (easiest!) results you process them in _descending_ order from the
+        // end of the listing to the beginning.
+        arrangeEditsForMerge(edits);
+        for (final var edit : edits) {
+            switch (edit.getKind()) {
+                case INSERT -> inserter.accept(edit);
+                case DELETE -> deleter.accept(edit);
+                case REPLACE -> {
+                    deleter.accept(edit);
+                    inserter.accept(edit);
+                }
+            }
+        }
+
+        return merged;
+    }
+
+    /**
+     * Edits must be non-overlapping and in _reverse_ line range order to be merged with an assembly
+     * list
+     */
+    protected static void arrangeEditsForMerge(@NonNull final List<Edit> edits) {
+        Objects.requireNonNull(edits);
+        if (!hasNoOverlappingEdits(edits)) throw new IndexOutOfBoundsException("Edits overlap");
+        edits.sort(comparing(rng -> rng.lineRange().from(), reverseOrder()));
+    }
+
+    /** Given a range into a list of lines, get the bytecode range they encompass */
+    @SuppressWarnings("java:S2293") // Replace type specification...with diamond operator (for `Range<...>`)
+    protected @NonNull Range<Byte> getByteRangeFromLines(@NonNull final Range<Line> lineRange) {
+        Objects.requireNonNull(lineRange);
+        if (lineRange.isEmpty()) return Range.<Byte>empty();
+
+        /* Scan the range looking for the first and last Code line.  From that compute the
+         * byte range.  If there are no Code lines in the range, rescan from the beginning of
+         * the baseLines.
+         */
+
+        Code[] firstLast = getCodeRangeFromLines(lineRange);
+        if (null == firstLast[0]) firstLast = getCodeRangeFromLines(new Range<Line>(0, lineRange.to()));
+        if (null == firstLast[0]) return Range.<Byte>empty();
+        return new Range<Byte>(
+                firstLast[0].getCodeOffset(),
+                firstLast[1].getCodeOffset() + firstLast[1].getCodeSize() /*exclusive at this end*/);
+    }
+
+    /** Given a range into a list of lines, get the first and last Code line */
+    protected @NonNull Code[] getCodeRangeFromLines(@NonNull final Range<Line> lineRange) {
+        Objects.requireNonNull(lineRange);
+        Code firstCode = null;
+        Code lastCode = null;
+
+        for (int i = lineRange.from(); i < lineRange.to(); i++) {
+            final var line = baseLines.get(i);
+            if (line instanceof Code code) {
+                if (null == firstCode) firstCode = code;
+                lastCode = code;
+            }
+        }
+        return new Code[] {firstCode, lastCode};
+    }
+
+    /**
+     * Given a Code line (probably a macro) get (from its offset and size) the range of lines that
+     * it covers
+     */
+    protected @NonNull Range<Line> getLineRangeFromCode(@NonNull final Code codeLine) {
+        Objects.requireNonNull(codeLine);
+        final var atOffset = codeLine.getCodeOffset();
+        final var toOffset = atOffset + codeLine.getCodeSize();
+
+        // Look for the line of code at the given code offset
+        int firstLine = -1;
+        int i = 0;
+        while (i < baseLines.size()) {
+            if (baseLines.get(i) instanceof Code code) {
+                if (code.getCodeOffset() == atOffset) {
+                    firstLine = i;
+                    break;
+                }
+            }
+            i++;
+        }
+        if (firstLine < 0)
+            throw new IndexOutOfBoundsException("can't find code line at code offset 0x%04X".formatted(atOffset));
+
+        if (atOffset == toOffset) {
+            return new Range<>(firstLine, firstLine);
+        }
+
+        // Now look for the line of code that extends to the end of the given code line
+        int lastLine = -1;
+        while (i < baseLines.size()) {
+            if (baseLines.get(i) instanceof Code code) {
+                if (code.getCodeOffset() + code.getCodeSize() == toOffset) {
+                    lastLine = i + 1;
+                    break;
+                }
+            }
+            i++;
+        }
+        if (lastLine < 0)
+            throw new IndexOutOfBoundsException(
+                    "can't find code line with last offset at 0x%04X, code line %s".formatted(toOffset, codeLine));
+
+        return new Range<>(firstLine, lastLine);
+    }
+
+    /**
+     * Check that the range of lines is valid in general and also in particular
+     *
+     * <p>Check that the range of lines is valid in general and also with respect to the particular
+     * list of lines we're dealing with.
+     */
+    protected boolean isValidLineRange(@NonNull final Range<Line> lineRange) {
+        Objects.requireNonNull(lineRange);
+
+        if (lineRange.from() < 0 || lineRange.from() > baseLines.size()) return false;
+        return lineRange.to() >= lineRange.from() && lineRange.to() <= baseLines.size();
+    }
+
+    /** Throws if the line range given is not valid, otherwise returns it */
+    protected @NonNull Range<Line> validateLineRange(@NonNull final Range<Line> lineRange) {
+        Objects.requireNonNull(lineRange);
+
+        if (!isValidLineRange(lineRange)) throw new IllegalArgumentException("EDIT: invalid lineRange");
+        return lineRange;
+    }
+
+    /**
+     * Check that the range of bytes is valid in general and also in particular
+     *
+     * <p>Check that the range of bytes is valid in general and also with respect to the particular
+     * list of lines we're dealing with.
+     *
+     * <p>Precondition: `validLineRange(baseLines, lineRange)` => `true`
+     */
+    protected boolean isValidByteRange(@NonNull final Range<Line> lineRange, @NonNull final Range<Byte> byteRange) {
+        Objects.requireNonNull(lineRange);
+        Objects.requireNonNull(byteRange);
+
+        final var actualBaseLinesByteRange = getByteRangeFromLines(lineRange);
+        if (byteRange.from() < actualBaseLinesByteRange.from() || byteRange.from() > actualBaseLinesByteRange.to())
+            return false;
+        return byteRange.to() >= byteRange.from() && byteRange.to() <= actualBaseLinesByteRange.to();
+    }
+
+    /** Throws if the byte range given is not valid, otherwise returns it */
+    protected @NonNull Range<Byte> validateByteRange(
+            @NonNull final Range<Line> lineRange, final Range<Byte> byteRange) {
+        Objects.requireNonNull(lineRange);
+        Objects.requireNonNull(byteRange);
+        if (null == byteRange || !isValidByteRange(lineRange, byteRange))
+            throw new IllegalArgumentException("EDIT: invalid byteRange");
+        return byteRange;
+    }
+
+    /** Predicate testing whether any of the Edits in a collection of them overlap in Lines */
+    protected static boolean hasNoOverlappingEdits(@NonNull final List<Edit> edits) {
+        Objects.requireNonNull(edits);
+
+        // Although this method takes Edits it only deals with the line ranges of those edits.
+
+        // Empty line ranges signal an INSERT.  These are _not_ allowed to happen:
+        //    a) Properly _within_ another range (but it's ok at either _end_ of a range), and
+        //    b) _at the same location_ as another INSERT.
+        // Because of these special rules empty ranges are treated separately from non-empty ranges.
+
+        // Partition on "emptiness" of range: `true` is empty
+        final var emptyAndProperRanges =
+                edits.stream().map(Edit::lineRange).collect(Collectors.partitioningBy(Range<Line>::isEmpty));
+
+        {
+            // Handle the empty ranges (INSERTS)
+
+            // For the empty ranges we need only the line they're pointing to.
+            final var emptyLines =
+                    emptyAndProperRanges.get(true).stream().map(Range::from).toList();
+            final var properRanges = emptyAndProperRanges.get(false);
+
+            // a) all must be distinct
+            var distinctLines = new HashSet<Integer>();
+            for (final var line : emptyLines) {
+                if (!distinctLines.add(line)) return false;
+            }
+            // b) none must be properly within a properRange (this is 𝑂(𝑚𝑛), but there aren't
+            // going to be many edits)
+            for (final var line : emptyLines) {
+                if (properRanges.stream().anyMatch(l -> l.properlyWithin(line))) return false;
+            }
+        }
+
+        {
+            // Handle the proper ranges: none can _overlap_
+            if (Range.hasOverlappingRanges(emptyAndProperRanges.get(false))) return false;
+        }
+
+        return true;
+    }
+
+    enum Verbose {
+        NO,
+        YES
+    }
+
+    String toString(Verbose verbose) {
+
+        var kinds = edits.stream()
+                .map(Edit::getKind)
+                .collect(groupingBy(
+                        k -> k, () -> new TreeMap<Edit.Kind, Long>(comparing(Edit.Kind::name)), Collectors.counting()));
+        for (final var k : Edit.Kind.class.getEnumConstants()) kinds.putIfAbsent(k, 0L);
+
+        var basicInfo = "%d baselines, %d edits %s".formatted(baseLines.size(), edits.size(), kinds.toString());
+        return switch (verbose) {
+            case NO -> "Editor[%s]".formatted(basicInfo);
+            case YES -> "Editor[%s baselines: %s edits: %s]".formatted(basicInfo, baseLines, edits);
+        };
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/LabelLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/LabelLine.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.EOL_COMMENT_PREFIX;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/** Represents a label in the generated assembly (a named offset in the code) */
+public record LabelLine(int codeOffset, @NonNull String label, @NonNull String comment) implements Code {
+
+    public static final String LABEL_PREFIX = "";
+    public static final String LABEL_SUFFIX = ":";
+
+    public LabelLine {
+        Objects.requireNonNull(label);
+        Objects.requireNonNull(comment);
+    }
+
+    public LabelLine(int codeOffset, @NonNull String label) {
+        this(codeOffset, label, "");
+    }
+
+    @Override
+    public void formatLine(@NonNull final StringBuilder sb) {
+        Objects.requireNonNull(sb);
+        extendWithBlanksTo(sb, Columns.LABEL.getColumn());
+        sb.append(LABEL_PREFIX);
+        sb.append(label);
+        sb.append(LABEL_SUFFIX);
+
+        if (!comment.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            sb.append(EOL_COMMENT_PREFIX);
+            sb.append(comment);
+        }
+    }
+
+    @Override
+    public int getCodeOffset() {
+        return codeOffset;
+    }
+
+    @Override
+    public int getCodeSize() {
+        return 0;
+    }
+
+    @Override
+    @NonNull
+    public String mnemonic() {
+        return LABEL_PREFIX + label + LABEL_SUFFIX;
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Line.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Line.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static com.hedera.services.cli.contracts.assembly.Constants.MAX_EXPECTED_LINE;
+import static com.hedera.services.cli.contracts.assembly.Constants.UPPERCASE_HEX_FORMATTER;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HexFormat;
+import java.util.Objects;
+
+public interface Line {
+
+    /** Formats the line into a string suitable for directly putting in the disassembly */
+    void formatLine(@NonNull final StringBuilder sb);
+
+    /**
+     * Formats the line into a string suitable for directly putting in the disassembly
+     *
+     * <p>Convenience method so that holders of Lines don't have to create their own
+     * StringBuilder
+     */
+    default @NonNull String formatLine() {
+        var sb = new StringBuilder(MAX_EXPECTED_LINE);
+        formatLine(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Extend a string until it reaches the goal column
+     *
+     * <p>Utility function useful for lining up fields (opcode, mnemonic, comment, etc.) into
+     * columns.
+     */
+    default void extendWithBlanksTo(@NonNull final StringBuilder sb, int goalColumn) {
+        Objects.requireNonNull(sb);
+        if (goalColumn <= sb.length()) {
+            // Already past the goal column ... just pad with a couple of blanks
+            sb.append("  ");
+            return;
+        }
+
+        // Need to pad to goal column - keep sticking blanks on to the end until past
+        // the goal, then truncate to correct size
+        while (sb.length() < goalColumn) {
+            sb.append("                ");
+        }
+        sb.setLength(goalColumn);
+    }
+
+    /**
+     * Check if this Line is a specific instruction opcodes
+     *
+     * <p>Convenience method for check to see if this line is an instruction with the given
+     * opcode.
+     */
+    default boolean thisLineIsA(int opcode) {
+        return this instanceof CodeLine codeLine && codeLine.opcode() == opcode;
+    }
+
+    default boolean thisLineIsA(@NonNull final String mnemonic) {
+        Objects.requireNonNull(mnemonic);
+        return this instanceof CodeLine codeLine && codeLine.isA(mnemonic);
+    }
+
+    /** Make a HexFormatter available to all Lines */
+    default @NonNull HexFormat hexer() {
+        return UPPERCASE_HEX_FORMATTER;
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/MacroLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/MacroLine.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+public abstract class MacroLine implements Code {
+
+    final int codeOffset;
+    final int codeSize;
+    final @NonNull String mnemonic;
+
+    public MacroLine(int codeOffset, int codeSize, @NonNull String mnemonic) {
+        Objects.requireNonNull(mnemonic);
+        this.codeOffset = codeOffset;
+        this.codeSize = codeSize;
+        this.mnemonic = mnemonic;
+    }
+
+    @Override
+    public int getCodeOffset() {
+        return codeOffset;
+    }
+
+    @Override
+    public int getCodeSize() {
+        return codeSize;
+    }
+
+    @Override
+    public @NonNull String mnemonic() {
+        return mnemonic;
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Opcodes.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Opcodes.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.contracts.assembly;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Contains a type (Descr) describing an EVM opcode, and table lookup
+ *
+ * <p>Contained record type Descr describes an EVM opcode, and there is table lookup to get from a
+ * byte to the opcode (mnemonic) or the other way around.
+ */
+public class Opcodes {
+
+    /** Properties associated with EVM opcodes, categorizing them */
+    public enum Properties {
+        CALL,
+        RETURN,
+        JUMP1WAY,
+        JUMP2WAY,
+        JUMPDEST,
+        TERMINAL,
+        UNASSIGNED;
+
+        public static @NonNull Set<Properties> parse(@Nullable final String s) {
+            if (null == s || s.isEmpty()) return EnumSet.noneOf(Properties.class);
+            final var values =
+                    splitter.splitAsStream(s).map(Properties::valueOf).toList();
+            return EnumSet.copyOf(values);
+        }
+
+        private static final Pattern splitter = Pattern.compile(",");
+    }
+
+    /**
+     * Describes an EVM opcode
+     *
+     * @param opcode - value of the opcode, e.g., 0x62 for a "push 2 bytes" instruction
+     * @param extraBytes - how many extra bytes go with this opcode, e.g., 2 for "push 2 bytes"
+     * @param mnemonic - mnemonic for this opcode, e.g., "PUSH2" for "push 2 bytes" instruction
+     */
+    public record Descr(int opcode, int extraBytes, @NonNull String mnemonic, @NonNull Set<Properties> properties) {
+
+        public Descr {
+            Objects.requireNonNull(mnemonic);
+            Objects.requireNonNull(properties);
+        }
+
+        public Descr(int opcode, final @NonNull String mnemonic) {
+            this(opcode, 0, mnemonic, EMPTY_PROPERTIES);
+        }
+
+        public Descr(int opcode, final @NonNull String mnemonic, @NonNull Set<Properties> properties) {
+            this(opcode, 0, mnemonic, properties);
+        }
+
+        public Descr(int opcode, int extraBytes, final @NonNull String mnemonic) {
+            this(opcode, extraBytes, mnemonic, EMPTY_PROPERTIES);
+        }
+
+        public boolean isAssigned() {
+            return !properties.contains(Properties.UNASSIGNED);
+        }
+
+        public boolean isBasicBlockStart() {
+            return properties.contains(Properties.JUMPDEST);
+        }
+
+        public boolean isBasicBlockEnd() {
+            return properties.contains(Properties.JUMP1WAY)
+                    || properties.contains(Properties.JUMP2WAY)
+                    || properties.contains(Properties.RETURN)
+                    || properties.contains(Properties.TERMINAL);
+            // The definition of the _end_ of a basic block includes _call_ instructions that
+            // _can not return_.  But this predicate isn't strong enough to determine that (since
+            // it requires context of the _called_ basic block).  So, for a _call_ instruction,
+            // this will always return _false_.
+        }
+
+        public boolean isTerminal() {
+            return properties.contains(Properties.TERMINAL);
+        }
+
+        @Override
+        public String toString() {
+            final var extra = extraBytes > 0 ? "+%d".formatted(extraBytes) : "";
+            final var props = properties.isEmpty() ? "" : trimMatched("[]", properties.toString());
+            var sb = new StringBuilder();
+            sb.append(extra);
+            if (!extra.isEmpty() && !props.isEmpty()) sb.append(", ");
+            sb.append(props);
+            return "%s(%#02X)[%s]".formatted(mnemonic, opcode, sb);
+        }
+
+        static final Set<Properties> EMPTY_PROPERTIES = Set.of();
+    }
+
+    /** Table of opcodes, indexed by opcode */
+    @NonNull
+    private static final ImmutableList<Descr> byOpcode;
+
+    /** Get an opcode Descr, given opcode value */
+    public static @NonNull Descr getOpcode(int opcode) {
+        return byOpcode.get(opcode & 0xFF);
+    }
+
+    /** Table of opcodes, indexed by mnemonic */
+    @NonNull
+    private static final ImmutableSortedMap<String, Descr> byMnemonic;
+
+    /** Get an opcode Descr, given mnemonic */
+    public static @NonNull Descr getDescrFor(@NonNull final String mnemonic) {
+        Objects.requireNonNull(mnemonic);
+        final var descr = Opcodes.byMnemonic.get(mnemonic.toUpperCase());
+        if (null == descr) throw new IllegalArgumentException("opcode '%s' not found in table".formatted(mnemonic));
+        return descr;
+    }
+
+    static {
+        // Create the opcode tables ... see https://ethereum.org/en/developers/docs/evm/opcodes/
+
+        var descrs = new ArrayList<Descr>(256);
+
+        // Start with all the unique/ordinary opcodes
+        """
+          00 STOP           TERMINAL
+          01 ADD
+          02 MUL
+          03 SUB
+          04 DIV
+          05 SDIV
+          06 MOD
+          07 SMOD
+          08 ADDMOD
+          09 MULMOD
+          0A EXP
+          0B SIGNEXTEND
+          10 LT
+          11 GT
+          12 SLT
+          13 SGT
+          14 EQ
+          15 ISZERO
+          16 AND
+          17 OR
+          18 XOR
+          19 NOT
+          1A BYTE
+          1B SHL
+          1C SHR
+          1D SAR
+          20 KECCAK256
+          30 ADDRESS
+          31 BALANCE
+          32 ORIGIN
+          33 CALLER
+          34 CALLVALUE
+          35 CALLDATALOAD
+          36 CALLDATASIZE
+          37 CALLDATACOPY
+          38 CODESIZE
+          39 CODECOPY
+          3A GASPRICE
+          3B EXTCODESIZE
+          3C EXTCODECOPY
+          3D RETURNDATASIZE
+          3E RETURNDATACOPY
+          3F EXTCODEHASH
+          40 BLOCKHASH
+          41 COINBASE
+          42 TIMESTAMP
+          43 NUMBER
+          44 PREVRANDAO
+          45 GASLIMIT
+          46 CHAIND
+          47 SELFBALANCE
+          48 BASEFEE
+          50 POP
+          51 MLOAD
+          52 MSTORE
+          53 MSTORE8
+          54 SLOAD
+          55 SSTORE
+          56 JUMP           JUMP1WAY
+          57 JUMPI          JUMP2WAY
+          58 PC
+          59 MSIZE
+          5A GAS
+          5B JUMPDEST       JUMPDEST
+          F0 CREATE
+          F1 CALL           CALL
+          F2 CALLCODE       CALL
+          F3 RETURN         RETURN
+          F4 DELEGATECALL   CALL
+          F5 CREATE2
+          FA STATICCALL     CALL
+          FD REVERT         TERMINAL
+          FE INVALID        TERMINAL
+          FF SELFDESTRUCT   TERMINAL
+          """
+                .lines()
+                .forEach(line -> {
+                    final var no = line.split(" +");
+                    final var op = Integer.parseUnsignedInt(no[0], 16);
+                    final var properties = Properties.parse(no.length > 2 ? no[2] : "");
+                    descrs.add(new Descr(op, no[1], properties));
+                });
+
+        // Add all the "multiple" opcodes
+        for (int i = 1; i <= 32; i++) {
+            descrs.add(new Descr(0x60 + i - 1, i, "PUSH" + Integer.toString(i)));
+        }
+        for (int i = 1; i <= 16; i++) {
+            descrs.add(new Descr(0x80 + i - 1, "DUP" + Integer.toString(i)));
+        }
+        for (int i = 1; i <= 16; i++) {
+            descrs.add(new Descr(0x90 + i - 1, "SWAP" + Integer.toString(i)));
+        }
+        for (int i = 0; i <= 4; i++) {
+            descrs.add(new Descr(0xA0 + i, "LOG" + Integer.toString(i)));
+        }
+        // Add all the unassigned (thus invalid) opcodes
+        concatStreams(
+                        intRange(0x0C, 0x0F),
+                        intRange(0x1E, 0x1F),
+                        intRange(0x21, 0x2F),
+                        intRange(0x49, 0x4F),
+                        intRange(0x5C, 0x5F),
+                        intRange(0xA5, 0xEF),
+                        intRange(0xF6, 0xF9),
+                        intRange(0xFB, 0xFC))
+                // (Say, you'd think Guava's `RangeSet` would be perfect for this ... except you
+                // can't iterate it.  A set which you can't iterate over its members ... it's a good
+                // idea, because ... I dunno ...)
+                .forEach(i -> {
+                    final var n = "%02X".formatted(i);
+                    descrs.add(new Descr(i, "UNASSIGNED-" + n, EnumSet.of(Properties.UNASSIGNED)));
+                });
+
+        // Validate we've got all 256 opcodes defined
+        final var allOpcodes = descrs.stream().map(Descr::opcode).collect(toSet());
+
+        // sanity check this data constructor ...
+        if (256 != allOpcodes.size()) {
+            throw new IllegalStateException(
+                    "EVM opcode table incomplete, only %s opcodes present".formatted(allOpcodes.size()));
+        }
+
+        descrs.sort(Comparator.comparingInt(Descr::opcode));
+        byOpcode = ImmutableList.copyOf(descrs);
+        byMnemonic = ImmutableSortedMap.copyOf(descrs.stream().collect(toMap(Descr::mnemonic, d -> d)));
+    }
+
+    /** Returns a Stream<Integer> of a range of integers, inclusive of both ends */
+    private static Stream<Integer> intRange(int low, int high) {
+        return IntStream.rangeClosed(low, high).boxed();
+    }
+
+    /** Variadic Stream concatenation (why isn't this part of Java Streams class?) */
+    @SafeVarargs
+    private static @NonNull Stream<Integer> concatStreams(@NonNull final Stream<Integer>... sis) {
+        Objects.requireNonNull(sis);
+        Stream<Integer> s = Stream.empty();
+        for (var str : sis) s = Stream.concat(s, str);
+        return s;
+    }
+
+    /** Utility method to trim matched "brackets" from the ends of a string */
+    private static @NonNull String trimMatched(@NonNull final String brackets, @NonNull final String s) {
+        Objects.requireNonNull(brackets);
+        Objects.requireNonNull(s);
+        if (brackets.length() < 2) throw new IllegalArgumentException("brackets too short");
+        if (s.length() < 2) return s;
+        if (s.charAt(0) != brackets.charAt(0)) return s;
+        if (s.charAt(s.length() - 1) != brackets.charAt(1)) return s;
+        return s.substring(1, s.length() - 1);
+    }
+
+    /** Provide a formatted EVM opcode table (as a multi-line string) */
+    public static @NonNull String formatOpcodeTable() {
+        final var LARGE_BLUE_CIRCLE = "\uD83D\uDD35";
+        var sb = new StringBuilder();
+        for (int i = 0; i < 256; i++) {
+            final var opcode = getOpcode(i);
+            final var bbstart = opcode.isBasicBlockStart();
+            final var bbend = opcode.isBasicBlockEnd();
+            final var lineStart = sb.length();
+            sb.append("%3d: ".formatted(i));
+            sb.append(opcode);
+            if (bbstart || bbend) {
+                sb.append("                                        ");
+                sb.setLength(lineStart + 40);
+                sb.append(LARGE_BLUE_CIRCLE + " basic block");
+                if (bbstart) sb.append(" START");
+                if (bbend) sb.append(" END");
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+
+    private Opcodes() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/HexToBytesConverter.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/HexToBytesConverter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.utils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.ByteBuffer;
+import java.util.HexFormat;
+import java.util.regex.Pattern;
+import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.TypeConversionException;
+
+/**
+ * Converts a hex string command line argument to a byte array
+ *
+ * <p>For Picocli library - implements a type-specific converter from hex string to bytes.
+ */
+public class HexToBytesConverter implements ITypeConverter<HexToBytesConverter.Bytes> {
+
+    // Unfortunately can't return `byte[]` directly from the custom type converter because Piccoli
+    // gets confused: When the argument is declared (at the command class) it thinks it wants a
+    // multi-value type (even if `arity=1` is specified). Thus: need to wrap it in a stupid class.
+    // Would have used a record but Sonarlint complains (properly) that records with array members
+    // need overrides for `equals`/`hashcode`/`toString`, and at that point, why bother?
+    // See https://stackoverflow.com/a/74207195/751579.
+    public static class Bytes {
+        @NonNull
+        public final byte[] contents;
+
+        public Bytes(@Nullable final byte[] b) {
+            if (null == b) throw new TypeConversionException("-b bytecode missing an array value (somehow)");
+            contents = b;
+        }
+    }
+
+    /** "Converts the specified command line argument value to some domain object" */
+    @Override
+    @NonNull
+    public Bytes convert(@NonNull final String value) {
+        if (0 != value.length() % 2) throw new TypeConversionException("-b bytecode must have even number of hexits");
+        if (!Pattern.compile("[0-9a-fA-F]+").matcher(value).matches())
+            throw new TypeConversionException("-b bytecode has invalid characters (not hexits)");
+        return new Bytes(HexFormat.of().parseHex(value));
+    }
+
+    public static long asUnsignedInt(@NonNull final Bytes bytes) {
+        return ByteBuffer.allocate(8)
+                .put(8 - Math.min(8, bytes.contents.length), bytes.contents, 0, bytes.contents.length)
+                .getLong();
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Range.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Range.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.utils;
+
+import static com.google.common.collect.Range.closedOpen;
+
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.TreeRangeSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
+import java.util.HexFormat;
+import java.util.Objects;
+
+/**
+ * Represents a range of integers
+ *
+ * <p>A range of integers specified by inclusive index at the low end, exclusive at the high end,
+ * thus an empty range is from == to. (There is no check _on construction_ that this range is
+ * "valid", i.e., 0 <= from, from <= to.)
+ *
+ * @param from - inclusive
+ * @param to - exclusive
+ * @param <T> - just used for typing purposes, because we're using ranges of bytecodes and lines
+ */
+public record Range<T>(int from, int to) {
+
+    /** Get length of range */
+    public int length() {
+        return Math.max(0, to - from);
+    }
+
+    /** Returns an empty range */
+    public static <T> @NonNull Range<T> empty() {
+        return new Range<>(0, 0);
+    }
+
+    /** Predicate: is this range empty? */
+    public boolean isEmpty() {
+        return 0 == length();
+    }
+
+    /** Returns index _at_ this range's end (beware of empty) */
+    public int last() {
+        return isEmpty() ? 0 : to - 1;
+    }
+
+    /** Returns index _following_ this range's end (beware of empty) */
+    public int onePastEnd() {
+        return to;
+    }
+
+    /** Predicate returns true iff a range contains a point */
+    public boolean contains(int point) {
+        return point >= from && point < to;
+    }
+
+    /** Predicate returns true iff the given point is at one end or the other of the range */
+    public boolean atAnEnd(int point) {
+        return point == from || point == to - 1;
+    }
+
+    /** Predicate returns true iff the given point is _within_ the range (_not_ at either end) */
+    public boolean properlyWithin(int point) {
+        return contains(point) && !atAnEnd(point);
+    }
+
+    /**
+     * Predicate returns true iff none of the ranges given _overlap_ (though they may be adjacent).
+     *
+     * <p>N.B.: Major limitation of this method is that it _ignores_ all empty ranges given in the
+     * argument collection. Because the underlying Guava `RangeSet` does. This is fine w.r.t.
+     * current uses of this method but may not match _your_ use case.
+     *
+     * <p>(SuppressWarnings is due to use of Guava's `RangeSet` which is marked `@Beta` (though it
+     * has in fact been fairly stable for quite some time).
+     */
+    @SuppressWarnings("UnstableApiUsage")
+    public static <T> boolean hasOverlappingRanges(@NonNull Collection<Range<T>> ranges) {
+        Objects.requireNonNull(ranges);
+        var set = TreeRangeSet.<Integer>create();
+        for (final var r : ranges) {
+            // Convert to Guava `Range`
+            final var gr = closedOpen(r.from, r.to).canonical(DiscreteDomain.integers());
+            if (set.intersects(gr)) return true;
+            set.add(gr);
+        }
+        return false;
+    }
+
+    /** Validate a range is in proper format - throw if it isn't */
+    public void validate() {
+        if (from < 0) throw new IllegalArgumentException("from < 0");
+        if (from > to) throw new IllegalArgumentException("from > to");
+    }
+
+    /** Test validity + canonicalize */
+    public @NonNull Range<T> canonicalize() {
+        validate();
+        if (from == 0 && from == to) return this;
+        if (from >= to) return new Range<>(0, 0);
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public String toString() {
+        return "Range[0x%04X,0x%04X)".formatted(from, to);
+    }
+
+    private static final HexFormat hexer = HexFormat.of().withUpperCase().withPrefix("0x");
+
+    public String toString(@NonNull final String type) {
+        Objects.requireNonNull(type);
+        return toString(type, 10);
+    }
+
+    public String toString(@NonNull final String type, int base) {
+        Objects.requireNonNull(type);
+        return "Range<%s>[%s,%s)"
+                .formatted(
+                        type,
+                        base != 16 ? Integer.toString(from, base) : hexer.toHexDigits(from, 4),
+                        base != 16 ? Integer.toString(to, base) : hexer.toHexDigits(to, 4));
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module com.hedera.node.services.cli {
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.platform.core;
     requires transitive info.picocli;
+    requires io.github.classgraph;
     requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.hapi;
     requires com.google.common;


### PR DESCRIPTION
**Description**:

Takes the contract disassembler and finally a) moves it over to PCLI and b) makes it a proper tool in this repo (instead of being in a separate branch)

Given a contract's bytecode will disassemble it.
* Knows about the presence of Solidity metadata at the end of a contract.
* Can identify the selector table and list the selectors for you.

**Related issue(s)**:

Fixes #7879

**Notes for reviewer**:

```bash
./hedera-node/cli-clients/services-cli.sh contract disassemble --id NNNN --bytecode <HEXIFIED-BYTECODE> --options OPTIONS
```
where the options are an (optional) comma-separated list of letters:

```
                            b    with contract bytecode header
                            d    do not decode before metadata
                            f    with code offsets in disassembly
                            m    list macros
                            p    with opcode (in hex)
                            q    recognize and analyze code sequences
                            r    list raw disassembly (before analyzed disassembly
                            s    list selectors
                            t    dump trace of recognizers
                            x    with metrics
```

**Checklist**

- [ ] Documented (Code comments, README, etc.) -- **documentation forthcoming, separate PR**
- [x] Tested (manual)
