### PR TITLE
8469: New VirtualMap metric: virtual node cache size, in Mb

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
@@ -53,6 +53,8 @@ public class VirtualMapStatistics {
     /** Virtual map entities - reads / s */
     private LongAccumulator readEntities;
 
+    /** Estimated virtual node cache size, Mb*/
+    private LongGauge nodeCacheSizeMb;
     /** Number of virtual root copies in the pipeline */
     private IntegerGauge pipelineSize;
     /** The number of virtual root node copies in virtual pipeline flush backlog */
@@ -133,6 +135,9 @@ public class VirtualMapStatistics {
                 "Read virtual map entities, " + label + ", per second");
 
         // Lifecycle
+        nodeCacheSizeMb = metrics.getOrCreate(
+                new LongGauge.Config(STAT_CATEGORY, VMAP_PREFIX + LIFECYCLE_PREFIX + "nodeCacheSizeMb_" + label)
+                        .withDescription("Virtual node cache size, " + label + ", Mb"));
         pipelineSize = metrics.getOrCreate(
                 new IntegerGauge.Config(STAT_CATEGORY, VMAP_PREFIX + LIFECYCLE_PREFIX + "pipelineSize_" + label)
                         .withDescription("Virtual pipeline size, " + label));
@@ -208,6 +213,17 @@ public class VirtualMapStatistics {
     public void countReadEntities() {
         if (readEntities != null) {
             readEntities.update(1);
+        }
+    }
+
+    /**
+     * Updates {@link #nodeCacheSizeMb} stat to the given value.
+     *
+     * @param value the value to set
+     */
+    public void setNodeCacheSize(final long value) {
+        if (this.nodeCacheSizeMb != null) {
+            this.nodeCacheSizeMb.set(value);
         }
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -1052,9 +1052,11 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
      */
     @Override
     public boolean shouldBeFlushed() {
+        // Check if this copy was explicitly marked to flush
         if (shouldBeFlushed.get()) {
             return true;
         }
+        // Otherwise check its size and compare against flush threshold
         final long threshold = flushThreshold.get();
         return (threshold > 0) && (estimatedSize() >= threshold);
     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -473,7 +473,6 @@ public class VirtualPipeline {
         for (PipelineListNode<VirtualRoot> node = copies.getFirst(); node != null; node = node.getNext()) {
             final VirtualRoot copy = node.getValue();
             if (!copy.isImmutable()) {
-                assert node.getNext() == null;
                 break;
             }
             final long estimatedSize = copy.estimatedSize();
@@ -562,8 +561,10 @@ public class VirtualPipeline {
                 logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merge {}", copy.getFastCopyVersion());
                 merge(next);
                 copies.remove(next);
-                statistics.setPipelineSize(copies.getSize());
             }
+            statistics.setPipelineSize(copies.getSize());
+            final long totalSize = currentTotalSize();
+            statistics.setNodeCacheSize(totalSize);
             next = next.getNext();
         }
     }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapStatisticsTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapStatisticsTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.virtualmap;
+
+import static com.swirlds.common.metrics.Metric.ValueType.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.swirlds.common.metrics.Metric;
+import com.swirlds.common.metrics.Metrics;
+import com.swirlds.common.metrics.config.MetricsConfig;
+import com.swirlds.common.metrics.platform.DefaultMetrics;
+import com.swirlds.common.metrics.platform.DefaultMetricsFactory;
+import com.swirlds.common.metrics.platform.MetricKeyRegistry;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.test.framework.config.TestConfigBuilder;
+import com.swirlds.virtualmap.internal.merkle.VirtualMapStatistics;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class VirtualMapStatisticsTest {
+
+    private static final String LABEL = "VMST";
+
+    private VirtualMapStatistics statistics;
+    private Metrics metrics;
+
+    private Metric getMetric(final String section, final String suffix) {
+        return getMetric(metrics, "vmap_" + section + suffix);
+    }
+
+    private Metric getMetric(final Metrics metrics, final String name) {
+        return metrics.getMetric(VirtualMapStatistics.STAT_CATEGORY, name);
+    }
+
+    private static void assertValueSet(final Metric metric) {
+        assertNotEquals(0.0, metric.get(VALUE));
+    }
+
+    private static <T> void assertValueEquals(final Metric metric, final T value) {
+        assertEquals(value, metric.get(VALUE));
+    }
+
+    @BeforeEach
+    void setupTest() {
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+        final MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
+
+        final MetricKeyRegistry registry = mock(MetricKeyRegistry.class);
+        when(registry.register(any(), any(), any())).thenReturn(true);
+        metrics = new DefaultMetrics(
+                null,
+                registry,
+                mock(ScheduledExecutorService.class),
+                new DefaultMetricsFactory(metricsConfig),
+                metricsConfig);
+        statistics = new VirtualMapStatistics(LABEL);
+        statistics.registerMetrics(metrics);
+    }
+
+    @Test
+    void testSetSize() {
+        // given
+        final Metric metric = getMetric(metrics, "vmap_size_" + LABEL);
+        // when
+        statistics.setSize(12345678L);
+        // then
+        assertValueEquals(metric, 12345678L);
+    }
+
+    @Test
+    void testCountAddedEntities() {
+        // given
+        final Metric metric = getMetric("queries_", "addedEntities_" + LABEL);
+        // when
+        statistics.countAddedEntities();
+        // then
+        assertValueSet(metric);
+    }
+
+    @Test
+    void testCountUpdatedEntities() {
+        // given
+        final Metric metric = getMetric("queries_", "updatedEntities_" + LABEL);
+        // when
+        statistics.countUpdatedEntities();
+        // then
+        assertValueSet(metric);
+    }
+
+    @Test
+    void testCountRemovedEntities() {
+        // given
+        final Metric metric = getMetric("queries_", "removedEntities_" + LABEL);
+        // when
+        statistics.countRemovedEntities();
+        // then
+        assertValueSet(metric);
+    }
+
+    @Test
+    void testCountReadEntities() {
+        // given
+        final Metric metric = getMetric("queries_", "readEntities_" + LABEL);
+        // when
+        statistics.countReadEntities();
+        // then
+        assertValueSet(metric);
+    }
+
+    @Test
+    void testNodeCacheSize() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "nodeCacheSizeMb_" + LABEL);
+        // when
+        statistics.setNodeCacheSize(2345L);
+        // then
+        assertValueEquals(metric, 2345L);
+    }
+
+    @Test
+    void testPipelineSize() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "pipelineSize_" + LABEL);
+        // when
+        statistics.setPipelineSize(23456);
+        // then
+        assertValueEquals(metric, 23456);
+    }
+
+    @Test
+    void testFlushBacklogSize() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "flushBacklogSize_" + LABEL);
+        // when
+        statistics.recordFlushBacklogSize(3456);
+        // then
+        assertValueEquals(metric, 3456);
+    }
+
+    @Test
+    void testFlushBackpressureMs() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "flushBackpressureMs_" + LABEL);
+        // when
+        statistics.recordFlushBackpressureMs(34567);
+        // then
+        assertValueSet(metric);
+    }
+
+    @Test
+    void testFamilySizeBackpressureMs() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "familySizeBackpressureMs_" + LABEL);
+        // when
+        statistics.recordFamilySizeBackpressureMs(4567);
+        // then
+        assertValueSet(metric);
+    }
+
+    @Test
+    void testMergeDurationMs() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "mergeDurationMs_" + LABEL);
+        // when
+        statistics.recordMerge(45678L);
+        // then
+        assertValueEquals(metric, 45678L);
+    }
+
+    @Test
+    void testFlushCountAndDurationMs() {
+        // given
+        final Metric metricDurationMs = getMetric("lifecycle_", "flushDurationMs_" + LABEL);
+        final Metric metricCount = getMetric("lifecycle_", "flushCount_" + LABEL);
+        // when
+        statistics.recordFlush(5678L);
+        // then
+        assertValueEquals(metricDurationMs, 5678L);
+        assertValueEquals(metricCount, 1L);
+    }
+
+    @Test
+    void testHashDurationMs() {
+        // given
+        final Metric metric = getMetric("lifecycle_", "hashDurationMs_" + LABEL);
+        // when
+        statistics.recordHash(56789L);
+        // then
+        assertValueEquals(metric, 56789L);
+    }
+}


### PR DESCRIPTION
Fix summary:

* A new VirtualMap metric is added, `nodeCacheSizeMb`
* The metric is updated on every virtual pipeline thread iteration (e.g. after flush, merge, etc.)
* A new unit test is provided
* A few related issues are fixed, see my comments in the files

Fixes: https://github.com/hashgraph/hedera-services/issues/8469
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
