### PR TITLE
Match mono behaviour for Grant Approval system contract

### DIFF
--- a/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
@@ -17,7 +17,10 @@
 package contract;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AMOUNT_EXCEEDS_ALLOWANCE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.FUNGIBLE_TOKEN_IN_NFT_ALLOWANCES;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SPENDER_DOES_NOT_HAVE_ALLOWANCE;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersTranslator.ERC_20_TRANSFER_FROM;
 import static contract.HtsErc721TransferXTestConstants.APPROVED_ID;
@@ -36,11 +39,14 @@ import static contract.XTestConstants.OWNER_ID;
 import static contract.XTestConstants.RECEIVER_HEADLONG_ADDRESS;
 import static contract.XTestConstants.RECEIVER_ID;
 import static contract.XTestConstants.SENDER_CONTRACT_ID_KEY;
+import static contract.XTestConstants.SENDER_HEADLONG_ADDRESS;
 import static contract.XTestConstants.SENDER_ID;
 import static contract.XTestConstants.SN_1234;
 import static contract.XTestConstants.SN_1234_METADATA;
 import static contract.XTestConstants.SN_2345;
 import static contract.XTestConstants.SN_2345_METADATA;
+import static contract.XTestConstants.SN_3456;
+import static contract.XTestConstants.SN_3456_METADATA;
 import static contract.XTestConstants.addErc20Relation;
 import static contract.XTestConstants.addErc721Relation;
 import static contract.XTestConstants.assertSuccess;
@@ -57,7 +63,6 @@ import com.hedera.hapi.node.state.token.AccountFungibleTokenAllowance;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersTranslator;
 import java.math.BigInteger;
@@ -127,16 +132,13 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                 AMOUNT_EXCEEDS_ALLOWANCE,
                 "Excessive spending (100 units vs 50 approved)");
         // TRY APPROVE NFT WITH INVALID SERIAL
-        runHtsCallAndExpectOnSuccess(
+        runHtsCallAndExpectRevert(
                 OWNER_BESU_ADDRESS,
                 Bytes.wrap(GrantApprovalTranslator.GRANT_APPROVAL_NFT
                         .encodeCallWithArgs(
                                 ERC721_TOKEN_ADDRESS, UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS, BigInteger.valueOf(9L))
                         .array()),
-                output -> assertEquals(
-                        Bytes.wrap(ReturnTypes.encodedRc(INVALID_TOKEN_NFT_SERIAL_NUMBER)
-                                .array()),
-                        output),
+                INVALID_TOKEN_NFT_SERIAL_NUMBER,
                 "Owner granting approval on missing SN#9");
         // APPROVE NFT
         runHtsCallAndExpectOnSuccess(
@@ -149,6 +151,39 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         .array()),
                 assertSuccess(),
                 "Owner granting approval on present SN#1234");
+        // TRY APPROVE NFT WITH WITH NOT OWNED SERIAL
+        runHtsCallAndExpectRevert(
+                OWNER_BESU_ADDRESS,
+                Bytes.wrap(GrantApprovalTranslator.GRANT_APPROVAL_NFT
+                        .encodeCallWithArgs(
+                                ERC721_TOKEN_ADDRESS,
+                                UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS,
+                                BigInteger.valueOf(SN_3456.serialNumber()))
+                        .array()),
+                SENDER_DOES_NOT_OWN_NFT_SERIAL_NO,
+                "Owner granting approval on not owned SN#3456");
+        // TRY APPROVE NFT WITH WITH FUNGIBLE TOKEN
+        runHtsCallAndExpectRevert(
+                OWNER_BESU_ADDRESS,
+                Bytes.wrap(GrantApprovalTranslator.GRANT_APPROVAL_NFT
+                        .encodeCallWithArgs(
+                                ERC20_TOKEN_ADDRESS,
+                                UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS,
+                                BigInteger.valueOf(SN_3456.serialNumber()))
+                        .array()),
+                FUNGIBLE_TOKEN_IN_NFT_ALLOWANCES,
+                "Owner granting nft approval on erc20 token");
+        // TRY APPROVE NFT WITH WITH INVALID TOKEN ADDRESS
+        runHtsCallAndExpectRevert(
+                OWNER_BESU_ADDRESS,
+                Bytes.wrap(GrantApprovalTranslator.GRANT_APPROVAL_NFT
+                        .encodeCallWithArgs(
+                                SENDER_HEADLONG_ADDRESS,
+                                UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS,
+                                BigInteger.valueOf(SN_3456.serialNumber()))
+                        .array()),
+                INVALID_TOKEN_ID,
+                "Owner granting approval on invalid id");
         // TRANSFER NFT
         runHtsCallAndExpectOnSuccess(
                 UNAUTHORIZED_SPENDER_BESU_ADDRESS,
@@ -188,7 +223,7 @@ public class GrantApprovalXTest extends AbstractContractXTest {
         runHtsCallAndExpectOnSuccess(
                 OWNER_BESU_ADDRESS,
                 bytesForRedirect(
-                        GrantApprovalTranslator.ERC_GRANT_APPROVAL.encodeCallWithArgs(
+                        GrantApprovalTranslator.ERC_GRANT_APPROVAL_NFT.encodeCallWithArgs(
                                 UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS, BigInteger.valueOf(SN_2345.serialNumber())),
                         ERC721_TOKEN_ID),
                 output -> assertEquals(
@@ -300,6 +335,14 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                                 .ownerId(OWNER_ID)
                                 .spenderId(SENDER_ID)
                                 .metadata(SN_2345_METADATA)
+                                .build());
+                put(
+                        SN_3456,
+                        Nft.newBuilder()
+                                .nftId(SN_3456)
+                                .ownerId(SENDER_ID)
+                                .spenderId(SENDER_ID)
+                                .metadata(SN_3456_METADATA)
                                 .build());
             }
         };

--- a/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
@@ -78,12 +78,20 @@ import org.apache.tuweni.bytes.Bytes;
  * <ol>
  *     <li>Transfer {@code ERC20_TOKEN} to RECEIVER. This should fail with code SPENDER_DOES_NOT_HAVE_ALLOWANCE.</li>
  *     <li>Approve {@code ERC20_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL}.</li>
+ *     <li>Approve {@code ERC20_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL}.
+ *     This should fail with code TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.</li>
  *     <li>Transfer {@code ERC20_TOKEN} from SENDER to RECEIVER. This should now succeed.</li>
  *     <li>Transfer {@code ERC20_TOKEN} from SENDER to RECEIVER. This should fail with code AMOUNT_EXCEEDS_ALLOWANCE.</li>
  *     <li>Transfer {@code ERC721_TOKEN} to RECEIVER. This should fail with code SPENDER_DOES_NOT_HAVE_ALLOWANCE.</li>
  *     <li>Approve NFT {@code ERC721_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL_NFT}.
  *     This should fail with code INVALID_TOKEN_NFT_SERIAL_NUMBER.</li>
  *     <li>Approve NFT {@code ERC721_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL_NFT}.</li>
+ *     <li>Approve NFT {@code ERC721_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL_NFT}.
+ *     This should fail with code SENDER_DOES_NOT_OWN_NFT_SERIAL_NO.</li>
+ *     <li>Approve NFT {@code ERC721_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL_NFT}.
+ *     This should fail with code FUNGIBLE_TOKEN_IN_NFT_ALLOWANCES.</li>
+ *     <li>Approve NFT {@code ERC721_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#GRANT_APPROVAL_NFT}.
+ *     This should fail with code INVALID_TOKEN_ID.</li>
  *     <li>Transfer {@code ERC721_TOKEN} from  SENDER to RECEIVER. This should now succeed.</li>
  *     <li> ERC Approve {@code ERC20_TOKEN} via {@link com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator#ERC_GRANT_APPROVAL}.</li>
  *     <li>Transfer {@code ERC20_TOKEN} from  SENDER to RECEIVER. This should now succeed.</li>

--- a/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NftID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.state.common.EntityIDPair;
@@ -112,6 +113,14 @@ public class GrantApprovalXTest extends AbstractContractXTest {
                         .array()),
                 assertSuccess(),
                 "Owner granting approval of 100 fungible units");
+        // TRY APPROVE AND EXPECT IVALID
+        runHtsCallAndExpectRevert(
+                OWNER_BESU_ADDRESS,
+                Bytes.wrap(GrantApprovalTranslator.GRANT_APPROVAL
+                        .encodeCallWithArgs(ERC20_TOKEN_ADDRESS, ERC721_TOKEN_ADDRESS, BigInteger.valueOf(100L))
+                        .array()),
+                ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT,
+                "Owner granting approval of 100 fungible units for invalid spender");
         // TRY TRANSFER AND EXPECT SUCCESS
         runHtsCallAndExpectOnSuccess(
                 UNAUTHORIZED_SPENDER_BESU_ADDRESS,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
@@ -55,7 +55,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
         this.tokenType = tokenType;
     }
 
-    public TransactionBody callERCGrantApproval() {
+    public TransactionBody callGrantApproval() {
         return TransactionBody.newBuilder()
                 .transactionID(TransactionID.newBuilder().accountID(sender).build())
                 .cryptoApproveAllowance(approve(token, spender, amount, tokenType))

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.token.CryptoApproveAllowanceTransactionBody;
+import com.hedera.hapi.node.token.NftAllowance;
+import com.hedera.hapi.node.token.TokenAllowance;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AbstractHtsCall;
+import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
+
+public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
+    protected final VerificationStrategy verificationStrategy;
+    protected final AccountID sender;
+    protected final TokenID token;
+    protected final AccountID spender;
+    protected final BigInteger amount;
+    protected final TokenType tokenType;
+
+    protected AbstractGrantApprovalCall(
+            @NonNull final Enhancement enhancement,
+            @NonNull final VerificationStrategy verificationStrategy,
+            @NonNull final AccountID sender,
+            @NonNull final TokenID token,
+            @NonNull final AccountID spender,
+            @NonNull final BigInteger amount,
+            @NonNull final TokenType tokenType) {
+        super(enhancement);
+        this.verificationStrategy = verificationStrategy;
+        this.sender = sender;
+        this.token = token;
+        this.spender = spender;
+        this.amount = amount;
+        this.tokenType = tokenType;
+    }
+
+    public TransactionBody callERCGrantApproval() {
+        return TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder().accountID(sender).build())
+                .cryptoApproveAllowance(approve(token, spender, amount, tokenType))
+                .build();
+    }
+
+    private CryptoApproveAllowanceTransactionBody approve(
+            @NonNull final TokenID token,
+            @NonNull final AccountID spender,
+            @NonNull final BigInteger amount,
+            @NonNull final TokenType tokenType) {
+        return tokenType.equals(TokenType.FUNGIBLE_COMMON)
+                ? CryptoApproveAllowanceTransactionBody.newBuilder()
+                        .tokenAllowances(TokenAllowance.newBuilder()
+                                .tokenId(token)
+                                .spender(spender)
+                                .owner(sender)
+                                .amount(amount.longValue())
+                                .build())
+                        .build()
+                : CryptoApproveAllowanceTransactionBody.newBuilder()
+                        .nftAllowances(NftAllowance.newBuilder()
+                                .tokenId(token)
+                                .spender(spender)
+                                .owner(sender)
+                                .serialNumbers(amount.longValue())
+                                .build())
+                        .build();
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
@@ -17,8 +17,6 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.revertResult;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.successResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCall.PricedResult.gasOnly;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -26,14 +24,15 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 
-public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
+public class ClassicGrantApprovalCall extends AbstractGrantApprovalCall {
 
-    public ERCGrantApprovalCall(
+    public ClassicGrantApprovalCall(
             @NonNull final Enhancement enhancement,
             @NonNull final VerificationStrategy verificationStrategy,
             @NonNull final AccountID sender,
@@ -47,21 +46,21 @@ public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
     @NonNull
     @Override
     public PricedResult execute() {
-        // TODO - gas calculation
+        // TODO: gas calculation
         if (token == null) {
             return reversionWith(INVALID_TOKEN_ID, 0L);
         }
         final var recordBuilder = systemContractOperations()
-                .dispatch(callERCGrantApproval(), verificationStrategy, sender, SingleTransactionRecordBuilder.class);
-        if (recordBuilder.status() != ResponseCodeEnum.SUCCESS) {
-            return gasOnly(revertResult(recordBuilder.status(), 0L));
+                .dispatch(callERCGrantApproval(), verificationStrategy, spender, SingleTransactionRecordBuilder.class);
+        final var status = recordBuilder.status();
+        if (status != ResponseCodeEnum.SUCCESS) {
+            return reversionWith(status, 0L);
         } else {
             final var encodedOutput = tokenType.equals(TokenType.FUNGIBLE_COMMON)
-                    ? GrantApprovalTranslator.ERC_GRANT_APPROVAL.getOutputs().encodeElements(true)
-                    : GrantApprovalTranslator.ERC_GRANT_APPROVAL_NFT
-                            .getOutputs()
-                            .encodeElements();
-            return gasOnly(successResult(encodedOutput, 0L));
+                    ? GrantApprovalTranslator.GRANT_APPROVAL.getOutputs().encodeElements((long) status.protoOrdinal())
+                    : GrantApprovalTranslator.GRANT_APPROVAL_NFT.getOutputs().encodeElements((long)
+                            status.protoOrdinal());
+            return gasOnly(FullResult.successResult(encodedOutput, 0L));
         }
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
@@ -52,7 +52,7 @@ public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
             return reversionWith(INVALID_TOKEN_ID, 0L);
         }
         final var recordBuilder = systemContractOperations()
-                .dispatch(callERCGrantApproval(), verificationStrategy, sender, SingleTransactionRecordBuilder.class);
+                .dispatch(callGrantApproval(), verificationStrategy, sender, SingleTransactionRecordBuilder.class);
         if (recordBuilder.status() != ResponseCodeEnum.SUCCESS) {
             return gasOnly(revertResult(recordBuilder.status(), 0L));
         } else {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
@@ -23,18 +23,15 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHO
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.asBytesResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenType;
-import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ClassicGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
 import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import java.math.BigInteger;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -60,12 +57,7 @@ public class ClassicGrantApprovalCallTest extends HtsCallTestBase {
                 UNAUTHORIZED_SPENDER_ID,
                 BigInteger.valueOf(100L),
                 TokenType.FUNGIBLE_COMMON);
-        given(systemContractOperations.dispatch(
-                        any(TransactionBody.class),
-                        eq(verificationStrategy),
-                        eq(UNAUTHORIZED_SPENDER_ID),
-                        eq(SingleTransactionRecordBuilder.class)))
-                .willReturn(recordBuilder);
+        given(systemContractOperations.dispatch(any(), any(), any(), any())).willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         final var result = subject.execute().fullResult().result();
 
@@ -87,12 +79,7 @@ public class ClassicGrantApprovalCallTest extends HtsCallTestBase {
                 UNAUTHORIZED_SPENDER_ID,
                 BigInteger.valueOf(100L),
                 TokenType.NON_FUNGIBLE_UNIQUE);
-        given(systemContractOperations.dispatch(
-                        any(TransactionBody.class),
-                        eq(verificationStrategy),
-                        eq(UNAUTHORIZED_SPENDER_ID),
-                        eq(SingleTransactionRecordBuilder.class)))
-                .willReturn(recordBuilder);
+        given(systemContractOperations.dispatch(any(), any(), any(), any())).willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         final var result = subject.execute().fullResult().result();
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.grantapproval;
+
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_ID;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUNGIBLE_TOKEN_ID;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_ID;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.asBytesResult;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ClassicGrantApprovalCall;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
+import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
+import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import java.math.BigInteger;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class ClassicGrantApprovalCallTest extends HtsCallTestBase {
+
+    private ClassicGrantApprovalCall subject;
+
+    @Mock
+    private VerificationStrategy verificationStrategy;
+
+    @Mock
+    private CryptoTransferRecordBuilder recordBuilder;
+
+    @Test
+    void fungibleApprove() {
+        subject = new ClassicGrantApprovalCall(
+                mockEnhancement(),
+                verificationStrategy,
+                OWNER_ID,
+                FUNGIBLE_TOKEN_ID,
+                UNAUTHORIZED_SPENDER_ID,
+                BigInteger.valueOf(100L),
+                TokenType.FUNGIBLE_COMMON);
+        given(systemContractOperations.dispatch(
+                        any(TransactionBody.class),
+                        eq(verificationStrategy),
+                        eq(UNAUTHORIZED_SPENDER_ID),
+                        eq(SingleTransactionRecordBuilder.class)))
+                .willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
+        final var result = subject.execute().fullResult().result();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
+        assertEquals(
+                asBytesResult(
+                        GrantApprovalTranslator.GRANT_APPROVAL.getOutputs().encodeElements((long)
+                                ResponseCodeEnum.SUCCESS.protoOrdinal())),
+                result.getOutput());
+    }
+
+    @Test
+    void nftApprove() {
+        subject = new ClassicGrantApprovalCall(
+                mockEnhancement(),
+                verificationStrategy,
+                OWNER_ID,
+                NON_FUNGIBLE_TOKEN_ID,
+                UNAUTHORIZED_SPENDER_ID,
+                BigInteger.valueOf(100L),
+                TokenType.NON_FUNGIBLE_UNIQUE);
+        given(systemContractOperations.dispatch(
+                        any(TransactionBody.class),
+                        eq(verificationStrategy),
+                        eq(UNAUTHORIZED_SPENDER_ID),
+                        eq(SingleTransactionRecordBuilder.class)))
+                .willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
+        final var result = subject.execute().fullResult().result();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
+        assertEquals(
+                asBytesResult(
+                        GrantApprovalTranslator.GRANT_APPROVAL_NFT.getOutputs().encodeElements((long)
+                                ResponseCodeEnum.SUCCESS.protoOrdinal())),
+                result.getOutput());
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslatorTest.java
@@ -20,8 +20,6 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBL
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUNGIBLE_TOKEN_ID;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_BESU_ADDRESS;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_ID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,8 +32,8 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
-import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ClassicGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ERCGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
@@ -115,15 +113,13 @@ class GrantApprovalTranslatorTest {
                 .toArray();
         given(attempt.addressIdConverter()).willReturn(addressIdConverter);
         given(addressIdConverter.convert(any())).willReturn(UNAUTHORIZED_SPENDER_ID);
-        given(attempt.addressIdConverter().convertSender(any())).willReturn(OWNER_ID);
-        given(attempt.senderAddress()).willReturn(OWNER_BESU_ADDRESS);
         given(attempt.enhancement()).willReturn(enhancement);
         given(attempt.defaultVerificationStrategy()).willReturn(verificationStrategy);
         given(attempt.selector()).willReturn(GrantApprovalTranslator.GRANT_APPROVAL.selector());
         given(attempt.inputBytes()).willReturn(inputBytes);
 
         final var call = subject.callFrom(attempt);
-        assertInstanceOf(DispatchForResponseCodeHtsCall.class, call);
+        assertInstanceOf(ClassicGrantApprovalCall.class, call);
     }
 
     @Test
@@ -134,15 +130,13 @@ class GrantApprovalTranslatorTest {
                 .toArray();
         given(attempt.addressIdConverter()).willReturn(addressIdConverter);
         given(addressIdConverter.convert(any())).willReturn(UNAUTHORIZED_SPENDER_ID);
-        given(attempt.addressIdConverter().convertSender(any())).willReturn(OWNER_ID);
-        given(attempt.senderAddress()).willReturn(OWNER_BESU_ADDRESS);
         given(attempt.enhancement()).willReturn(enhancement);
         given(attempt.defaultVerificationStrategy()).willReturn(verificationStrategy);
         given(attempt.selector()).willReturn(GrantApprovalTranslator.GRANT_APPROVAL_NFT.selector());
         given(attempt.inputBytes()).willReturn(inputBytes);
 
         final var call = subject.callFrom(attempt);
-        assertInstanceOf(DispatchForResponseCodeHtsCall.class, call);
+        assertInstanceOf(ClassicGrantApprovalCall.class, call);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Implemented `HTSCall` for the classic `GrantApproval` functions and extended the X tests to match the `mono` service behaviour.

**Related issue(s)**:

Fixes #
#9191  #9192 
**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
