### PR TITLE
Fix contract and schedule entities limits

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/WritableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/WritableStoreFactory.java
@@ -29,6 +29,9 @@ import com.hedera.node.app.service.file.impl.WritableFileStore;
 import com.hedera.node.app.service.file.impl.WritableUpgradeFileStore;
 import com.hedera.node.app.service.networkadmin.FreezeService;
 import com.hedera.node.app.service.networkadmin.impl.WritableFreezeStore;
+import com.hedera.node.app.service.schedule.ScheduleService;
+import com.hedera.node.app.service.schedule.WritableScheduleStore;
+import com.hedera.node.app.service.schedule.impl.WritableScheduleStoreImpl;
 import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
@@ -79,6 +82,8 @@ public class WritableStoreFactory {
         newMap.put(
                 WritableContractStateStore.class,
                 new StoreEntry(ContractService.NAME, WritableContractStateStore::new));
+        // ScheduleService
+        newMap.put(WritableScheduleStore.class, new StoreEntry(ScheduleService.NAME, WritableScheduleStoreImpl::new));
         // EntityIdService
         newMap.put(WritableEntityIdStore.class, new StoreEntry(EntityIdService.NAME, WritableEntityIdStore::new));
         return Collections.unmodifiableMap(newMap);

--- a/hedera-node/hedera-app/src/xtest/java/common/AbstractXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/AbstractXTest.java
@@ -1,0 +1,373 @@
+package common;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.NftID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.ResponseHeader;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.hapi.node.state.common.EntityIDPair;
+import com.hedera.hapi.node.state.common.EntityNumber;
+import com.hedera.hapi.node.state.contract.Bytecode;
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.state.token.Nft;
+import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.state.token.TokenRelation;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.fees.FeeService;
+import com.hedera.node.app.fixtures.state.FakeHederaState;
+import com.hedera.node.app.ids.EntityIdService;
+import com.hedera.node.app.records.BlockRecordService;
+import com.hedera.node.app.service.contract.impl.ContractServiceImpl;
+import com.hedera.node.app.service.contract.impl.state.ContractSchema;
+import com.hedera.node.app.service.file.impl.FileServiceImpl;
+import com.hedera.node.app.service.token.TokenService;
+import com.hedera.node.app.service.token.impl.TokenServiceImpl;
+import com.hedera.node.app.spi.state.ReadableKVState;
+import com.hedera.node.app.spi.workflows.QueryHandler;
+import com.hedera.node.app.spi.workflows.TransactionHandler;
+import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.metrics.Metrics;
+import contract.AbstractContractXTest;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static common.CommonXTestConstants.SET_OF_TRADITIONAL_RATES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class AbstractXTest {
+    private static final AccountID[] SOME_NUMERIC_ACCOUNT_IDS = new AccountID[]{
+            AccountID.newBuilder().accountNum(242424L).build(),
+            AccountID.newBuilder().accountNum(252525L).build(),
+            AccountID.newBuilder().accountNum(262626L).build(),
+            AccountID.newBuilder().accountNum(313131L).build(),
+            AccountID.newBuilder().accountNum(343434L).build(),
+            AccountID.newBuilder().accountNum(373737L).build(),
+    };
+    private int numNamedAccounts = 0;
+    protected final Map<String, AccountID> namedAccountIds = new HashMap<>();
+
+    private static final TokenID[] SOME_NUMERIC_TOKEN_IDS = new TokenID[]{
+            TokenID.newBuilder().tokenNum(777777L).build(),
+            TokenID.newBuilder().tokenNum(888888L).build(),
+            TokenID.newBuilder().tokenNum(999999L).build(),
+    };
+    private int numNamedTokens = 0;
+    protected final Map<String, TokenID> namedTokenIds = new HashMap<>();
+
+    @Mock
+    protected Metrics metrics;
+
+    @Test
+    void scenarioPasses() {
+        setupFeeManager();
+        setupInitialStates();
+        setupExchangeManager();
+
+        doScenarioOperations();
+
+        assertExpectedNfts(finalNfts());
+        assertExpectedAliases(finalAliases());
+        assertExpectedAccounts(finalAccounts());
+        assertExpectedBytecodes(finalBytecodes());
+        assertExpectedStorage(finalStorage(), finalAccounts());
+        assertExpectedTokenRelations(finalTokenRelations());
+    }
+
+    protected abstract BaseScaffoldingComponent component();
+
+    protected abstract void doScenarioOperations();
+
+    protected void answerSingleQuery(
+            @NonNull final QueryHandler handler,
+            @NonNull final Query query,
+            @NonNull final AccountID payerId,
+            @NonNull final Consumer<Response> assertions) {
+        final var context = component().queryContextFactory().apply(query, payerId);
+        assertions.accept(handler.findResponse(context, ResponseHeader.DEFAULT));
+    }
+
+    protected void handleAndCommitSingleTransaction(
+            @NonNull final TransactionHandler handler,
+            @NonNull final TransactionBody txn) {
+        handleAndCommitSingleTransaction(handler, txn, ResponseCodeEnum.SUCCESS);
+    }
+
+    protected void handleAndCommitSingleTransaction(
+            @NonNull final TransactionHandler handler,
+            @NonNull final TransactionBody txn,
+            @NonNull final ResponseCodeEnum expectedStatus) {
+        final var context = component().txnContextFactory().apply(txn);
+        handler.handle(context);
+        ((SavepointStackImpl) context.savepointStack()).commitFullStack();
+        final var recordBuilder = context.recordBuilder(SingleTransactionRecordBuilder.class);
+        assertEquals(expectedStatus, recordBuilder.status());
+    }
+
+    protected void addNamedAccount(
+            @NonNull final String name,
+            @NonNull final Map<AccountID, Account> accounts) {
+        addNamedAccount(name, b -> {}, accounts);
+    }
+
+    protected void addNamedAccount(
+            @NonNull final String name,
+            @NonNull final Consumer<Account.Builder> spec,
+            @NonNull final Map<AccountID, Account> accounts) {
+        final var accountId = SOME_NUMERIC_ACCOUNT_IDS[numNamedAccounts++];
+        namedAccountIds.put(name, accountId);
+        final var builder = Account.newBuilder().accountId(accountId);
+        spec.accept(builder);
+        accounts.put(accountId, builder.build());
+    }
+
+    protected AccountID idOfNamedAccount(@NonNull final String name) {
+        return Objects.requireNonNull(namedAccountIds.get(name));
+    }
+
+    protected void addNamedFungibleToken(
+            @NonNull final String name,
+            @NonNull final Consumer<Token.Builder> spec,
+            @NonNull final Map<TokenID, Token> tokens) {
+        addNamedToken(name, spec.andThen(b -> b.tokenType(TokenType.FUNGIBLE_COMMON)), tokens);
+    }
+
+    protected void addNamedNonFungibleToken(
+            @NonNull final String name,
+            @NonNull final Consumer<Token.Builder> spec,
+            @NonNull final Map<TokenID, Token> tokens) {
+        addNamedToken(name, spec.andThen(b -> b.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)), tokens);
+    }
+
+    protected void addNewRelation(
+            @NonNull final String account,
+            @NonNull final String token,
+            @NonNull final Consumer<TokenRelation.Builder> spec,
+            @NonNull final Map<EntityIDPair, TokenRelation> tokenRels) {
+        final Consumer<TokenRelation.Builder> defaultSpec = b -> b.kycGranted(true);
+        addNewRelation(
+                idOfNamedAccount(account),
+                idOfNamedToken(token),
+                defaultSpec.andThen(spec),
+                tokenRels);
+    }
+
+    protected void addNewRelation(
+            @NonNull final AccountID accountID,
+            @NonNull final TokenID tokenID,
+            @NonNull final Consumer<TokenRelation.Builder> spec,
+            @NonNull final Map<EntityIDPair, TokenRelation> tokenRels) {
+        final var builder = TokenRelation.newBuilder()
+                .accountId(accountID)
+                .tokenId(tokenID);
+        spec.accept(builder);
+        tokenRels.put(new EntityIDPair(accountID, tokenID), builder.build());
+    }
+
+    protected void addNamedToken(
+            @NonNull final String name,
+            @NonNull final Consumer<Token.Builder> spec,
+            @NonNull final Map<TokenID, Token> tokens) {
+        final var tokenId = SOME_NUMERIC_TOKEN_IDS[numNamedTokens++];
+        namedTokenIds.put(name, tokenId);
+        final var builder = Token.newBuilder().tokenId(tokenId);
+        spec.accept(builder);
+        tokens.put(tokenId, builder.build());
+    }
+
+    protected TokenID idOfNamedToken(@NonNull final String name) {
+        return Objects.requireNonNull(namedTokenIds.get(name));
+    }
+
+    protected long initialEntityNum() {
+        // An x-test that doesn't override this can't create entities
+        return Long.MAX_VALUE;
+    }
+
+    protected Map<TokenID, Token> initialTokens() {
+        return new HashMap<>();
+    }
+
+    protected Map<EntityIDPair, TokenRelation> initialTokenRelationships() {
+        return new HashMap<>();
+    }
+
+    protected Map<NftID, Nft> initialNfts() {
+        return new HashMap<>();
+    }
+
+    protected Map<FileID, File> initialFiles() {
+        return new HashMap<>();
+    }
+
+    protected Map<ProtoBytes, AccountID> initialAliases() {
+        return new HashMap<>();
+    }
+
+    protected Map<AccountID, Account> initialAccounts() {
+        return new HashMap<>();
+    }
+
+    protected RunningHashes initialRunningHashes() {
+        return RunningHashes.DEFAULT;
+    }
+
+    protected Bytes resourceAsBytes(@NonNull final String loc) {
+        try {
+            try (final var in = AbstractContractXTest.class.getClassLoader().getResourceAsStream(loc)) {
+                final var bytes = Objects.requireNonNull(in).readAllBytes();
+                return Bytes.wrap(bytes);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    protected void assertExpectedStorage(
+            @NonNull ReadableKVState<SlotKey, SlotValue> storage,
+            @NonNull ReadableKVState<AccountID, Account> accounts) {
+    }
+
+    protected void assertExpectedNfts(@NonNull ReadableKVState<NftID, Nft> nfts) {
+    }
+
+    protected void assertExpectedAliases(@NonNull ReadableKVState<ProtoBytes, AccountID> aliases) {
+    }
+
+    protected void assertExpectedTokenRelations(@NonNull ReadableKVState<EntityIDPair, TokenRelation> tokenRels) {
+    }
+
+    protected void assertExpectedAccounts(@NonNull ReadableKVState<AccountID, Account> accounts) {
+    }
+
+    protected void assertExpectedBytecodes(@NonNull ReadableKVState<EntityNumber, Bytecode> bytecodes) {
+    }
+
+    private ReadableKVState<NftID, Nft> finalNfts() {
+        return component()
+                .hederaState()
+                .createReadableStates(TokenServiceImpl.NAME)
+                .get(TokenServiceImpl.NFTS_KEY);
+    }
+
+    private ReadableKVState<ProtoBytes, AccountID> finalAliases() {
+        return component()
+                .hederaState()
+                .createReadableStates(TokenServiceImpl.NAME)
+                .get(TokenServiceImpl.ALIASES_KEY);
+    }
+
+    private ReadableKVState<SlotKey, SlotValue> finalStorage() {
+        return component()
+                .hederaState()
+                .createReadableStates(ContractServiceImpl.NAME)
+                .get(ContractSchema.STORAGE_KEY);
+    }
+
+    private ReadableKVState<EntityNumber, Bytecode> finalBytecodes() {
+        return component()
+                .hederaState()
+                .createReadableStates(ContractServiceImpl.NAME)
+                .get(ContractSchema.BYTECODE_KEY);
+    }
+
+    private ReadableKVState<AccountID, Account> finalAccounts() {
+        return component()
+                .hederaState()
+                .createReadableStates(TokenServiceImpl.NAME)
+                .get(TokenServiceImpl.ACCOUNTS_KEY);
+    }
+
+    private ReadableKVState<EntityIDPair, TokenRelation> finalTokenRelations() {
+        return component()
+                .hederaState()
+                .createReadableStates(TokenServiceImpl.NAME)
+                .get(TokenServiceImpl.TOKEN_RELS_KEY);
+    }
+
+    private Map<FileID, File> initialFilesWithExchangeRate() {
+        final var scenarioFiles = initialFiles();
+        scenarioFiles.put(
+                FileID.newBuilder().fileNum(112).build(),
+                File.newBuilder()
+                        .contents(ExchangeRateSet.PROTOBUF.toBytes(SET_OF_TRADITIONAL_RATES))
+                        .build());
+        return scenarioFiles;
+    }
+
+    private void setupFeeManager() {
+        var feeScheduleBytes = resourceAsBytes("feeSchedules.bin");
+        component().feeManager().update(feeScheduleBytes);
+    }
+
+    private void setupExchangeManager() {
+        final var state = Objects.requireNonNull(
+                component().workingStateAccessor().getHederaState());
+        final var midnightRates = state.createReadableStates(FeeService.NAME)
+                .<ExchangeRateSet>getSingleton("MIDNIGHT_RATES")
+                .get();
+
+        component().exchangeRateManager().init(state, ExchangeRateSet.PROTOBUF.toBytes(midnightRates));
+    }
+
+    private void setupInitialStates() {
+        final var fakeHederaState = (FakeHederaState) component().hederaState();
+
+        fakeHederaState.addService(
+                EntityIdService.NAME, Map.of("ENTITY_ID", new AtomicReference<>(new EntityNumber(initialEntityNum()))));
+
+        fakeHederaState.addService("RecordCache", Map.of("TransactionRecordQueue", new ArrayDeque<>()));
+
+        fakeHederaState.addService(
+                FeeService.NAME, Map.of("MIDNIGHT_RATES", new AtomicReference<>(SET_OF_TRADITIONAL_RATES)));
+
+        fakeHederaState.addService(
+                BlockRecordService.NAME,
+                Map.of(
+                        BlockRecordService.BLOCK_INFO_STATE_KEY, new AtomicReference<>(BlockInfo.DEFAULT),
+                        BlockRecordService.RUNNING_HASHES_STATE_KEY, new AtomicReference<>(initialRunningHashes())));
+
+        fakeHederaState.addService(
+                TokenService.NAME,
+                Map.of(
+                        TokenServiceImpl.ACCOUNTS_KEY, initialAccounts(),
+                        TokenServiceImpl.TOKENS_KEY, initialTokens(),
+                        TokenServiceImpl.TOKEN_RELS_KEY, initialTokenRelationships(),
+                        TokenServiceImpl.ALIASES_KEY, initialAliases(),
+                        TokenServiceImpl.NFTS_KEY, initialNfts()));
+        fakeHederaState.addService(
+                FileServiceImpl.NAME, Map.of(FileServiceImpl.BLOBS_KEY, initialFilesWithExchangeRate()));
+        fakeHederaState.addService(
+                ContractServiceImpl.NAME,
+                Map.of(
+                        ContractSchema.BYTECODE_KEY, new HashMap<EntityNumber, Bytecode>(),
+                        ContractSchema.STORAGE_KEY, new HashMap<SlotKey, SlotValue>()));
+
+        component().workingStateAccessor().setHederaState(fakeHederaState);
+    }
+}

--- a/hedera-node/hedera-app/src/xtest/java/common/AbstractXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/AbstractXTest.java
@@ -1,4 +1,23 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package common;
+
+import static common.CommonXTestConstants.SET_OF_TRADITIONAL_RATES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.FileID;
@@ -42,11 +61,6 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.metrics.Metrics;
 import contract.AbstractContractXTest;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
@@ -55,27 +69,28 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-
-import static common.CommonXTestConstants.SET_OF_TRADITIONAL_RATES;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class AbstractXTest {
-    private static final AccountID[] SOME_NUMERIC_ACCOUNT_IDS = new AccountID[]{
-            AccountID.newBuilder().accountNum(242424L).build(),
-            AccountID.newBuilder().accountNum(252525L).build(),
-            AccountID.newBuilder().accountNum(262626L).build(),
-            AccountID.newBuilder().accountNum(313131L).build(),
-            AccountID.newBuilder().accountNum(343434L).build(),
-            AccountID.newBuilder().accountNum(373737L).build(),
+    private static final AccountID[] SOME_NUMERIC_ACCOUNT_IDS = new AccountID[] {
+        AccountID.newBuilder().accountNum(242424L).build(),
+        AccountID.newBuilder().accountNum(252525L).build(),
+        AccountID.newBuilder().accountNum(262626L).build(),
+        AccountID.newBuilder().accountNum(313131L).build(),
+        AccountID.newBuilder().accountNum(343434L).build(),
+        AccountID.newBuilder().accountNum(373737L).build(),
     };
     private int numNamedAccounts = 0;
     protected final Map<String, AccountID> namedAccountIds = new HashMap<>();
 
-    private static final TokenID[] SOME_NUMERIC_TOKEN_IDS = new TokenID[]{
-            TokenID.newBuilder().tokenNum(777777L).build(),
-            TokenID.newBuilder().tokenNum(888888L).build(),
-            TokenID.newBuilder().tokenNum(999999L).build(),
+    private static final TokenID[] SOME_NUMERIC_TOKEN_IDS = new TokenID[] {
+        TokenID.newBuilder().tokenNum(777777L).build(),
+        TokenID.newBuilder().tokenNum(888888L).build(),
+        TokenID.newBuilder().tokenNum(999999L).build(),
     };
     private int numNamedTokens = 0;
     protected final Map<String, TokenID> namedTokenIds = new HashMap<>();
@@ -113,9 +128,8 @@ public abstract class AbstractXTest {
     }
 
     protected void handleAndCommitSingleTransaction(
-            @NonNull final TransactionHandler handler,
-            @NonNull final TransactionBody txn) {
-        handleAndCommitSingleTransaction(handler, txn, ResponseCodeEnum.SUCCESS);
+            @NonNull final TransactionHandler handler, @NonNull final TransactionBody txn) {
+        handleAndCommitSingleTransaction(handler, txn, ResponseCodeEnum.OK);
     }
 
     protected void handleAndCommitSingleTransaction(
@@ -129,9 +143,7 @@ public abstract class AbstractXTest {
         assertEquals(expectedStatus, recordBuilder.status());
     }
 
-    protected void addNamedAccount(
-            @NonNull final String name,
-            @NonNull final Map<AccountID, Account> accounts) {
+    protected void addNamedAccount(@NonNull final String name, @NonNull final Map<AccountID, Account> accounts) {
         addNamedAccount(name, b -> {}, accounts);
     }
 
@@ -170,11 +182,7 @@ public abstract class AbstractXTest {
             @NonNull final Consumer<TokenRelation.Builder> spec,
             @NonNull final Map<EntityIDPair, TokenRelation> tokenRels) {
         final Consumer<TokenRelation.Builder> defaultSpec = b -> b.kycGranted(true);
-        addNewRelation(
-                idOfNamedAccount(account),
-                idOfNamedToken(token),
-                defaultSpec.andThen(spec),
-                tokenRels);
+        addNewRelation(idOfNamedAccount(account), idOfNamedToken(token), defaultSpec.andThen(spec), tokenRels);
     }
 
     protected void addNewRelation(
@@ -182,9 +190,7 @@ public abstract class AbstractXTest {
             @NonNull final TokenID tokenID,
             @NonNull final Consumer<TokenRelation.Builder> spec,
             @NonNull final Map<EntityIDPair, TokenRelation> tokenRels) {
-        final var builder = TokenRelation.newBuilder()
-                .accountId(accountID)
-                .tokenId(tokenID);
+        final var builder = TokenRelation.newBuilder().accountId(accountID).tokenId(tokenID);
         spec.accept(builder);
         tokenRels.put(new EntityIDPair(accountID, tokenID), builder.build());
     }
@@ -250,23 +256,19 @@ public abstract class AbstractXTest {
 
     protected void assertExpectedStorage(
             @NonNull ReadableKVState<SlotKey, SlotValue> storage,
-            @NonNull ReadableKVState<AccountID, Account> accounts) {
-    }
+            @NonNull ReadableKVState<AccountID, Account> accounts) {}
 
-    protected void assertExpectedNfts(@NonNull ReadableKVState<NftID, Nft> nfts) {
-    }
+    protected void assertExpectedNfts(@NonNull ReadableKVState<NftID, Nft> nfts) {}
 
-    protected void assertExpectedAliases(@NonNull ReadableKVState<ProtoBytes, AccountID> aliases) {
-    }
+    protected void assertExpectedAliases(@NonNull ReadableKVState<ProtoBytes, AccountID> aliases) {}
 
-    protected void assertExpectedTokenRelations(@NonNull ReadableKVState<EntityIDPair, TokenRelation> tokenRels) {
-    }
+    protected void assertExpectedTokenRelations(@NonNull ReadableKVState<EntityIDPair, TokenRelation> tokenRels) {}
 
-    protected void assertExpectedAccounts(@NonNull ReadableKVState<AccountID, Account> accounts) {
-    }
+    protected void assertExpectedAccounts(@NonNull ReadableKVState<AccountID, Account> accounts) {}
 
-    protected void assertExpectedBytecodes(@NonNull ReadableKVState<EntityNumber, Bytecode> bytecodes) {
-    }
+    protected void assertExpectedBytecodes(@NonNull ReadableKVState<EntityNumber, Bytecode> bytecodes) {}
+
+    protected void assertExpectedTokens(@NonNull ReadableKVState<TokenID, Token> tokens) {}
 
     private ReadableKVState<NftID, Nft> finalNfts() {
         return component()
@@ -326,8 +328,8 @@ public abstract class AbstractXTest {
     }
 
     private void setupExchangeManager() {
-        final var state = Objects.requireNonNull(
-                component().workingStateAccessor().getHederaState());
+        final var state =
+                Objects.requireNonNull(component().workingStateAccessor().getHederaState());
         final var midnightRates = state.createReadableStates(FeeService.NAME)
                 .<ExchangeRateSet>getSingleton("MIDNIGHT_RATES")
                 .get();

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
@@ -29,6 +29,9 @@ import com.swirlds.config.api.Configuration;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+/**
+ * The common provision methods needed for practically any kind of x-test, no matter the target service.
+ */
 public interface BaseScaffoldingComponent {
     HederaState hederaState();
 

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package common;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -10,7 +26,6 @@ import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.app.state.HederaState;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.swirlds.config.api.Configuration;
-
 import java.util.function.BiFunction;
 import java.util.function.Function;
 

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
@@ -1,0 +1,31 @@
+package common;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.fees.ExchangeRateManager;
+import com.hedera.node.app.fees.FeeManager;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.QueryContext;
+import com.hedera.node.app.state.HederaState;
+import com.hedera.node.app.state.WorkingStateAccessor;
+import com.swirlds.config.api.Configuration;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public interface BaseScaffoldingComponent {
+    HederaState hederaState();
+
+    Configuration config();
+
+    WorkingStateAccessor workingStateAccessor();
+
+    Function<TransactionBody, HandleContext> txnContextFactory();
+
+    BiFunction<Query, AccountID, QueryContext> queryContextFactory();
+
+    FeeManager feeManager();
+
+    ExchangeRateManager exchangeRateManager();
+}

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingModule.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingModule.java
@@ -71,7 +71,6 @@ import com.hedera.node.app.workflows.query.QueryContextImpl;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.data.HederaConfig;
-import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.stream.Signer;
@@ -169,14 +168,6 @@ public interface BaseScaffoldingModule {
     @Singleton
     static BlockRecordFormat provideBlockRecordFormat() {
         return BlockRecordFormatV6.INSTANCE;
-    }
-
-    @Provides
-    @Singleton
-    static Configuration provideConfiguration() {
-        return HederaTestConfigBuilder.create()
-                .withValue("contracts.chainId", "298")
-                .getOrCreateConfig();
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingModule.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package contract;
+package common;
 
 import static com.hedera.node.app.spi.HapiUtils.functionOf;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
@@ -76,6 +76,7 @@ import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.stream.Signer;
 import com.swirlds.config.api.Configuration;
+import contract.ContractScaffoldingComponent;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -89,7 +90,7 @@ import java.util.function.Function;
 import javax.inject.Singleton;
 
 /**
- * A helper module for Dagger2 to instantiate an {@link ScaffoldingComponent}; provides
+ * A helper module for Dagger2 to instantiate an {@link ContractScaffoldingComponent}; provides
  * any bindings not already provided by {@link HandlersInjectionModule}. Most of the
  * bindings in this module are the production implementations of their interfaces, but
  * some are not. The exceptions are,
@@ -103,7 +104,7 @@ import javax.inject.Singleton;
  * since the persistence layer and some "environment" details are faked.
  */
 @Module
-public interface ScaffoldingModule {
+public interface BaseScaffoldingModule {
     @Provides
     @Singleton
     static HederaState provideState() {

--- a/hedera-node/hedera-app/src/xtest/java/common/CommonXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/CommonXTestConstants.java
@@ -1,0 +1,25 @@
+package common;
+
+import com.hedera.hapi.node.base.TimestampSeconds;
+import com.hedera.hapi.node.transaction.ExchangeRate;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+
+import java.time.Instant;
+
+public class CommonXTestConstants {
+    /**
+     * The exchange rate long used in dev environments to run HAPI spec; expected to be in effect for
+     * some x-tests to pass.
+     */
+    public static final ExchangeRate TRADITIONAL_HAPI_SPEC_RATE = ExchangeRate.newBuilder()
+            .hbarEquiv(1)
+            .centEquiv(12)
+            .expirationTime(TimestampSeconds.newBuilder()
+                    .seconds(Instant.MAX.getEpochSecond())
+                    .build())
+            .build();
+    public static final ExchangeRateSet SET_OF_TRADITIONAL_RATES = ExchangeRateSet.newBuilder()
+            .currentRate(TRADITIONAL_HAPI_SPEC_RATE)
+            .nextRate(TRADITIONAL_HAPI_SPEC_RATE)
+            .build();
+}

--- a/hedera-node/hedera-app/src/xtest/java/common/CommonXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/CommonXTestConstants.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package common;
 
 import com.hedera.hapi.node.base.TimestampSeconds;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
-
 import java.time.Instant;
 
 public class CommonXTestConstants {
@@ -18,6 +33,7 @@ public class CommonXTestConstants {
                     .seconds(Instant.MAX.getEpochSecond())
                     .build())
             .build();
+
     public static final ExchangeRateSet SET_OF_TRADITIONAL_RATES = ExchangeRateSet.newBuilder()
             .currentRate(TRADITIONAL_HAPI_SPEC_RATE)
             .nextRate(TRADITIONAL_HAPI_SPEC_RATE)

--- a/hedera-node/hedera-app/src/xtest/java/contract/AbstractContractXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/AbstractContractXTest.java
@@ -16,46 +16,16 @@
 
 package contract;
 
-import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.CONFIG_CONTEXT_VARIABLE;
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asLongZeroAddress;
-import static contract.XTestConstants.PLACEHOLDER_CALL_BODY;
-import static contract.XTestConstants.SET_OF_TRADITIONAL_RATES;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Duration;
-import com.hedera.hapi.node.base.FileID;
-import com.hedera.hapi.node.base.NftID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.contract.ContractCallTransactionBody;
-import com.hedera.hapi.node.state.blockrecords.BlockInfo;
-import com.hedera.hapi.node.state.blockrecords.RunningHashes;
-import com.hedera.hapi.node.state.common.EntityIDPair;
-import com.hedera.hapi.node.state.common.EntityNumber;
-import com.hedera.hapi.node.state.contract.Bytecode;
-import com.hedera.hapi.node.state.contract.SlotKey;
-import com.hedera.hapi.node.state.contract.SlotValue;
-import com.hedera.hapi.node.state.file.File;
-import com.hedera.hapi.node.state.primitives.ProtoBytes;
-import com.hedera.hapi.node.state.token.Account;
-import com.hedera.hapi.node.state.token.Nft;
-import com.hedera.hapi.node.state.token.Token;
-import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.hapi.node.transaction.ExchangeRateSet;
-import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fees.FeeService;
-import com.hedera.node.app.fixtures.state.FakeHederaState;
-import com.hedera.node.app.ids.EntityIdService;
-import com.hedera.node.app.records.BlockRecordService;
-import com.hedera.node.app.service.contract.impl.ContractServiceImpl;
 import com.hedera.node.app.service.contract.impl.exec.scope.HandleHederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.HandleHederaOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.HandleSystemContractOperations;
@@ -66,20 +36,19 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.SyntheticIds;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.state.ContractSchema;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
-import com.hedera.node.app.service.file.impl.FileServiceImpl;
-import com.hedera.node.app.service.token.TokenService;
-import com.hedera.node.app.service.token.impl.TokenServiceImpl;
-import com.hedera.node.app.spi.state.ReadableKVState;
-import com.hedera.node.app.spi.workflows.QueryHandler;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.common.metrics.Metrics;
+import common.AbstractXTest;
+import common.BaseScaffoldingComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
@@ -87,31 +56,23 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.precompile.PrecompiledContract;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.CONFIG_CONTEXT_VARIABLE;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asLongZeroAddress;
+import static contract.XTestConstants.PLACEHOLDER_CALL_BODY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
 
 /**
  * Base class for {@code xtest} scenarios that focus on contract operations.
  */
-@ExtendWith(MockitoExtension.class)
-public abstract class AbstractContractXTest {
+public abstract class AbstractContractXTest extends AbstractXTest {
     private static final SyntheticIds LIVE_SYNTHETIC_IDS = new SyntheticIds();
     private static final VerificationStrategies LIVE_VERIFICATION_STRATEGIES = new VerificationStrategies();
     static final long GAS_TO_OFFER = 2_000_000L;
     static final Duration STANDARD_AUTO_RENEW_PERIOD = new Duration(7776000L);
-
-    @Mock
-    private Metrics metrics;
 
     @Mock
     private MessageFrame frame;
@@ -127,86 +88,26 @@ public abstract class AbstractContractXTest {
 
     private HtsCallFactory callAttemptFactory;
 
-    private ScaffoldingComponent scaffoldingComponent;
+    private ContractScaffoldingComponent component;
 
     @BeforeEach
     void setUp() {
-        scaffoldingComponent = DaggerScaffoldingComponent.factory().create(metrics);
+        component = DaggerContractScaffoldingComponent.factory().create(metrics);
         callAttemptFactory = new HtsCallFactory(
                 LIVE_SYNTHETIC_IDS,
                 addressChecks,
                 LIVE_VERIFICATION_STRATEGIES,
-                scaffoldingComponent.callTranslators());
+                component.callTranslators());
     }
 
-    @Test
-    void scenarioPasses() {
-        setupFeeManager();
-        setupInitialStates();
-        setupExchangeManager();
-
-        doScenarioOperations();
-
-        assertExpectedNfts(finalNfts());
-        assertExpectedAliases(finalAliases());
-        assertExpectedAccounts(finalAccounts());
-        assertExpectedBytecodes(finalBytecodes());
-        assertExpectedStorage(finalStorage(), finalAccounts());
-        assertExpectedTokenRelations(finalTokenRelations());
-        assertExpectedTokens(finalTokens());
+    @Override
+    protected BaseScaffoldingComponent component() {
+        return component;
     }
-
-    protected long initialEntityNum() {
-        // An x-test that doesn't override this can't create entities
-        return Long.MAX_VALUE;
-    }
-
-    protected Map<TokenID, Token> initialTokens() {
-        return new HashMap<>();
-    }
-
-    protected Map<EntityIDPair, TokenRelation> initialTokenRelationships() {
-        return new HashMap<>();
-    }
-
-    protected Map<NftID, Nft> initialNfts() {
-        return new HashMap<>();
-    }
-
-    protected Map<FileID, File> initialFiles() {
-        // An x-test that doesn't use external initcode in HAPI ops won't need any files
-        return new HashMap<>();
-    }
-
-    protected abstract Map<ProtoBytes, AccountID> initialAliases();
-
-    protected abstract Map<AccountID, Account> initialAccounts();
-
-    protected RunningHashes initialRunningHashes() {
-        return RunningHashes.DEFAULT;
-    }
-
-    protected abstract void doScenarioOperations();
-
-    protected void assertExpectedStorage(
-            @NonNull ReadableKVState<SlotKey, SlotValue> storage,
-            @NonNull ReadableKVState<AccountID, Account> accounts) {}
-
-    protected void assertExpectedNfts(@NonNull ReadableKVState<NftID, Nft> nfts) {}
-
-    protected void assertExpectedAliases(@NonNull ReadableKVState<ProtoBytes, AccountID> aliases) {}
-
-    protected void assertExpectedTokenRelations(@NonNull ReadableKVState<EntityIDPair, TokenRelation> tokenRels) {}
-
-    protected void assertExpectedTokens(@NonNull ReadableKVState<TokenID, Token> tokens) {}
-
-    protected void assertExpectedAccounts(@NonNull ReadableKVState<AccountID, Account> accounts) {}
-
-    protected void assertExpectedBytecodes(@NonNull ReadableKVState<EntityNumber, Bytecode> bytecodes) {}
 
     protected void handleAndCommit(@NonNull final TransactionHandler handler, @NonNull final TransactionBody... txns) {
         for (final var txn : txns) {
-            final var context = scaffoldingComponent.txnContextFactory().apply(txn);
+            final var context = component.txnContextFactory().apply(txn);
             handler.handle(context);
             ((SavepointStackImpl) context.savepointStack()).commitFullStack();
         }
@@ -267,16 +168,16 @@ public abstract class AbstractContractXTest {
             @NonNull final org.hyperledger.besu.datatypes.Address sender,
             @NonNull final org.apache.tuweni.bytes.Bytes input,
             @NonNull final Consumer<HtsCall.PricedResult> resultAssertions) {
-        final var context = scaffoldingComponent.txnContextFactory().apply(PLACEHOLDER_CALL_BODY);
+        final var context = component.txnContextFactory().apply(PLACEHOLDER_CALL_BODY);
         final var enhancement = new HederaWorldUpdater.Enhancement(
-                new HandleHederaOperations(scaffoldingComponent.config().getConfigData(LedgerConfig.class), context),
+                new HandleHederaOperations(component.config().getConfigData(LedgerConfig.class), context),
                 new HandleHederaNativeOperations(context),
                 new HandleSystemContractOperations(context));
         given(proxyUpdater.enhancement()).willReturn(enhancement);
         given(frame.getWorldUpdater()).willReturn(proxyUpdater);
         given(frame.getSenderAddress()).willReturn(sender);
         final Deque<MessageFrame> stack = new ArrayDeque<>();
-        given(initialFrame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(scaffoldingComponent.config());
+        given(initialFrame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(component.config());
         stack.push(initialFrame);
         stack.addFirst(frame);
         given(frame.getMessageFrameStack()).willReturn(stack);
@@ -288,31 +189,6 @@ public abstract class AbstractContractXTest {
         resultAssertions.accept(pricedResult);
         // Note that committing a reverted calls should have no effect on state
         ((SavepointStackImpl) context.savepointStack()).commitFullStack();
-    }
-
-    protected void answerSingleQuery(
-            @NonNull final QueryHandler handler,
-            @NonNull final Query query,
-            @NonNull final AccountID payerId,
-            @NonNull final Consumer<Response> assertions) {
-        final var context = scaffoldingComponent.queryContextFactory().apply(query, payerId);
-        assertions.accept(handler.findResponse(context, ResponseHeader.DEFAULT));
-    }
-
-    protected void handleAndCommitSingleTransaction(
-            @NonNull final TransactionHandler handler, @NonNull final TransactionBody txn) {
-        handleAndCommitSingleTransaction(handler, txn, ResponseCodeEnum.SUCCESS);
-    }
-
-    protected void handleAndCommitSingleTransaction(
-            @NonNull final TransactionHandler handler,
-            @NonNull final TransactionBody txn,
-            @NonNull final ResponseCodeEnum expectedStatus) {
-        final var context = scaffoldingComponent.txnContextFactory().apply(txn);
-        handler.handle(context);
-        ((SavepointStackImpl) context.savepointStack()).commitFullStack();
-        final var recordBuilder = context.recordBuilder(SingleTransactionRecordBuilder.class);
-        assertEquals(expectedStatus, recordBuilder.status());
     }
 
     protected TransactionBody createCallTransactionBody(
@@ -336,17 +212,6 @@ public abstract class AbstractContractXTest {
                 .build();
     }
 
-    protected Bytes resourceAsBytes(@NonNull final String loc) {
-        try {
-            try (final var in = AbstractContractXTest.class.getClassLoader().getResourceAsStream(loc)) {
-                final var bytes = Objects.requireNonNull(in).readAllBytes();
-                return Bytes.wrap(bytes);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
     protected Address addressOf(@NonNull final Bytes address) {
         return Address.wrap(Address.toChecksumAddress(new BigInteger(1, address.toByteArray())));
     }
@@ -357,115 +222,6 @@ public abstract class AbstractContractXTest {
                 response.contractCallLocalOrThrow().functionResultOrThrow().contractCallResult());
     }
 
-    private void setupFeeManager() {
-        var feeScheduleBytes = resourceAsBytes("feeSchedules.bin");
-        scaffoldingComponent.feeManager().update(feeScheduleBytes);
-    }
-
-    private void setupInitialStates() {
-        final var fakeHederaState = (FakeHederaState) scaffoldingComponent.hederaState();
-
-        fakeHederaState.addService(
-                EntityIdService.NAME, Map.of("ENTITY_ID", new AtomicReference<>(new EntityNumber(initialEntityNum()))));
-
-        fakeHederaState.addService("RecordCache", Map.of("TransactionRecordQueue", new ArrayDeque<>()));
-
-        fakeHederaState.addService(
-                FeeService.NAME, Map.of("MIDNIGHT_RATES", new AtomicReference<>(SET_OF_TRADITIONAL_RATES)));
-
-        fakeHederaState.addService(
-                BlockRecordService.NAME,
-                Map.of(
-                        BlockRecordService.BLOCK_INFO_STATE_KEY, new AtomicReference<>(BlockInfo.DEFAULT),
-                        BlockRecordService.RUNNING_HASHES_STATE_KEY, new AtomicReference<>(initialRunningHashes())));
-
-        fakeHederaState.addService(
-                TokenService.NAME,
-                Map.of(
-                        TokenServiceImpl.TOKEN_RELS_KEY, initialTokenRelationships(),
-                        TokenServiceImpl.ACCOUNTS_KEY, initialAccounts(),
-                        TokenServiceImpl.ALIASES_KEY, initialAliases(),
-                        TokenServiceImpl.TOKENS_KEY, initialTokens(),
-                        TokenServiceImpl.NFTS_KEY, initialNfts()));
-        fakeHederaState.addService(
-                FileServiceImpl.NAME, Map.of(FileServiceImpl.BLOBS_KEY, initialFilesWithExchangeRate()));
-        fakeHederaState.addService(
-                ContractServiceImpl.NAME,
-                Map.of(
-                        ContractSchema.BYTECODE_KEY, new HashMap<EntityNumber, Bytecode>(),
-                        ContractSchema.STORAGE_KEY, new HashMap<SlotKey, SlotValue>()));
-
-        scaffoldingComponent.workingStateAccessor().setHederaState(fakeHederaState);
-    }
-
-    private Map<FileID, File> initialFilesWithExchangeRate() {
-        final var scenarioFiles = initialFiles();
-        scenarioFiles.put(
-                FileID.newBuilder().fileNum(112).build(),
-                File.newBuilder()
-                        .contents(ExchangeRateSet.PROTOBUF.toBytes(SET_OF_TRADITIONAL_RATES))
-                        .build());
-        return scenarioFiles;
-    }
-
-    private void setupExchangeManager() {
-        final var state = Objects.requireNonNull(
-                scaffoldingComponent.workingStateAccessor().getHederaState());
-        final var midnightRates = state.createReadableStates(FeeService.NAME)
-                .<ExchangeRateSet>getSingleton("MIDNIGHT_RATES")
-                .get();
-
-        scaffoldingComponent.exchangeRateManager().init(state, ExchangeRateSet.PROTOBUF.toBytes(midnightRates));
-    }
-
-    private ReadableKVState<NftID, Nft> finalNfts() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(TokenServiceImpl.NAME)
-                .get(TokenServiceImpl.NFTS_KEY);
-    }
-
-    private ReadableKVState<ProtoBytes, AccountID> finalAliases() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(TokenServiceImpl.NAME)
-                .get(TokenServiceImpl.ALIASES_KEY);
-    }
-
-    private ReadableKVState<SlotKey, SlotValue> finalStorage() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(ContractServiceImpl.NAME)
-                .get(ContractSchema.STORAGE_KEY);
-    }
-
-    private ReadableKVState<EntityNumber, Bytecode> finalBytecodes() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(ContractServiceImpl.NAME)
-                .get(ContractSchema.BYTECODE_KEY);
-    }
-
-    private ReadableKVState<AccountID, Account> finalAccounts() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(TokenServiceImpl.NAME)
-                .get(TokenServiceImpl.ACCOUNTS_KEY);
-    }
-
-    private ReadableKVState<EntityIDPair, TokenRelation> finalTokenRelations() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(TokenServiceImpl.NAME)
-                .get(TokenServiceImpl.TOKEN_RELS_KEY);
-    }
-
-    private ReadableKVState<TokenID, Token> finalTokens() {
-        return scaffoldingComponent
-                .hederaState()
-                .createReadableStates(TokenServiceImpl.NAME)
-                .get(TokenServiceImpl.TOKENS_KEY);
-    }
 
     private Consumer<HtsCall.PricedResult> resultOnlyAssertion(
             @NonNull final Consumer<PrecompiledContract.PrecompileContractResult> resultAssertion) {

--- a/hedera-node/hedera-app/src/xtest/java/contract/AssortedOpsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/AssortedOpsXTest.java
@@ -204,10 +204,8 @@ public class AssortedOpsXTest extends AbstractContractXTest {
         final var finalizedAndDestructed = Objects.requireNonNull(accounts.get(FINALIZED_AND_DESTRUCTED_ID));
         assertEquals(1, finalizedAndDestructed.contractKvPairsNumber());
 
-        // TODO - uncomment once we have, hopefully, a SavepointStack.commit() method that
-        //  will allow the root updater to see the storage diff for the entire transaction
         final var pointlessIntermediary = Objects.requireNonNull(accounts.get(POINTLESS_INTERMEDIARY_ID));
-        //        assertEquals(2, pointlessIntermediary.contractKvPairsNumber());
+        assertEquals(2, pointlessIntermediary.contractKvPairsNumber());
 
         final var survivingChild = Objects.requireNonNull(accounts.get(RUBE_GOLDBERG_CHILD_ID));
         assertEquals(1, survivingChild.contractKvPairsNumber());

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractLimitsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractLimitsXTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package contract;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
+import static com.hedera.node.app.service.contract.impl.ContractServiceImpl.CONTRACT_SERVICE;
+import static contract.AssortedOpsXTestConstants.ONE_HBAR;
+import static contract.AssortedOpsXTestConstants.SENDER_ALIAS;
+import static contract.Erc721XTestConstants.COINBASE_ID;
+import static contract.XTestConstants.SENDER_ADDRESS;
+import static contract.XTestConstants.SENDER_ID;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
+import com.hedera.hapi.node.state.common.EntityNumber;
+import com.hedera.hapi.node.state.contract.Bytecode;
+import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ContractLimitsXTest extends AbstractContractXTest {
+    static final long GAS = 300_000L;
+    static final long NEXT_ENTITY_NUM = 1234L;
+    private static final FileID FUSE_INITCODE_ID =
+            FileID.newBuilder().fileNum(1002L).build();
+
+    @Override
+    protected void doScenarioOperations() {
+        handleAndCommitSingleTransaction(
+                CONTRACT_SERVICE.handlers().contractCreateHandler(),
+                synthCreateTxn(),
+                MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
+    }
+
+    @Override
+    protected Configuration configuration() {
+        // Override to set the max number of contracts to 2 (since we already have 2 bytecode, no more can be created)
+        return HederaTestConfigBuilder.create()
+                .withValue("contracts.chainId", "298")
+                .withValue("contracts.maxNumber", "2")
+                .getOrCreateConfig();
+    }
+
+    @Override
+    protected long initialEntityNum() {
+        return NEXT_ENTITY_NUM - 1;
+    }
+
+    @Override
+    protected Map<FileID, File> initialFiles() {
+        final var files = new HashMap<FileID, File>();
+        files.put(
+                FUSE_INITCODE_ID,
+                File.newBuilder().contents(resourceAsBytes("initcode/Fuse.bin")).build());
+        return files;
+    }
+
+    @Override
+    protected Map<EntityNumber, Bytecode> initialBytecodes() {
+        final var bytecodes = super.initialBytecodes();
+        bytecodes.put(new EntityNumber(234567890), new Bytecode(Bytes.wrap("NONSENSICAL")));
+        bytecodes.put(new EntityNumber(123456789), new Bytecode(Bytes.wrap("PLACEHOLDER")));
+        return bytecodes;
+    }
+
+    @Override
+    protected Map<ProtoBytes, AccountID> initialAliases() {
+        final var aliases = new HashMap<ProtoBytes, AccountID>();
+        aliases.put(ProtoBytes.newBuilder().value(SENDER_ALIAS).build(), SENDER_ID);
+        aliases.put(ProtoBytes.newBuilder().value(SENDER_ADDRESS).build(), SENDER_ID);
+        return aliases;
+    }
+
+    @Override
+    protected Map<AccountID, Account> initialAccounts() {
+        final var accounts = new HashMap<AccountID, Account>();
+        accounts.put(
+                SENDER_ID,
+                Account.newBuilder()
+                        .accountId(SENDER_ID)
+                        .alias(SENDER_ALIAS)
+                        .tinybarBalance(100 * ONE_HBAR)
+                        .build());
+        accounts.put(COINBASE_ID, Account.newBuilder().accountId(COINBASE_ID).build());
+        return accounts;
+    }
+
+    private TransactionBody synthCreateTxn() {
+        return TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder().accountID(SENDER_ID))
+                .contractCreateInstance(ContractCreateTransactionBody.newBuilder()
+                        .autoRenewPeriod(STANDARD_AUTO_RENEW_PERIOD)
+                        .fileID(FUSE_INITCODE_ID)
+                        .gas(GAS)
+                        .build())
+                .build();
+    }
+}

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractLimitsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractLimitsXTest.java
@@ -34,12 +34,17 @@ import com.hedera.hapi.node.state.file.File;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Small test verifying behavior of the {@link CustomContractCreationProcessor} when the number of
+ * bytecodes in state already equals the configured limit.
+ */
 public class ContractLimitsXTest extends AbstractContractXTest {
     static final long GAS = 300_000L;
     static final long NEXT_ENTITY_NUM = 1234L;

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
@@ -63,5 +63,6 @@ public interface ContractScaffoldingComponent extends BaseScaffoldingComponent {
     interface Factory {
         ContractScaffoldingComponent create(@BindsInstance Metrics metrics);
     }
+
     List<HtsCallTranslator> callTranslators();
 }

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
@@ -16,52 +16,28 @@
 
 package contract;
 
-import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fixtures.state.FakeHederaState;
 import com.hedera.node.app.service.contract.impl.exec.processors.HtsTranslatorsModule;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsCallTranslator;
-import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.app.workflows.handle.HandleContextImpl;
 import com.hedera.node.app.workflows.handle.HandlersInjectionModule;
-import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.swirlds.common.metrics.Metrics;
+import com.swirlds.config.api.Configuration;
 import common.BaseScaffoldingComponent;
 import common.BaseScaffoldingModule;
 import dagger.BindsInstance;
 import dagger.Component;
 import java.util.List;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Used by Dagger2 to instantiate an object graph with three roots:
- * <ol>
- *     <li>An empty {@link FakeHederaState} that a test can populate with
- *     its preconditions (e.g., next entity number) and well-known entities.</li>
- *     <li>A function mapping a {@link TransactionBody} to a
- *     {@link HandleContext} based on the above {@link FakeHederaState};
- *     tests can pass this context to a {@link TransactionHandler}
- *     implementation for the {@link TransactionBody} with no additional
- *     use of mocks.</li>
- *     <li>The singleton {@link SavepointStackImpl} based on the
- *     {@link FakeHederaState} that a test can use to commit changes
- *     after calling its handler.</li>
- * </ol>
- *
- * <p>Whenever the dependency graph of {@link HandleContextImpl}
- * expands with new bindings that Dagger2 cannot construct via
- * {@link Inject}-able constructors, this class will need to be
- * updated, either with a new {@link dagger.Module} that provides
- * the new bindings; or with additions to the existing
- * {@link BaseScaffoldingModule}.
+ * Used by Dagger2 to instantiate an object graph with just the roots needed for testing
+ * {@link com.hedera.node.app.service.contract.ContractService} handlers.
  */
 @Singleton
 @Component(modules = {HandlersInjectionModule.class, BaseScaffoldingModule.class, HtsTranslatorsModule.class})
 public interface ContractScaffoldingComponent extends BaseScaffoldingComponent {
     @Component.Factory
     interface Factory {
-        ContractScaffoldingComponent create(@BindsInstance Metrics metrics);
+        ContractScaffoldingComponent create(@BindsInstance Metrics metrics, @BindsInstance Configuration configuration);
     }
 
     List<HtsCallTranslator> callTranslators();

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
@@ -16,29 +16,21 @@
 
 package contract;
 
-import com.hedera.hapi.node.base.AccountID;
-import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fees.ExchangeRateManager;
-import com.hedera.node.app.fees.FeeManager;
 import com.hedera.node.app.fixtures.state.FakeHederaState;
 import com.hedera.node.app.service.contract.impl.exec.processors.HtsTranslatorsModule;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsCallTranslator;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.app.state.HederaState;
-import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.app.workflows.handle.HandleContextImpl;
 import com.hedera.node.app.workflows.handle.HandlersInjectionModule;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.swirlds.common.metrics.Metrics;
-import com.swirlds.config.api.Configuration;
+import common.BaseScaffoldingComponent;
+import common.BaseScaffoldingModule;
 import dagger.BindsInstance;
 import dagger.Component;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -62,29 +54,14 @@ import javax.inject.Singleton;
  * {@link Inject}-able constructors, this class will need to be
  * updated, either with a new {@link dagger.Module} that provides
  * the new bindings; or with additions to the existing
- * {@link ScaffoldingModule}.
+ * {@link BaseScaffoldingModule}.
  */
 @Singleton
-@Component(modules = {HandlersInjectionModule.class, ScaffoldingModule.class, HtsTranslatorsModule.class})
-public interface ScaffoldingComponent {
+@Component(modules = {HandlersInjectionModule.class, BaseScaffoldingModule.class, HtsTranslatorsModule.class})
+public interface ContractScaffoldingComponent extends BaseScaffoldingComponent {
     @Component.Factory
     interface Factory {
-        ScaffoldingComponent create(@BindsInstance Metrics metrics);
+        ContractScaffoldingComponent create(@BindsInstance Metrics metrics);
     }
-
-    HederaState hederaState();
-
-    Configuration config();
-
-    WorkingStateAccessor workingStateAccessor();
-
-    Function<TransactionBody, HandleContext> txnContextFactory();
-
-    BiFunction<Query, AccountID, QueryContext> queryContextFactory();
-
-    FeeManager feeManager();
-
-    ExchangeRateManager exchangeRateManager();
-
     List<HtsCallTranslator> callTranslators();
 }

--- a/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
@@ -96,7 +96,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         ERC_20_TRANSFER_FROM.encodeCallWithArgs(
                                 OWNER_HEADLONG_ADDRESS, RECEIVER_HEADLONG_ADDRESS, BigInteger.valueOf(100L)),
                         ERC20_TOKEN_ID),
-                SPENDER_DOES_NOT_HAVE_ALLOWANCE);
+                SPENDER_DOES_NOT_HAVE_ALLOWANCE,
+                "Unauthorized spending of fungible units");
         // APPROVE
         runHtsCallAndExpectOnSuccess(
                 OWNER_BESU_ADDRESS,
@@ -104,7 +105,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         .encodeCallWithArgs(
                                 ERC20_TOKEN_ADDRESS, UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS, BigInteger.valueOf(100L))
                         .array()),
-                assertSuccess());
+                assertSuccess(),
+                "Owner granting approval of 100 fungible units");
         // TRY TRANSFER AND EXPECT SUCCESS
         runHtsCallAndExpectOnSuccess(
                 UNAUTHORIZED_SPENDER_BESU_ADDRESS,
@@ -113,7 +115,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                                 OWNER_HEADLONG_ADDRESS, RECEIVER_HEADLONG_ADDRESS, BigInteger.valueOf(50L)),
                         ERC20_TOKEN_ID),
                 output -> assertEquals(
-                        asBytesResult(ERC_20_TRANSFER_FROM.getOutputs().encodeElements(true)), output));
+                        asBytesResult(ERC_20_TRANSFER_FROM.getOutputs().encodeElements(true)), output),
+                "Owner transferring 50 of its own units");
         // TRY TRANSFER AND EXPECT FAIL
         runHtsCallAndExpectRevert(
                 UNAUTHORIZED_SPENDER_BESU_ADDRESS,
@@ -121,7 +124,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         ERC_20_TRANSFER_FROM.encodeCallWithArgs(
                                 OWNER_HEADLONG_ADDRESS, RECEIVER_HEADLONG_ADDRESS, BigInteger.valueOf(100L)),
                         ERC20_TOKEN_ID),
-                AMOUNT_EXCEEDS_ALLOWANCE);
+                AMOUNT_EXCEEDS_ALLOWANCE,
+                "Excessive spending (100 units vs 50 approved)");
         // TRY APPROVE NFT WITH INVALID SERIAL
         runHtsCallAndExpectOnSuccess(
                 OWNER_BESU_ADDRESS,
@@ -132,7 +136,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                 output -> assertEquals(
                         Bytes.wrap(ReturnTypes.encodedRc(INVALID_TOKEN_NFT_SERIAL_NUMBER)
                                 .array()),
-                        output));
+                        output),
+                "Owner granting approval on missing SN#9");
         // APPROVE NFT
         runHtsCallAndExpectOnSuccess(
                 OWNER_BESU_ADDRESS,
@@ -142,7 +147,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                                 UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS,
                                 BigInteger.valueOf(SN_1234.serialNumber()))
                         .array()),
-                assertSuccess());
+                assertSuccess(),
+                "Owner granting approval on present SN#1234");
         // TRANSFER NFT
         runHtsCallAndExpectOnSuccess(
                 UNAUTHORIZED_SPENDER_BESU_ADDRESS,
@@ -153,7 +159,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                                 RECEIVER_HEADLONG_ADDRESS,
                                 SN_1234.serialNumber())
                         .array()),
-                assertSuccess());
+                assertSuccess(),
+                "Owner transferring SN#1234");
         // ERC APPROVE FUNGIBLE
         runHtsCallAndExpectOnSuccess(
                 OWNER_BESU_ADDRESS,
@@ -165,16 +172,18 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         asBytesResult(GrantApprovalTranslator.ERC_GRANT_APPROVAL
                                 .getOutputs()
                                 .encodeElements(true)),
-                        output));
+                        output),
+                "Owner granting approval on fungible units via ERC call");
         // TRY TRANSFER AND EXPECT SUCCESS
         runHtsCallAndExpectOnSuccess(
-                UNAUTHORIZED_SPENDER_BESU_ADDRESS,
+                OWNER_BESU_ADDRESS,
                 bytesForRedirect(
                         ERC_20_TRANSFER_FROM.encodeCallWithArgs(
                                 OWNER_HEADLONG_ADDRESS, RECEIVER_HEADLONG_ADDRESS, BigInteger.valueOf(100L)),
                         ERC20_TOKEN_ID),
                 output -> assertEquals(
-                        asBytesResult(ERC_20_TRANSFER_FROM.getOutputs().encodeElements(true)), output));
+                        asBytesResult(ERC_20_TRANSFER_FROM.getOutputs().encodeElements(true)), output),
+                "Owner transferring 100 of its own units via ERC call");
         // ERC APPROVE NFT
         runHtsCallAndExpectOnSuccess(
                 OWNER_BESU_ADDRESS,
@@ -186,7 +195,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         asBytesResult(GrantApprovalTranslator.ERC_GRANT_APPROVAL_NFT
                                 .getOutputs()
                                 .encodeElements()),
-                        output));
+                        output),
+                "Owner granting approval on SN#2345");
         // TRANSFER NFT
         runHtsCallAndExpectOnSuccess(
                 UNAUTHORIZED_SPENDER_BESU_ADDRESS,
@@ -197,7 +207,8 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                                 RECEIVER_HEADLONG_ADDRESS,
                                 SN_2345.serialNumber())
                         .array()),
-                assertSuccess());
+                assertSuccess(),
+                "Spender transferring SN#2345 via classic transfer");
     }
 
     @Override

--- a/hedera-node/hedera-app/src/xtest/java/contract/PausesXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/PausesXTest.java
@@ -21,6 +21,7 @@ import static contract.HtsErc721TransferXTestConstants.APPROVED_ID;
 import static contract.HtsErc721TransferXTestConstants.UNAUTHORIZED_SPENDER_ID;
 import static contract.MiscClassicTransfersXTestConstants.INITIAL_RECEIVER_AUTO_ASSOCIATIONS;
 import static contract.MiscClassicTransfersXTestConstants.NEXT_ENTITY_NUM;
+import static contract.XTestConstants.AN_ED25519_KEY;
 import static contract.XTestConstants.ERC721_TOKEN_ADDRESS;
 import static contract.XTestConstants.ERC721_TOKEN_ID;
 import static contract.XTestConstants.OWNER_ADDRESS;
@@ -102,7 +103,9 @@ public class PausesXTest extends AbstractContractXTest {
                                 SN_2345.serialNumber())
                         .array()),
                 output -> assertEquals(
-                        Bytes.wrap(ReturnTypes.encodedRc(TOKEN_IS_PAUSED).array()), output));
+                        Bytes.wrap(ReturnTypes.encodedRc(TOKEN_IS_PAUSED).array()),
+                        output,
+                        "Token should have been paused"));
 
         // UNPAUSE
         runHtsCallAndExpectOnSuccess(
@@ -110,7 +113,7 @@ public class PausesXTest extends AbstractContractXTest {
                 Bytes.wrap(PausesTranslator.UNPAUSE
                         .encodeCallWithArgs(ERC721_TOKEN_ADDRESS)
                         .array()),
-                assertSuccess());
+                assertSuccess("Unpause failed"));
 
         // Transfer series 2345 of ERC721_TOKEN to RECEIVER - should succeed now.
         runHtsCallAndExpectOnSuccess(
@@ -122,7 +125,7 @@ public class PausesXTest extends AbstractContractXTest {
                                 RECEIVER_HEADLONG_ADDRESS,
                                 SN_2345.serialNumber())
                         .array()),
-                assertSuccess());
+                assertSuccess("Post-unpause transfer failed"));
     }
 
     @Override
@@ -147,6 +150,7 @@ public class PausesXTest extends AbstractContractXTest {
                         .tokenId(ERC721_TOKEN_ID)
                         .treasuryAccountId(UNAUTHORIZED_SPENDER_ID)
                         .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .pauseKey(AN_ED25519_KEY)
                         .build());
         return tokens;
     }

--- a/hedera-node/hedera-app/src/xtest/java/contract/XTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/XTestConstants.java
@@ -27,18 +27,15 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.NftID;
-import com.hedera.hapi.node.base.TimestampSeconds;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.contract.ContractCallTransactionBody;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.hapi.node.transaction.ExchangeRate;
-import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.time.Instant;
+
 import java.util.Map;
 import java.util.function.Consumer;
 import org.hyperledger.besu.datatypes.Address;
@@ -47,22 +44,7 @@ import org.hyperledger.besu.datatypes.Address;
  * Common constants used in "x-test" classes.
  */
 class XTestConstants {
-    /**
-     * The exchange rate long used in dev environments to run HAPI spec; expected to be in effect for
-     * some x-tests to pass.
-     */
-    static final ExchangeRate TRADITIONAL_HAPI_SPEC_RATE = ExchangeRate.newBuilder()
-            .hbarEquiv(1)
-            .centEquiv(12)
-            .expirationTime(TimestampSeconds.newBuilder()
-                    .seconds(Instant.MAX.getEpochSecond())
-                    .build())
-            .build();
 
-    static final ExchangeRateSet SET_OF_TRADITIONAL_RATES = ExchangeRateSet.newBuilder()
-            .currentRate(TRADITIONAL_HAPI_SPEC_RATE)
-            .nextRate(TRADITIONAL_HAPI_SPEC_RATE)
-            .build();
     static final AccountID MISC_PAYER_ID =
             AccountID.newBuilder().accountNum(950L).build();
 

--- a/hedera-node/hedera-app/src/xtest/java/contract/XTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/XTestConstants.java
@@ -35,7 +35,6 @@ import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-
 import java.util.Map;
 import java.util.function.Consumer;
 import org.hyperledger.besu.datatypes.Address;
@@ -130,5 +129,9 @@ class XTestConstants {
 
     public static Consumer<org.apache.tuweni.bytes.Bytes> assertSuccess() {
         return output -> assertEquals(SUCCESS_AS_BYTES, output);
+    }
+
+    public static Consumer<org.apache.tuweni.bytes.Bytes> assertSuccess(String failureMessage) {
+        return output -> assertEquals(SUCCESS_AS_BYTES, output, failureMessage);
     }
 }

--- a/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
@@ -1,0 +1,123 @@
+package token;
+
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Fraction;
+import com.hedera.hapi.node.base.NftTransfer;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
+import com.hedera.hapi.node.token.TokenMintTransactionBody;
+import com.hedera.hapi.node.transaction.CustomFee;
+import com.hedera.hapi.node.transaction.RoyaltyFee;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import common.AbstractXTest;
+import common.BaseScaffoldingComponent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public abstract class AbstractTokenXTest extends AbstractXTest {
+    protected static final AccountID DEFAULT_PAYER_ID = AccountID.newBuilder().accountNum(2L).build();
+    protected TokenScaffoldingComponent component;
+
+    @BeforeEach
+    void setUp() {
+        component = DaggerTokenScaffoldingComponent.factory().create(metrics);
+    }
+
+    @Override
+    protected BaseScaffoldingComponent component() {
+        return component;
+    }
+
+    protected Consumer<CryptoTransferTransactionBody.Builder> movingFungibleUnits(
+            @NonNull final String token, @NonNull final String from, @NonNull final String to, long amount) {
+        return movingFungibleUnits(idOfNamedToken(token), idOfNamedAccount(from), idOfNamedAccount(to), amount);
+    }
+
+    protected Consumer<CryptoTransferTransactionBody.Builder> movingFungibleUnits(
+            @NonNull final TokenID tokenID, @NonNull final AccountID from, @NonNull final AccountID to, long amount) {
+        return b -> {
+            final List<TokenTransferList> newTransfers = new ArrayList<>(b.build().tokenTransfersOrThrow());
+            newTransfers.add(TokenTransferList.newBuilder()
+                    .token(tokenID)
+                    .transfers(new AccountAmount(from, -amount, false), new AccountAmount(to, amount, false))
+                    .build());
+            b.tokenTransfers(newTransfers);
+        };
+    }
+
+    protected Consumer<CryptoTransferTransactionBody.Builder> movingNft(
+            @NonNull final String token, @NonNull final String from, @NonNull final String to, long serialNo) {
+        return movingNft(idOfNamedToken(token), idOfNamedAccount(from), idOfNamedAccount(to), serialNo);
+    }
+
+    protected Consumer<CryptoTransferTransactionBody.Builder> movingNft(
+            @NonNull final TokenID tokenID, @NonNull final AccountID from, @NonNull final AccountID to, long serialNo) {
+        return b -> {
+            final List<TokenTransferList> newTransfers = new ArrayList<>(b.build().tokenTransfersOrThrow());
+            newTransfers.add(TokenTransferList.newBuilder()
+                    .token(tokenID)
+                    .nftTransfers(new NftTransfer(from, to, serialNo, false))
+                    .build());
+            b.tokenTransfers(newTransfers);
+        };
+    }
+
+    protected CustomFee royaltyFeeNoFallback(final long numerator, final long denominator, String collector) {
+        return royaltyFeeNoFallback(numerator, denominator, idOfNamedAccount(collector));
+    }
+
+    protected CustomFee royaltyFeeNoFallback(final long numerator, final long denominator, AccountID collectorId) {
+        return CustomFee.newBuilder()
+                .royaltyFee(RoyaltyFee.newBuilder()
+                        .exchangeValueFraction(Fraction.newBuilder()
+                                .numerator(numerator)
+                                .denominator(denominator))
+                        .build())
+                .feeCollectorAccountId(collectorId)
+                .build();
+    }
+
+
+    @SafeVarargs
+    protected final TransactionBody transfer(Consumer<CryptoTransferTransactionBody.Builder>... specs) {
+        final var b = CryptoTransferTransactionBody.newBuilder();
+        for (final var spec : specs) {
+            spec.accept(b);
+        }
+        return TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder().accountID(DEFAULT_PAYER_ID))
+                .cryptoTransfer(b).build();
+    }
+
+    protected final TransactionBody nftMint(@NonNull final Bytes metadata, @NonNull final String token) {
+        return nftMint(metadata, idOfNamedToken(token));
+    }
+
+    protected final TransactionBody nftMint(@NonNull final Bytes metadata, @NonNull final TokenID tokenID) {
+        final var b = TokenMintTransactionBody.newBuilder();
+        b.metadata(metadata).token(tokenID);
+        return TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder().accountID(DEFAULT_PAYER_ID))
+                .tokenMint(b).build();
+    }
+
+    @Override
+    protected Map<AccountID, Account> initialAccounts() {
+        final var accounts = super.initialAccounts();
+        accounts.put(DEFAULT_PAYER_ID, Account.newBuilder()
+                .accountId(DEFAULT_PAYER_ID)
+                .tinybarBalance(Long.MAX_VALUE / 2)
+                .build());
+        return accounts;
+    }
+}

--- a/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
@@ -29,7 +29,9 @@ import com.hedera.hapi.node.token.TokenMintTransactionBody;
 import com.hedera.hapi.node.transaction.CustomFee;
 import com.hedera.hapi.node.transaction.RoyaltyFee;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
 import common.AbstractXTest;
 import common.BaseScaffoldingComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -46,7 +48,11 @@ public abstract class AbstractTokenXTest extends AbstractXTest {
 
     @BeforeEach
     void setUp() {
-        component = DaggerTokenScaffoldingComponent.factory().create(metrics);
+        component = DaggerTokenScaffoldingComponent.factory().create(metrics, configuration());
+    }
+
+    protected Configuration configuration() {
+        return HederaTestConfigBuilder.create().getOrCreateConfig();
     }
 
     @Override

--- a/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package token;
 
 import com.hedera.hapi.node.base.AccountAmount;
@@ -17,15 +33,15 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import common.AbstractXTest;
 import common.BaseScaffoldingComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.junit.jupiter.api.BeforeEach;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractTokenXTest extends AbstractXTest {
-    protected static final AccountID DEFAULT_PAYER_ID = AccountID.newBuilder().accountNum(2L).build();
+    protected static final AccountID DEFAULT_PAYER_ID =
+            AccountID.newBuilder().accountNum(2L).build();
     protected TokenScaffoldingComponent component;
 
     @BeforeEach
@@ -46,7 +62,8 @@ public abstract class AbstractTokenXTest extends AbstractXTest {
     protected Consumer<CryptoTransferTransactionBody.Builder> movingFungibleUnits(
             @NonNull final TokenID tokenID, @NonNull final AccountID from, @NonNull final AccountID to, long amount) {
         return b -> {
-            final List<TokenTransferList> newTransfers = new ArrayList<>(b.build().tokenTransfersOrThrow());
+            final List<TokenTransferList> newTransfers =
+                    new ArrayList<>(b.build().tokenTransfersOrThrow());
             newTransfers.add(TokenTransferList.newBuilder()
                     .token(tokenID)
                     .transfers(new AccountAmount(from, -amount, false), new AccountAmount(to, amount, false))
@@ -63,7 +80,8 @@ public abstract class AbstractTokenXTest extends AbstractXTest {
     protected Consumer<CryptoTransferTransactionBody.Builder> movingNft(
             @NonNull final TokenID tokenID, @NonNull final AccountID from, @NonNull final AccountID to, long serialNo) {
         return b -> {
-            final List<TokenTransferList> newTransfers = new ArrayList<>(b.build().tokenTransfersOrThrow());
+            final List<TokenTransferList> newTransfers =
+                    new ArrayList<>(b.build().tokenTransfersOrThrow());
             newTransfers.add(TokenTransferList.newBuilder()
                     .token(tokenID)
                     .nftTransfers(new NftTransfer(from, to, serialNo, false))
@@ -79,14 +97,12 @@ public abstract class AbstractTokenXTest extends AbstractXTest {
     protected CustomFee royaltyFeeNoFallback(final long numerator, final long denominator, AccountID collectorId) {
         return CustomFee.newBuilder()
                 .royaltyFee(RoyaltyFee.newBuilder()
-                        .exchangeValueFraction(Fraction.newBuilder()
-                                .numerator(numerator)
-                                .denominator(denominator))
+                        .exchangeValueFraction(
+                                Fraction.newBuilder().numerator(numerator).denominator(denominator))
                         .build())
                 .feeCollectorAccountId(collectorId)
                 .build();
     }
-
 
     @SafeVarargs
     protected final TransactionBody transfer(Consumer<CryptoTransferTransactionBody.Builder>... specs) {
@@ -96,7 +112,8 @@ public abstract class AbstractTokenXTest extends AbstractXTest {
         }
         return TransactionBody.newBuilder()
                 .transactionID(TransactionID.newBuilder().accountID(DEFAULT_PAYER_ID))
-                .cryptoTransfer(b).build();
+                .cryptoTransfer(b)
+                .build();
     }
 
     protected final TransactionBody nftMint(@NonNull final Bytes metadata, @NonNull final String token) {
@@ -108,16 +125,19 @@ public abstract class AbstractTokenXTest extends AbstractXTest {
         b.metadata(metadata).token(tokenID);
         return TransactionBody.newBuilder()
                 .transactionID(TransactionID.newBuilder().accountID(DEFAULT_PAYER_ID))
-                .tokenMint(b).build();
+                .tokenMint(b)
+                .build();
     }
 
     @Override
     protected Map<AccountID, Account> initialAccounts() {
         final var accounts = super.initialAccounts();
-        accounts.put(DEFAULT_PAYER_ID, Account.newBuilder()
-                .accountId(DEFAULT_PAYER_ID)
-                .tinybarBalance(Long.MAX_VALUE / 2)
-                .build());
+        accounts.put(
+                DEFAULT_PAYER_ID,
+                Account.newBuilder()
+                        .accountId(DEFAULT_PAYER_ID)
+                        .tinybarBalance(Long.MAX_VALUE / 2)
+                        .build());
         return accounts;
     }
 }

--- a/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
@@ -1,17 +1,28 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package token;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.hapi.node.base.Fraction;
-import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.hapi.node.transaction.CustomFee;
-import com.hedera.hapi.node.transaction.RoyaltyFee;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-
 import java.util.Map;
 
 public class RoyaltyCollectorAutoAssociationXTest extends AbstractTokenXTest {
@@ -23,23 +34,17 @@ public class RoyaltyCollectorAutoAssociationXTest extends AbstractTokenXTest {
                 component.cryptoTransferHandler(),
                 transfer(
                         movingFungibleUnits(FIRST_FUNGIBLE, TOKEN_TREASURY, COUNTERPARTY, INITIAL_BALANCE),
-                        movingFungibleUnits(SECOND_FUNGIBLE, TOKEN_TREASURY, COUNTERPARTY, INITIAL_BALANCE)),
-                ResponseCodeEnum.OK);
+                        movingFungibleUnits(SECOND_FUNGIBLE, TOKEN_TREASURY, COUNTERPARTY, INITIAL_BALANCE)));
         handleAndCommitSingleTransaction(
-                component.tokenMintHandler(),
-                nftMint(Bytes.wrap("HOLD"), NON_FUNGIBLE_UNIQUE),
-                ResponseCodeEnum.OK);
+                component.tokenMintHandler(), nftMint(Bytes.wrap("HOLD"), NON_FUNGIBLE_UNIQUE));
         handleAndCommitSingleTransaction(
-                component.cryptoTransferHandler(),
-                transfer(movingNft(NON_FUNGIBLE_UNIQUE, TOKEN_TREASURY, PARTY, 1)),
-                ResponseCodeEnum.OK);
+                component.cryptoTransferHandler(), transfer(movingNft(NON_FUNGIBLE_UNIQUE, TOKEN_TREASURY, PARTY, 1)));
         handleAndCommitSingleTransaction(
                 component.cryptoTransferHandler(),
                 transfer(
                         movingNft(NON_FUNGIBLE_UNIQUE, PARTY, COUNTERPARTY, 1),
                         movingFungibleUnits(FIRST_FUNGIBLE, COUNTERPARTY, PARTY, EXCHANGE_AMOUNT),
-                        movingFungibleUnits(SECOND_FUNGIBLE, COUNTERPARTY, PARTY, EXCHANGE_AMOUNT)),
-                ResponseCodeEnum.OK);
+                        movingFungibleUnits(SECOND_FUNGIBLE, COUNTERPARTY, PARTY, EXCHANGE_AMOUNT)));
     }
 
     @Override
@@ -56,14 +61,17 @@ public class RoyaltyCollectorAutoAssociationXTest extends AbstractTokenXTest {
     @Override
     protected Map<TokenID, Token> initialTokens() {
         final var tokens = super.initialTokens();
-        addNamedFungibleToken(FIRST_FUNGIBLE, b -> b
-                .treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
-                .totalSupply(INITIAL_SUPPLY), tokens);
-        addNamedFungibleToken(SECOND_FUNGIBLE, b -> b
-                .treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
-                .totalSupply(INITIAL_SUPPLY), tokens);
-        addNamedNonFungibleToken(NON_FUNGIBLE_UNIQUE, b -> b
-                        .treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
+        addNamedFungibleToken(
+                FIRST_FUNGIBLE,
+                b -> b.treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY)).totalSupply(INITIAL_SUPPLY),
+                tokens);
+        addNamedFungibleToken(
+                SECOND_FUNGIBLE,
+                b -> b.treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY)).totalSupply(INITIAL_SUPPLY),
+                tokens);
+        addNamedNonFungibleToken(
+                NON_FUNGIBLE_UNIQUE,
+                b -> b.treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
                         .customFees(royaltyFeeNoFallback(1, 12, FIRST_ROYALTY_COLLECTOR))
                         .customFees(royaltyFeeNoFallback(1, 15, SECOND_ROYALTY_COLLECTOR)),
                 tokens);

--- a/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
@@ -18,12 +18,11 @@ public class RoyaltyCollectorAutoAssociationXTest extends AbstractTokenXTest {
 
     @Override
     protected void doScenarioOperations() {
-        System.out.println(namedTokenIds);
         // Transfer some initial balance to the party and counterparty accounts
         handleAndCommitSingleTransaction(
                 component.cryptoTransferHandler(),
                 transfer(
-                        movingFungibleUnits(FIRST_FUNGIBLE, TOKEN_TREASURY, PARTY, INITIAL_BALANCE),
+                        movingFungibleUnits(FIRST_FUNGIBLE, TOKEN_TREASURY, COUNTERPARTY, INITIAL_BALANCE),
                         movingFungibleUnits(SECOND_FUNGIBLE, TOKEN_TREASURY, COUNTERPARTY, INITIAL_BALANCE)),
                 ResponseCodeEnum.OK);
         handleAndCommitSingleTransaction(

--- a/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
@@ -1,0 +1,98 @@
+package token;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Fraction;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.state.common.EntityIDPair;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.state.token.TokenRelation;
+import com.hedera.hapi.node.transaction.CustomFee;
+import com.hedera.hapi.node.transaction.RoyaltyFee;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+
+import java.util.Map;
+
+public class RoyaltyCollectorAutoAssociationXTest extends AbstractTokenXTest {
+
+    @Override
+    protected void doScenarioOperations() {
+        System.out.println(namedTokenIds);
+        // Transfer some initial balance to the party and counterparty accounts
+        handleAndCommitSingleTransaction(
+                component.cryptoTransferHandler(),
+                transfer(
+                        movingFungibleUnits(FIRST_FUNGIBLE, TOKEN_TREASURY, PARTY, INITIAL_BALANCE),
+                        movingFungibleUnits(SECOND_FUNGIBLE, TOKEN_TREASURY, COUNTERPARTY, INITIAL_BALANCE)),
+                ResponseCodeEnum.OK);
+        handleAndCommitSingleTransaction(
+                component.tokenMintHandler(),
+                nftMint(Bytes.wrap("HOLD"), NON_FUNGIBLE_UNIQUE),
+                ResponseCodeEnum.OK);
+        handleAndCommitSingleTransaction(
+                component.cryptoTransferHandler(),
+                transfer(movingNft(NON_FUNGIBLE_UNIQUE, TOKEN_TREASURY, PARTY, 1)),
+                ResponseCodeEnum.OK);
+        handleAndCommitSingleTransaction(
+                component.cryptoTransferHandler(),
+                transfer(
+                        movingNft(NON_FUNGIBLE_UNIQUE, PARTY, COUNTERPARTY, 1),
+                        movingFungibleUnits(FIRST_FUNGIBLE, COUNTERPARTY, PARTY, EXCHANGE_AMOUNT),
+                        movingFungibleUnits(SECOND_FUNGIBLE, COUNTERPARTY, PARTY, EXCHANGE_AMOUNT)),
+                ResponseCodeEnum.OK);
+    }
+
+    @Override
+    protected Map<AccountID, Account> initialAccounts() {
+        final var accounts = super.initialAccounts();
+        addNamedAccount(TOKEN_TREASURY, accounts);
+        addNamedAccount(FIRST_ROYALTY_COLLECTOR, b -> b.maxAutoAssociations(PLENTY_OF_SLOTS), accounts);
+        addNamedAccount(SECOND_ROYALTY_COLLECTOR, b -> b.maxAutoAssociations(PLENTY_OF_SLOTS), accounts);
+        addNamedAccount(PARTY, b -> b.maxAutoAssociations(PLENTY_OF_SLOTS), accounts);
+        addNamedAccount(COUNTERPARTY, b -> b.maxAutoAssociations(PLENTY_OF_SLOTS), accounts);
+        return accounts;
+    }
+
+    @Override
+    protected Map<TokenID, Token> initialTokens() {
+        final var tokens = super.initialTokens();
+        addNamedFungibleToken(FIRST_FUNGIBLE, b -> b
+                .treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
+                .totalSupply(INITIAL_SUPPLY), tokens);
+        addNamedFungibleToken(SECOND_FUNGIBLE, b -> b
+                .treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
+                .totalSupply(INITIAL_SUPPLY), tokens);
+        addNamedNonFungibleToken(NON_FUNGIBLE_UNIQUE, b -> b
+                        .treasuryAccountId(idOfNamedAccount(TOKEN_TREASURY))
+                        .customFees(royaltyFeeNoFallback(1, 12, FIRST_ROYALTY_COLLECTOR))
+                        .customFees(royaltyFeeNoFallback(1, 15, SECOND_ROYALTY_COLLECTOR)),
+                tokens);
+        return tokens;
+    }
+
+    @Override
+    protected Map<EntityIDPair, TokenRelation> initialTokenRelationships() {
+        final var tokenRels = super.initialTokenRelationships();
+        addNewRelation(TOKEN_TREASURY, FIRST_FUNGIBLE, b -> b.balance(INITIAL_SUPPLY), tokenRels);
+        addNewRelation(TOKEN_TREASURY, SECOND_FUNGIBLE, b -> b.balance(INITIAL_SUPPLY), tokenRels);
+        addNewRelation(TOKEN_TREASURY, NON_FUNGIBLE_UNIQUE, b -> b.balance(0), tokenRels);
+        return tokenRels;
+    }
+
+    private static final String PARTY = "party";
+    private static final String COUNTERPARTY = "counterparty";
+    private static final String TOKEN_TREASURY = "tokenTreasury";
+    private static final String UNIQUE_WITH_ROYALTY = "uniqueWithRoyalty";
+    private static final String FIRST_FUNGIBLE = "firstFungible";
+    private static final String SECOND_FUNGIBLE = "secondFungible";
+    private static final String NON_FUNGIBLE_UNIQUE = "nonFungibleUnique";
+    private static final String FIRST_ROYALTY_COLLECTOR = "firstRoyaltyCollector";
+    private static final String SECOND_ROYALTY_COLLECTOR = "secondRoyaltyCollector";
+    private static final int PLENTY_OF_SLOTS = 10;
+    private static final long INITIAL_SUPPLY = 123456789;
+    private static final long INITIAL_BALANCE = 1000;
+    private static final long EXCHANGE_AMOUNT = 12 * 15;
+    private static final long FIRST_ROYALTY_AMOUNT = EXCHANGE_AMOUNT / 12;
+    private static final long SECOND_ROYALTY_AMOUNT = EXCHANGE_AMOUNT / 15;
+}

--- a/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
@@ -20,6 +20,7 @@ import com.hedera.node.app.service.token.impl.handlers.CryptoTransferHandler;
 import com.hedera.node.app.service.token.impl.handlers.TokenMintHandler;
 import com.hedera.node.app.workflows.handle.HandlersInjectionModule;
 import com.swirlds.common.metrics.Metrics;
+import com.swirlds.config.api.Configuration;
 import common.BaseScaffoldingComponent;
 import common.BaseScaffoldingModule;
 import dagger.BindsInstance;
@@ -35,7 +36,7 @@ import javax.inject.Singleton;
 public interface TokenScaffoldingComponent extends BaseScaffoldingComponent {
     @Component.Factory
     interface Factory {
-        TokenScaffoldingComponent create(@BindsInstance Metrics metrics);
+        TokenScaffoldingComponent create(@BindsInstance Metrics metrics, @BindsInstance Configuration configuration);
     }
 
     CryptoTransferHandler cryptoTransferHandler();

--- a/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package token;
 
 import com.hedera.node.app.service.token.impl.handlers.CryptoTransferHandler;
@@ -8,7 +24,6 @@ import common.BaseScaffoldingComponent;
 import common.BaseScaffoldingModule;
 import dagger.BindsInstance;
 import dagger.Component;
-
 import javax.inject.Singleton;
 
 /**

--- a/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
@@ -1,0 +1,29 @@
+package token;
+
+import com.hedera.node.app.service.token.impl.handlers.CryptoTransferHandler;
+import com.hedera.node.app.service.token.impl.handlers.TokenMintHandler;
+import com.hedera.node.app.workflows.handle.HandlersInjectionModule;
+import com.swirlds.common.metrics.Metrics;
+import common.BaseScaffoldingComponent;
+import common.BaseScaffoldingModule;
+import dagger.BindsInstance;
+import dagger.Component;
+
+import javax.inject.Singleton;
+
+/**
+ * Used by Dagger2 to instantiate an object graph with just the roots needed for testing
+ * {@link com.hedera.node.app.service.token.TokenService} handlers.
+ */
+@Singleton
+@Component(modules = {HandlersInjectionModule.class, BaseScaffoldingModule.class})
+public interface TokenScaffoldingComponent extends BaseScaffoldingComponent {
+    @Component.Factory
+    interface Factory {
+        TokenScaffoldingComponent create(@BindsInstance Metrics metrics);
+    }
+
+    CryptoTransferHandler cryptoTransferHandler();
+
+    TokenMintHandler tokenMintHandler();
+}

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreImpl.java
@@ -82,4 +82,9 @@ public class ReadableScheduleStoreImpl implements ReadableScheduleStore {
         final ScheduleList inStateValue = schedulesByExpirationSecond.get(new ProtoLong(expirationTime));
         return inStateValue != null ? inStateValue.schedules() : null;
     }
+
+    @Override
+    public long numSchedulesInState() {
+        return schedulesById.size();
+    }
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
@@ -135,6 +135,9 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
                 if (isPresentIn(possibleDuplicates, provisionalSchedule)) {
                     throw new HandleException(ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED);
                 }
+                if (scheduleStore.numSchedulesInState() + 1 > schedulingConfig.maxNumber()) {
+                    throw new HandleException(ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
+                }
                 // Need to process the child transaction again, to get the *primitive* keys possibly required
                 final ScheduleKeysResult requiredKeysResult = allKeysForTransaction(provisionalSchedule, context);
                 final Set<Key> allRequiredKeys = requiredKeysResult.remainingRequiredKeys();

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreTest.java
@@ -46,6 +46,11 @@ class ReadableScheduleStoreTest extends ScheduleTestBase {
     }
 
     @Test
+    void getsExpectedSize() {
+        assertThat(scheduleStore.numSchedulesInState()).isEqualTo(2);
+    }
+
+    @Test
     void returnsEmptyIfMissingSchedule() {
         final long missingId = testScheduleID.scheduleNum() + 15_000L;
         final ScheduleID missing =

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandlerTest.java
@@ -16,8 +16,10 @@
 
 package com.hedera.node.app.service.schedule.impl.handlers;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
 import static org.assertj.core.api.BDDAssertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -30,6 +32,7 @@ import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody.DataOneOfType;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.schedule.WritableScheduleStore;
 import com.hedera.node.app.service.schedule.impl.ScheduledTransactionFactory;
 import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
 import com.hedera.node.app.spi.fixtures.Assertions;
@@ -191,6 +194,33 @@ class ScheduleCreateHandlerTest extends ScheduleHandlerTestBase {
             } else {
                 throwsHandleException(
                         () -> subject.handle(mockContext), ResponseCodeEnum.SCHEDULED_TRANSACTION_NOT_IN_WHITELIST);
+            }
+        }
+    }
+
+    @Test
+    void handleRefusesToExceedCreationLimit() throws HandleException, PreCheckException {
+        final Set<HederaFunctionality> configuredWhitelist =
+                scheduleConfig.whitelist().functionalitySet();
+        // make sure we have at least four items in the whitelist to test.
+        assertThat(configuredWhitelist.size()).isGreaterThan(4);
+
+        final WritableScheduleStore fullStore = mock(WritableScheduleStore.class);
+        given(fullStore.numSchedulesInState()).willReturn(scheduleConfig.maxNumber() + 1);
+        given(mockContext.writableStore(WritableScheduleStore.class)).willReturn(fullStore);
+
+        for (final Schedule next : listOfScheduledOptions) {
+            final TransactionBody createTransaction = next.originalCreateTransaction();
+            final SchedulableTransactionBody child = next.scheduledTransaction();
+            final DataOneOfType transactionType = child.data().kind();
+            final HederaFunctionality functionType = HandlerUtility.functionalityForType(transactionType);
+            prepareContext(createTransaction, next.scheduleId().scheduleNum());
+            // all keys are "valid" with this mock setup
+            given(mockContext.verificationFor(BDDMockito.any(Key.class), BDDMockito.any(VerificationAssistant.class)))
+                    .willReturn(new SignatureVerificationImpl(nullKey, null, true));
+            if (configuredWhitelist.contains(functionType)) {
+                throwsHandleException(
+                        () -> subject.handle(mockContext), MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
             }
         }
     }

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
@@ -71,4 +71,11 @@ public interface ReadableScheduleStore {
      */
     @Nullable
     public List<Schedule> getByExpirationSecond(final long expirationTime);
+
+    /**
+     * Returns the number of schedules in state, for use in enforcing creation limits.
+     *
+     * @return the number of schedules in state
+     */
+    long numSchedulesInState();
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
@@ -56,7 +56,7 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
     private final HydratedEthTxData hydratedEthTxData;
 
     private final ActionSidecarContentTracer tracer;
-    private final RootProxyWorldUpdater worldUpdater;
+    private final RootProxyWorldUpdater rootProxyWorldUpdater;
     private final HevmTransactionFactory hevmTransactionFactory;
     private final Supplier<HederaWorldUpdater> feesOnlyUpdater;
     private final Map<HederaEvmVersion, TransactionProcessor> processors;
@@ -78,7 +78,7 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
         this.tracer = Objects.requireNonNull(tracer);
         this.feesOnlyUpdater = Objects.requireNonNull(feesOnlyUpdater);
         this.processors = Objects.requireNonNull(processors);
-        this.worldUpdater = Objects.requireNonNull(worldUpdater);
+        this.rootProxyWorldUpdater = Objects.requireNonNull(worldUpdater);
         this.configuration = Objects.requireNonNull(configuration);
         this.contractsConfig = Objects.requireNonNull(contractsConfig);
         this.hederaEvmContext = Objects.requireNonNull(hederaEvmContext);
@@ -98,10 +98,11 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
 
         // Process the transaction
         final var result = processor.processTransaction(
-                hevmTransaction, worldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, configuration);
+                hevmTransaction, rootProxyWorldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, configuration);
 
         // Return the outcome, maybe enriched with details of the base commit and Ethereum transaction
-        return new CallOutcome(result.asProtoResultOf(ethTxDataIfApplicable(), worldUpdater), result.finalStatus());
+        return new CallOutcome(
+                result.asProtoResultOf(ethTxDataIfApplicable(), rootProxyWorldUpdater), result.finalStatus());
     }
 
     private void assertEthTxDataValidIfApplicable() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FrameRunner.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FrameRunner.java
@@ -85,7 +85,6 @@ public class FrameRunner {
         // Now run the transaction implied by the frame
         tracer.traceOriginAction(frame);
         final var stack = frame.getMessageFrameStack();
-        stack.addFirst(frame);
         while (!stack.isEmpty()) {
             runToCompletion(stack.peekFirst(), tracer, messageCall, contractCreation);
         }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionModule.java
@@ -120,7 +120,7 @@ public interface TransactionModule {
         requireNonNull(operations);
         requireNonNull(nativeOperations);
         requireNonNull(systemContractOperations);
-        return new HederaWorldUpdater.Enhancement(operations, nativeOperations, systemContractOperations);
+        return new HederaWorldUpdater.Enhancement(operations.begin(), nativeOperations, systemContractOperations);
     }
 
     @Binds

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/CustomExceptionalHaltReason.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/CustomExceptionalHaltReason.java
@@ -32,6 +32,7 @@ public enum CustomExceptionalHaltReason implements ExceptionalHaltReason {
     ERROR_DECODING_PRECOMPILE_INPUT("Error when decoding precompile input."),
     FAILURE_DURING_LAZY_ACCOUNT_CREATION("Failure during lazy account creation"),
     NOT_SUPPORTED("Not supported."),
+    CONTRACT_ENTITY_LIMIT_REACHED("Contract entity limit reached."),
     INVALID_FEE_SUBMITTED("Invalid fee submitted for an EVM call.");
 
     private final String description;
@@ -59,6 +60,8 @@ public enum CustomExceptionalHaltReason implements ExceptionalHaltReason {
             return ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
         } else if (reason == INVALID_SIGNATURE) {
             return ResponseCodeEnum.INVALID_SIGNATURE;
+        } else if (reason == CONTRACT_ENTITY_LIMIT_REACHED) {
+            return ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
         } else if (reason == ExceptionalHaltReason.INSUFFICIENT_GAS) {
             return ResponseCodeEnum.INSUFFICIENT_GAS;
         } else if (reason == ExceptionalHaltReason.ILLEGAL_STATE_CHANGE) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/ResourceExhaustedException.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/ResourceExhaustedException.java
@@ -23,9 +23,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@link HandleException} specialization that indicates that a resource limit
- * has been exceeded. Unlike a "normal" {@link HandleException}, this generally
- * means the entire transaction needs to be reverted.
+ * A {@link HandleException} specialization that indicates that a resource limit has been exceeded.
  */
 public class ResourceExhaustedException extends HandleException {
     public ResourceExhaustedException(@NonNull final ResponseCodeEnum status) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -87,7 +87,7 @@ public class HandleHederaOperations implements HederaOperations {
      */
     @Override
     public void commit() {
-        // Currently the savepoint stack only supports reverting savepoints; then commits all remaining at the end
+        context.savepointStack().commit();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -35,6 +35,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -59,11 +60,16 @@ public class HandleHederaOperations implements HederaOperations {
             "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
 
     private final LedgerConfig ledgerConfig;
+    private final ContractsConfig contractsConfig;
     private final HandleContext context;
 
     @Inject
-    public HandleHederaOperations(@NonNull final LedgerConfig ledgerConfig, @NonNull final HandleContext context) {
+    public HandleHederaOperations(
+            @NonNull final LedgerConfig ledgerConfig,
+            @NonNull final ContractsConfig contractsConfig,
+            @NonNull final HandleContext context) {
         this.ledgerConfig = requireNonNull(ledgerConfig);
+        this.contractsConfig = requireNonNull(contractsConfig);
         this.context = requireNonNull(context);
     }
 
@@ -114,6 +120,11 @@ public class HandleHederaOperations implements HederaOperations {
     @Override
     public long useNextEntityNumber() {
         return context.newEntityNum();
+    }
+
+    @Override
+    public long contractCreationLimit() {
+        return contractsConfig.maxNumber();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
@@ -81,6 +81,13 @@ public interface HederaOperations {
     long useNextEntityNumber();
 
     /**
+     * Returns the maximum number of contracts that we should allow in this operation scope.
+     *
+     * @return the maximum number of contracts
+     */
+    long contractCreationLimit();
+
+    /**
      * Returns the entropy available in this scope. See <a href="https://hips.hedera.com/hip/hip-351">HIP-351</a>
      * for details on how the Hedera node implements this.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaOperations.java
@@ -100,6 +100,11 @@ public class QueryHederaOperations implements HederaOperations {
         throw new UnsupportedOperationException("Queries cannot use entity numbers");
     }
 
+    @Override
+    public long contractCreationLimit() {
+        throw new UnsupportedOperationException("Queries should not be considering creations");
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
@@ -100,7 +100,7 @@ public class ERCGrantApprovalCall extends AbstractHtsCall {
             return reversionWith(INVALID_TOKEN_ID, 0L);
         }
         final var recordBuilder = systemContractOperations()
-                .dispatch(callERCGrantApproval(), verificationStrategy, spender, SingleTransactionRecordBuilder.class);
+                .dispatch(callERCGrantApproval(), verificationStrategy, sender, SingleTransactionRecordBuilder.class);
         if (recordBuilder.status() != ResponseCodeEnum.SUCCESS) {
             return gasOnly(revertResult(recordBuilder.status(), 0L));
         } else {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ContractStateStore.java
@@ -96,4 +96,11 @@ public interface ContractStateStore {
      * @return the number of slots
      */
     long getNumSlots();
+
+    /**
+     * Returns the number of bytecodes.
+     *
+     * @return the number of bytecodes
+     */
+    long getNumBytecodes();
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
@@ -323,6 +323,11 @@ public class DispatchingEvmFrameState implements EvmFrameState {
         nativeOperations.finalizeHollowAccountAsContract(tuweniToPbjBytes(address));
     }
 
+    @Override
+    public long numBytecodesInState() {
+        return contractStateStore.getNumBytecodes();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameState.java
@@ -42,6 +42,13 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
  * types, implementations might need to do internal caching to avoid excessive conversions.
  */
 public interface EvmFrameState {
+    /**
+     * Returns the number of bytecodes in state; we use this to enforce the contract creation
+     * limit.
+     *
+     * @return the number of bytecodes in state
+     */
+    long numBytecodesInState();
 
     /**
      * Tries to transfer the given amount from a sending contract to the recipient. The sender

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ReadableContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ReadableContractStateStore.java
@@ -115,4 +115,9 @@ public class ReadableContractStateStore implements ContractStateStore {
     public long getNumSlots() {
         return storage.size();
     }
+
+    @Override
+    public long getNumBytecodes() {
+        return bytecode.size();
+    }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/WritableContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/WritableContractStateStore.java
@@ -104,4 +104,9 @@ public class WritableContractStateStore implements ContractStateStore {
     public long getNumSlots() {
         return storage.size();
     }
+
+    @Override
+    public long getNumBytecodes() {
+        return bytecode.size();
+    }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FrameRunnerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FrameRunnerTest.java
@@ -208,8 +208,9 @@ class FrameRunnerTest {
         givenBaseScenarioWithDetails(receiver, false);
     }
 
-    private void givenBaseScenarioWithDetails(@NonNull final Address receiver, final boolean sucess) {
+    private void givenBaseScenarioWithDetails(@NonNull final Address receiver, final boolean success) {
         final Deque<MessageFrame> messageFrameStack = new ArrayDeque<>();
+        messageFrameStack.addFirst(frame);
         given(frame.getType()).willReturn(MessageFrame.Type.CONTRACT_CREATION);
         given(childFrame.getType()).willReturn(MessageFrame.Type.MESSAGE_CALL);
         doAnswer(invocation -> {
@@ -235,7 +236,7 @@ class FrameRunnerTest {
                 .getOrCreateConfig();
         given(frame.getContextVariable(FrameUtils.CONFIG_CONTEXT_VARIABLE)).willReturn(config);
         given(frame.getGasPrice()).willReturn(Wei.of(NETWORK_GAS_PRICE));
-        if (sucess) {
+        if (success) {
             given(frame.getState()).willReturn(MessageFrame.State.COMPLETED_SUCCESS);
             given(frame.getLogs()).willReturn(List.of(BESU_LOG));
             given(frame.getOutputData()).willReturn(pbjToTuweniBytes(OUTPUT_DATA));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionModuleTest.java
@@ -114,6 +114,7 @@ class TransactionModuleTest {
 
     @Test
     void providesEnhancement() {
+        given(hederaOperations.begin()).willReturn(hederaOperations);
         assertNotNull(
                 TransactionModule.provideEnhancement(hederaOperations, nativeOperations, systemContractOperations));
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/failure/CustomExceptionalHaltReasonTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/failure/CustomExceptionalHaltReasonTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.contract.impl.test.exec.failure;
 
+import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.CONTRACT_ENTITY_LIMIT_REACHED;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SIGNATURE;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.SELF_DESTRUCT_TO_SELF;
@@ -37,6 +38,9 @@ class CustomExceptionalHaltReasonTest {
         assertEquals(
                 ResponseCodeEnum.LOCAL_CALL_MODIFICATION_EXCEPTION,
                 statusFor(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
+        assertEquals(
+                ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED,
+                statusFor(CONTRACT_ENTITY_LIMIT_REACHED));
         assertEquals(ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION, statusFor(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -153,7 +153,11 @@ class HandleHederaOperationsTest {
 
     @Test
     void commitIsNoopUntilSavepointExposesIt() {
-        assertDoesNotThrow(subject::commit);
+        given(context.savepointStack()).willReturn(savepointStack);
+
+        subject.commit();
+
+        verify(savepointStack).commit();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -23,6 +23,7 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.A_NEW_A
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.B_NEW_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CANONICAL_ALIAS;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONTRACTS_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_LEDGER_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_SYSTEM_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SOME_DURATION;
@@ -90,7 +91,7 @@ class HandleHederaOperationsTest {
 
     @BeforeEach
     void setUp() {
-        subject = new HandleHederaOperations(DEFAULT_LEDGER_CONFIG, context);
+        subject = new HandleHederaOperations(DEFAULT_LEDGER_CONFIG, DEFAULT_CONTRACTS_CONFIG, context);
     }
 
     @Test
@@ -98,6 +99,11 @@ class HandleHederaOperationsTest {
         given(context.writableStore(WritableContractStateStore.class)).willReturn(stateStore);
 
         assertSame(stateStore, subject.getStore());
+    }
+
+    @Test
+    void usesExpectedLimit() {
+        assertEquals(DEFAULT_CONTRACTS_CONFIG.maxNumber(), subject.contractCreationLimit());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaOperationsTest.java
@@ -120,6 +120,7 @@ class QueryHederaOperationsTest {
 
     @Test
     void creatingAndDeletingContractsNotSupported() {
+        assertThrows(UnsupportedOperationException.class, subject::contractCreationLimit);
         assertThrows(UnsupportedOperationException.class, () -> subject.createContract(1L, 2L, null));
         assertThrows(
                 UnsupportedOperationException.class,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
@@ -63,7 +63,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),
                         eq(verificationStrategy),
-                        eq(UNAUTHORIZED_SPENDER_ID),
+                        eq(OWNER_ID),
                         eq(SingleTransactionRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
@@ -89,7 +89,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),
                         eq(verificationStrategy),
-                        eq(UNAUTHORIZED_SPENDER_ID),
+                        eq(OWNER_ID),
                         eq(SingleTransactionRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
@@ -134,6 +134,13 @@ class DispatchingEvmFrameStateTest {
     }
 
     @Test
+    void dispatchesToNumBytecodes() {
+        given(contractStateStore.getNumBytecodes()).willReturn(1234L);
+
+        assertEquals(1234L, subject.numBytecodesInState());
+    }
+
+    @Test
     void extFrameScopeesToFinalizeHollowAccount() {
         subject.finalizeHollowAccount(EVM_ADDRESS);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
@@ -281,6 +281,14 @@ class ProxyWorldUpdaterTest {
     }
 
     @Test
+    void commitIsNoopAfterRevert() {
+        subject.revert();
+        subject.commit();
+        verify(hederaOperations).revert();
+        verify(hederaOperations, never()).commit();
+    }
+
+    @Test
     void commitDelegatesToScope() {
         subject.commit();
         verify(hederaOperations).commit();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
@@ -44,6 +44,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
+import com.hedera.node.app.service.contract.impl.exec.failure.ResourceExhaustedException;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
@@ -241,10 +242,20 @@ class ProxyWorldUpdaterTest {
     @Test
     void cannotCreateUnlessPendingCreationHasExpectedAddress() {
         given(hederaOperations.peekNextEntityNumber()).willReturn(NEXT_NUMBER);
+        given(hederaOperations.contractCreationLimit()).willReturn(1234L);
 
         subject.setupInternalCreate(ALTBN128_ADD);
 
         assertThrows(IllegalStateException.class, () -> subject.createAccount(LONG_ZERO_ADDRESS, 1, Wei.ZERO));
+    }
+
+    @Test
+    void cannotCreateUnlessLimitIsHighEnough() {
+        given(hederaOperations.peekNextEntityNumber()).willReturn(NEXT_NUMBER);
+
+        subject.setupInternalCreate(ALTBN128_ADD);
+
+        assertThrows(ResourceExhaustedException.class, () -> subject.createAccount(LONG_ZERO_ADDRESS, 1, Wei.ZERO));
     }
 
     @Test
@@ -256,6 +267,7 @@ class ProxyWorldUpdaterTest {
     @Test
     void cannotCreateUnlessPendingCreationHasExpectedNumber() {
         given(hederaOperations.peekNextEntityNumber()).willReturn(NEXT_NUMBER).willReturn(NEXT_NUMBER + 1);
+        given(hederaOperations.contractCreationLimit()).willReturn(1234L);
 
         subject.setupInternalCreate(ALTBN128_ADD);
 
@@ -280,6 +292,7 @@ class ProxyWorldUpdaterTest {
         given(evmFrameState.getMutableAccount(SOME_EVM_ADDRESS)).willReturn(mutableAccount);
         given(evmFrameState.getIdNumber(ALTBN128_ADD))
                 .willReturn(ALTBN128_ADD.toBigInteger().longValueExact());
+        given(hederaOperations.contractCreationLimit()).willReturn(1234L);
 
         subject.setupInternalAliasedCreate(ALTBN128_ADD, SOME_EVM_ADDRESS);
         subject.createAccount(SOME_EVM_ADDRESS, 1, Wei.ZERO);
@@ -292,6 +305,7 @@ class ProxyWorldUpdaterTest {
     void usesAliasIfBodyCreatedWithAlias() {
         given(hederaOperations.peekNextEntityNumber()).willReturn(NEXT_NUMBER);
         given(evmFrameState.getMutableAccount(SOME_EVM_ADDRESS)).willReturn(mutableAccount);
+        given(hederaOperations.contractCreationLimit()).willReturn(1234L);
 
         subject.setupAliasedTopLevelCreate(ContractCreateTransactionBody.DEFAULT, SOME_EVM_ADDRESS);
         subject.createAccount(SOME_EVM_ADDRESS, 1, Wei.ZERO);
@@ -313,6 +327,7 @@ class ProxyWorldUpdaterTest {
     @Test
     void doesNotUseAliasIfBodyCreatedWithoutAlias() {
         given(hederaOperations.peekNextEntityNumber()).willReturn(NEXT_NUMBER);
+        given(hederaOperations.contractCreationLimit()).willReturn(1234L);
 
         assertEquals(NEXT_LONG_ZERO_ADDRESS, subject.setupTopLevelCreate(ContractCreateTransactionBody.DEFAULT));
         subject.createAccount(NEXT_LONG_ZERO_ADDRESS, 1, Wei.ZERO);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ReadableContractStateStoreTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ReadableContractStateStoreTest.java
@@ -105,4 +105,11 @@ class ReadableContractStateStoreTest {
 
         assertSame(1L, subject.getNumSlots());
     }
+
+    @Test
+    void getsNumBytecodesAsExpected() {
+        given(bytecode.size()).willReturn(123L);
+
+        assertSame(123L, subject.getNumBytecodes());
+    }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/WritableContractStateStoreTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/WritableContractStateStoreTest.java
@@ -120,4 +120,11 @@ class WritableContractStateStoreTest {
 
         assertSame(1L, subject.getNumSlots());
     }
+
+    @Test
+    void getsNumBytecodesAsExpected() {
+        given(bytecode.size()).willReturn(123L);
+
+        assertSame(123L, subject.getNumBytecodes());
+    }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -213,7 +213,7 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
         final var accountConfig = context.configuration().getConfigData(AccountsConfig.class);
 
-        if(accountStore.getNumberOfAccounts() >= accountConfig.maxNumber()) {
+        if (accountStore.getNumberOfAccounts() >= accountConfig.maxNumber()) {
             throw new HandleException(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
         }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomRoyaltyFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomRoyaltyFeeAssessor.java
@@ -144,7 +144,7 @@ public class CustomRoyaltyFeeAssessor {
                 adjustHbarFees(result, account, fee);
             } else {
                 // exchange is for token
-                adjustHtsFees(result, account, feeCollector, feeMeta, amount, denom);
+                adjustHtsFees(result, account, feeCollector, feeMeta, royalty, denom);
             }
             /* Note that this account has now paid all royalties for this NFT type */
             result.addToRoyaltiesPaid(Pair.of(account, tokenId));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -248,7 +248,7 @@ public class FileUpdateSuite extends HapiSuite {
                 .then(getFileContents(specialFile).hasContents(ignore -> specialFileContents.toByteArray()));
     }
 
-    //It is not implemented yet in SystemFileUpdateFacility line number 127
+    // It is not implemented yet in SystemFileUpdateFacility line number 127
     private HapiSpec apiPermissionsChangeDynamically() {
         final var civilian = CIVILIAN;
         return defaultHapiSpec("ApiPermissionsChangeDynamically")
@@ -371,7 +371,7 @@ public class FileUpdateSuite extends HapiSuite {
                         .has(resultWith().gasUsed(26_451)));
     }
 
-    //It is not implemented yet in contracts
+    // It is not implemented yet in contracts
     private HapiSpec gasLimitOverMaxGasLimitFailsPrecheck() {
         return propertyPreservingHapiSpec("GasLimitOverMaxGasLimitFailsPrecheck")
                 .preserving(CONS_MAX_GAS_PROP)
@@ -386,7 +386,7 @@ public class FileUpdateSuite extends HapiSuite {
                         .hasCostAnswerPrecheckFrom(MAX_GAS_LIMIT_EXCEEDED, BUSY));
     }
 
-    //It is not implemented yet in contracts
+    // It is not implemented yet in contracts
     private HapiSpec kvLimitsEnforced() {
         final var contract = "User";
         final var gasToOffer = 1_000_000;
@@ -560,7 +560,8 @@ public class FileUpdateSuite extends HapiSuite {
                                 "topics.maxNumber", "0")))
                 .when(
                         cryptoCreate(notToBe).hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
-//                        contractCreate("Multipurpose").hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
+                        //
+                        // contractCreate("Multipurpose").hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
                         fileCreate(notToBe)
                                 .contents("NOPE")
                                 .hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
@@ -571,7 +572,7 @@ public class FileUpdateSuite extends HapiSuite {
                 .then();
     }
 
-    //It is not implemented yet in contracts
+    // It is not implemented yet in contracts
     private HapiSpec rentItemizedAsExpectedWithOverridePriceTiers() {
         final var slotUser = "SlotUser";
         final var creation = "creation";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -560,8 +560,7 @@ public class FileUpdateSuite extends HapiSuite {
                                 "topics.maxNumber", "0")))
                 .when(
                         cryptoCreate(notToBe).hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
-                        //
-                        // contractCreate("Multipurpose").hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
+                        contractCreate("Multipurpose").hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),
                         fileCreate(notToBe)
                                 .contents("NOPE")
                                 .hasKnownStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED),


### PR DESCRIPTION
**Description**:
 - Updates `ContractService` and `ScheduleService` to enforce `MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED`.
 - Fixes some contract `XTest` and adds one to validate contract creation limit.
 - Refactors `AbstractContractXTest` to extend `AbstractXTest` and introduces `AbstractTokenXTest`.