### PR TITLE
Make an Executor available to freeze handler via Dagger injection

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -476,6 +476,7 @@ public final class Hedera implements SwirldMain {
             // com.hedera.node.app.service.mono.state.logic.StateWriteToDiskListener
             // which looks like it is related to freeze / upgrade.
             // daggerApp.stateWriteToDiskListener());
+            // see issue #8660
 
             // TBD: notifications.register(NewSignedStateListener.class, daggerApp.newSignedStateListener());
             // com.hedera.node.app.service.mono.state.exports.NewSignedStateListener

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandlersInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandlersInjectionModule.java
@@ -29,7 +29,10 @@ import com.hedera.node.app.workflows.dispatcher.TransactionHandlers;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 @Module
@@ -38,6 +41,13 @@ public interface HandlersInjectionModule {
     @Singleton
     static Supplier<ContractHandlers> provideContractHandlers() {
         return CONTRACT_SERVICE::handlers;
+    }
+
+    @Provides
+    @Named("FreezeService")
+    static Executor provideFreezeServiceExecutor() {
+        return new ForkJoinPool(
+                1, ForkJoinPool.defaultForkJoinWorkerThreadFactory, Thread.getDefaultUncaughtExceptionHandler(), true);
     }
 
     @Provides

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
@@ -26,10 +26,6 @@ import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransaction
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkUncheckedSubmitHandler;
 import dagger.Module;
-import dagger.Provides;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
-import javax.inject.Named;
 
 /**
  * Dagger module of the networkadmin service
@@ -38,13 +34,6 @@ import javax.inject.Named;
 public interface NetworkAdminServiceInjectionModule {
 
     FreezeHandler freezeHandler();
-
-    @Provides
-    @Named("FreezeService")
-    static Executor freezeServiceExecutor() {
-        return new ForkJoinPool(
-                1, ForkJoinPool.defaultForkJoinWorkerThreadFactory, Thread.getDefaultUncaughtExceptionHandler(), true);
-    }
 
     NetworkGetAccountDetailsHandler networkGetAccountDetailsHandler();
 

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
@@ -26,6 +26,10 @@ import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransaction
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkUncheckedSubmitHandler;
 import dagger.Module;
+import dagger.Provides;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import javax.inject.Named;
 
 /**
  * Dagger module of the networkadmin service
@@ -34,6 +38,13 @@ import dagger.Module;
 public interface NetworkAdminServiceInjectionModule {
 
     FreezeHandler freezeHandler();
+
+    @Provides
+    @Named("FreezeService")
+    static Executor freezeServiceExecutor() {
+        return new ForkJoinPool(
+                1, ForkJoinPool.defaultForkJoinWorkerThreadFactory, Thread.getDefaultUncaughtExceptionHandler(), true);
+    }
 
     NetworkGetAccountDetailsHandler networkGetAccountDetailsHandler();
 

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
@@ -45,7 +45,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -57,9 +59,11 @@ public class FreezeHandler implements TransactionHandler {
     // used for a quick sanity check that the file hash is not invalid
     public static final int UPDATE_FILE_HASH_LEN = 48;
 
+    private final Executor freezeExecutor;
+
     @Inject
-    public FreezeHandler() {
-        // Dagger2
+    public FreezeHandler(@NonNull @Named("FreezeService") final Executor freezeExecutor) {
+        this.freezeExecutor = requireNonNull(freezeExecutor);
     }
 
     /**
@@ -129,10 +133,10 @@ public class FreezeHandler implements TransactionHandler {
 
         validateSemantics(freezeTxn, freezeStore, upgradeFileStore);
 
-        final FreezeUpgradeActions upgradeActions = new FreezeUpgradeActions(adminServiceConfig, freezeStore);
+        final FreezeUpgradeActions upgradeActions =
+                new FreezeUpgradeActions(adminServiceConfig, freezeStore, freezeExecutor);
         final Timestamp freezeStartTime = freezeTxn.startTime(); // may be null for some freeze types
 
-        // @todo('Issue #6761') - the below switch returns a CompletableFuture, need to use this with an ExecutorService
         switch (freezeTxn.freezeType()) {
             case PREPARE_UPGRADE -> {
                 // by the time we get here, we've already checked that fileHash is non-null in preHandle()
@@ -147,7 +151,6 @@ public class FreezeHandler implements TransactionHandler {
             case FREEZE_ABORT -> {
                 upgradeActions.abortScheduledFreeze();
                 freezeStore.updateFileHash(null);
-                // todo: need to null out the update file num as well
             }
             case TELEMETRY_UPGRADE -> {
                 try {

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeUpgradeActions.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeUpgradeActions.java
@@ -32,9 +32,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
-import javax.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -56,22 +56,24 @@ public class FreezeUpgradeActions {
     private final NetworkAdminConfig adminServiceConfig;
     private final WritableFreezeStore freezeStore;
 
-    @Inject
+    private final Executor executor;
+
     public FreezeUpgradeActions(
-            @NonNull final NetworkAdminConfig adminServiceConfig, @NonNull final WritableFreezeStore freezeStore) {
+            @NonNull final NetworkAdminConfig adminServiceConfig,
+            @NonNull final WritableFreezeStore freezeStore,
+            @NonNull final Executor executor) {
         requireNonNull(adminServiceConfig);
         requireNonNull(freezeStore);
+        requireNonNull(executor);
 
         this.adminServiceConfig = adminServiceConfig;
         this.freezeStore = freezeStore;
+        this.executor = executor;
     }
 
     public void externalizeFreezeIfUpgradePending() {
-        // @todo('Issue #6201'): call networkCtx.hasPreparedUpgrade()
-        // final var isUpgradePrepared = networkCtx.hasPreparedUpgrade()
-        final boolean isUpgradePrepared = true;
-
-        if (isUpgradePrepared) {
+        // @todo('Issue #8660') this code is not currently triggered anywhere
+        if (freezeStore.updateFileHash() != null) {
             writeCheckMarker(NOW_FROZEN_MARKER);
         }
     }
@@ -87,26 +89,23 @@ public class FreezeUpgradeActions {
         return extractNow(archiveData, PREPARE_UPGRADE_DESC, EXEC_IMMEDIATE_MARKER, null);
     }
 
-    public CompletableFuture<Void> scheduleFreezeOnlyAt(@NonNull final Timestamp freezeTime) {
+    public void scheduleFreezeOnlyAt(@NonNull final Timestamp freezeTime) {
         requireNonNull(freezeTime);
         requireNonNull(freezeStore, "Cannot schedule freeze without access to the dual state");
         freezeStore.freezeTime(freezeTime);
-        return CompletableFuture.completedFuture(null); // return a future which completes immediately
     }
 
-    public CompletableFuture<Void> scheduleFreezeUpgradeAt(@NonNull final Timestamp freezeTime) {
+    public void scheduleFreezeUpgradeAt(@NonNull final Timestamp freezeTime) {
         requireNonNull(freezeTime);
         requireNonNull(freezeStore, "Cannot schedule freeze without access to the dual state");
         freezeStore.freezeTime(freezeTime);
         writeSecondMarker(FREEZE_SCHEDULED_MARKER, freezeTime);
-        return CompletableFuture.completedFuture(null); // return a future which completes immediately
     }
 
-    public CompletableFuture<Void> abortScheduledFreeze() {
+    public void abortScheduledFreeze() {
         requireNonNull(freezeStore, "Cannot abort freeze without access to the dual state");
         freezeStore.freezeTime(null);
         writeCheckMarker(FREEZE_ABORTED_MARKER);
-        return CompletableFuture.completedFuture(null); // return a future which completes immediately
     }
 
     public boolean isFreezeScheduled() {
@@ -134,7 +133,7 @@ public class FreezeUpgradeActions {
         log.info("About to unzip {} bytes for {} update into {}", size, desc, artifactsLoc);
         // we spin off a separate thread to avoid blocking handleTransaction
         // if we block handle, there could be a dramatic spike in E2E latency at the time of PREPARE_UPGRADE
-        return runAsync(() -> extractAndReplaceArtifacts(artifactsLoc, archiveData, size, desc, marker, now));
+        return runAsync(() -> extractAndReplaceArtifacts(artifactsLoc, archiveData, size, desc, marker, now), executor);
     }
 
     private void extractAndReplaceArtifacts(

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
@@ -54,6 +54,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import java.io.IOException;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,7 +86,8 @@ class FreezeHandlerTest {
             .build();
     private final AccountID nonAdminAccount =
             AccountID.newBuilder().accountNum(9999L).build();
-    private final FreezeHandler subject = new FreezeHandler();
+    private final FreezeHandler subject = new FreezeHandler(new ForkJoinPool(
+            1, ForkJoinPool.defaultForkJoinWorkerThreadFactory, Thread.getDefaultUncaughtExceptionHandler(), true));
 
     @BeforeEach
     void setUp() {

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradeActionsTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradeActionsTest.java
@@ -42,6 +42,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,7 +84,9 @@ class FreezeUpgradeActionsTest {
         noiseFileLoc = zipOutputDir.toPath().resolve("forgotten.cfg");
         noiseSubFileLoc = zipOutputDir.toPath().resolve("edargpu");
 
-        subject = new FreezeUpgradeActions(adminServiceConfig, freezeStore);
+        final Executor freezeExectuor = new ForkJoinPool(
+                1, ForkJoinPool.defaultForkJoinWorkerThreadFactory, Thread.getDefaultUncaughtExceptionHandler(), true);
+        subject = new FreezeUpgradeActions(adminServiceConfig, freezeStore, freezeExectuor);
 
         // set up test zip
         zipSourceDir = Files.createTempDirectory("zipSourceDir");
@@ -145,6 +149,7 @@ class FreezeUpgradeActionsTest {
         rmIfPresent(NOW_FROZEN_MARKER);
 
         given(adminServiceConfig.upgradeArtifactsPath()).willReturn(zipOutputDir.toString());
+        given(freezeStore.updateFileHash()).willReturn(Bytes.wrap("fake hash"));
 
         subject.externalizeFreezeIfUpgradePending();
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
@@ -46,6 +47,7 @@ public class CryptoTransferThenFreezeTest extends CryptoTransferLoadTest {
         return List.of(runCryptoTransfers(), freezeAfterTransfers());
     }
 
+    @HapiTest
     private HapiSpec freezeAfterTransfers() {
         PerfTestLoadSettings settings = new PerfTestLoadSettings();
         return defaultHapiSpec("FreezeAfterTransfers")


### PR DESCRIPTION
- Make an Executor available to freeze handler via Dagger injection
- Use Executor to launch long-running code which unzips the upgrade file
- Other misc cleanup of freeze service

**Related issue(s)**:

Fixes #6761
