### PR TITLE
Fix unreliable behavior in Unit Test

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -40,7 +40,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -363,7 +363,7 @@ abstract class AbstractScheduleHandler {
          */
         @Override
         public Set<Key> apply(final Key key) {
-            final Set<Key> remainingUnverifiedKeys = new HashSet<>();
+            final Set<Key> remainingUnverifiedKeys = new LinkedHashSet<>();
             final var assistant = new ScheduleVerificationAssistant(signatories, remainingUnverifiedKeys);
             final SignatureVerification isVerified = context.verificationFor(key, assistant);
             // unverified primitive keys only count if the top-level key failed verification.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandlerTest.java
@@ -36,7 +36,7 @@ import com.hedera.node.app.workflows.prehandle.PreHandleContextImpl;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.security.InvalidKeyException;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -164,8 +164,8 @@ class ScheduleSignHandlerTest extends ScheduleHandlerTestBase {
             // all keys are "valid" on the transaction with this mock setup
             prepareContextAllPass(signTransaction);
             subject.handle(mockContext);
-            verifySignHandleSucceededAndExecuted(next, parentId, startCount);
             verifyAllSignatories(next, testChildKeys);
+            verifySignHandleSucceededAndExecuted(next, parentId, startCount);
             successCount++;
         }
         // verify that all the transactions succeeded.
@@ -173,7 +173,7 @@ class ScheduleSignHandlerTest extends ScheduleHandlerTestBase {
     }
 
     private void verifyAllSignatories(final Schedule original, final TransactionKeys expectedKeys) {
-        final Set<Key> combinedSet = new HashSet<>(3);
+        final Set<Key> combinedSet = new LinkedHashSet<>(5);
         combinedSet.addAll(expectedKeys.requiredNonPayerKeys());
         combinedSet.addAll(expectedKeys.optionalNonPayerKeys());
         combinedSet.add(expectedKeys.payerKey());
@@ -183,6 +183,7 @@ class ScheduleSignHandlerTest extends ScheduleHandlerTestBase {
     private void verifySignatorySet(final Schedule original, final Set<Key> expectedKeys) {
         assertThat(original.signatories()).isEmpty();
         final Schedule modified = writableSchedules.get(original.scheduleId());
+        assertThat(modified).isNotNull();
         assertThat(original.signatories()).isEmpty();
         assertThat(modified.signatories()).containsExactlyInAnyOrderElementsOf(expectedKeys);
     }


### PR DESCRIPTION
ScheduleSignHandlerTest `handleExecutesImmediateIfPossible` was not behaving deterministically.  This was traced to a HashSet that was allowing duplicate PBJ values, somehow, for reference-equal objects.  The set implementation was changed to LinkedHashSet, and appears to be behaving correctly now.
