### PR TITLE
Fix deserializeKeySize method

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKeySerializer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKeySerializer.java
@@ -106,7 +106,7 @@ public final class OnDiskKeySerializer<K> implements KeySerializer<OnDiskKey<K>>
 
     @Override
     public int deserializeKeySize(@NonNull final ByteBuffer byteBuffer) {
-        return byteBuffer.getInt();
+        return byteBuffer.getInt() + Integer.BYTES;
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKeySerializer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKeySerializer.java
@@ -106,12 +106,7 @@ public final class OnDiskKeySerializer<K> implements KeySerializer<OnDiskKey<K>>
 
     @Override
     public int deserializeKeySize(@NonNull final ByteBuffer byteBuffer) {
-        try {
-            return codec.measure(BufferedData.wrap(byteBuffer)) + 4;
-        } catch (IOException e) {
-            // Maybe log here?
-            return -1;
-        }
+        return byteBuffer.getInt();
     }
 
     @Override


### PR DESCRIPTION
Fixes #9201

The implementation of deserializeKeySize() does the wrong thing, as size is written as int in first 4 bytes all is needed is to read that size.
