### PR TITLE
Allow build to run without internet connection using --offline

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -148,12 +148,15 @@ gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))
     // check branch in repo for updates every second
     refreshIntervalMillis.set(1000)
-    include("hedera-protobufs") {
-        uri.set("https://github.com/hashgraph/hedera-protobufs.git")
-        // HAPI repo version
-        tag.set(hapiProtoBranchOrTag)
-        // do not load project from repo
-        autoInclude.set(false)
+
+    if (!gradle.startParameter.isOffline) {
+        include("hedera-protobufs") {
+            uri.set("https://github.com/hashgraph/hedera-protobufs.git")
+            // HAPI repo version
+            tag.set(hapiProtoBranchOrTag)
+            // do not load project from repo
+            autoInclude.set(false)
+        }
     }
 }
 


### PR DESCRIPTION
**Description**:
Do not attempt to clone/update `hedera-protobufs.git` if build was started in _offline mode_. 

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
