### PR TITLE
Disable CryptoTransferThenFreezeTest

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
@@ -21,8 +21,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
-import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.perf.PerfTestLoadSettings;
@@ -31,7 +29,6 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@HapiTestSuite
 public class CryptoTransferThenFreezeTest extends CryptoTransferLoadTest {
     private static final Logger log = LogManager.getLogger(CryptoTransferThenFreezeTest.class);
 
@@ -47,7 +44,6 @@ public class CryptoTransferThenFreezeTest extends CryptoTransferLoadTest {
         return List.of(runCryptoTransfers(), freezeAfterTransfers());
     }
 
-    @HapiTest
     private HapiSpec freezeAfterTransfers() {
         PerfTestLoadSettings settings = new PerfTestLoadSettings();
         return defaultHapiSpec("FreezeAfterTransfers")


### PR DESCRIPTION
This PR disables `CryptoTransferThenFreezeTest`, because it causes many other tests to fail. It probably needs to be executed manually for now.
