### PR TITLE
9013: Virtual node cache size metric name should be updated to bytes instead of mebibytes

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
@@ -53,8 +53,8 @@ public class VirtualMapStatistics {
     /** Virtual map entities - reads / s */
     private LongAccumulator readEntities;
 
-    /** Estimated virtual node cache size, Mb*/
-    private LongGauge nodeCacheSizeMb;
+    /** Estimated virtual node cache size, bytes*/
+    private LongGauge nodeCacheSizeB;
     /** Number of virtual root copies in the pipeline */
     private IntegerGauge pipelineSize;
     /** The number of virtual root node copies in virtual pipeline flush backlog */
@@ -135,9 +135,9 @@ public class VirtualMapStatistics {
                 "Read virtual map entities, " + label + ", per second");
 
         // Lifecycle
-        nodeCacheSizeMb = metrics.getOrCreate(
-                new LongGauge.Config(STAT_CATEGORY, VMAP_PREFIX + LIFECYCLE_PREFIX + "nodeCacheSizeMb_" + label)
-                        .withDescription("Virtual node cache size, " + label + ", Mb"));
+        nodeCacheSizeB = metrics.getOrCreate(
+                new LongGauge.Config(STAT_CATEGORY, VMAP_PREFIX + LIFECYCLE_PREFIX + "nodeCacheSizeB_" + label)
+                        .withDescription("Virtual node cache size, " + label + ", bytes"));
         pipelineSize = metrics.getOrCreate(
                 new IntegerGauge.Config(STAT_CATEGORY, VMAP_PREFIX + LIFECYCLE_PREFIX + "pipelineSize_" + label)
                         .withDescription("Virtual pipeline size, " + label));
@@ -217,13 +217,13 @@ public class VirtualMapStatistics {
     }
 
     /**
-     * Updates {@link #nodeCacheSizeMb} stat to the given value.
+     * Updates {@link #nodeCacheSizeB} stat to the given value.
      *
      * @param value the value to set
      */
     public void setNodeCacheSize(final long value) {
-        if (this.nodeCacheSizeMb != null) {
-            this.nodeCacheSizeMb.set(value);
+        if (this.nodeCacheSizeB != null) {
+            this.nodeCacheSizeB.set(value);
         }
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapStatisticsTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapStatisticsTest.java
@@ -129,7 +129,7 @@ public class VirtualMapStatisticsTest {
     @Test
     void testNodeCacheSize() {
         // given
-        final Metric metric = getMetric("lifecycle_", "nodeCacheSizeMb_" + LABEL);
+        final Metric metric = getMetric("lifecycle_", "nodeCacheSizeB_" + LABEL);
         // when
         statistics.setNodeCacheSize(2345L);
         // then

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -868,7 +868,7 @@ class VirtualMapTests extends VirtualTestBase {
 
     @Test
     @Tags({@Tag("VirtualMerkle")})
-    @DisplayName("Tests nodeCacheSizeMb metric")
+    @DisplayName("Tests nodeCacheSizeB metric")
     void testNodeCacheSizeMetric() throws IOException, InterruptedException {
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         final MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
@@ -884,7 +884,7 @@ class VirtualMapTests extends VirtualTestBase {
         VirtualMap<TestKey, TestValue> map0 = createMap();
         map0.registerMetrics(metrics);
 
-        Metric metric = metrics.getMetric(VirtualMapStatistics.STAT_CATEGORY, "vmap_lifecycle_nodeCacheSizeMb_Test");
+        Metric metric = metrics.getMetric(VirtualMapStatistics.STAT_CATEGORY, "vmap_lifecycle_nodeCacheSizeB_Test");
         assertNotNull(metric);
         if (!(metric instanceof LongGauge)) {
             throw new AssertionError("nodeCacheSizeMb metric is not a gauge");


### PR DESCRIPTION

Fixes: https://github.com/hashgraph/hedera-services/issues/9013
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
