### PR TITLE
Fix TxnRecordRegression

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
@@ -86,7 +86,7 @@ public class NetworkTransactionGetRecordHandler extends PaidQueryHandler {
 
         final var recordCache = context.recordCache();
         final var receipt = recordCache.getReceipt(txnId);
-        mustExist(receipt, INVALID_TRANSACTION_ID);
+        mustExist(receipt, RECORD_NOT_FOUND);
     }
 
     @Override
@@ -125,12 +125,14 @@ public class NetworkTransactionGetRecordHandler extends PaidQueryHandler {
         return Response.newBuilder().transactionGetRecord(responseBuilder).build();
     }
 
-    private List<TransactionRecord> transformedChildrenOf(TransactionID transactionID, RecordCache recordCache) {
+    private List<TransactionRecord> transformedChildrenOf(
+            final TransactionID transactionID, final RecordCache recordCache) {
         final List<TransactionRecord> children = new ArrayList<>();
         // In a transaction id if nonce is 0 it is a parent and if we have any other number it is a child
         for (int nonce = 1; ; nonce++) {
-            var childTransactionId = transactionID.copyBuilder().nonce(nonce).build();
-            var maybeChildRecord = recordCache.getRecord(childTransactionId);
+            final var childTransactionId =
+                    transactionID.copyBuilder().nonce(nonce).build();
+            final var maybeChildRecord = recordCache.getRecord(childTransactionId);
             if (maybeChildRecord == null) {
                 break;
             } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
@@ -29,6 +29,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECEIPT_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -46,7 +47,7 @@ import org.apache.logging.log4j.Logger;
 public class TxnRecordRegression extends HapiSuite {
     static final Logger log = LogManager.getLogger(TxnRecordRegression.class);
 
-    public static void main(String... args) {
+    public static void main(final String... args) {
         new TxnRecordRegression().runSuiteSync();
     }
 
@@ -101,13 +102,14 @@ public class TxnRecordRegression extends HapiSuite {
                 .then(getTxnRecord("").useDefaultTxnId().hasCostAnswerPrecheck(INVALID_ACCOUNT_ID));
     }
 
+    @HapiTest
     private HapiSpec recordNotFoundIfNotInPayerState() {
         return defaultHapiSpec("RecordNotFoundIfNotInPayerState")
                 .given(
                         cryptoCreate("misc").via("success"),
                         usableTxnIdNamed("rightAccountWrongId").payerId("misc"))
                 .when()
-                .then(getTxnRecord("rightAccountWrongId").hasCostAnswerPrecheck(RECORD_NOT_FOUND));
+                .then(getTxnRecord("rightAccountWrongId").hasCostAnswerPrecheck(INVALID_TRANSACTION_ID));
     }
 
     private HapiSpec recordUnavailableBeforeConsensus() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
@@ -29,7 +29,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECEIPT_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -109,7 +108,7 @@ public class TxnRecordRegression extends HapiSuite {
                         cryptoCreate("misc").via("success"),
                         usableTxnIdNamed("rightAccountWrongId").payerId("misc"))
                 .when()
-                .then(getTxnRecord("rightAccountWrongId").hasCostAnswerPrecheck(INVALID_TRANSACTION_ID));
+                .then(getTxnRecord("rightAccountWrongId").hasCostAnswerPrecheck(RECORD_NOT_FOUND));
     }
 
     private HapiSpec recordUnavailableBeforeConsensus() {


### PR DESCRIPTION
**Description**:
Fix one of `TxnRecordRegression` tests.

**Related issue(s)**:

Fixes #8943 

**Notes for reviewer**:
Added @HapiTest annotation to `recordNotFoundIfNotInPayerState()` test, had to change the expected return to `INVALID_TRANSACTION_ID` as that is the implemented logic.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
