### PR TITLE
08138 Increased `reconnect.asyncStreamTimeout` property to 5 minutes

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfig.java
@@ -54,7 +54,7 @@ public record ReconnectConfig(
         @ConfigProperty(defaultValue = "true") boolean active,
         @ConfigProperty(defaultValue = "-1") int reconnectWindowSeconds,
         @ConfigProperty(defaultValue = "0.50") double fallenBehindThreshold,
-        @ConfigProperty(defaultValue = "180s") Duration asyncStreamTimeout,
+        @ConfigProperty(defaultValue = "300s") Duration asyncStreamTimeout,
         @ConfigProperty(defaultValue = "100ms") Duration asyncOutputStreamFlush,
         @ConfigProperty(defaultValue = "10000") int asyncStreamBufferSize,
         @ConfigProperty(defaultValue = "10ms") Duration maxAckDelay,


### PR DESCRIPTION
**Description**:

This is a follow up for https://github.com/hashgraph/hedera-services/pull/9135

**Related issue(s)**:

Fixes #8138

