### PR TITLE
Fix genesis records creation order

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
@@ -33,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Singleton;
@@ -132,16 +133,18 @@ public class GenesisRecordsConsensusHook implements GenesisRecordsBuilder, Conse
             @NonNull final TokenContext context,
             @Nullable final String recordMemo,
             @Nullable final Long overrideAutoRenewPeriod) {
-        for (Map.Entry<Account, CryptoCreateTransactionBody.Builder> entry : map.entrySet()) {
+        final var orderedAccts = map.keySet().stream()
+                .sorted(Comparator.comparingLong(acct -> acct.accountId().accountNum()))
+                .toList();
+        for (final Account key : orderedAccts) {
             final var recordBuilder = context.addPrecedingChildRecordBuilder(GenesisAccountRecordBuilder.class);
-
-            final var accountId = requireNonNull(entry.getKey().accountId());
+            final var accountId = requireNonNull(key.accountId());
             recordBuilder.accountID(accountId);
             if (recordMemo != null) {
                 recordBuilder.memo(recordMemo);
             }
 
-            var txnBody = entry.getValue();
+            var txnBody = map.get(key);
             if (overrideAutoRenewPeriod != null) {
                 txnBody.autoRenewPeriod(Duration.newBuilder().seconds(overrideAutoRenewPeriod));
             }


### PR DESCRIPTION
The genesis account records were being created in different orders, causing an ISS. Ordering by account ID fixes the issue. 