### PR TITLE
fix: change contractCallLocalMethod to Query instead of transaction

### DIFF
--- a/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/SmartContractServiceDefinition.java
+++ b/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/SmartContractServiceDefinition.java
@@ -36,7 +36,7 @@ public final class SmartContractServiceDefinition implements RpcServiceDefinitio
             new RpcMethodDefinition<>("createContract", Transaction.class, TransactionResponse.class),
             new RpcMethodDefinition<>("updateContract", Transaction.class, TransactionResponse.class),
             new RpcMethodDefinition<>("contractCallMethod", Transaction.class, TransactionResponse.class),
-            new RpcMethodDefinition<>("contractCallLocalMethod", Transaction.class, TransactionResponse.class),
+            new RpcMethodDefinition<>("contractCallLocalMethod", Query.class, Response.class),
             new RpcMethodDefinition<>("deleteContract", Transaction.class, TransactionResponse.class),
             new RpcMethodDefinition<>("systemDelete", Transaction.class, TransactionResponse.class),
             new RpcMethodDefinition<>("systemUndelete", Transaction.class, TransactionResponse.class),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CallOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CallOperationSuite.java
@@ -29,6 +29,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
@@ -57,6 +58,7 @@ public class CallOperationSuite extends HapiSuite {
         return true;
     }
 
+    @HapiTest
     HapiSpec verifiesExistence() {
         final var contract = "CallOperationsChecker";
         final var INVALID_ADDRESS = "0x0000000000000000000000000000000000123456";
@@ -82,6 +84,7 @@ public class CallOperationSuite extends HapiSuite {
                         }));
     }
 
+    @HapiTest
     HapiSpec callingContract() {
         final var contract = "CallingContract";
         final var INVALID_ADDRESS = "0x0000000000000000000000000000000000123456";


### PR DESCRIPTION
**Description**:
Fixing CallOperationSuite tests

**Related issue(s)**:
Changing the SmartContractServiceDefinition of contractCallLocalMethod to query instead of transaction. Same fix as in https://github.com/hashgraph/hedera-services/pull/8812

Fixes https://github.com/hashgraph/hedera-services/issues/8854