### PR TITLE
Remove hapi test suite annotation from suite that not need to be fixed

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PrngSeedOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PrngSeedOperationSuite.java
@@ -44,7 +44,6 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@HapiTestSuite
 public class PrngSeedOperationSuite extends HapiSuite {
 
     private static final Logger log = LogManager.getLogger(PrngSeedOperationSuite.class);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PrngSeedOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PrngSeedOperationSuite.java
@@ -34,7 +34,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.swirlds.common.utility.CommonUtils;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
@@ -22,7 +22,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.junit.utils.AccountClassifier;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@HapiTestSuite
 public class BalanceValidation extends HapiSuite {
     private static final Logger log = LogManager.getLogger(BalanceValidation.class);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TokenBalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TokenBalanceValidation.java
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.Logger;
 /**
  * Tests to validate that token balances are correct after token transfers occur.
  */
-@HapiTestSuite
 public class TokenBalanceValidation extends HapiSuite {
     private static final Logger log = LogManager.getLogger(TokenBalanceValidation.class);
     private final Map<AccountNumTokenNum, Long> expectedTokenBalances;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TokenBalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TokenBalanceValidation.java
@@ -29,7 +29,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.junit.utils.AccountClassifier;
 import com.hedera.services.bdd.junit.validators.AccountNumTokenNum;
 import com.hedera.services.bdd.spec.HapiSpec;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TransactionBodyValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TransactionBodyValidation.java
@@ -20,7 +20,6 @@ import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertEventuallyPasses;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.junit.TransactionBodyValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TransactionBodyValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TransactionBodyValidation.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@HapiTestSuite
 public class TransactionBodyValidation extends HapiSuite {
     private static final Logger log = LogManager.getLogger(TransactionBodyValidation.class);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RecordStreamValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RecordStreamValidation.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@HapiTestSuite
 public class RecordStreamValidation extends HapiSuite {
     private static final Logger log = LogManager.getLogger(RecordStreamValidation.class);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RecordStreamValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RecordStreamValidation.java
@@ -20,7 +20,6 @@ import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.verifyRecordStreams;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

We have some suites that do not look like a regular suite that should be run on it’s own, but rather as an additional step after the execution of all suites to check the behaviour after them:
- `BalanceValidation`
- `TokenBalanceValidation`
- `TransactionBodyValidation`
- `RecordStreamValidation`

Also `PrngSeedOperationSuite` is broken and is not being run against mono, removing the annotation from it as well as won't fix for now.
  
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
