### PR TITLE
HIP-786

### DIFF
--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/IdUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/IdUtils.java
@@ -97,7 +97,7 @@ public class IdUtils {
     public static NftID asNftID(final String v, final long serialNum) {
         final var tokenID = asToken(v);
 
-        return NftID.newBuilder().setTokenId(tokenID).setSerialNumber(serialNum).build();
+        return NftID.newBuilder().setTokenID(tokenID).setSerialNumber(serialNum).build();
     }
 
     public static String asAccountString(final AccountID account) {

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/StakingConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/StakingConfig.java
@@ -33,9 +33,10 @@ public record StakingConfig(
                 int feesStakingRewardPercentage,
         // @ConfigProperty(defaultValue = "") Map<Long, Long> nodeMaxToMinStakeRatios,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean isEnabled,
-        @ConfigProperty(defaultValue = "" + Long.MAX_VALUE) @NetworkProperty long maxDailyStakeRewardThPerH,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean requireMinStakeToReward,
-        @ConfigProperty(defaultValue = "0") @NetworkProperty long rewardRate,
+        // Can be renamed to just "rewardRate" when the "staking.rewardRate" property is removed
+        // from all production 0.0.121 system files
+        @ConfigProperty(defaultValue = "6849") @NetworkProperty long perHbarRewardRate,
         @ConfigProperty(defaultValue = "25000000000000000") @NetworkProperty long startThreshold,
         @ConfigProperty(defaultValue = "500") @NetworkProperty int sumOfConsensusWeights,
         @ConfigProperty(defaultValue = "0") @NetworkProperty long rewardBalanceThreshold,

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileTestBase.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileTestBase.java
@@ -279,16 +279,16 @@ public class FileTestBase {
     }
 
     protected void givenValidFile(boolean deleted, boolean withKeys) {
-        file = new File(fileId, expirationTime, withKeys ? keys : null, Bytes.wrap(contents), memo, deleted);
-        fileWithNoKeysAndMemo = new File(fileId, expirationTime, null, Bytes.wrap(contents), null, deleted);
-        fileWithNoContent = new File(fileId, expirationTime, withKeys ? keys : null, null, memo, deleted);
-        fileSystem =
-                new File(fileSystemFileId, expirationTime, withKeys ? keys : null, Bytes.wrap(contents), memo, deleted);
+        file = new File(fileId, expirationTime, withKeys ? keys : null, Bytes.wrap(contents), memo, deleted, 0L);
+        fileWithNoKeysAndMemo = new File(fileId, expirationTime, null, Bytes.wrap(contents), null, deleted, 0L);
+        fileWithNoContent = new File(fileId, expirationTime, withKeys ? keys : null, null, memo, deleted, 0L);
+        fileSystem = new File(
+                fileSystemFileId, expirationTime, withKeys ? keys : null, Bytes.wrap(contents), memo, deleted, 0L);
     }
 
     protected void givenValidUpgradeFile(boolean deleted, boolean withKeys) {
         upgradeFile = new File(
-                fileUpgradeFileId, expirationTime, withKeys ? keys : null, Bytes.wrap(contents), memo, deleted);
+                fileUpgradeFileId, expirationTime, withKeys ? keys : null, Bytes.wrap(contents), memo, deleted, 0L);
     }
 
     protected File createFile() {

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileAppendTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileAppendTest.java
@@ -323,7 +323,7 @@ class FileAppendTest extends FileTestBase {
                         .build())
                 .build();
 
-        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false);
+        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false, 0L);
 
         given(handleContext.body()).willReturn(txBody);
         writableFileState = writableFileStateWithOneKey();

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
@@ -189,7 +189,7 @@ class FileDeleteTest extends FileTestBase {
     void keysDoesntExist() {
         final var txn = newDeleteTxn().fileDeleteOrThrow();
 
-        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false);
+        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false, 0L);
 
         writableFileState = writableFileStateWithOneKey();
         given(writableStates.<FileID, File>get(FILES)).willReturn(writableFileState);
@@ -229,7 +229,7 @@ class FileDeleteTest extends FileTestBase {
     @Test
     @DisplayName("File without keys returns error")
     void noFileKeys() {
-        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false);
+        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false, 0L);
         refreshStoresWithCurrentFileInBothReadableAndWritable();
 
         final var txn = newDeleteTxn().fileDeleteOrThrow();

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemDeleteTest.java
@@ -174,7 +174,7 @@ class FileSystemDeleteTest extends FileTestBase {
     @DisplayName("Fails handle if keys doesn't exist on file system to be deleted")
     void keysDoesntExist() {
         given(handleContext.body()).willReturn(newFileDeleteTxn());
-        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false);
+        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false, 0L);
 
         writableFileState = writableFileStateWithOneKey();
         given(writableStates.<FileID, File>get(FILES)).willReturn(writableFileState);

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemUndeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemUndeleteTest.java
@@ -174,7 +174,7 @@ class FileSystemUndeleteTest extends FileTestBase {
     @DisplayName("Fails handle if keys doesn't exist on file system to be deleted")
     void keysDoesntExist() {
         given(handleContext.body()).willReturn(newFileUnDeleteTxn());
-        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false);
+        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false, 0L);
 
         writableFileState = writableFileStateWithOneKey();
         given(writableStates.<FileID, File>get(FILES)).willReturn(writableFileState);

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileUpdateTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileUpdateTest.java
@@ -246,7 +246,7 @@ class FileUpdateTest extends FileTestBase {
     @Test
     @DisplayName("Fails handle if keys doesn't exist on file to be updated")
     void failForImmutableFile() {
-        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false);
+        file = new File(fileId, expirationTime, null, Bytes.wrap(contents), memo, false, 0L);
         refreshStoresWithCurrentFileInBothReadableAndWritable();
 
         final var op = OP_BUILDER.fileID(fileId).keys(anotherKeys).build();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/StateView.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/StateView.java
@@ -301,7 +301,7 @@ public class StateView {
 
     public Optional<TokenNftInfo> infoForNft(final NftID target) {
         final var currentNfts = uniqueTokens();
-        final var tokenId = EntityNum.fromTokenId(target.getTokenId());
+        final var tokenId = EntityNum.fromTokenId(target.getTokenID());
         final var targetKey = NftId.withDefaultShardRealm(tokenId.longValue(), target.getSerialNumber());
         if (!currentNfts.containsKey(targetKey)) {
             return Optional.empty();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
@@ -203,12 +203,18 @@ public class EndOfStakingPeriodCalculator {
                 curNetworkCtx.pendingRewards(),
                 rewardsBalance());
 
+        final long reservedStakingRewards = curNetworkCtx.pendingRewards();
+        final long unreservedStakingRewardBalance = rewardsBalance() - reservedStakingRewards;
         final var syntheticNodeStakeUpdateTxn = syntheticTxnFactory.nodeStakeUpdate(
                 lastInstantOfPreviousPeriodFor(consensusTime),
                 nodeStakingInfos,
                 properties,
                 totalStakedRewardStart,
-                perHbarRate);
+                perHbarRate,
+                reservedStakingRewards,
+                unreservedStakingRewardBalance,
+                dynamicProperties.stakingRewardBalanceThreshold(),
+                dynamicProperties.maxStakeRewarded());
         log.info("Exporting:\n{}", nodeStakingInfos);
         recordsHistorian.trackPrecedingChildRecord(
                 DEFAULT_SOURCE_ID,

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswer.java
@@ -78,7 +78,7 @@ public class GetTokenNftInfoAnswer implements AnswerService {
     @Override
     public ResponseCodeEnum checkValidity(final Query query, final StateView view) {
         final var nftID = query.getTokenGetNftInfo().getNftID();
-        if (!nftID.hasTokenId()) {
+        if (!nftID.hasTokenID()) {
             return INVALID_TOKEN_ID;
         }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccess.java
@@ -316,7 +316,7 @@ public class StaticEntityAccess implements EntityAccess {
 
     public Optional<TokenNftInfo> infoForNft(final NftID target) {
         final var nft = nfts.get(NftId.withDefaultShardRealm(
-                EntityNum.fromTokenId(target.getTokenId()).longValue(), target.getSerialNumber()));
+                EntityNum.fromTokenId(target.getTokenID()).longValue(), target.getSerialNumber()));
         validateTrueOrRevert(nft != null, INVALID_TOKEN_NFT_SERIAL_NUMBER);
         return view.infoForNft(target);
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/TokenAccessorImpl.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/TokenAccessorImpl.java
@@ -59,7 +59,7 @@ public class TokenAccessorImpl implements TokenAccessor {
     public Optional<EvmNftInfo> evmNftInfo(final Address token, long serialNo) {
         final var target = NftID.newBuilder()
                 .setSerialNumber(serialNo)
-                .setTokenId(tokenIdFromEvmAddress(token))
+                .setTokenID(tokenIdFromEvmAddress(token))
                 .build();
         return trackingLedgers.evmNftInfo(target, ledgerId);
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgers.java
@@ -179,7 +179,7 @@ public class WorldLedgers {
         if (staticEntityAccess != null) {
             return staticEntityAccess.infoForNft(target);
         } else {
-            final var tokenId = EntityNum.fromTokenId(target.getTokenId());
+            final var tokenId = EntityNum.fromTokenId(target.getTokenID());
             final var targetKey = NftId.withDefaultShardRealm(tokenId.longValue(), target.getSerialNumber());
             if (!nftsLedger.contains(targetKey)) {
                 return Optional.empty();
@@ -188,7 +188,7 @@ public class WorldLedgers {
             var accountId = targetNft.getOwner().toGrpcAccountId();
 
             if (WILDCARD_OWNER.equals(accountId)) {
-                var merkleToken = tokensLedger.getImmutableRef(target.getTokenId());
+                var merkleToken = tokensLedger.getImmutableRef(target.getTokenID());
                 if (merkleToken == null) {
                     return Optional.empty();
                 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/NonFungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/NonFungibleTokenInfoPrecompile.java
@@ -67,7 +67,7 @@ public class NonFungibleTokenInfoPrecompile extends AbstractTokenInfoPrecompile
         validateTrue(tokenInfo != null, ResponseCodeEnum.INVALID_TOKEN_ID);
 
         final var nftID = NftID.newBuilder()
-                .setTokenId(tokenId)
+                .setTokenID(tokenId)
                 .setSerialNumber(serialNumber)
                 .build();
         final var nonFungibleTokenInfo =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/NftId.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/NftId.java
@@ -44,7 +44,7 @@ public record NftId(long shard, long realm, long num, long serialNo) implements 
     }
 
     public static NftId fromGrpc(final NftID nftId) {
-        return fromGrpc(nftId.getTokenId(), nftId.getSerialNumber());
+        return fromGrpc(nftId.getTokenID(), nftId.getSerialNumber());
     }
 
     public static NftId fromGrpc(final TokenID tokenId, final long serialNo) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityIdUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityIdUtils.java
@@ -75,7 +75,7 @@ public final class EntityIdUtils {
             return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getScheduleNum());
         }
         if (o instanceof NftID id) {
-            final var tokenID = id.getTokenId();
+            final var tokenID = id.getTokenID();
             return String.format(
                     ENTITY_ID_FORMAT + ".%d",
                     tokenID.getShardNum(),

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityNumPair.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityNumPair.java
@@ -52,7 +52,7 @@ public record EntityNumPair(long value) implements Comparable<EntityNumPair> {
     }
 
     public static EntityNumPair fromGrpcNftId(NftID grpcId) {
-        final var tokenId = grpcId.getTokenId();
+        final var tokenId = grpcId.getTokenID();
         if (!areValidNums(tokenId.getShardNum(), tokenId.getRealmNum())) {
             return MISSING_NUM_PAIR;
         }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
@@ -720,7 +720,7 @@ class StateViewTest {
     @Test
     void getInfoForNftMissing() {
         final var nftID =
-                NftID.newBuilder().setTokenId(tokenId).setSerialNumber(123L).build();
+                NftID.newBuilder().setTokenID(tokenId).setSerialNumber(123L).build();
 
         final var actualTokenNftInfo = subject.infoForNft(nftID);
 
@@ -1376,11 +1376,11 @@ class StateViewTest {
     private final Instant nftCreation = Instant.ofEpochSecond(1_234_567L, 8);
     private final byte[] nftMeta = "abcdefgh".getBytes();
     private final NftID targetNftId = NftID.newBuilder()
-            .setTokenId(IdUtils.asToken("0.0.3"))
+            .setTokenID(IdUtils.asToken("0.0.3"))
             .setSerialNumber(4L)
             .build();
     private final NftID missingNftId = NftID.newBuilder()
-            .setTokenId(IdUtils.asToken("0.0.9"))
+            .setTokenID(IdUtils.asToken("0.0.9"))
             .setSerialNumber(5L)
             .build();
     private final EntityNumPair targetNftKey = EntityNumPair.fromLongs(3, 4);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsageTest.java
@@ -48,7 +48,7 @@ import org.mockito.MockedStatic;
 
 class GetTokenNftInfoResourceUsageTest {
     private static final NftID target = NftID.newBuilder()
-            .setTokenId(IdUtils.asToken("0.0.123"))
+            .setTokenID(IdUtils.asToken("0.0.123"))
             .setSerialNumber(1)
             .build();
     private static final ByteString metadata = ByteString.copyFromUtf8("LMAO");

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculatorTest.java
@@ -101,7 +101,9 @@ class EndOfStakingPeriodCalculatorTest {
 
         verify(merkleNetworkContext, never()).setTotalStakedRewardStart(anyLong());
         verify(merkleNetworkContext, never()).setTotalStakedStart(anyLong());
-        verify(syntheticTxnFactory, never()).nodeStakeUpdate(any(), anyList(), any(), anyLong(), anyLong());
+        verify(syntheticTxnFactory, never())
+                .nodeStakeUpdate(
+                        any(), anyList(), any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswerTest.java
@@ -64,7 +64,7 @@ class GetTokenNftInfoAnswerTest {
     private final String node = "0.0.3";
     private final String payer = "0.0.12345";
     private NftID nftId =
-            NftID.newBuilder().setTokenId(asToken("1.2.3")).setSerialNumber(2).build();
+            NftID.newBuilder().setTokenID(asToken("1.2.3")).setSerialNumber(2).build();
     private final long fee = 1_234L;
     private final AccountID owner = asAccount("3.4.5");
     private final AccountID spender = asAccount("5.6.7");
@@ -146,7 +146,7 @@ class GetTokenNftInfoAnswerTest {
     @Test
     void validatesWrongSerialNumber() throws Throwable {
         // setup:
-        nftId = NftID.newBuilder().setTokenId(nftId.getTokenId()).build();
+        nftId = NftID.newBuilder().setTokenID(nftId.getTokenID()).build();
         final Query query = validQuery(COST_ANSWER, fee, nftId);
 
         // when:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccessTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccessTest.java
@@ -243,7 +243,7 @@ class StaticEntityAccessTest {
     @Test
     void infoForNftToken() {
         final var nftId = NftID.newBuilder()
-                .setTokenId(nft.tokenId())
+                .setTokenID(nft.tokenId())
                 .setSerialNumber(nft.serialNo())
                 .build();
         given(nfts.get(EntityNumPair.fromNftId(nft))).willReturn(treasuryOwned);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgersTest.java
@@ -481,7 +481,7 @@ class WorldLedgersTest {
     void staticNftTokenInfoWorks() {
         worldLedgers = WorldLedgers.staticLedgersWith(aliases, staticEntityAccess);
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
 
         given(staticEntityAccess.infoForNft(nftId)).willReturn(Optional.of(tokenNftInfo));
 
@@ -507,7 +507,7 @@ class WorldLedgersTest {
         worldLedgers = WorldLedgers.staticLedgersWith(aliases, staticEntityAccess);
         tokenAccessor();
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
         final var nftAddr = asTypedEvmAddress(nftTokenId);
 
         given(staticEntityAccess.infoForNft(nftId)).willReturn(Optional.of(tokenNftInfo));
@@ -531,7 +531,7 @@ class WorldLedgersTest {
     void staticEvmNftTokenInfoEmpty() {
         worldLedgers = WorldLedgers.staticLedgersWith(aliases, staticEntityAccess);
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
         given(staticEntityAccess.infoForNft(nftId)).willReturn(Optional.empty());
         final var tokenNftInfo = worldLedgers.evmNftInfo(nftId, ledgerId);
 
@@ -541,7 +541,7 @@ class WorldLedgersTest {
     @Test
     void nonStaticNftTokenInfoWorks() {
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
         final var targetKey = NftId.withDefaultShardRealm(nftTokenId.getTokenNum(), 1L);
         given(nftsLedger.contains(targetKey)).willReturn(true);
         given(nftsLedger.getImmutableRef(targetKey)).willReturn(targetNft);
@@ -559,7 +559,7 @@ class WorldLedgersTest {
     @Test
     void nonStaticNftTokenInfoWorksForMissingSerialNumber() {
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
         final var targetKey = NftId.withDefaultShardRealm(nftTokenId.getTokenNum(), 1L);
         given(nftsLedger.contains(targetKey)).willReturn(false);
 
@@ -571,7 +571,7 @@ class WorldLedgersTest {
     @Test
     void nonStaticNftTokenInfoWorksForWildCardOwner() {
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
         final var targetKey = NftId.withDefaultShardRealm(nftTokenId.getTokenNum(), 1L);
         targetNft.setOwner(MISSING_ENTITY_ID);
         given(nftsLedger.contains(targetKey)).willReturn(true);
@@ -591,7 +591,7 @@ class WorldLedgersTest {
     @Test
     void nonStaticNftTokenInfoWorksForWildCardOwnerWithMissingToken() {
         final var nftId =
-                NftID.newBuilder().setTokenId(nftTokenId).setSerialNumber(1L).build();
+                NftID.newBuilder().setTokenID(nftTokenId).setSerialNumber(1L).build();
         final var targetKey = NftId.withDefaultShardRealm(nftTokenId.getTokenNum(), 1L);
         targetNft.setOwner(MISSING_ENTITY_ID);
         given(nftsLedger.contains(targetKey)).willReturn(true);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenInfoPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenInfoPrecompilesTest.java
@@ -246,7 +246,7 @@ class GetTokenInfoPrecompilesTest {
 
     // Info objects
     private final NftID nftID = NftID.newBuilder()
-            .setTokenId(tokenMerkleId)
+            .setTokenID(tokenMerkleId)
             .setSerialNumber(serialNumber)
             .build();
     private TokenInfo.Builder tokenInfo;
@@ -300,7 +300,7 @@ class GetTokenInfoPrecompilesTest {
         nonFungibleTokenInfo = TokenNftInfo.newBuilder()
                 .setLedgerId(fromString("0x03"))
                 .setNftID(NftID.newBuilder()
-                        .setTokenId(tokenMerkleId)
+                        .setTokenID(tokenMerkleId)
                         .setSerialNumber(serialNumber)
                         .build())
                 .setAccountID(payer)
@@ -510,7 +510,7 @@ class GetTokenInfoPrecompilesTest {
         given(wrappedLedgers.evmNftInfo(
                         NftID.newBuilder()
                                 .setSerialNumber(serialNumber)
-                                .setTokenId(tokenMerkleId)
+                                .setTokenID(tokenMerkleId)
                                 .build(),
                         networkInfo.ledgerId()))
                 .willReturn(Optional.of(evmNftInfo));
@@ -664,7 +664,7 @@ class GetTokenInfoPrecompilesTest {
                 .willReturn(Optional.of(evmTokenInfo));
         given(wrappedLedgers.evmNftInfo(
                         NftID.newBuilder()
-                                .setTokenId(tokenMerkleId)
+                                .setTokenID(tokenMerkleId)
                                 .setSerialNumber(serialNumber)
                                 .build(),
                         networkInfo.ledgerId()))
@@ -712,7 +712,7 @@ class GetTokenInfoPrecompilesTest {
                 .willReturn(Optional.of(evmTokenInfo));
         given(wrappedLedgers.evmNftInfo(
                         NftID.newBuilder()
-                                .setTokenId(tokenMerkleId)
+                                .setTokenID(tokenMerkleId)
                                 .setSerialNumber(serialNumber)
                                 .build(),
                         networkInfo.ledgerId()))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutorTest.java
@@ -340,7 +340,7 @@ class ViewExecutorTest {
                     .willReturn(Optional.of(evmTokenInfo));
             given(ledgers.evmNftInfo(
                             NftID.newBuilder()
-                                    .setTokenId(nonfungibletoken)
+                                    .setTokenID(nonfungibletoken)
                                     .setSerialNumber(1L)
                                     .build(),
                             networkInfo.ledgerId()))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityIdUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityIdUtilsTest.java
@@ -319,7 +319,7 @@ class EntityIdUtilsTest {
     @Test
     void prettyPrintsNftIds() {
         final var tokenID = TokenID.newBuilder().setShardNum(1).setRealmNum(2).setTokenNum(3);
-        final var id = NftID.newBuilder().setTokenId(tokenID).setSerialNumber(1).build();
+        final var id = NftID.newBuilder().setTokenID(tokenID).setSerialNumber(1).build();
 
         assertEquals("1.2.3.1", EntityIdUtils.readableId(id));
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityNumPairTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityNumPairTest.java
@@ -84,13 +84,13 @@ class EntityNumPairTest {
     @Test
     void grpcNftIdFactoryWorks() {
         final var notOkId = NftID.newBuilder()
-                .setTokenId(
+                .setTokenID(
                         TokenID.newBuilder().setShardNum(1).setTokenNum(1234).build())
                 .setSerialNumber(1)
                 .build();
         assertSame(MISSING_NUM_PAIR, EntityNumPair.fromGrpcNftId(notOkId));
         final var okId = NftID.newBuilder()
-                .setTokenId(TokenID.newBuilder().setTokenNum(1234).build())
+                .setTokenID(TokenID.newBuilder().setTokenNum(1234).build())
                 .setSerialNumber(1)
                 .build();
         assertEquals(EntityNumPair.fromLongs(1234L, 1L), EntityNumPair.fromGrpcNftId(okId));

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
@@ -594,18 +594,18 @@ public interface TxnHandlingScenario {
     AccountID TOKEN_RECEIVER = asAccount(TOKEN_RECEIVER_ID);
 
     NftID KNOWN_TOKEN_NFT = NftID.newBuilder()
-            .setTokenId(KNOWN_TOKEN_WITH_WIPE)
+            .setTokenID(KNOWN_TOKEN_WITH_WIPE)
             .setSerialNumber(1L)
             .build();
     NftID ROYALTY_TOKEN_NFT = NftID.newBuilder()
-            .setTokenId(KNOWN_TOKEN_WITH_ROYALTY_FEE_AND_FALLBACK)
+            .setTokenID(KNOWN_TOKEN_WITH_ROYALTY_FEE_AND_FALLBACK)
             .setSerialNumber(1L)
             .build();
 
     String UNKNOWN_TOKEN_ID = "0.0.666";
     TokenID MISSING_TOKEN = asToken(UNKNOWN_TOKEN_ID);
     NftID MISSING_TOKEN_NFT =
-            NftID.newBuilder().setTokenId(MISSING_TOKEN).setSerialNumber(1L).build();
+            NftID.newBuilder().setTokenID(MISSING_TOKEN).setSerialNumber(1L).build();
 
     KeyTree FIRST_TOKEN_SENDER_KT = withRoot(ed25519());
     KeyTree SECOND_TOKEN_SENDER_KT = withRoot(ed25519());

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoTransferFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoTransferFactory.java
@@ -153,9 +153,9 @@ public class CryptoTransferFactory extends SignedTxnFactory<CryptoTransferFactor
                                 .build()));
                 ownershipChanges.entrySet().stream()
                         .sorted(comparingLong(
-                                entry -> entry.getKey().getTokenId().getTokenNum()))
+                                entry -> entry.getKey().getTokenID().getTokenNum()))
                         .forEach(entry -> xfers.addTokenTransfers(TokenTransferList.newBuilder()
-                                .setToken(entry.getKey().getTokenId())
+                                .setToken(entry.getKey().getTokenID())
                                 .addNftTransfers(entry.getValue())));
                 xfers.setTransfers(TransferList.newBuilder().addAllAccountAmounts(hbarAdjustments));
                 adjustmentsAreSet = true;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
@@ -222,9 +222,9 @@ class EndOfStakingPeriodUpdaterTest {
         Assertions.assertThat(resultStakingInfo1.unclaimedStakeRewardStart()).isZero();
         Assertions.assertThat(resultStakingInfo2.unclaimedStakeRewardStart()).isZero();
         Assertions.assertThat(resultStakingInfo3.unclaimedStakeRewardStart()).isZero();
-        Assertions.assertThat(resultStakingInfo1.rewardSumHistory()).isEqualTo(List.of(14L, 6L, 5L));
-        Assertions.assertThat(resultStakingInfo2.rewardSumHistory()).isEqualTo(List.of(11L, 1L, 1L));
-        Assertions.assertThat(resultStakingInfo3.rewardSumHistory()).isEqualTo(List.of(3L, 3L, 1L));
+        Assertions.assertThat(resultStakingInfo1.rewardSumHistory()).isEqualTo(List.of(86L, 6L, 5L));
+        Assertions.assertThat(resultStakingInfo2.rewardSumHistory()).isEqualTo(List.of(101L, 1L, 1L));
+        Assertions.assertThat(resultStakingInfo3.rewardSumHistory()).isEqualTo(List.of(11L, 3L, 1L));
         Assertions.assertThat(resultStakingInfo1.weight()).isEqualTo(307);
         Assertions.assertThat(resultStakingInfo2.weight()).isEqualTo(192);
         Assertions.assertThat(resultStakingInfo3.weight()).isZero();

--- a/hedera-node/settings.gradle.kts
+++ b/hedera-node/settings.gradle.kts
@@ -82,7 +82,7 @@ fun include(name: String, path: String) {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.43.0-rc-SNAPSHOT"
-val hapiProtoCommit = "adf878895af821f17acf93ebc503d80cd5b09f9a";
+val hapiProtoCommit = "adf878895af821f17acf93ebc503d80cd5b09f9a"
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hapi"))

--- a/hedera-node/settings.gradle.kts
+++ b/hedera-node/settings.gradle.kts
@@ -82,7 +82,7 @@ fun include(name: String, path: String) {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.43.0-rc-SNAPSHOT"
-val hapiProtoBranchOrTag = "revert-nft-token-id-case" // hapiProtoVersion
+val hapiProtoCommit = "adf878895af821f17acf93ebc503d80cd5b09f9a";
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hapi"))
@@ -91,7 +91,7 @@ gitRepositories {
     include("hedera-protobufs") {
         uri.set("https://github.com/hashgraph/hedera-protobufs.git")
         // HAPI repo version
-        tag.set(hapiProtoBranchOrTag)
+        commit.set(hapiProtoCommit)
         // do not load project from repo
         autoInclude.set(false)
     }

--- a/hedera-node/settings.gradle.kts
+++ b/hedera-node/settings.gradle.kts
@@ -81,8 +81,8 @@ fun include(name: String, path: String) {
 
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
-val hapiProtoVersion = "0.40.0-blocks-state-SNAPSHOT"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state" // hapiProtoVersion
+val hapiProtoVersion = "0.43.0-rc-SNAPSHOT"
+val hapiProtoBranchOrTag = "revert-nft-token-id-case" // hapiProtoVersion
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hapi"))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetAccountNftInfos.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetAccountNftInfos.java
@@ -73,7 +73,7 @@ public class HapiGetAccountNftInfos extends HapiQueryOp<HapiGetAccountNftInfos> 
                 var expectedNftId = NftID.newBuilder();
 
                 nftInfo.getExpectedTokenID().ifPresent(e -> {
-                    expectedNftId.setTokenId(TxnUtils.asTokenId(e, spec));
+                    expectedNftId.setTokenID(TxnUtils.asTokenId(e, spec));
                     expectedNftElement.setCreationTime(spec.registry().getCreationTime(e));
                 });
                 nftInfo.getExpectedSerialNum().ifPresent(expectedNftId::setSerialNumber);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfo.java
@@ -136,7 +136,7 @@ public class HapiGetTokenNftInfo extends HapiQueryOp<HapiGetTokenNftInfo> {
         var registry = spec.registry();
 
         assertFor(
-                actualInfo.getNftID().getTokenId(),
+                actualInfo.getNftID().getTokenID(),
                 expectedTokenID,
                 (n, r) -> r.getTokenID(n),
                 "Wrong token id!",
@@ -181,7 +181,7 @@ public class HapiGetTokenNftInfo extends HapiQueryOp<HapiGetTokenNftInfo> {
         TokenGetNftInfoQuery getTokenNftQuery = TokenGetNftInfoQuery.newBuilder()
                 .setHeader(costOnly ? answerCostHeader(payment) : answerHeader(payment))
                 .setNftID(NftID.newBuilder()
-                        .setTokenId(id)
+                        .setTokenID(id)
                         .setSerialNumber(serialNum)
                         .build())
                 .build();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfos.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfos.java
@@ -70,7 +70,7 @@ public class HapiGetTokenNftInfos extends HapiQueryOp<HapiGetTokenNftInfos> {
                 var expectedNftElement = TokenNftInfo.newBuilder();
 
                 nftInfo.getExpectedTokenID().ifPresent(e -> {
-                    expectedNftId.setTokenId(TxnUtils.asTokenId(e, spec));
+                    expectedNftId.setTokenID(TxnUtils.asTokenId(e, spec));
                     expectedNftElement.setCreationTime(spec.registry().getCreationTime(e));
                 });
                 nftInfo.getExpectedSerialNum().ifPresent(expectedNftId::setSerialNumber);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
@@ -766,7 +766,7 @@ public class TokenInfoHTSSuite extends HapiSuite {
         return TokenNftInfo.newBuilder()
                 .setLedgerId(fromString("0x03"))
                 .setNftID(NftID.newBuilder()
-                        .setTokenId(tokenId)
+                        .setTokenID(tokenId)
                         .setSerialNumber(1L)
                         .build())
                 .setAccountID(ownerId)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSV1SecurityModelSuite.java
@@ -623,7 +623,7 @@ public class TokenInfoHTSV1SecurityModelSuite extends HapiSuite {
         return TokenNftInfo.newBuilder()
                 .setLedgerId(fromString("0x03"))
                 .setNftID(NftID.newBuilder()
-                        .setTokenId(tokenId)
+                        .setTokenID(tokenId)
                         .setSerialNumber(1L)
                         .build())
                 .setAccountID(ownerId)


### PR DESCRIPTION
**Description**:
 - Reverts unintentional change of `NftID#tokenID` case to `tokenId`.
 - Updates `File` constructor usages for the [new `preSystemDeleteExpirationSecond` field](https://github.com/hashgraph/hedera-protobufs/blob/revert-nft-token-id-case/services/state/file/file.proto#L62).
 - Closes #8535
 - Closes #8549 
