### PR TITLE
9072 Enable Hapi Tests - General Improvements

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -21,7 +21,13 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asSources;
 import static com.hedera.services.bdd.spec.HapiPropertySource.inPriorityOrder;
 import static com.hedera.services.bdd.spec.HapiSpec.CostSnapshotMode.COMPARE;
 import static com.hedera.services.bdd.spec.HapiSpec.CostSnapshotMode.TAKE;
-import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.*;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.ERROR;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.FAILED;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.FAILED_AS_EXPECTED;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.PASSED;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.PASSED_UNEXPECTEDLY;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.PENDING;
+import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.RUNNING;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.infrastructure.HapiApiClients.clientsFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getScheduleInfo;
@@ -29,7 +35,8 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleSign;
-import static com.hedera.services.bdd.spec.utilops.UtilStateChange.*;
+import static com.hedera.services.bdd.spec.utilops.UtilStateChange.initializeEthereumAccountForSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilStateChange.isEthereumAccountCreatedForSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
@@ -386,7 +393,7 @@ public class HapiSpec implements Runnable {
                         Thread.currentThread().interrupt();
                     }
                 }
-            } catch (RuntimeException | ReflectiveOperationException | GeneralSecurityException e) {
+            } catch (IllegalStateException | ReflectiveOperationException | GeneralSecurityException e) {
                 status = ERROR; // These are unrecoverable; save a lot of time and just fail the test.
                 log.error("Irrecoverable error in test nodes or client JVM. Unable to continue.", e);
                 return false;
@@ -405,6 +412,7 @@ public class HapiSpec implements Runnable {
                 loadCostSnapshot();
             } catch (RuntimeException ignore) {
                 status = ERROR;
+                log.warn("Failed to load cost snapshot.", ignore);
                 return false;
             }
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
@@ -23,7 +23,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTransferList;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.toReadableString;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_NOT_ACTIVE;
 
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
@@ -52,6 +51,7 @@ import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -190,21 +190,32 @@ public class FeesAndRatesProvider {
                     .getFileContent(query)
                     .getFileGetContents();
             status = response.getHeader().getNodeTransactionPrecheckCode();
-            if (status == OK || status == PLATFORM_NOT_ACTIVE) {
-                break;
-            } else {
+            if (status != OK) {
                 log.warn(
-                        "'{}' download attempt paid with {} got status {}, retrying...",
+                        "'{}' download attempt paid with {} got status {}; retrying {}...",
                         asFileString(fid),
                         toReadableString(payment),
-                        status);
+                        status,
+                        attemptsLeft);
+                simpleSleep(1);
             }
-        } while (--attemptsLeft > 0);
+        } while (status != OK && --attemptsLeft > 0);
         if (status != OK) {
             throw new IllegalStateException(
                     String.format("Could not download '%s' final status %s", asFileString(fid), status));
         }
         return response;
+    }
+
+    // Should really be in a utility somewhere, but it doesn't seem to be.
+    private void simpleSleep(final int secondsToSleep) {
+        if (secondsToSleep <= Byte.MAX_VALUE) {
+            try {
+                TimeUnit.SECONDS.sleep(secondsToSleep);
+            } catch (final InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private Query downloadQueryWith(Transaction payment, boolean costOnly, FileID fileId) {


### PR DESCRIPTION
* Minor additional cleanup of exception handling
* re-enable retry in downloadWith of FeesAndRatesProvider to allow some retry attempts without locking up the test run for hours.
   * This was requested because some node failures are recoverable
