### PR TITLE
08138 Increased `reconnect.asyncStreamTimeout` property to prevent genesis reconnect from failure

### DIFF
--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -32,7 +32,6 @@ event.creation.maxCreationRate,                20
                                           #############################
 
 reconnect.active,                              true
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 
                                           #############################
                                           #          Metrics          #

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -32,7 +32,6 @@ event.creation.maxCreationRate,                20
                                           #############################
 
 reconnect.active,                              true
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 
                                           #############################
                                           #          Metrics          #

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -31,7 +31,6 @@ event.maxEventQueueForCons,                    1000
                                           #############################
 
 reconnect.active,                              true
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 
                                           #############################
                                           #          Metrics          #

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -31,7 +31,6 @@ event.maxEventQueueForCons,                    1000
                                           #############################
 
 reconnect.active,                              true
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 
                                           #############################
                                           #          Metrics          #

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -31,7 +31,6 @@ event.maxEventQueueForCons,                    1000
                                           #############################
 
 reconnect.active,                              true
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 
                                           #############################
                                           #          Metrics          #

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -31,7 +31,6 @@ event.maxEventQueueForCons,                    1000
                                           #############################
 
 reconnect.active,                              true
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 
                                           #############################
                                           #          Metrics          #

--- a/hedera-node/hedera-app/src/test/resources/signedState/MHS/settingsUsed.txt
+++ b/hedera-node/hedera-app/src/test/resources/signedState/MHS/settingsUsed.txt
@@ -96,7 +96,6 @@ data/threadDump = threadDumpLogDir
            true = reconnect.active
              -1 = reconnect.reconnectWindowSeconds
             0.5 = reconnect.fallenBehindThreshold
-          60000 = reconnect.asyncStreamTimeoutMilliseconds
             100 = reconnect.asyncOutputStreamFlushMilliseconds
           10000 = reconnect.asyncStreamBufferSize
            true = reconnect.asyncStreams

--- a/hedera-node/settings.txt
+++ b/hedera-node/settings.txt
@@ -4,7 +4,6 @@ doUpnp,                                        false
 loadKeysFromPfxFiles,                          0
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
 state.saveStatePeriod,                         300

--- a/hedera-node/test-clients/src/eet/resources/network/config/settings.txt
+++ b/hedera-node/test-clients/src/eet/resources/network/config/settings.txt
@@ -5,7 +5,6 @@ loadKeysFromPfxFiles,                          0
 doUpnp,                                        false
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
 state.saveStatePeriod,                         300

--- a/hedera-node/test-clients/src/itest/resources/network/config/settings.txt
+++ b/hedera-node/test-clients/src/itest/resources/network/config/settings.txt
@@ -5,7 +5,6 @@ loadKeysFromPfxFiles,                          0
 doUpnp,                                        false
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
-reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
 state.saveStatePeriod,                         300

--- a/hedera-node/test-clients/src/main/resource/testfiles/updateFeature/updateSettings/sdk/settings.txt
+++ b/hedera-node/test-clients/src/main/resource/testfiles/updateFeature/updateSettings/sdk/settings.txt
@@ -12,7 +12,6 @@ maxEventQueueForCons,                          1000
 maxOutgoingSyncs,                              4
 numConnections,                                1000
 reconnect.active,                              0
-reconnect.asyncStreamTimeoutMilliseconds, 60000
 reconnect.reconnectWindowSeconds,              300
 showDbStats,                                   0
 showInternalStats,                             1

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfig.java
@@ -54,7 +54,7 @@ public record ReconnectConfig(
         @ConfigProperty(defaultValue = "true") boolean active,
         @ConfigProperty(defaultValue = "-1") int reconnectWindowSeconds,
         @ConfigProperty(defaultValue = "0.50") double fallenBehindThreshold,
-        @ConfigProperty(defaultValue = "60s") Duration asyncStreamTimeout,
+        @ConfigProperty(defaultValue = "180s") Duration asyncStreamTimeout,
         @ConfigProperty(defaultValue = "100ms") Duration asyncOutputStreamFlush,
         @ConfigProperty(defaultValue = "10000") int asyncStreamBufferSize,
         @ConfigProperty(defaultValue = "10ms") Duration maxAckDelay,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/internal/ConfigMappings.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/internal/ConfigMappings.java
@@ -78,7 +78,6 @@ public final class ConfigMappings {
             new ConfigMapping("thread.threadPriorityNonSync", "threadPriorityNonSync"),
             new ConfigMapping("thread.threadDumpPeriodMs", "threadDumpPeriodMs"),
             new ConfigMapping("thread.threadDumpLogDir", "threadDumpLogDir"),
-            new ConfigMapping("reconnect.asyncStreamTimeout", "reconnect.asyncStreamTimeoutMilliseconds"),
             new ConfigMapping("reconnect.asyncOutputStreamFlush", "reconnect.asyncOutputStreamFlushMilliseconds"),
             new ConfigMapping("reconnect.maxAckDelay", "reconnect.maxAckDelayMilliseconds"));
 


### PR DESCRIPTION
Increased `reconnect.asyncStreamTimeout` property to prevent genesis reconnect from failure

**Description**:

In case the tree gets too big, hashing may take more that 60s and in this case the learner node doesn't send the lesson confirmation on time, and the teacher node assumes that a connection between nodes should be closed. After that the nodes are not able to finish the reconnect properly. 

**Related issue(s)**:

Fixes #8138 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
