### PR TITLE
Fix `smallContractCreate()` and enable `ethereumCallWithCalldataBiggerThanMaxSucceeds()`

### DIFF
--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -1,4 +1,4 @@
 balances.exportDir.path=data/accountBalances/
-ledger.autoRenewPeriod.minDuration=2592000
+ledger.autoRenewPeriod.minDuration=10
 ledger.autoRenewPeriod.maxDuration=1000000000
 upgrade.artifacts.path=data/upgrade

--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -1,4 +1,4 @@
 balances.exportDir.path=data/accountBalances/
-ledger.autoRenewPeriod.minDuration=10
+ledger.autoRenewPeriod.minDuration=2592000
 ledger.autoRenewPeriod.maxDuration=1000000000
 upgrade.artifacts.path=data/upgrade

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.token.impl;
 
+import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.isAliasSizeGreaterThanEvmAddress;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.isOfEvmAddressSize;
 
@@ -23,6 +24,7 @@ import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.service.evm.contracts.execution.StaticProperties;
@@ -30,9 +32,11 @@ import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import com.hedera.node.app.spi.state.ReadableStates;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -85,8 +89,7 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
     @Override
     @Nullable
     public Account getAccountById(@NonNull final AccountID accountID) {
-        final var account = getAccountLeaf(accountID);
-        return account == null ? null : account;
+        return getAccountLeaf(accountID);
     }
 
     @Override
@@ -116,8 +119,8 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
                         if (isOfEvmAddressSize(alias) && isMirror(alias)) {
                             yield fromMirror(alias);
                         } else {
-                            final var entityNum = aliases.get(new ProtoBytes(alias));
-                            yield entityNum == null ? 0L : entityNum.accountNum();
+                            final var entityId = unaliasWithEvmAddressConversionIfNeeded(alias);
+                            yield entityId == null ? null : entityId.accountNumOrThrow();
                         }
                     }
                     case UNSET -> 0L;
@@ -130,6 +133,33 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
                         .shardNum(id.shardNum())
                         .accountNum(accountNum)
                         .build());
+    }
+
+    /**
+     * Returns the {@link AccountID} referenced by the given alias, whether it is a direct reference or
+     * an "indirect" reference by a proto ECDSA key whose implied EVM address is the alias.
+     *
+     * @param alias the alias to look up
+     * @return the account id referenced by the alias, or null if not found
+     */
+    private @Nullable AccountID unaliasWithEvmAddressConversionIfNeeded(@NonNull final Bytes alias) {
+        final var maybeDirectReference = aliases.get(new ProtoBytes(alias));
+        if (maybeDirectReference != null) {
+            return maybeDirectReference;
+        } else {
+            try {
+                final var protoKey = Key.PROTOBUF.parseStrict(BufferedData.wrap(alias.toByteArray()));
+                if (protoKey.hasEcdsaSecp256k1()) {
+                    final var evmAddress = recoverAddressFromPubKey(
+                            protoKey.ecdsaSecp256k1OrThrow().toByteArray());
+                    return evmAddress.length > 0 ? aliases.get(new ProtoBytes(Bytes.wrap(evmAddress))) : null;
+                } else {
+                    return null;
+                }
+            } catch (IOException ignore) {
+                return null;
+            }
+        }
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -152,7 +152,9 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
             final var info = AccountInfo.newBuilder();
             info.ledgerId(ledgerConfig.id());
             if (!isEmpty(account.key())) info.key(account.key());
-            info.accountID(accountID);
+            // Set this field with the account's id since that's guaranteed to be a numeric 0.0.X id;
+            // the request might have been made using a 0.0.<alias> id
+            info.accountID(account.accountIdOrThrow());
             info.receiverSigRequired(account.receiverSigRequired());
             info.deleted(account.deleted());
             info.memo(account.memo());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
@@ -139,7 +139,8 @@ public class AutoAccountCreator {
         }
         childRecord.transactionFee(fee);
 
-        final var createdAccountId = accountStore.getAccountIDByAlias(evmAddress == null ? alias : Bytes.wrap(evmAddress));
+        final var createdAccountId =
+                accountStore.getAccountIDByAlias(evmAddress == null ? alias : Bytes.wrap(evmAddress));
         validateTrue(createdAccountId != null, FAIL_INVALID);
         return createdAccountId;
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
@@ -116,7 +116,7 @@ public class CryptoCreateValidator {
         }
         final boolean isValidAlias = op.alias().length() == EVM_ADDRESS_SIZE
                 || (op.alias().length() == ECDSA_SECP256K1_ALIAS_SIZE
-                && op.alias().toHex().startsWith(ECDSA_KEY_ALIAS_PREFIX));
+                        && op.alias().toHex().startsWith(ECDSA_KEY_ALIAS_PREFIX));
         validateTrue(isValidAlias, INVALID_ALIAS_KEY);
         validateFalse(isMirror(op.alias()), INVALID_ALIAS_KEY);
         validateTrue(readableAccountStore.getAccountIDByAlias(op.alias()) == null, ALIAS_ALREADY_ASSIGNED);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableAccountStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableAccountStoreImplTest.java
@@ -17,12 +17,15 @@
 package com.hedera.node.app.service.token.impl.test;
 
 import static com.hedera.node.app.service.mono.utils.Units.HBARS_TO_TINYBARS;
+import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.asAccount;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.node.app.service.evm.utils.EthSigsUtils;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -157,6 +160,64 @@ class ReadableAccountStoreImplTest extends CryptoHandlerTestBase {
         readableStore = subject;
 
         final var result = subject.getAccountById(id);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void retriesEcdsaKeyAliasAsEvmAddressWhenMissing() {
+        final var aSecp256K1Key = Key.newBuilder()
+                .ecdsaSecp256k1(Bytes.fromHex("030101010101010101010101010101010101010101010101010101010101010101"))
+                .build();
+        final var evmAddress = EthSigsUtils.recoverAddressFromPubKey(
+                aSecp256K1Key.ecdsaSecp256k1OrThrow().toByteArray());
+
+        readableAccounts = emptyReadableAccountStateBuilder().value(id, account).build();
+        given(readableStates.<AccountID, Account>get(ACCOUNTS)).willReturn(readableAccounts);
+        readableAliases = emptyReadableAliasStateBuilder()
+                .value(new ProtoBytes(Bytes.wrap(evmAddress)), asAccount(accountNum))
+                .build();
+        given(readableStates.<ProtoBytes, AccountID>get(ALIASES)).willReturn(readableAliases);
+
+        subject = new ReadableAccountStoreImpl(readableStates);
+
+        final var protoKeyId = AccountID.newBuilder()
+                .alias(Key.PROTOBUF.toBytes(aSecp256K1Key))
+                .build();
+        final var result = subject.getAccountById(protoKeyId);
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void ignoresInvalidEcdsaKey() {
+        final var aSecp256K1Key = Key.newBuilder()
+                .ecdsaSecp256k1(Bytes.fromHex("990101010101010101010101010101010101010101010101010101010101010101"))
+                .build();
+        final var protoKeyId = AccountID.newBuilder()
+                .alias(Key.PROTOBUF.toBytes(aSecp256K1Key))
+                .build();
+        final var result = subject.getAccountById(protoKeyId);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void doesNotRetryNonEcdsaKeyAlias() {
+        final var aEd25519Key = Key.newBuilder()
+                .ed25519(Bytes.fromHex("0101010101010101010101010101010101010101010101010101010101010101"))
+                .build();
+
+        final var protoKeyId =
+                AccountID.newBuilder().alias(Key.PROTOBUF.toBytes(aEd25519Key)).build();
+        final var result = subject.getAccountById(protoKeyId);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void ignoresNonsenseAlias() {
+        subject = new ReadableAccountStoreImpl(readableStates);
+        final var nonsenseId = AccountID.newBuilder()
+                .alias(Bytes.wrap("Not an alias of any sort"))
+                .build();
+        final var result = subject.getAccountById(nonsenseId);
         assertThat(result).isNull();
     }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
@@ -240,7 +240,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {
@@ -270,7 +270,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {
@@ -301,7 +301,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
 
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
         assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
-        assertThat(writableAliases.get(ecKeyAlias)).isEqualTo(hbarReceiverId);
+        assertThat(writableAliases.get(ecEvmAlias)).isEqualTo(hbarReceiverId);
         assertThat(writableAliases.get(edKeyAlias)).isEqualTo(tokenReceiverId);
 
         final var endSenderBalance = writableAccountStore.get(ownerId).tinybarBalance();
@@ -346,7 +346,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {
@@ -392,7 +392,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AutoAccountCreatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AutoAccountCreatorTest.java
@@ -76,7 +76,7 @@ class AutoAccountCreatorTest extends StepsBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 });
         given(handleContext.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
@@ -85,7 +85,7 @@ class AutoAccountCreatorTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAccountsInState()).isEmpty();
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNull();
         assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNull();
-        assertThat(writableAliases.get(ecKeyAlias)).isNull();
+        assertThat(writableAliases.get(ecEvmAlias)).isNull();
 
         subject.create(ecKeyAlias.value(), 0);
 
@@ -93,7 +93,7 @@ class AutoAccountCreatorTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAccountsInState()).hasSize(1);
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(3);
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
-        assertThat(writableAliases.get(ecKeyAlias).accountNum()).isEqualTo(hbarReceiver);
+        assertThat(writableAliases.get(ecEvmAlias).accountNum()).isEqualTo(hbarReceiver);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
@@ -70,7 +70,7 @@ class EnsureAliasesStepTest extends StepsBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {
@@ -86,7 +86,7 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAccountsInState()).isEmpty();
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNull();
         assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNull();
-        assertThat(writableAliases.get(ecKeyAlias)).isNull();
+        assertThat(writableAliases.get(ecEvmAlias)).isNull();
         assertThat(writableAliases.get(edKeyAlias)).isNull();
 
         ensureAliasesStep.doIn(transferContext);
@@ -96,7 +96,7 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(4);
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
         assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
-        assertThat(writableAliases.get(ecKeyAlias).accountNum()).isEqualTo(hbarReceiver);
+        assertThat(writableAliases.get(ecEvmAlias).accountNum()).isEqualTo(hbarReceiver);
         assertThat(writableAliases.get(edKeyAlias).accountNum()).isEqualTo(tokenReceiver);
 
         assertThat(transferContext.numOfAutoCreations()).isEqualTo(2);
@@ -231,7 +231,7 @@ class EnsureAliasesStepTest extends StepsBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
@@ -65,7 +65,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {
@@ -81,7 +81,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAccountsInState()).isEmpty();
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNull();
         assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNull();
-        assertThat(writableAliases.get(ecKeyAlias)).isNull();
+        assertThat(writableAliases.get(ecEvmAlias)).isNull();
         assertThat(writableAliases.get(edKeyAlias)).isNull();
 
         ensureAliasesStep.doIn(transferContext);
@@ -91,7 +91,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(4);
         assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
         assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
-        assertThat(writableAliases.get(ecKeyAlias).accountNum()).isEqualTo(hbarReceiver);
+        assertThat(writableAliases.get(ecEvmAlias).accountNum()).isEqualTo(hbarReceiver);
         assertThat(writableAliases.get(edKeyAlias).accountNum()).isEqualTo(tokenReceiver);
 
         assertThat(transferContext.numOfAutoCreations()).isEqualTo(2);
@@ -232,7 +232,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {
@@ -272,7 +272,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
@@ -126,6 +126,7 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
     protected static final byte[] ecdsaKeyBytes =
             Hex.decode("3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
     protected static final ProtoBytes ecKeyAlias = new ProtoBytes(Bytes.wrap(ecdsaKeyBytes));
+    protected static final ProtoBytes ecEvmAlias = new ProtoBytes(Bytes.fromHex("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"));
 
     protected static final byte[] evmAddress = unhex("0000000000000000000000000000000000000003");
     protected static final byte[] create2Address = unhex("0111111111111111111111111111111111defbbb");
@@ -213,11 +214,11 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
                         any(), eq(CryptoCreateRecordBuilder.class), any(Predicate.class), eq(syntheticPayer)))
                 .will((invocation) -> {
                     final var copy = account.copyBuilder()
-                            .alias(ecKeyAlias.value())
+                            .alias(ecEvmAlias.value())
                             .accountId(AccountID.newBuilder().accountNum(hbarReceiver))
                             .build();
                     writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(hbarReceiver));
+                    writableAliases.put(ecEvmAlias, asAccount(hbarReceiver));
                     return cryptoCreateRecordBuilder.accountID(asAccount(hbarReceiver));
                 })
                 .will((invocation) -> {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoHandlerTestBase.java
@@ -70,7 +70,7 @@ public class CryptoHandlerTestBase {
     protected final Instant consensusInstant = Instant.ofEpochSecond(consensusTimestamp.seconds());
     protected final Key accountKey = A_COMPLEX_KEY;
     protected final HederaKey accountHederaKey = asHederaKey(accountKey).get();
-    protected final Long accountNum = id.accountNum();
+    protected final Long accountNum = id.accountNumOrThrow();
 
     private static final Key aPrimitiveKey = Key.newBuilder()
             .ed25519(Bytes.wrap("01234567890123456789012345678901"))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
@@ -69,11 +69,7 @@ public class HapiTestEnv {
                 final var workingDir = Path.of("./build/hapi-test/" + testName + "/node" + nodeId)
                         .normalize();
                 setupWorkingDirectory(workingDir, configText);
-                if (nodeId == 0) {
-                    nodes.add(new InProcessHapiTestNode(workingDir, 0, FIRST_GRPC_PORT));
-                } else {
-                    nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
-                }
+                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -134,31 +130,31 @@ public class HapiTestEnv {
                     .replace(
                             "</Appenders>\n" + "  <Loggers>",
                             """
-                    <RollingFile name="TestClientRollingFile" fileName="output/test-clients.log"
-                      filePattern="output/test-clients-%d{yyyy-MM-dd}-%i.log.gz">
-                      <PatternLayout>
-                        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
-                      </PatternLayout>
-                      <Policies>
-                        <TimeBasedTriggeringPolicy/>
-                        <SizeBasedTriggeringPolicy size="100 MB"/>
-                      </Policies>
-                      <DefaultRolloverStrategy max="10">
-                        <Delete basePath="output" maxDepth="3">
-                          <IfFileName glob="test-clients-*.log.gz">
-                            <IfLastModified age="P3D"/>
-                          </IfFileName>
-                        </Delete>
-                      </DefaultRolloverStrategy>
-                    </RollingFile>
-                  </Appenders>
-                  <Loggers>
+                                      <RollingFile name="TestClientRollingFile" fileName="output/test-clients.log"
+                                        filePattern="output/test-clients-%d{yyyy-MM-dd}-%i.log.gz">
+                                        <PatternLayout>
+                                          <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
+                                        </PatternLayout>
+                                        <Policies>
+                                          <TimeBasedTriggeringPolicy/>
+                                          <SizeBasedTriggeringPolicy size="100 MB"/>
+                                        </Policies>
+                                        <DefaultRolloverStrategy max="10">
+                                          <Delete basePath="output" maxDepth="3">
+                                            <IfFileName glob="test-clients-*.log.gz">
+                                              <IfLastModified age="P3D"/>
+                                            </IfFileName>
+                                          </Delete>
+                                        </DefaultRolloverStrategy>
+                                      </RollingFile>
+                                    </Appenders>
+                                    <Loggers>
 
-                    <Logger name="com.hedera.services.bdd" level="info" additivity="false">
-                      <AppenderRef ref="Console"/>
-                      <AppenderRef ref="TestClientRollingFile"/>
-                    </Logger>
-                    """)
+                                      <Logger name="com.hedera.services.bdd" level="info" additivity="false">
+                                        <AppenderRef ref="Console"/>
+                                        <AppenderRef ref="TestClientRollingFile"/>
+                                      </Logger>
+                                      """)
                     .replace(
                             "output/",
                             workingDir.resolve("output").toAbsolutePath().normalize() + "/");

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -203,6 +203,7 @@ public class EthereumSuite extends HapiSuite {
                 }));
     }
 
+    @HapiTest
     HapiSpec etx010TransferToCryptoAccountSucceeds() {
         String RECEIVER = "RECEIVER";
         final String aliasBalanceSnapshot = "aliasBalance";
@@ -553,6 +554,7 @@ public class EthereumSuite extends HapiSuite {
     }
 
     // ETX-011 and ETX-030
+    @HapiTest
     HapiSpec originAndSenderAreEthereumSigner() {
         return defaultHapiSpec("originAndSenderAreEthereumSigner")
                 .given(
@@ -672,6 +674,7 @@ public class EthereumSuite extends HapiSuite {
                 .then();
     }
 
+    @HapiTest
     HapiSpec etxSvc003ContractGetBytecodeQueryReturnsDeployedCode() {
         final var txn = "creation";
         final var contract = "EmptyConstructor";
@@ -753,6 +756,7 @@ public class EthereumSuite extends HapiSuite {
                                                         .withErcFungibleTransferStatus(true)))))));
     }
 
+    @HapiTest
     HapiSpec transferHbarsViaEip2930TxSuccessfully() {
         final String RECEIVER = "RECEIVER";
         final String aliasBalanceSnapshot = "aliasBalance";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -218,6 +218,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                         .logged());
     }
 
+    @HapiTest
     HapiSpec depositSuccess() {
         return defaultHapiSpec("depositSuccess")
                 .given(
@@ -390,6 +391,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                 .has(accountWith().nonce(1L)));
     }
 
+    @HapiTest
     HapiSpec bigContractCreate() {
         final var contractAdminKey = "contractAdminKey";
         return defaultHapiSpec("bigContractCreate")
@@ -435,6 +437,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                 .has(accountWith().nonce(1L)));
     }
 
+    @HapiTest
     HapiSpec contractCreateWithConstructorArgs() {
         final var contractAdminKey = "contractAdminKey";
         return defaultHapiSpec("contractCreateWithConstructorArgs")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -59,7 +59,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVER
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
@@ -287,6 +286,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                 .has(accountWith().nonce(3L)));
     }
 
+    @HapiTest
     HapiSpec ethereumCallWithCalldataBiggerThanMaxSucceeds() {
         final var largerThanMaxCalldata = new byte[MAX_CALL_DATA_SIZE + 1];
         return defaultHapiSpec("ethereumCallWithCalldataBiggerThanMaxSucceeds")


### PR DESCRIPTION
**Description**:
 - Avoids ISS in `smallContractCreate()` by removing special treatment of `node0` in `HapiTestEnv`.
 - When un-aliasing an `0.0.<alias>` form `AccountID` in `ReadableAccountStoreImpl`, also considers "indirect" references where an ECDSA key has an implied EVM address that is an in-use alias.
 - When answering a `CryptoGetInfo` query, ensures the returned `AccountID` is a numeric `0.0.X` id.
 - Also enables a passing `ethereumCallWithCalldataBiggerThanMaxSucceeds()` spec (have not checked others).