### PR TITLE
Fix fee calculation for TokenWipe and TokenBurn

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -194,9 +194,15 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
     @Override
     public Fees calculateFees(@NonNull final FeeContext feeContext) {
         final var op = feeContext.body();
+        final var readableTokenStore = feeContext.readableStore(ReadableTokenStore.class);
+        final var tokenType =
+                readableTokenStore.get(op.tokenWipeOrThrow().tokenOrThrow()).tokenType();
         final var meta = TOKEN_OPS_USAGE_UTILS.tokenWipeUsageFrom(fromPbj(op));
         return feeContext
-                .feeCalculator(SubType.DEFAULT)
+                .feeCalculator(
+                        tokenType.equals(TokenType.FUNGIBLE_COMMON)
+                                ? SubType.TOKEN_FUNGIBLE_COMMON
+                                : SubType.TOKEN_NON_FUNGIBLE_UNIQUE)
                 .addBytesPerTransaction(meta.getBpt())
                 .addNetworkRamByteSeconds(meta.getTransferRecordDb() * USAGE_PROPERTIES.legacyReceiptStorageSecs())
                 .calculate();

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
@@ -158,9 +158,15 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
     @Override
     public Fees calculateFees(@NonNull final FeeContext feeContext) {
         final var op = feeContext.body();
+        final var readableTokenStore = feeContext.readableStore(ReadableTokenStore.class);
+        final var tokenType =
+                readableTokenStore.get(op.tokenBurnOrThrow().tokenOrThrow()).tokenType();
         final var meta = TOKEN_OPS_USAGE_UTILS.tokenBurnUsageFrom(fromPbj(op));
         return feeContext
-                .feeCalculator(SubType.DEFAULT)
+                .feeCalculator(
+                        tokenType.equals(TokenType.FUNGIBLE_COMMON)
+                                ? SubType.TOKEN_FUNGIBLE_COMMON
+                                : SubType.TOKEN_NON_FUNGIBLE_UNIQUE)
                 .addBytesPerTransaction(meta.getBpt())
                 .addNetworkRamByteSeconds(meta.getTransferRecordDb() * USAGE_PROPERTIES.legacyReceiptStorageSecs())
                 .calculate();


### PR DESCRIPTION
**Description**:
This PR adds logic to the fee calculation for TokenWipe and TokenBurn to check for token type, which will be then used for  selection from the feeDataMap

**Related issue(s)**:

Fixes #8760 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
