### PR TITLE
Add checks for immutable keys

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreHandleContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreHandleContext.java
@@ -92,9 +92,10 @@ public interface PreHandleContext extends TransactionKeys {
      * @param key key to be added
      * @return {@code this} object
      * @throws NullPointerException if the key is null
+     * @throws PreCheckException if the key is not accepted
      */
     @NonNull
-    PreHandleContext requireKey(@NonNull final Key key);
+    PreHandleContext requireKey(@NonNull final Key key) throws PreCheckException;
 
     /**
      * Adds the given key to optional non-payer keys.
@@ -104,9 +105,10 @@ public interface PreHandleContext extends TransactionKeys {
      * @param key key to be added
      * @return {@code this} object
      * @throws NullPointerException if the key is null
+     * @throws PreCheckException if the key is not accepted
      */
     @NonNull
-    PreHandleContext optionalKey(@NonNull final Key key);
+    PreHandleContext optionalKey(@NonNull final Key key) throws PreCheckException;
 
     /**
      * Adds the given set of keys to optional non-payer keys.
@@ -116,9 +118,10 @@ public interface PreHandleContext extends TransactionKeys {
      * @param keys the set of keys to be added
      * @return {@code this} object
      * @throws NullPointerException if the set of keys is null
+     * @throws PreCheckException if the key is not accepted
      */
     @NonNull
-    PreHandleContext optionalKeys(@NonNull final Set<Key> keys);
+    PreHandleContext optionalKeys(@NonNull final Set<Key> keys) throws PreCheckException;
 
     /**
      * Adds the given hollow account to the optional signing set.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/workflows/FakePreHandleContext.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/workflows/FakePreHandleContext.java
@@ -257,6 +257,9 @@ public class FakePreHandleContext implements PreHandleContext {
             throw new PreCheckException(responseCode);
         }
 
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, responseCode);
+
         return requireKey(key);
     }
 
@@ -410,5 +413,23 @@ public class FakePreHandleContext implements PreHandleContext {
                 + requiredNonPayerKeys + ", innerContext="
                 + innerContext + ", stores="
                 + stores + '}';
+    }
+
+    /**
+     * THIS IS A COPY of {@code verifyIsNotImmutableAccount} in the token service package. It should
+     * NOT exist here, but needs to in order for this class to function correctly. However, it
+     * should be removed as soon as possible (along with this deprecated class).
+     * <p>
+     * Checks that a key does not represent an immutable account, e.g. the staking rewards account.
+     * Throws a {@link PreCheckException} with the designated response code otherwise.
+     * @param key the key to check
+     * @param responseCode the response code to throw
+     * @throws PreCheckException if the account is considered immutable
+     */
+    private static void verifyIsNotImmutableAccount(
+            @Nullable final Key key, @NonNull final ResponseCodeEnum responseCode) throws PreCheckException {
+        if (EMPTY_KEY_LIST.equals(key)) {
+            throw new PreCheckException(responseCode);
+        }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.workflows.prehandle;
 
+import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.verifyIsNotImmutableAccount;
 import static com.hedera.node.app.spi.HapiUtils.EMPTY_KEY_LIST;
 import static com.hedera.node.app.spi.HapiUtils.isHollow;
 import static com.hedera.node.app.spi.key.KeyUtils.isValid;
@@ -160,7 +161,10 @@ public class PreHandleContextImpl implements PreHandleContext {
 
     @NonNull
     @Override
-    public PreHandleContext optionalKey(@NonNull final Key key) {
+    public PreHandleContext optionalKey(@NonNull final Key key) throws PreCheckException {
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, ResponseCodeEnum.INVALID_ACCOUNT_ID);
+
         if (!key.equals(payerKey) && isValid(key)) {
             optionalNonPayerKeys.add(key);
         }
@@ -169,7 +173,7 @@ public class PreHandleContextImpl implements PreHandleContext {
 
     @NonNull
     @Override
-    public PreHandleContext optionalKeys(@NonNull final Set<Key> keys) {
+    public PreHandleContext optionalKeys(@NonNull final Set<Key> keys) throws PreCheckException {
         for (final Key nextKey : keys) {
             optionalKey(nextKey);
         }
@@ -227,6 +231,10 @@ public class PreHandleContextImpl implements PreHandleContext {
         if (!isValid(key)) {
             throw new PreCheckException(responseCode);
         }
+
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, responseCode);
+
         return requireKey(key);
     }
 
@@ -253,6 +261,9 @@ public class PreHandleContextImpl implements PreHandleContext {
             throw new PreCheckException(responseCode);
         }
 
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, responseCode);
+
         return requireKey(key);
     }
 
@@ -277,6 +288,9 @@ public class PreHandleContextImpl implements PreHandleContext {
             // keys? Or KeyList with Contract keys only?
             throw new PreCheckException(responseCode);
         }
+
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, responseCode);
 
         return requireKey(key);
     }
@@ -312,6 +326,9 @@ public class PreHandleContextImpl implements PreHandleContext {
             throw new PreCheckException(responseCode);
         }
 
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, responseCode);
+
         return requireKey(key);
     }
 
@@ -344,6 +361,9 @@ public class PreHandleContextImpl implements PreHandleContext {
             // keys? Or KeyList with Contract keys only?
             throw new PreCheckException(responseCode);
         }
+
+        // Verify this key isn't for an immutable account
+        verifyIsNotImmutableAccount(key, responseCode);
 
         return requireKey(key);
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
@@ -101,7 +101,7 @@ class PreHandleContextImplTest implements Scenarios {
     }
 
     @Test
-    void gettersWork() {
+    void gettersWork() throws PreCheckException {
         subject.requireKey(otherKey);
 
         assertThat(subject.body()).isEqualTo(createAccountTransaction());

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
@@ -104,9 +104,8 @@ public class FileServiceUtils {
      * @param context the prehandle context for the transaction.
      */
     public static void validateAndAddRequiredKeys(
-            @Nullable final File file,
-            @Nullable final KeyList transactionKeys,
-            @NonNull final PreHandleContext context) {
+            @Nullable final File file, @Nullable final KeyList transactionKeys, @NonNull final PreHandleContext context)
+            throws PreCheckException {
         if (file != null) {
             KeyList fileKeyList = file.keys();
 
@@ -132,7 +131,7 @@ public class FileServiceUtils {
      * @param context the prehandle context for the transaction.
      */
     public static void validateAndAddRequiredKeysForDelete(
-            @Nullable final File file, @NonNull final PreHandleContext context) {
+            @Nullable final File file, @NonNull final PreHandleContext context) throws PreCheckException {
         if (file != null) {
             KeyList fileKeyList = file.keys();
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.token.impl.handlers;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_IS_IMMUTABLE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
@@ -277,7 +276,8 @@ public class CryptoTransferHandler implements TransactionHandler {
                 // a key, unless `receiverSigRequired` is true.
                 final var accountKey = account.key();
                 if ((isEmpty(accountKey)) && (isDebit || isCredit && !hbarTransfer)) {
-                    throw new PreCheckException(ACCOUNT_IS_IMMUTABLE);
+                    // NOTE: should change to ACCOUNT_IS_IMMUTABLE after modularization
+                    throw new PreCheckException(INVALID_ACCOUNT_ID);
                 }
 
                 // We only need signing keys for accounts that are being debited OR those being credited
@@ -286,7 +286,8 @@ public class CryptoTransferHandler implements TransactionHandler {
                 // signing requirements were met ("isApproval" is a way for the client to say "I don't need a key
                 // because I'm approved which you will see when you handle this transaction").
                 if (isDebit && !accountAmount.isApproval()) {
-                    ctx.requireKeyOrThrow(account.key(), ACCOUNT_IS_IMMUTABLE);
+                    // NOTE: should change to ACCOUNT_IS_IMMUTABLE after modularization
+                    ctx.requireKeyOrThrow(account.key(), INVALID_ACCOUNT_ID);
                 } else if (isCredit && account.receiverSigRequired()) {
                     ctx.requireKeyOrThrow(account.key(), INVALID_TRANSFER_ACCOUNT_ID);
                 }
@@ -349,8 +350,9 @@ public class CryptoTransferHandler implements TransactionHandler {
 
         final var receiverKey = receiverAccount.key();
         if (isEmpty(receiverKey)) {
-            // If the receiver account has no key, then fail with ACCOUNT_IS_IMMUTABLE.
-            throw new PreCheckException(ACCOUNT_IS_IMMUTABLE);
+            // If the receiver account has no key, then fail with INVALID_ACCOUNT_ID.
+            // NOTE: should change to ACCOUNT_IS_IMMUTABLE after modularization
+            throw new PreCheckException(INVALID_ACCOUNT_ID);
         } else if (receiverAccount.receiverSigRequired()) {
             // If receiverSigRequired is set, and if there is no key on the receiver's account, then fail with
             // INVALID_TRANSFER_ACCOUNT_ID. Otherwise, add the key.
@@ -384,8 +386,9 @@ public class CryptoTransferHandler implements TransactionHandler {
         // If the sender account is immutable, then we throw an exception.
         final var key = senderAccount.key();
         if (key == null || !isValid(key)) {
-            // If the sender account has no key, then fail with ACCOUNT_IS_IMMUTABLE.
-            throw new PreCheckException(ACCOUNT_IS_IMMUTABLE);
+            // If the sender account has no key, then fail with INVALID_ACCOUNT_ID.
+            // NOTE: should change to ACCOUNT_IS_IMMUTABLE
+            throw new PreCheckException(INVALID_ACCOUNT_ID);
         } else if (!nftTransfer.isApproval()) {
             meta.requireKey(key);
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -16,13 +16,14 @@
 
 package com.hedera.node.app.service.token.impl.handlers;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
 import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.txnEstimateFactory;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.verifyIsNotImmutableAccount;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Collections.emptyList;
@@ -57,6 +58,7 @@ import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.node.config.data.TokensConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import javax.inject.Inject;
@@ -91,7 +93,8 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
         final var tokenCreateTxnBody = txn.tokenCreationOrThrow();
         if (tokenCreateTxnBody.hasTreasury()) {
             final var treasuryId = tokenCreateTxnBody.treasuryOrThrow();
-            context.requireKeyOrThrow(treasuryId, INVALID_TREASURY_ACCOUNT_FOR_TOKEN);
+            // Note: should throw INVALID_TREASURY_ACCOUNT_FOR_TOKEN after modularization
+            context.requireKeyOrThrow(treasuryId, INVALID_ACCOUNT_ID);
         }
         if (tokenCreateTxnBody.hasAutoRenewAccount()) {
             final var autoRenewalAccountId = tokenCreateTxnBody.autoRenewAccountOrThrow();
@@ -250,14 +253,10 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
 
     /**
      * Get the expiry metadata for the token to be created from the transaction body.
-     * @param consensusTime consensus time
      * @param op token creation transaction body
      * @return given expiry metadata
      */
-    private ExpiryMeta getExpiryMeta(
-            final long consensusTime,
-            @NonNull final TokenCreateTransactionBody op,
-            @NonNull final HandleContext context) {
+    private ExpiryMeta getExpiryMeta(@NonNull final TokenCreateTransactionBody op) {
         final var impliedExpiry = op.hasExpiry() ? op.expiry().seconds() : NA;
 
         return new ExpiryMeta(
@@ -290,7 +289,7 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
         tokenCreateValidator.validate(context, accountStore, op, config);
 
         // validate expiration and auto-renew account if present
-        final var givenExpiryMeta = getExpiryMeta(context.consensusNow().getEpochSecond(), op, context);
+        final var givenExpiryMeta = getExpiryMeta(op);
         final var resolvedExpiryMeta = context.expiryValidator().resolveCreationAttempt(false, givenExpiryMeta);
 
         // validate auto-renew account exists
@@ -318,6 +317,15 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
 
         for (final var customFee : customFeesList) {
             final var collector = customFee.feeCollectorAccountIdOrElse(AccountID.DEFAULT);
+
+            // Verify that the collector either has a non-empty alias OR a mutable key
+            final var acctStore = context.createStore(ReadableAccountStore.class);
+            final var collectorAcct = acctStore.getAccountById(collector);
+            if (collectorAcct != null
+                    && (collectorAcct.alias() == null || Bytes.EMPTY.equals(collectorAcct.alias()))
+                    && (collectorAcct.hasKey())) {
+                verifyIsNotImmutableAccount(collectorAcct.keyOrThrow(), INVALID_CUSTOM_FEE_COLLECTOR);
+            }
 
             /* A fractional fee collector and a collector for a fixed fee denominated
             in the units of the newly created token both must always sign a TokenCreate,

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenHandlerHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenHandlerHelper.java
@@ -42,11 +42,13 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_IS_PAUSED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_WAS_DELETED;
+import static com.hedera.node.app.spi.HapiUtils.EMPTY_KEY_LIST;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
@@ -58,7 +60,9 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.spi.validation.EntityType;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.app.spi.workflows.PreCheckException;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Class for retrieving objects in a certain context, e.g. during a {@code handler.handle(...)} call.
@@ -199,5 +203,19 @@ public class TokenHandlerHelper {
         validateTrue(!tokenRel.frozen(), ACCOUNT_FROZEN_FOR_TOKEN);
 
         return tokenRel;
+    }
+
+    /**
+     * Checks that a key does not represent an immutable account, e.g. the staking rewards account.
+     * Throws a {@link PreCheckException} with the designated response code otherwise.
+     * @param key the key to check
+     * @param responseCode the response code to throw
+     * @throws PreCheckException if the account is considered immutable
+     */
+    public static void verifyIsNotImmutableAccount(
+            @Nullable final Key key, @NonNull final ResponseCodeEnum responseCode) throws PreCheckException {
+        if (EMPTY_KEY_LIST.equals(key)) {
+            throw new PreCheckException(responseCode);
+        }
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerParityTest.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.token.impl.test.handlers;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_IS_IMMUTABLE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
@@ -143,7 +142,7 @@ class CryptoTransferHandlerParityTest extends ParityTestBase {
         final var theTxn = txnFrom(CRYPTO_TRANSFER_TOKEN_TO_IMMUTABLE_RECEIVER_SCENARIO);
         final var context = new FakePreHandleContext(readableAccountStore, theTxn);
         context.registerStore(ReadableTokenStore.class, readableTokenStore);
-        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_IS_IMMUTABLE);
+        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
     }
 
     @Test
@@ -169,7 +168,7 @@ class CryptoTransferHandlerParityTest extends ParityTestBase {
         final var theTxn = txnFrom(CRYPTO_TRANSFER_NFT_FROM_IMMUTABLE_SENDER_SCENARIO);
         final var context = new FakePreHandleContext(readableAccountStore, theTxn);
         context.registerStore(ReadableTokenStore.class, readableTokenStore);
-        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_IS_IMMUTABLE);
+        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
     }
 
     @Test
@@ -177,7 +176,7 @@ class CryptoTransferHandlerParityTest extends ParityTestBase {
         final var theTxn = txnFrom(CRYPTO_TRANSFER_NFT_TO_IMMUTABLE_RECEIVER_SCENARIO);
         final var context = new FakePreHandleContext(readableAccountStore, theTxn);
         context.registerStore(ReadableTokenStore.class, readableTokenStore);
-        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_IS_IMMUTABLE);
+        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
     }
 
     @Test
@@ -185,7 +184,7 @@ class CryptoTransferHandlerParityTest extends ParityTestBase {
         final var theTxn = txnFrom(CRYPTO_TRANSFER_FROM_IMMUTABLE_SENDER_SCENARIO);
         final var context = new FakePreHandleContext(readableAccountStore, theTxn);
         context.registerStore(ReadableTokenStore.class, readableTokenStore);
-        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_IS_IMMUTABLE);
+        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandleParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandleParityTest.java
@@ -16,9 +16,9 @@
 
 package com.hedera.node.app.service.token.impl.test.handlers;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
 import static com.hedera.node.app.service.token.impl.test.util.MetaAssertion.basicContextAssertions;
 import static com.hedera.node.app.service.token.impl.test.util.SigReqAdapterUtils.txnFrom;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
@@ -137,7 +137,7 @@ class TokenCreateHandleParityTest {
         final var txn = txnFrom(TOKEN_CREATE_WITH_MISSING_TREASURY);
 
         final var context = new FakePreHandleContext(accountStore, txn);
-        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_TREASURY_ACCOUNT_FOR_TOKEN);
+        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -593,6 +593,7 @@ public class CryptoTransferSuite extends HapiSuite {
                                                 .between(partyLiteral.get(), counterLiteral.get()))))));
     }
 
+    @HapiTest
     private HapiSpec cannotTransferFromImmutableAccounts() {
         final var contract = "PayableConstructor";
         final var multiKey = "swiss";


### PR DESCRIPTION
Part of #8466.

This fixes one test in the crypto transfer suite, testing various attempts at using immutable accounts.