### PR TITLE
07672 Run Hapi Tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyFactory.java
@@ -42,6 +42,7 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.util.AbstractMap;
@@ -223,7 +224,7 @@ public class KeyFactory implements Serializable {
     }
 
     public Transaction signWithFullPrefixEd25519Keys(final Transaction.Builder txn, final List<Key> keys)
-            throws Throwable {
+            throws IOException, GeneralSecurityException {
         final List<Entry<Key, SigControl>> authors = keys.stream()
                 .<Entry<Key, SigControl>>map(k -> Pair.of(k, SigControl.ED25519_ON))
                 .toList();
@@ -252,14 +253,14 @@ public class KeyFactory implements Serializable {
             this.authors = authors;
         }
 
-        public List<Entry<byte[], byte[]>> completed() throws Throwable {
+        public List<Entry<byte[], byte[]>> completed() throws GeneralSecurityException {
             for (final var author : authors) {
                 signRecursively(author.getKey(), author.getValue());
             }
             return keySigs;
         }
 
-        private void signRecursively(final Key key, final SigControl controller) throws Throwable {
+        private void signRecursively(final Key key, final SigControl controller) throws GeneralSecurityException {
             switch (controller.getNature()) {
                 case SIG_OFF:
                 case CONTRACT_ID:
@@ -277,7 +278,7 @@ public class KeyFactory implements Serializable {
             }
         }
 
-        private void signIfNecessary(final Key key) throws Throwable {
+        private void signIfNecessary(final Key key) throws GeneralSecurityException {
             final var pk = extractPubKey(key);
             final var hexedPk = com.swirlds.common.utility.CommonUtils.hex(pk);
             if (!used.contains(hexedPk)) {


### PR DESCRIPTION
* Fixed extremely bad exception design that resulted in massive runaway and time expansion when the hapi node fails.

Basically, we had methods declaring `Throwable` in signature, which makes correct exception handling practically impossible, so I cleaned up a few of those that impacted the runaway code path.  Then I changed the catch blocks to retry when possible, but fail completely when no amount of retry could fix the problem.  Now, instead of burning 6 hours at 100% CPU retrying connection to dead nodes, the HAPI test clients just fail all subsequent tests.

If PR #8733 revives, then a node restart can be added after that to restart the nodes when they fail, instead of just failing all the tests, but for now failing quickly is far preferrable to hours of useless retry.

