### PR TITLE
Reduce number of ops

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
@@ -112,7 +112,7 @@ public class AutoRenewEntitiesForReconnect extends HapiSuite {
                         // do some transfers to save a state before reconnect
                         withOpContext((spec, ctxLog) -> {
                             List<HapiSpecOperation> opsList = new ArrayList<HapiSpecOperation>();
-                            for (int i = 0; i < 500; i++) {
+                            for (int i = 0; i < 125; i++) {
                                 opsList.add(cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, 1L)));
                             }
                             CustomSpecAssert.allRunFor(spec, opsList);


### PR DESCRIPTION
**Description**:

Before adding network latency to nightly regression, it takes about 8 minutes to finihs
transactions, ( TPS about 1.3) . After adding network latency, TPS dropped to about 0.3.

So client could not finish transaction within expected time interval.


Reduce number of transactions, so transactions can be finished in about 7~8 minutes. (about 0.3 TPS)



