### PR TITLE
Fix CreateOperationSuite test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
@@ -66,7 +66,7 @@ public class CreateOperationSuite extends HapiSuite {
     private static final String CONTRACT_INFO = "contractInfo";
     private static final String PARENT_INFO = "parentInfo";
 
-    public static void main(String... args) {
+    public static void main(final String... args) {
         new CreateOperationSuite().runSuiteAsync();
     }
 
@@ -292,6 +292,7 @@ public class CreateOperationSuite extends HapiSuite {
                                 "AbandoningParentCreateResult", 6, "AbandoningParentParentInfo"));
     }
 
+    @HapiTest
     HapiSpec childContractStorageWorks() {
         final var contract = "CreateTrivial";
         final var CREATED_TRIVIAL_CONTRACT_RETURNS = 7;
@@ -354,7 +355,7 @@ public class CreateOperationSuite extends HapiSuite {
 
                     CustomSpecAssert.allRunFor(spec, subop4);
 
-                    ContractGetInfoResponse.ContractInfo createdContractInfo =
+                    final ContractGetInfoResponse.ContractInfo createdContractInfo =
                             spec.registry().getContractInfo("createdContractInfoSaved");
 
                     Assertions.assertTrue(createdContractInfo.hasContractID());


### PR DESCRIPTION
**Description**:
Fixes a  `CreateOperationSuite` test

**Related issue(s)**:

Fixes #
#8855 
**Notes for reviewer**:
Added a `@HapiTest` annotation to the `childContractStorageWorks` test as it was passing.
I did some debugging for the rest of the tests and opened an issue to address the failing ones #8899 .

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
