### PR TITLE
Fix ContractCallSuite tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -2312,14 +2312,12 @@ public class ContractCallSuite extends HapiSuite {
                 .then(
                         getTxnRecord(failingCall)
                                 .exposingTo(failureRecord -> parentConsTime.set(failureRecord.getConsensusTimestamp())),
-                                                sourcing(() -> childRecordsCheck(
-                                                        failingCall,
-                                                        CONTRACT_REVERT_EXECUTED,
-                                                        recordWith()
-                                                                .status(INSUFFICIENT_GAS)
-                                                                .consensusTimeImpliedByNonce(parentConsTime.get(),
-                         1)))
-                        );
+                        sourcing(() -> childRecordsCheck(
+                                failingCall,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INSUFFICIENT_GAS)
+                                        .consensusTimeImpliedByNonce(parentConsTime.get(), 1))));
     }
 
     private String getNestedContractAddress(final String contract, final HapiSpec spec) {


### PR DESCRIPTION
**Description**:

Fix ContactCallSuite tests

**Related issue(s)**:

Fixes #8857 

**Notes for reviewer**:
I did some debugging for the rest of the tests left to be fixed:
1. insufficientGas, insufficientFee - we need fee implementations
2. whitelistingAliasedContract, cannotUseMirrorAddressOfAliasedContractInPrecompileMethod, bitcarbonTestStillPasses,  - we have issue for this https://github.com/hashgraph/hedera-services/issues/8721
3. contractTransferToSigReqAccountWithoutKeyFails, hscsEvm010ReceiverMustSignContractTx, hscsEvm010MultiSignatureAccounts - we need signature verification logic here
4. sendHbarsToDifferentAddresses, sendHbarsFromDifferentAddressessToAddress, sendHbarsToOuterContractFromDifferentAddresses - RecordFinalizerBase netHbarBallance is not equal to 0 on line 73


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
