### PR TITLE
8815: sort dirty leaves during flush

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -67,6 +67,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Objects;
@@ -1255,8 +1256,7 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         }
 
         // iterate over leaf records
-        dirtyLeaves.forEach(leafRecord -> {
-            // update objectKeyToPath
+        dirtyLeaves.sorted(Comparator.comparingLong(VirtualLeafRecord::getPath)).forEachOrdered(leafRecord -> {
             if (isLongKeyMode) {
                 longKeyToPath.put(((VirtualLongKey) leafRecord.getKey()).getKeyAsLong(), leafRecord.getPath());
             } else {


### PR DESCRIPTION
**Description**:
Add sorting by path to processing the dirty leaves stream in `MerkleDbDataSource.writeLeavesToPathToKeyValue()`.

**Related issue(s)**:

Fixes #8815 

**Notes for reviewer**:
```
Benchmark                             (keySize)   (maxKey)  (numFiles)  (numRecords)  (numThreads)  (recordSize)  Mode  Cnt      Score   Error  Units
CryptoBenchMerkleDb.transferPrefetch         24  500000000        6000        100000            32          1024  avgt       22085.657           s/op
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
