### PR TITLE
Fix tests from ContractCreateSuite

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -208,7 +208,8 @@ public class HandleHederaOperations implements HederaOperations {
         dispatchAndMarkCreation(
                 number,
                 synthAccountCreationFromHapi(
-                        ContractID.newBuilder().contractNum(number).build(), evmAddress, impliedContractCreation));
+                        ContractID.newBuilder().contractNum(number).build(), evmAddress, impliedContractCreation),
+                null);
     }
 
     /**
@@ -221,7 +222,8 @@ public class HandleHederaOperations implements HederaOperations {
         dispatchAndMarkCreation(
                 number,
                 synthAccountCreationFromHapi(
-                        ContractID.newBuilder().contractNum(number).build(), evmAddress, body));
+                        ContractID.newBuilder().contractNum(number).build(), evmAddress, body),
+                body.autoRenewAccountId());
     }
 
     /**
@@ -289,7 +291,10 @@ public class HandleHederaOperations implements HederaOperations {
         return 0;
     }
 
-    private void dispatchAndMarkCreation(final long number, @NonNull final CryptoCreateTransactionBody body) {
+    private void dispatchAndMarkCreation(
+            final long number,
+            @NonNull final CryptoCreateTransactionBody body,
+            @Nullable final AccountID autoRenewAccountId) {
         final var recordBuilder = context.dispatchChildTransaction(
                 TransactionBody.newBuilder().cryptoCreateAccount(body).build(),
                 CryptoCreateRecordBuilder.class,
@@ -302,6 +307,7 @@ public class HandleHederaOperations implements HederaOperations {
         // Then use the TokenService API to mark the created account as a contract
         final var tokenServiceApi = context.serviceApi(TokenServiceApi.class);
         final var accountId = AccountID.newBuilder().accountNum(number).build();
-        tokenServiceApi.markAsContract(accountId);
+
+        tokenServiceApi.markAsContract(accountId, autoRenewAccountId);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -55,6 +55,10 @@ public class ContractCallHandler implements TransactionHandler {
                 .contractCallResult(outcome.result())
                 .contractID(outcome.recipientIdIfCalled())
                 .status(outcome.status());
+
+        if (!outcome.isSuccess()) {
+            throw new HandleException(outcome.status());
+        }
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
@@ -60,6 +60,10 @@ public class ContractCreateHandler implements TransactionHandler {
                 .contractCreateResult(outcome.result())
                 .contractID(outcome.recipientIdIfCreated())
                 .status(outcome.status());
+
+        if (!outcome.isSuccess()) {
+            throw new HandleException(outcome.status());
+        }
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -243,7 +243,7 @@ class HandleHederaOperationsTest {
                 .dispatchChildTransaction(
                         eq(synthTxn), eq(CryptoCreateRecordBuilder.class), any(Predicate.class), eq(A_NEW_ACCOUNT_ID));
         verify(tokenServiceApi)
-                .markAsContract(AccountID.newBuilder().accountNum(666L).build());
+                .markAsContract(AccountID.newBuilder().accountNum(666L).build(), null);
     }
 
     @Test
@@ -271,7 +271,7 @@ class HandleHederaOperationsTest {
                 .dispatchChildTransaction(
                         eq(synthTxn), eq(CryptoCreateRecordBuilder.class), any(Predicate.class), eq(A_NEW_ACCOUNT_ID));
         verify(tokenServiceApi)
-                .markAsContract(AccountID.newBuilder().accountNum(666L).build());
+                .markAsContract(AccountID.newBuilder().accountNum(666L).build(), NON_SYSTEM_ACCOUNT_ID);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -115,11 +115,12 @@ public class TokenServiceApiImpl implements TokenServiceApi {
      * {@inheritDoc}
      */
     @Override
-    public void markAsContract(@NonNull final AccountID accountId) {
+    public void markAsContract(@NonNull final AccountID accountId, @Nullable AccountID autoRenewAccountId) {
         requireNonNull(accountId);
         final var accountAsContract = requireNonNull(store.get(accountId))
                 .copyBuilder()
                 .smartContract(true)
+                .autoRenewAccountId(autoRenewAccountId)
                 .build();
         store.put(accountAsContract);
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiImplTest.java
@@ -188,7 +188,7 @@ class TokenServiceApiImplTest {
         accountStore.put(Account.newBuilder().accountId(CONTRACT_ACCOUNT_ID).build());
 
         assertNull(accountStore.getContractById(CONTRACT_ID_BY_NUM));
-        subject.markAsContract(CONTRACT_ACCOUNT_ID);
+        subject.markAsContract(CONTRACT_ACCOUNT_ID, null);
 
         assertEquals(1, accountStore.sizeOfAccountState());
         assertNotNull(accountStore.getContractById(CONTRACT_ID_BY_NUM));

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
@@ -61,7 +61,7 @@ public interface TokenServiceApi {
      * Marks an account as a contract.
      *
      */
-    void markAsContract(@NonNull AccountID accountId);
+    void markAsContract(@NonNull AccountID accountId, @Nullable AccountID autoRenewAccountId);
 
     /**
      * Finalizes a hollow account as a contract.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -208,6 +208,7 @@ public class ContractCreateSuite extends HapiSuite {
                         .hasPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
+    @HapiTest
     HapiSpec cannotSendToNonExistentAccount() {
         final var contract = "Multipurpose";
         Object[] donationArgs = new Object[] {666666L, "Hey, Ma!"};
@@ -374,6 +375,7 @@ public class ContractCreateSuite extends HapiSuite {
                 .then(contractCreate(contract).hasKnownStatus(ERROR_DECODING_BYTESTRING));
     }
 
+    @HapiTest
     private HapiSpec revertsNonzeroBalance() {
         return defaultHapiSpec("RevertsNonzeroBalance")
                 .given(uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT))
@@ -571,6 +573,7 @@ public class ContractCreateSuite extends HapiSuite {
                 }));
     }
 
+    @HapiTest
     HapiSpec contractWithAutoRenewNeedSignatures() {
         final var contract = "CreateTrivial";
         final var autoRenewAccount = "autoRenewAccount";


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Fixes for some of the `ContractCreateSuite` failing tests.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/8637

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

I did some debugging for the rest of the tests left to be fixed and here is some of the things I have found that can give a direction for their fixes:

- `rejectsInsufficientFee`: looks like it would need calculateFees() implementation for ContractCreateHandler
- `delegateContractIdRequiredForTransferInDelegateCall`: spent some time debugging it but it does not look like something straightforward to fix, seems to be failing due to the initial transfer to the beneficiary in the contract function for some reason
- `childCreationsHaveExpectedKeysWithOmittedAdminKey`: fails due to incorrect implementation for getCreatedContractIDs
- `vanillaSuccess`: failure seems to be caused by same reason as in `childCreationsHaveExpectedKeysWithOmittedAdminKey`
- `createContractWithStakingFields`: staking id logic from ContractCreateTransitionLogic.validate() should be implemented in mod codebase
- `blockTimestampChangesWithinFewSeconds`: seems like it's caused by contract call local being handled as transaction instead of query
- `cannotCreateTooLargeContract`: failing due to too large file and after that is fixed it will fail with FILE_CONTENT_EMPTY a couple of lines later in the test


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
