### PR TITLE
Resolve `TokenTotalSupplyAfterMintBurnWipeSuite` errors

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -183,7 +183,8 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
 
         // Change the supply on token
         changeSupply(token, treasuryRel, metadataCount, FAIL_INVALID, accountStore, tokenStore, tokenRelStore);
-
+        // The token is modified in previous step, so we need to get the modified token
+        final var modifiedToken = tokenStore.get(token.tokenId());
         final var mintedSerials = new ArrayList<Long>(metadata.size());
 
         // for each serial number minted increment serial numbers and create new unique token
@@ -198,11 +199,10 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
         }
         // Update last used serial number and number of owned nfts and put the updated token and treasury
         // into the store
-        final var copyToken = token.copyBuilder();
+        final var copyToken = modifiedToken.copyBuilder();
         final var copyTreasury = treasuryAccount.copyBuilder();
         // Update Token and treasury
         copyToken.lastUsedSerialNumber(currentSerialNumber);
-        copyToken.totalSupply(token.totalSupply() + metadataCount);
         copyTreasury.numberOwnedNfts(treasuryAccount.numberOwnedNfts() + metadataCount);
 
         tokenStore.put(copyToken.build());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -202,6 +202,7 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
         final var copyTreasury = treasuryAccount.copyBuilder();
         // Update Token and treasury
         copyToken.lastUsedSerialNumber(currentSerialNumber);
+        copyToken.totalSupply(token.totalSupply() + metadataCount);
         copyTreasury.numberOwnedNfts(treasuryAccount.numberOwnedNfts() + metadataCount);
 
         tokenStore.put(copyToken.build());

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
@@ -134,8 +134,8 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
 
         // number of owned NFTs should increase
         assertThat(writableAccountStore.get(treasuryId).numberOwnedNfts()).isEqualTo(4);
-        // treasury relation supply will not increase since its not fungible token change
-        assertThat(writableTokenStore.get(nonFungibleTokenId).totalSupply()).isEqualTo(1000L);
+        // token total supply should be increased
+        assertThat(writableTokenStore.get(nonFungibleTokenId).totalSupply()).isEqualTo(1002L);
         assertThat(recordBuilder.build().transactionRecord().receipt().serialNumbers())
                 .isEqualTo(List.of(3L, 4L));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
@@ -360,6 +360,7 @@ public class Hip17UnhappyTokensSuite extends HapiSuite {
                         .hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
+    @HapiTest
     private HapiSpec cannotBurnNftWhenDeleted() {
         return defaultHapiSpec("cannotBurnNftWhenDeleted")
                 .given(
@@ -390,6 +391,7 @@ public class Hip17UnhappyTokensSuite extends HapiSuite {
                 .then(burnToken(NFTdeleted, List.of(2L)).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
+    @HapiTest
     private HapiSpec cannotWipeNftWhenDeleted() {
         return defaultHapiSpec("cannotWipeNftWhenDeleted")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
@@ -31,6 +31,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccoun
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -55,6 +56,7 @@ public class TokenTotalSupplyAfterMintBurnWipeSuite extends HapiSuite {
         return List.of(new HapiSpec[] {checkTokenTotalSupplyAfterMintAndBurn(), totalSupplyAfterWipe()});
     }
 
+    @HapiTest
     public HapiSpec checkTokenTotalSupplyAfterMintAndBurn() {
         String tokenName = "tokenToTest";
         return defaultHapiSpec("checkTokenTotalSupplyAfterMintAndBurn")
@@ -83,6 +85,7 @@ public class TokenTotalSupplyAfterMintBurnWipeSuite extends HapiSuite {
                                 .hasTotalSupply(1800));
     }
 
+    @HapiTest
     public HapiSpec totalSupplyAfterWipe() {
         var tokenToWipe = "tokenToWipe";
 


### PR DESCRIPTION
**Description**:
This PR enables all tests in the `TokenTotalSupplyAfterMintBurnWipeSuite` spec as they are passing now.
Also fixes the remaining broken tests in the `Hip17UnhappyTokensSuite` by fixing the total supply for NFT minting.

**Related issue(s)**:

Fixes #8601 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
