### PR TITLE
Bump hapi version to 0.43.0

### DIFF
--- a/hedera-node/settings.gradle.kts
+++ b/hedera-node/settings.gradle.kts
@@ -81,8 +81,8 @@ fun include(name: String, path: String) {
 
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
-val hapiProtoVersion = "0.43.0-rc-SNAPSHOT"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state"
+val hapiProtoVersion = "0.43.0"
+val hapiProtoBranchOrTag = "v0.43.0"
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hapi"))


### PR DESCRIPTION
**Description**:
Bump the hapi version in use by services to 0.43.0

