### PR TITLE
[release/0.42] Remove unrecognized properties from testnet bootstrap and application config files

### DIFF
--- a/hedera-node/configuration/testnet/application.properties
+++ b/hedera-node/configuration/testnet/application.properties
@@ -1,11 +1,11 @@
-# This is intended to be an exact replica of file 121 on testnet and should match bootstrap.properties exactly.
+# Except for network-specific properties (e.g. testnet vs. mainnet), this file is intended to be an
+# exact replica of file 121 on testnet and should match bootstrap.properties exactly.
 # It will be used by modular code for all the property overrides.
 # It does not have to match bootstrap.properties once that file is deprecated by the switch from mono-service to hedera-config.
 accounts.maxNumber=20_000_000
 staking.fees.stakingRewardPercentage=10
 staking.maxStakeRewarded=650000000000000000
 staking.rewardBalanceThreshold=8500000000000000
-bogus.property=4
 tokens.nfts.maxAllowedMints=10_000_000
 # Overrides that differ based on the network
 ledger.id=0x01

--- a/hedera-node/configuration/testnet/application.properties
+++ b/hedera-node/configuration/testnet/application.properties
@@ -3,10 +3,8 @@
 # It does not have to match bootstrap.properties once that file is deprecated by the switch from mono-service to hedera-config.
 accounts.maxNumber=20_000_000
 staking.fees.stakingRewardPercentage=10
-staking.maxDailyStakeRewardThPerH=6_849
 staking.maxStakeRewarded=650000000000000000
 staking.rewardBalanceThreshold=8500000000000000
-staking.rewardRate=48630136986000
 tokens.nfts.maxAllowedMints=10_000_000
 #Overrides that differ based on the network
 ledger.id=0x01

--- a/hedera-node/configuration/testnet/application.properties
+++ b/hedera-node/configuration/testnet/application.properties
@@ -1,12 +1,13 @@
-# This is exact replica of file 121 on testnet and must match bootstrap.properties exactly.
+# This is intended to be an exact replica of file 121 on testnet and should match bootstrap.properties exactly.
 # It will be used by modular code for all the property overrides.
 # It does not have to match bootstrap.properties once that file is deprecated by the switch from mono-service to hedera-config.
 accounts.maxNumber=20_000_000
 staking.fees.stakingRewardPercentage=10
 staking.maxStakeRewarded=650000000000000000
 staking.rewardBalanceThreshold=8500000000000000
+bogus.property=4
 tokens.nfts.maxAllowedMints=10_000_000
-#Overrides that differ based on the network
+# Overrides that differ based on the network
 ledger.id=0x01
 contracts.chainId=296
 bootstrap.genesisPublicKey=e06b22e0966108fa5d63fc6ae53f9824319b891cd4d6050dbf2b242be7e13344

--- a/hedera-node/configuration/testnet/bootstrap.properties
+++ b/hedera-node/configuration/testnet/bootstrap.properties
@@ -5,10 +5,8 @@
 # This file will be deprecated when we deprecate using the mono-service config and fully move to hedera-config.
 accounts.maxNumber=20_000_000
 staking.fees.stakingRewardPercentage=10
-staking.maxDailyStakeRewardThPerH=6_849
 staking.maxStakeRewarded=650000000000000000
 staking.rewardBalanceThreshold=8500000000000000
-staking.rewardRate=48630136986000
 tokens.nfts.maxAllowedMints=10_000_000
 #Overrides that differ based on the network
 ledger.id=0x01

--- a/hedera-node/configuration/testnet/bootstrap.properties
+++ b/hedera-node/configuration/testnet/bootstrap.properties
@@ -1,14 +1,19 @@
-# This file needs to exist even though there aren't any properties in it.
-# Downstream processes depend on its existence.
-# This is an exact replica of file 121 on testnet and must match application.properties exactly.
-# It will be used by mono-service for all the property overrides.
+# NOTE: Downstream processes depend on this file's existence
+#
+# Except network-specific overrides (e.g. mainnet vs. testnet), this file is intended to
+# be an exact replica of file 121 on testnet and should match application.properties exactly.
+# Whenever a configuration change is made to file 121, it should be made here as well. There will be
+# some lag time between the property change in file 121 and that same change promoted to the repo and
+# to subsequent artifacts, but this span of time should be minimized as much as possible.
+#
+# This file will be used by mono-service for all the property overrides.
 # This file will be deprecated when we deprecate using the mono-service config and fully move to hedera-config.
 accounts.maxNumber=20_000_000
 staking.fees.stakingRewardPercentage=10
 staking.maxStakeRewarded=650000000000000000
 staking.rewardBalanceThreshold=8500000000000000
 tokens.nfts.maxAllowedMints=10_000_000
-#Overrides that differ based on the network
+# Overrides that differ based on the network
 ledger.id=0x01
 contracts.chainId=296
 bootstrap.genesisPublicKey=e06b22e0966108fa5d63fc6ae53f9824319b891cd4d6050dbf2b242be7e13344


### PR DESCRIPTION
The `0.42.4` tag threw the following error when starting in testnet:

```
java.lang.IllegalStateException: 'bootstrap.properties' contains unrecognized properties: [staking.maxDailyStakeRewardThPerH, staking.rewardRate]!
```

This PR fixes this issue by removing the errant properties from testnet's ` bootstrap.properties` and `application.properties` config files. 

These properties were removed in a 0.41.x release, but they are still in file 121 on testnet, and got accidentally copied to 0.42.

Additional related PRs:
* https://github.com/hashgraph/hedera-services/pull/9209
* https://github.com/hashgraph/hedera-services/pull/9210