### PR TITLE
Differential testing analytic engine: State file file dumper now dumps special files

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
@@ -499,7 +499,7 @@ public class DumpFilesSubcommand {
 
         final var r = new HashMap<Integer, HederaFile>();
         final int HIGHEST_NON_USER_ACCOUNT = 1000;
-        for (int id = 0; id < HIGHEST_NON_USER_ACCOUNT; id++) {
+        for (int id = 0; id <= HIGHEST_NON_USER_ACCOUNT; id++) {
             final var fileId = FileID.newBuilder().setFileNum(id).build();
             if (specialFileStore.contains(fileId)) {
                 final var contents = specialFileStore.get(fileId);
@@ -513,6 +513,10 @@ public class DumpFilesSubcommand {
         return Pair.of(fileSummary, r);
     }
 
+    /** Merge two (or more) maps.
+     *
+     * (Seems like it should be provided by the `Map` class, but maybe not.)
+     */
     @SafeVarargs
     @NonNull
     static <K, V> Map<K, V> merge(@NonNull final BinaryOperator<V> mergeFunction, @NonNull final Map<K, V>... maps) {
@@ -521,6 +525,10 @@ public class DumpFilesSubcommand {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, mergeFunction));
     }
 
+    /** Pick `a` or `b` arbitrarily.
+     *
+     *  Not usually a good idea, but in this case it is really never called, as it a merge function for disjoint sets
+     */
     <T> T arb(@NonNull final T a, @NonNull final T b) {
         final var choice = new Random().nextBoolean();
         return choice ? a : b;

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
@@ -17,6 +17,7 @@
 package com.hedera.services.cli.signedstate;
 
 import static com.hedera.services.cli.utils.ThingsToStrings.quoteForCsv;
+import static com.hedera.services.cli.utils.ThingsToStrings.squashLinesToEscapes;
 import static com.hedera.services.cli.utils.ThingsToStrings.toStringOfByteArray;
 import static com.hedera.services.cli.utils.ThingsToStrings.toStructureSummaryOfJKey;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
@@ -24,13 +25,16 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 import com.hedera.node.app.service.mono.files.HFileMeta;
 import com.hedera.node.app.service.mono.files.MetadataMapFactory;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
+import com.hedera.node.app.service.mono.state.merkle.MerkleSpecialFiles;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
 import com.hedera.node.app.service.mono.utils.MiscUtils;
 import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
 import com.hedera.services.cli.signedstate.DumpStateCommand.KeyDetails;
+import com.hedera.services.cli.signedstate.DumpStateCommand.OmitContents;
 import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
 import com.hedera.services.cli.utils.Writer;
+import com.hederahashgraph.api.proto.java.FileID;
 import com.swirlds.base.utility.Pair;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -39,8 +43,10 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -60,8 +66,9 @@ public class DumpFilesSubcommand {
             @NonNull final Path filesPath,
             @NonNull final EnumSet<KeyDetails> keyDetails,
             @NonNull final EmitSummary emitSummary,
+            @NonNull final OmitContents omitContents,
             @NonNull final Verbosity verbosity) {
-        new DumpFilesSubcommand(state, filesPath, keyDetails, emitSummary, verbosity).doit();
+        new DumpFilesSubcommand(state, filesPath, keyDetails, emitSummary, omitContents, verbosity).doit();
     }
 
     @NonNull
@@ -77,6 +84,9 @@ public class DumpFilesSubcommand {
     final EmitSummary emitSummary;
 
     @NonNull
+    final OmitContents omitContents;
+
+    @NonNull
     final Verbosity verbosity;
 
     DumpFilesSubcommand(
@@ -84,28 +94,36 @@ public class DumpFilesSubcommand {
             @NonNull final Path filesPath,
             @NonNull final EnumSet<KeyDetails> keyDetails,
             @NonNull final EmitSummary emitSummary,
+            @NonNull final OmitContents omitContents,
             @NonNull final Verbosity verbosity) {
         this.state = state;
         this.filesPath = filesPath;
         this.keyDetails = keyDetails;
         this.emitSummary = emitSummary;
+        this.omitContents = omitContents;
         this.verbosity = verbosity;
     }
 
     void doit() {
         final var fileStore = state.getFileStore();
+        final var specialFileStore = state.getSpecialFileStore();
 
         final var collectedFiles = collectFiles(fileStore);
-        final var fileSummary = collectedFiles.left();
-        final var allFiles = collectedFiles.right();
+        final var collectedSpecialFiles = collectSpecialFiles(specialFileStore);
+        final var fileSummary = collectedFiles.left().mergeWith(collectedSpecialFiles.left());
+        final var allFiles = merge(this::arb, collectedFiles.right(), collectedSpecialFiles.right());
 
-        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== %d data files ===%n", allFiles.size());
+        if (verbosity == Verbosity.VERBOSE)
+            System.out.printf(
+                    "=== %d data files (%d from special files store) ===%n",
+                    allFiles.size(), collectedSpecialFiles.right().size());
 
         int reportSize;
         try (@NonNull final var writer = new Writer(filesPath)) {
             if (EmitSummary.YES == emitSummary) reportSummary(writer, fileSummary, allFiles);
             if (EmitSummary.YES == emitSummary) reportFileSizes(writer, allFiles);
-            reportFileContents(writer, allFiles);
+            reportFileContentsHeader(writer);
+            reportFileContents(writer, allFiles, omitContents);
             if (keyDetails.contains(KeyDetails.STRUCTURE)) reportOnKeyStructure(writer, allFiles);
             if (keyDetails.contains(KeyDetails.STRUCTURE_WITH_IDS)) reportOnKeyIds(writer, allFiles);
             reportSize = writer.getSize();
@@ -114,32 +132,93 @@ public class DumpFilesSubcommand {
             throw ex;
         }
 
-        if (verbosity == Verbosity.VERBOSE) System.out.printf("=== files report is %d bytes%n", reportSize);
+        if (verbosity == Verbosity.VERBOSE)
+            System.out.printf(
+                    "=== files report is %d bytes%s%n",
+                    reportSize, omitContents == OmitContents.YES ? " (file contents omitted from report)" : "");
     }
 
     /** Holds summaries of how many files of each type there are in the store, also how many are missing content. */
     record FileSummary(
             @NonNull Map<VirtualBlobKey.Type, Integer> typeOccurrences,
             @NonNull Map<VirtualBlobKey.Type, Integer> nullValueOccurrences,
-            @NonNull Integer nNullMetadataValues) {}
+            @NonNull Integer nNullMetadataValues) {
+
+        public FileSummary mergeWith(@NonNull final FileSummary other) {
+            final var typeOccurrences = merge(Integer::sum, this.typeOccurrences, other.typeOccurrences);
+            final var nullValueOccurrences = merge(Integer::sum, this.nullValueOccurrences, other.nullValueOccurrences);
+            final var nNullMetadataValues = this.nNullMetadataValues + other.nNullMetadataValues;
+            return new FileSummary(typeOccurrences, nullValueOccurrences, nNullMetadataValues);
+        }
+    }
+
+    enum FileStore {
+        ORDINARY,
+        SPECIAL
+    }
+
+    enum SystemFileType {
+        ADDRESS_BOOK(101),
+        NODE_DETAILS(102),
+        FEE_SCHEDULES(111),
+        EXCHANGE_RATES(112),
+        NETWORK_PROPERTIES(121),
+        HAPI_PERMISSIONS(122),
+        THROTTLE_DEFINITIONS(123),
+        SOFTWARE_UPDATE0(150),
+        SOFTWARE_UPDATE1(151),
+        SOFTWARE_UPDATE2(152),
+        SOFTWARE_UPDATE3(153),
+        SOFTWARE_UPDATE4(154),
+        SOFTWARE_UPDATE5(155),
+        SOFTWARE_UPDATE6(156),
+        SOFTWARE_UPDATE7(157),
+        SOFTWARE_UPDATE8(158),
+        SOFTWARE_UPDATE9(159),
+        UNKNOWN(-1);
+
+        public final int id;
+
+        static final Map<Integer, SystemFileType> byId = new HashMap<>();
+
+        SystemFileType(final int id) {
+            this.id = id;
+        }
+
+        static {
+            EnumSet.allOf(SystemFileType.class).forEach(e -> byId.put(e.id, e));
+        }
+    }
 
     /** Holds the content and the metadata for a single data file in the store */
     @SuppressWarnings("java:S6218") // "Equals/hashcode methods should be overridden in records containing array fields"
     // not using this with equals
-    record HederaFile(@NonNull Integer contractId, @NonNull byte[] contents, @Nullable HFileMeta metadata) {
+    record HederaFile(
+            @NonNull FileStore fileStore,
+            @NonNull Integer fileId,
+            @NonNull byte[] contents,
+            @Nullable HFileMeta metadata,
+            @Nullable SystemFileType systemFileType) {
 
         @NonNull
-        static HederaFile of(@NonNull Integer contractId, @NonNull byte[] contents) {
-            return new HederaFile(contractId, contents, null);
+        static HederaFile of(final int fileId, @NonNull final byte[] contents) {
+            return new HederaFile(FileStore.ORDINARY, fileId, contents, null, SystemFileType.byId.get(fileId));
         }
 
         @NonNull
-        static HederaFile of(@NonNull Integer contractId, @NonNull byte[] contents, @NonNull HFileMeta metadata) {
-            return new HederaFile(contractId, contents, metadata);
+        static HederaFile of(final int fileId, @NonNull final byte[] contents, @NonNull final HFileMeta metadata) {
+            return new HederaFile(FileStore.ORDINARY, fileId, contents, metadata, SystemFileType.byId.get(fileId));
+        }
+
+        @NonNull
+        static HederaFile of(@NonNull final FileStore fileStore, final int fileId, @NonNull final byte[] contents) {
+            return new HederaFile(fileStore, fileId, contents, null, SystemFileType.byId.get(fileId));
         }
 
         boolean isActive() {
-            return null != metadata && !metadata.isDeleted();
+            if (null != systemFileType) return true;
+            if (null != metadata) return !metadata.isDeleted();
+            return false;
         }
 
         boolean isDeleted() {
@@ -154,19 +233,28 @@ public class DumpFilesSubcommand {
             @NonNull final Map<Integer, HederaFile> allFiles) {
         final var nTotalFiles = fileSummary.typeOccurrences().values().stream().reduce(0, Integer::sum);
 
-        final var nDataFiles = fileSummary.typeOccurrences().get(VirtualBlobKey.Type.FILE_DATA);
+        final var nDataFiles = fileSummary.typeOccurrences().getOrDefault(VirtualBlobKey.Type.FILE_DATA, 0);
         final var nDeletedDataFiles =
                 allFiles.values().stream().filter(HederaFile::isDeleted).count();
 
-        final var nMetadataFiles = fileSummary.typeOccurrences().get(VirtualBlobKey.Type.FILE_METADATA);
+        final var nMetadataFiles = fileSummary.typeOccurrences().getOrDefault(VirtualBlobKey.Type.FILE_METADATA, 0);
         final var nActiveDataFiles =
                 allFiles.values().stream().filter(HederaFile::isActive).count();
-        final var nActiveDataFilesWithMetadata =
-                allFiles.values().stream().filter(HederaFile::isActive).count();
+        final var nActiveDataFilesWithMetadata = allFiles.values().stream()
+                .filter(HederaFile::isActive)
+                .filter(hf -> null != hf.metadata())
+                .count();
         final var nActiveDataFilesMissingMetadata = nActiveDataFiles - nActiveDataFilesWithMetadata;
 
+        final var nSpecialFiles = allFiles.values().stream()
+                .filter(hf -> hf.fileStore() == FileStore.SPECIAL)
+                .count();
+        final var nSystemFiles = allFiles.values().stream()
+                .filter(hf -> hf.systemFileType() != null)
+                .count();
+
         Function<VirtualBlobKey.Type, String> wereNull = t -> {
-            final var n = fileSummary.nullValueOccurrences().get(t);
+            final var n = fileSummary.nullValueOccurrences().getOrDefault(t, 0);
             return 0 != n ? " (%d had missing content)".formatted(n) : "";
         };
 
@@ -176,7 +264,7 @@ public class DumpFilesSubcommand {
         sb.append("#   %7d total files%n".formatted(nTotalFiles));
         sb.append("#   %7d were contract bytecodes%s%n"
                 .formatted(
-                        fileSummary.typeOccurrences().get(VirtualBlobKey.Type.CONTRACT_BYTECODE),
+                        fileSummary.typeOccurrences().getOrDefault(VirtualBlobKey.Type.CONTRACT_BYTECODE, 0),
                         wereNull.apply(VirtualBlobKey.Type.CONTRACT_BYTECODE)));
         sb.append("#   %7d were data, of which %d were deleted, leaving %d live data files%s%s%n"
                 .formatted(
@@ -197,8 +285,10 @@ public class DumpFilesSubcommand {
                                 : ""));
         sb.append("#   %7d were system deleted/entity expiry%s%n"
                 .formatted(
-                        fileSummary.typeOccurrences().get(VirtualBlobKey.Type.SYSTEM_DELETED_ENTITY_EXPIRY),
+                        fileSummary.typeOccurrences().getOrDefault(VirtualBlobKey.Type.SYSTEM_DELETED_ENTITY_EXPIRY, 0),
                         wereNull.apply(VirtualBlobKey.Type.SYSTEM_DELETED_ENTITY_EXPIRY)));
+        sb.append("#   %7d were stored in the special files store%n".formatted(nSpecialFiles));
+        sb.append("#   %7d were system files%n".formatted(nSystemFiles));
 
         writer.write(sb);
     }
@@ -214,36 +304,50 @@ public class DumpFilesSubcommand {
 
         final var sb = new StringBuilder(1000);
 
-        sb.append("#   === Content Size Histogram ===%n".formatted());
-        sb.append("#        =0: %6d%n".formatted(histogram.getOrDefault(0, 0L)));
+        sb.append("#   === Content Size Histogram (size in bytes) ===%n".formatted());
+        sb.append("#          =0: %6d%n".formatted(histogram.getOrDefault(0, 0L)));
         for (int i = 1; i <= maxDigits; i++) {
-            sb.append("# %9s: %6d%n".formatted("<=" + (int) Math.pow(10, i), histogram.getOrDefault(i, 0L)));
+            sb.append("# %11s: %6d%n".formatted("<=" + (int) Math.pow(10, i), histogram.getOrDefault(i, 0L)));
         }
 
         writer.write(sb);
     }
 
-    /** Emits the actual content (hexified) for each file), and it's full key */
-    void reportFileContents(@NonNull final Writer writer, @NonNull final Map<Integer, HederaFile> allFiles) {
+    /** Emits the CSV header line for the file contents - **KEEP IN SYNC WITH reportFileContents!!!** */
+    void reportFileContentsHeader(@NonNull final Writer writer) {
+        final var header = "fileId,PRESENT/DELETED,SPECIAL file,SYSTEM file,length(bytes),expiry,memo,content,key";
+        writer.write("%s%n", header);
+    }
+
+    /** Emits the actual content (hexified) for each file, and it's full key */
+    void reportFileContents(
+            @NonNull final Writer writer,
+            @NonNull final Map<Integer, HederaFile> allFiles,
+            @NonNull final OmitContents omitContents) {
         for (@NonNull
         final var file :
                 allFiles.entrySet().stream().sorted(Map.Entry.comparingByKey()).toList()) {
-            // Is it correct to _skip_ files without metadata?  Or print them (none currently exist)
 
             final var contractId = file.getKey();
             final var hf = file.getValue();
             if (hf.isActive()) {
-                assert hf.metadata() != null;
                 final var sb = new StringBuilder();
-                toStringOfByteArray(sb, hf.contents());
+                if (omitContents == OmitContents.NO) toStringOfByteArray(sb, hf.contents());
                 writer.write(
-                        "%d,PRESENT,%d,%s,%d,%s,%s%n",
+                        "%d,PRESENT,%s,%s,%d,%s,%s,%s,%s%n",
                         contractId,
-                        hf.metadata().getExpiry(),
-                        quoteForCsv(",", hf.metadata().getMemo()),
+                        hf.fileStore() == FileStore.SPECIAL ? "SPECIAL" : "",
+                        hf.systemFileType() != null ? hf.systemFileType().name() : "",
                         hf.contents().length,
+                        hf.metadata() != null ? Long.toString(hf.metadata().getExpiry()) : "",
+                        hf.metadata() != null ? quoteForCsv(",", hf.metadata().getMemo()) : "",
                         sb,
-                        quoteForCsv(",", MiscUtils.describe(hf.metadata().getWacl())));
+                        hf.metadata() != null
+                                ? quoteForCsv(
+                                        ",",
+                                        squashLinesToEscapes(
+                                                MiscUtils.describe(hf.metadata().getWacl())))
+                                : "");
             } else {
                 writer.write("%d,DELETED%n", contractId);
             }
@@ -255,6 +359,7 @@ public class DumpFilesSubcommand {
         final var keySummary = new HashMap<String, Integer>();
         for (@NonNull final var hf : allFiles.values()) {
             if (hf.isDeleted()) continue;
+            if (hf.metadata() == null) continue;
             final var jkey = hf.metadata().getWacl();
             final var sb = new StringBuilder();
             final var b = toStructureSummaryOfJKey(sb, jkey);
@@ -272,13 +377,13 @@ public class DumpFilesSubcommand {
     }
 
     /** Emits a summary of key structure for each file that has a non-trivial key */
-    @SuppressWarnings(
-            "java:S135") // Reduce total # of break+continue statements to at most one" - disagree it would improve this
-    // code
+    @SuppressWarnings("java:S135") // "Reduce total # of break+continue statements to at most one" - disagree
+    // it would improve this code
     void reportOnKeyIds(@NonNull final Writer writer, @NonNull final Map<Integer, HederaFile> allFiles) {
         final var keySummary = new HashMap<Integer, String>();
         for (@NonNull final var hf : allFiles.values()) {
             if (hf.isDeleted()) continue;
+            if (hf.metadata() == null) continue;
             final var jkey = hf.metadata().getWacl();
             if (null == jkey) continue;
             final var key = jkey.getKeyList();
@@ -287,7 +392,7 @@ public class DumpFilesSubcommand {
             // Have a "complex" key (more than one key in key list)
             final var sb = new StringBuilder();
             final var b = toStructureSummaryOfJKey(sb, jkey);
-            if (b) keySummary.put(hf.contractId(), sb.toString());
+            if (b) keySummary.put(hf.fileId(), sb.toString());
         }
 
         writer.writeln("=== Files with complex keys ===");
@@ -318,7 +423,7 @@ public class DumpFilesSubcommand {
 
         final var nType = new ConcurrentHashMap<VirtualBlobKey.Type, Integer>();
         final var nNullValues = new ConcurrentHashMap<VirtualBlobKey.Type, Integer>();
-        final var nNulLMetadataValues = new AtomicInteger();
+        final var nNullMetadataValues = new AtomicInteger();
 
         Stream.of(nType, nNullValues)
                 .forEach(m -> EnumSet.allOf(VirtualBlobKey.Type.class).forEach(t -> m.put(t, 0)));
@@ -344,7 +449,7 @@ public class DumpFilesSubcommand {
                                     if (null != metadata) {
                                         foundMetadata.put(contractId, metadata);
                                     } else {
-                                        nNulLMetadataValues.incrementAndGet();
+                                        nNullMetadataValues.incrementAndGet();
 
                                         System.err.printf(
                                                 "*** collectFiles file metadata (HFileMeta) null for contract id %d, type %s%n",
@@ -383,7 +488,41 @@ public class DumpFilesSubcommand {
                             : HederaFile.of(contractId, contents));
         }
 
-        final var fileSummary = new FileSummary(Map.copyOf(nType), Map.copyOf(nNullValues), nNulLMetadataValues.get());
+        final var fileSummary = new FileSummary(Map.copyOf(nType), Map.copyOf(nNullValues), nNullMetadataValues.get());
         return Pair.of(fileSummary, r);
+    }
+
+    /** Collects the information for each special file in the special file store */
+    Pair<FileSummary, Map<Integer, HederaFile>> collectSpecialFiles(
+            @NonNull final MerkleSpecialFiles specialFileStore) {
+        // The MerkleSpecialFiles does _not_ support iteration.  So we do it by brute force.
+
+        final var r = new HashMap<Integer, HederaFile>();
+        final int HIGHEST_NON_USER_ACCOUNT = 1000;
+        for (int id = 0; id < HIGHEST_NON_USER_ACCOUNT; id++) {
+            final var fileId = FileID.newBuilder().setFileNum(id).build();
+            if (specialFileStore.contains(fileId)) {
+                final var contents = specialFileStore.get(fileId);
+                final var hfile = HederaFile.of(FileStore.SPECIAL, id, contents);
+                r.put(id, hfile);
+            }
+        }
+
+        final var typeMap = Map.of(VirtualBlobKey.Type.FILE_DATA, r.size());
+        final var fileSummary = new FileSummary(typeMap, Map.of(), 0);
+        return Pair.of(fileSummary, r);
+    }
+
+    @SafeVarargs
+    @NonNull
+    static <K, V> Map<K, V> merge(@NonNull final BinaryOperator<V> mergeFunction, @NonNull final Map<K, V>... maps) {
+        return Stream.of(maps)
+                .flatMap(m -> m.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, mergeFunction));
+    }
+
+    <T> T arb(@NonNull final T a, @NonNull final T b) {
+        final var choice = new Random().nextBoolean();
+        return choice ? a : b;
     }
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
@@ -21,6 +21,7 @@ import static com.hedera.services.cli.utils.ThingsToStrings.squashLinesToEscapes
 import static com.hedera.services.cli.utils.ThingsToStrings.toStringOfByteArray;
 import static com.hedera.services.cli.utils.ThingsToStrings.toStructureSummaryOfJKey;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+import static java.util.Objects.nonNull;
 
 import com.hedera.node.app.service.mono.files.HFileMeta;
 import com.hedera.node.app.service.mono.files.MetadataMapFactory;
@@ -242,7 +243,7 @@ public class DumpFilesSubcommand {
                 allFiles.values().stream().filter(HederaFile::isActive).count();
         final var nActiveDataFilesWithMetadata = allFiles.values().stream()
                 .filter(HederaFile::isActive)
-                .filter(hf -> null != hf.metadata())
+                .filter(hf -> nonNull(hf.metadata()))
                 .count();
         final var nActiveDataFilesMissingMetadata = nActiveDataFiles - nActiveDataFilesWithMetadata;
 
@@ -250,7 +251,7 @@ public class DumpFilesSubcommand {
                 .filter(hf -> hf.fileStore() == FileStore.SPECIAL)
                 .count();
         final var nSystemFiles = allFiles.values().stream()
-                .filter(hf -> hf.systemFileType() != null)
+                .filter(hf -> nonNull(hf.systemFileType()))
                 .count();
 
         Function<VirtualBlobKey.Type, String> wereNull = t -> {

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -66,6 +66,11 @@ public class DumpStateCommand extends AbstractCommand {
         YES
     }
 
+    enum OmitContents {
+        NO,
+        YES
+    }
+
     enum Format {
         CSV,
         ELIDED_DEFAULT_FIELDS
@@ -207,6 +212,10 @@ public class DumpStateCommand extends AbstractCommand {
                             description = "How to dump key summaries")
                     final EnumSet<KeyDetails> keyDetails,
             @Option(
+                            names = {"--omit-contents"},
+                            description = "Omit the contents (bytes) of the file")
+                    final boolean omitContents,
+            @Option(
                             names = {"-s", "--summary"},
                             description = "Emit a summary line")
                     final boolean emitSummary) {
@@ -218,6 +227,7 @@ public class DumpStateCommand extends AbstractCommand {
                 filesPath,
                 null != keyDetails ? keyDetails : EnumSet.noneOf(KeyDetails.class),
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
+                omitContents ? OmitContents.YES : OmitContents.NO,
                 parent.verbosity);
         finish();
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -19,6 +19,7 @@ package com.hedera.services.cli.signedstate;
 import com.hedera.node.app.service.mono.ServicesState;
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
+import com.hedera.node.app.service.mono.state.merkle.MerkleSpecialFiles;
 import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
@@ -265,6 +266,17 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
         final var fileStore = servicesState.storage();
         assertSignedStateComponentExists(fileStore, "fileStore");
         return fileStore;
+    }
+
+    /** Returns the special files store from the state
+     *
+     * The special files store contains, among other things, the system upgrade files.
+     */
+    @NonNull
+    public MerkleSpecialFiles getSpecialFileStore() {
+        final var specialFiles = servicesState.specialFiles();
+        assertSignedStateComponentExists(specialFiles, "specialFiles");
+        return specialFiles;
     }
 
     @NonNull

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
@@ -63,6 +63,12 @@ public class ThingsToStrings {
         return s;
     }
 
+    @NonNull
+    public static String squashLinesToEscapes(@Nullable String s) {
+        if (s == null) return "";
+        return s.replace("\r", "\\r").replace("\n", "\\n");
+    }
+
     // All of these converters from something to a String will check to see if that something is a "null" or is
     // an "empty" (whatever "empty" might mean for that thing).  They return `true` if the thing _existed_, otherwise
     // (null or "empty") return false.  (Thus, they are predicates.)


### PR DESCRIPTION
**Description**:

State file file dumper now dumps special files

* And for system files it tells you what file it is. 
* And you can ask for the report _without_ the file contents (much smaller file, suitable for putting into a spreadsheet.

**Related issue(s)**:

Fixes #8990 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (manual)
