### PR TITLE
Fix Paid query handler base class to not permit subclasses to be free.

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PaidQueryHandler.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PaidQueryHandler.java
@@ -22,6 +22,7 @@ import static com.hedera.hapi.node.base.ResponseType.COST_ANSWER;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ResponseType;
+import com.hedera.node.app.spi.fees.Fees;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -40,4 +41,8 @@ public abstract class PaidQueryHandler implements QueryHandler {
         requireNonNull(responseType);
         return COST_ANSWER == responseType;
     }
+
+    @NonNull
+    @Override
+    public abstract Fees computeFees(@NonNull final QueryContext queryContext);
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetByKeyHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetByKeyHandler.java
@@ -25,6 +25,7 @@ import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.transaction.GetByKeyResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -70,5 +71,11 @@ public class NetworkGetByKeyHandler extends PaidQueryHandler {
         requireNonNull(context);
         requireNonNull(header);
         throw new UnsupportedOperationException("Not supported");
+    }
+
+    @NonNull
+    @Override
+    public Fees computeFees(@NonNull final QueryContext context) {
+        return context.feeCalculator().calculate();
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
@@ -33,6 +33,7 @@ import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.hapi.node.transaction.TransactionGetRecordResponse;
 import com.hedera.hapi.node.transaction.TransactionRecord;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -140,5 +141,11 @@ public class NetworkTransactionGetRecordHandler extends PaidQueryHandler {
             }
         }
         return children;
+    }
+
+    @NonNull
+    @Override
+    public Fees computeFees(@NonNull final QueryContext context) {
+        return context.feeCalculator().calculate();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.service.contract.impl.exec.QueryComponent;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent.Factory;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -109,5 +110,11 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
         response.functionResult(outcome.result());
 
         return Response.newBuilder().contractCallLocal(response).build();
+    }
+
+    @NonNull
+    @Override
+    public Fees computeFees(@NonNull final QueryContext context) {
+        return context.feeCalculator().calculate();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetBytecodeHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetBytecodeHandler.java
@@ -33,6 +33,7 @@ import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.node.app.service.contract.impl.state.ContractStateStore;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -104,5 +105,11 @@ public class ContractGetBytecodeHandler extends PaidQueryHandler {
                 EntityNumber.newBuilder().number(contractNumber).build();
         final var bytecode = store.getBytecode(contractEntityNumber);
         return bytecode.code();
+    }
+
+    @NonNull
+    @Override
+    public Fees computeFees(@NonNull final QueryContext context) {
+        return context.feeCalculator().calculate();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
@@ -41,6 +41,7 @@ import com.hedera.node.app.service.token.ReadableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.ReadableStakingInfoStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -145,5 +146,11 @@ public class ContractGetInfoHandler extends PaidQueryHandler {
         final var contractId = context.query().contractGetInfoOrThrow().contractIDOrElse(ContractID.DEFAULT);
         final var contract = accountsStore.getContractById(contractId);
         return (contract == null || !contract.smartContract()) ? null : contract;
+    }
+
+    @NonNull
+    @Override
+    public Fees computeFees(@NonNull final QueryContext context) {
+        return context.feeCalculator().calculate();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetRecordsHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetRecordsHandler.java
@@ -24,6 +24,7 @@ import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.contract.ContractGetRecordsResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -67,5 +68,11 @@ public class ContractGetRecordsHandler extends PaidQueryHandler {
         requireNonNull(context);
         requireNonNull(header);
         throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @NonNull
+    @Override
+    public Fees computeFees(@NonNull final QueryContext context) {
+        return context.feeCalculator().calculate();
     }
 }


### PR DESCRIPTION
The query handler inferface has a default implementation for fee calculation that reutrns `FREE`.  This is clearly incorrect for paid queries.
   The paid query abstract base class does not override this default, however, and six (6) paid queries do not implement fee calculation as a result.
   This change adds an abstract declaration of the fee calculation method to the PaidQueryHandler interface so that _paid_ query subclasses must implement fee calculation.
* Made fee calculation for base class PaidQueryHandler an abstract declaration instead of defaulting to FREE (from interface).
   * Updated four(4) contract query handlers and two(2) network admin query handlers with a partial (just calculate the fee from workflow) non-free implementation of fee calculation to avoid compile issues.
   * All six handlers will need corrected implementations (or to not extend the PaidQueryHandler base class if they should actually be free queries).

Related issues:
#8971 
#9054 

Preceding PR:
https://github.com/hashgraph/hedera-services/pull/9035
