### PR TITLE
Update 'any stat' dashboard to also show merkledb stats

### DIFF
--- a/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/arbitrary-stat-prom.json
+++ b/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/arbitrary-stat-prom.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 38,
+  "id": 62,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -43,6 +43,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisShow": false,
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -52,6 +53,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -121,16 +123,18 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": [],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": [
+    "Platform"
+  ],
   "templating": {
     "list": [
       {
         "current": {
           "selected": false,
           "text": "grafanacloud-swirldslabspreproduction-prom",
-          "value": "grafanacloud-swirldslabspreproduction-prom"
+          "value": "grafanacloud-prom"
         },
         "hide": 0,
         "includeAll": false,
@@ -193,7 +197,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/^(Reconnect.*|app.*|internal.*|virtual.*|internal.*|platform.*)/",
+        "regex": "/^(Reconnect.*|app.*|internal.*|virtual.*|platform.*|merkle.*)/",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
@@ -252,6 +256,6 @@
   "timezone": "",
   "title": "Any Stat (Prometheus)",
   "uid": "any-stat-prom",
-  "version": 6,
+  "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR updates the "any stat" dashboard to also show all stats which have names that match the `merkle.*` pattern.