### PR TITLE
Fix `aliasKeysAreValidated` test in `CryptoTransferSuite`

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.token.impl.handlers.transfer;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ALIAS_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
 import static com.hedera.node.app.service.mono.txns.crypto.AbstractAutoCreationLogic.AUTO_MEMO;
 import static com.hedera.node.app.service.mono.txns.crypto.AbstractAutoCreationLogic.LAZY_MEMO;
@@ -26,6 +27,7 @@ import static com.hedera.node.app.service.token.impl.handlers.transfer.TransferC
 import static com.hedera.node.app.service.token.impl.validators.TokenAttributesValidator.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.spi.key.KeyUtils.ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
+import static com.hedera.node.app.spi.key.KeyUtils.isValid;
 import static com.swirlds.common.utility.CommonUtils.hex;
 import static java.util.Objects.requireNonNull;
 
@@ -98,6 +100,7 @@ public class AutoAccountCreator {
             memo = LAZY_MEMO;
         } else {
             final var key = asKeyFromAlias(alias);
+            validateTrue(isValid(key), INVALID_ALIAS_KEY);
             if (key.hasEcdsaSecp256k1()) {
                 evmAddress = tryAddressRecovery(key, EthSigsUtils::recoverAddressFromPubKey);
                 syntheticCreation = createAccount(Bytes.wrap(evmAddress), key, 0L, maxAutoAssociations);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
@@ -26,8 +26,8 @@ import static com.hedera.node.app.service.token.impl.handlers.transfer.AliasUtil
 import static com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl.isOfEvmAddressSize;
 import static com.hedera.node.app.service.token.impl.validators.TokenAttributesValidator.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.spi.key.KeyUtils.ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH;
-import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.key.KeyUtils.isValid;
+import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.swirlds.common.utility.CommonUtils.hex;
 import static java.util.Objects.requireNonNull;
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
@@ -52,6 +52,7 @@ public class CryptoCreateValidator {
     private static final int EVM_ADDRESS_SIZE = 20;
     public static final String ECDSA_KEY_ALIAS_PREFIX = "3a21";
     public static final int ECDSA_SECP256K1_ALIAS_SIZE = 35;
+    public static final int ED25519_ALIAS_SIZE = 34;
 
     @Inject
     public CryptoCreateValidator() { // Exists for injection
@@ -114,10 +115,11 @@ public class CryptoCreateValidator {
         if (!canSkipNormalKeyValidation(op.keyOrThrow(), isInternalDispatch)) {
             validateKey(op, attributeValidator);
         }
-        final boolean isValidAlias = op.alias().length() == EVM_ADDRESS_SIZE
+        final boolean isECDSAValidAlias = op.alias().length() == EVM_ADDRESS_SIZE
                 || (op.alias().length() == ECDSA_SECP256K1_ALIAS_SIZE
-                        && op.alias().toHex().startsWith(ECDSA_KEY_ALIAS_PREFIX));
-        validateTrue(isValidAlias, INVALID_ALIAS_KEY);
+                && op.alias().toHex().startsWith(ECDSA_KEY_ALIAS_PREFIX));
+        final boolean isED25519ValidAlias = op.alias().length() == ED25519_ALIAS_SIZE;
+        validateTrue(isECDSAValidAlias || isED25519ValidAlias, INVALID_ALIAS_KEY);
         validateFalse(isMirror(op.alias()), INVALID_ALIAS_KEY);
         validateTrue(readableAccountStore.getAccountIDByAlias(op.alias()) == null, ALIAS_ALREADY_ASSIGNED);
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
@@ -117,7 +117,7 @@ public class CryptoCreateValidator {
         }
         final boolean isECDSAValidAlias = op.alias().length() == EVM_ADDRESS_SIZE
                 || (op.alias().length() == ECDSA_SECP256K1_ALIAS_SIZE
-                && op.alias().toHex().startsWith(ECDSA_KEY_ALIAS_PREFIX));
+                        && op.alias().toHex().startsWith(ECDSA_KEY_ALIAS_PREFIX));
         final boolean isED25519ValidAlias = op.alias().length() == ED25519_ALIAS_SIZE;
         validateTrue(isECDSAValidAlias || isED25519ValidAlias, INVALID_ALIAS_KEY);
         validateFalse(isMirror(op.alias()), INVALID_ALIAS_KEY);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -362,6 +362,7 @@ public class CryptoTransferSuite extends HapiSuite {
                 .then(getTxnRecord(NFT_XFER).logged());
     }
 
+    @HapiTest
     private HapiSpec aliasKeysAreValidated() {
         final var validAlias = "validAlias";
         final var invalidAlias = "invalidAlias";


### PR DESCRIPTION
**Description**:
This PR fixes `aliasKeysAreValidated()` test in `CryptoTransferSuite` by enriching the validations of the aliases and keys.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
