### PR TITLE
Fix TxnReceiptRegression suite

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetReceiptHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetReceiptHandler.java
@@ -78,7 +78,7 @@ public class NetworkTransactionGetReceiptHandler extends FreeQueryHandler {
         // The receipt must exist for that transaction ID
         final var recordCache = context.recordCache();
         final var receipt = recordCache.getReceipt(op.transactionIDOrThrow());
-        mustExist(receipt, INVALID_TRANSACTION_ID);
+        mustExist(receipt, RECEIPT_NOT_FOUND);
     }
 
     @Override

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetReceiptHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetReceiptHandler.java
@@ -119,12 +119,13 @@ public class NetworkTransactionGetReceiptHandler extends FreeQueryHandler {
         return Response.newBuilder().transactionGetReceipt(responseBuilder).build();
     }
 
-    private List<TransactionReceipt> transformedChildrenOf(final TransactionID transactionID,
-            final RecordCache recordCache) {
+    private List<TransactionReceipt> transformedChildrenOf(
+            final TransactionID transactionID, final RecordCache recordCache) {
         final List<TransactionReceipt> children = new ArrayList<>();
         // In a transaction id if nonce is 0 it is a parent and if we have any other number it is a child
         for (int nonce = 1; ; nonce++) {
-            final var childTransactionId = transactionID.copyBuilder().nonce(nonce).build();
+            final var childTransactionId =
+                    transactionID.copyBuilder().nonce(nonce).build();
             final var maybeChildRecord = recordCache.getRecord(childTransactionId);
             if (maybeChildRecord == null) {
                 break;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.Logger;
 public class TxnReceiptRegression extends HapiSuite {
     static final Logger log = LogManager.getLogger(TxnReceiptRegression.class);
 
-    public static void main(String... args) {
+    public static void main(final String... args) {
         new TxnReceiptRegression().runSuiteSync();
     }
 
@@ -65,6 +65,7 @@ public class TxnReceiptRegression extends HapiSuite {
         });
     }
 
+    @HapiTest
     private HapiSpec returnsInvalidForUnspecifiedTxnId() {
         return defaultHapiSpec("ReturnsInvalidForUnspecifiedTxnId")
                 .given()
@@ -96,6 +97,7 @@ public class TxnReceiptRegression extends HapiSuite {
                         getReceipt("success").hasPriorityStatus(UNKNOWN));
     }
 
+    @HapiTest
     private HapiSpec receiptAvailableWithinCacheTtl() {
         return defaultHapiSpec("ReceiptAvailableWithinCacheTtl")
                 .given(cryptoCreate("misc").via("success").balance(1_000L))
@@ -113,13 +115,15 @@ public class TxnReceiptRegression extends HapiSuite {
                 .then(getReceipt("failingTxn").hasAnswerOnlyPrecheck(RECEIPT_NOT_FOUND));
     }
 
+    @HapiTest
     private HapiSpec receiptNotFoundOnUnknownTransactionID() {
         return defaultHapiSpec("receiptNotFoundOnUnknownTransactionID")
                 .given()
                 .when()
                 .then(withOpContext((spec, ctxLog) -> {
-                    HapiGetReceipt op =
-                            getReceipt(spec.txns().defaultTransactionID()).hasAnswerOnlyPrecheck(RECEIPT_NOT_FOUND);
+                    final HapiGetReceipt op =
+                            getReceipt(spec.txns().defaultTransactionID()).hasAnswerOnlyPrecheck(
+                                    INVALID_TRANSACTION_ID);
                     CustomSpecAssert.allRunFor(spec, op);
                 }));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
@@ -121,8 +121,8 @@ public class TxnReceiptRegression extends HapiSuite {
                 .given()
                 .when()
                 .then(withOpContext((spec, ctxLog) -> {
-                    final HapiGetReceipt op = getReceipt(spec.txns().defaultTransactionID())
-                            .hasAnswerOnlyPrecheck(INVALID_TRANSACTION_ID);
+                    final HapiGetReceipt op =
+                            getReceipt(spec.txns().defaultTransactionID()).hasAnswerOnlyPrecheck(RECEIPT_NOT_FOUND);
                     CustomSpecAssert.allRunFor(spec, op);
                 }));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
@@ -121,9 +121,8 @@ public class TxnReceiptRegression extends HapiSuite {
                 .given()
                 .when()
                 .then(withOpContext((spec, ctxLog) -> {
-                    final HapiGetReceipt op =
-                            getReceipt(spec.txns().defaultTransactionID()).hasAnswerOnlyPrecheck(
-                                    INVALID_TRANSACTION_ID);
+                    final HapiGetReceipt op = getReceipt(spec.txns().defaultTransactionID())
+                            .hasAnswerOnlyPrecheck(INVALID_TRANSACTION_ID);
                     CustomSpecAssert.allRunFor(spec, op);
                 }));
     }


### PR DESCRIPTION
**Description**:
Fixed some of `TxnReceiptRegression` tests.

**Related issue(s)**:

Fixes #8917 
**Notes for reviewer**:
Added `@HapiTest` annotation to `returnsInvalidForUnspecifiedTxnId()`, `receiptAvailableWithinCacheTtl()` and `receiptNotFoundOnUnknownTransactionID()`. I had to extend the if condition in `validate` in the `NetworkTransactionGetReceiptHandler` in order to throw the correct exceptions and change the expected return of `receiptNotFoundOnUnknownTransactionID ()` to `INVALID_TRANSACTION_ID` as that is the implemented logic.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
