### PR TITLE
Validate events; make event numbers longs

### DIFF
--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/components/Event.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/components/Event.java
@@ -1,12 +1,12 @@
 package com.swirlds.common.wiring.components;
 
 public final class Event {
-    private int number = -1; // We'll let the orphan buffer assign this, although I think consensus actually does
+    private long number = -1; // We'll let the orphan buffer assign this, although I think consensus actually does
     private final byte[] data = new byte[1024 * 32]; // Just gotta have some bytes. Whatever.
 
     public Event() { }
 
-    void reset(int number) {
+    void reset(long number) {
         this.number = number;
     }
 
@@ -15,7 +15,7 @@ public final class Event {
         return "Event {number=" + number + "}";
     }
 
-    public int number() {
+    public long number() {
         return number;
     }
 }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/components/EventPool.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/components/EventPool.java
@@ -13,7 +13,7 @@ public final class EventPool {
         }
     }
 
-    public synchronized Event checkout(int number) {
+    public Event checkout(long number) {
         try {
             Event event = pool.take();
             event.reset(number);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/components/TopologicalEventSorter.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/components/TopologicalEventSorter.java
@@ -6,20 +6,28 @@ public class TopologicalEventSorter implements Consumer<Event> {
     private static final int PRINT_FREQUENCY = 1_000_000;
     private final EventPool eventPool;
     private long lastTimestamp;
+    private long checkSum;
 
     public TopologicalEventSorter(EventPool eventPool) {
         this.eventPool = eventPool;
+        this.checkSum = 0;
     }
 
     @Override
     public void accept(Event event) {
-        if (event.number() % PRINT_FREQUENCY == 0) {
+        long number = event.number();
+        checkSum += number + 1;     // make 0 contribute to the sum
+        if (number % PRINT_FREQUENCY == 0) {
             long curTimestamp = System.currentTimeMillis();
-            if (event.number() != 0) {
-                System.out.format("Handled %d events, TPS: %d%n", event.number(), PRINT_FREQUENCY * 1000L / (curTimestamp - lastTimestamp));
+            if (number != 0) {
+                System.out.format("Handled %d events, TPS: %d%n", number, PRINT_FREQUENCY * 1000L / (curTimestamp - lastTimestamp));
             }
             lastTimestamp = curTimestamp;
         }
         eventPool.checkin(event);
+    }
+
+    public long getCheckSum() {
+        return checkSum;
     }
 }


### PR DESCRIPTION
Validate that all generated events have been processed. `Event` number is now `long` to allow for longer runs at ~1M TPS.
`TopologicalEventSorter.checkSum` is computed without synchronization to ensure that its `accept()` method is invoked in effectively single-threaded mode.

Related to #9005 