### PR TITLE
9225: Serialization/deserialization overhead in MerkleDb during reconnects

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
@@ -21,6 +21,7 @@ import com.swirlds.merkledb.collections.LongListOffHeap;
 import com.swirlds.merkledb.files.DataFileCollection;
 import com.swirlds.merkledb.files.DataFileReader;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -48,15 +49,13 @@ public class DataFileCollectionBench extends BaseBench {
 
         final LongListOffHeap index = new LongListOffHeap();
         final BenchmarkRecord[] map = new BenchmarkRecord[verify ? maxKey : 0];
+        final BenchmarkRecordSerializer serializer = new BenchmarkRecordSerializer();
         final var store =
                 new DataFileCollection<BenchmarkRecord>(
-                        getTestDir(),
-                        "mergeBench",
-                        null,
-                        new BenchmarkRecordSerializer(),
-                        (key, dataLocation, dataValue) -> {}) {
+                        getTestDir(), "mergeBench", null, serializer, (key, dataLocation, dataValue) -> {}) {
                     BenchmarkRecord read(long dataLocation) throws IOException {
-                        return readDataItem(dataLocation);
+                        final ByteBuffer buf = readDataItemBytes(dataLocation);
+                        return serializer.deserialize(buf, serializer.getCurrentDataVersion());
                     }
                 };
         System.out.println();

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableDataOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableDataOutputStream.java
@@ -104,6 +104,22 @@ public class SerializableDataOutputStream extends AugmentedDataOutputStream {
     }
 
     /**
+     * Writes a self serializable object to a stream. The object is provided as a byte array, assuming
+     * it has been serialized to the array previously. No class ID is written.
+     *
+     * @param serializedBytes
+     * 		the serialized object bytes
+     * @param version
+     * 		the serializable object class version
+     * @throws IOException
+     * 		thrown if any IO problems occur
+     */
+    public void writeSerializableBytes(final byte[] serializedBytes, final int version) throws IOException {
+        writeInt(version);
+        write(serializedBytes);
+    }
+
+    /**
      * Writes a list of objects returned by an {@link Iterator} when the size in known ahead of time. If the class is
      * known at the time of deserialization, the {@code writeClassId} param can be set to false. If the class might be
      * unknown when deserializing, then the {@code writeClassId} must be written.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -29,6 +29,7 @@ import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.metrics.FunctionGauge;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.threading.framework.config.ThreadConfiguration;
@@ -696,6 +697,16 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         }
         statistics.countLeafReads();
         return pathToKeyValue.get(path);
+    }
+
+    @Override
+    public boolean loadAndWriteLeafRecord(long path, SerializableDataOutputStream out) throws IOException {
+        final KeyRange leafPathRange = validLeafPathRange;
+        if (!leafPathRange.withinRange(path)) {
+            throw new IllegalArgumentException("path (" + path + ") is not valid; must be in range " + leafPathRange);
+        }
+        statistics.countLeafReads();
+        return pathToKeyValue.getAndWrite(path, out);
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -176,16 +176,10 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
      *
      * @param dataLocation The file index combined with the offset for the starting block of the
      *     data in the file
-     * @return Deserialized data item, or {@code null} if deserialization is not requested
+     * @return Deserialized data item
      * @throws IOException If there was a problem reading from data file
      * @throws ClosedChannelException if the data file was closed
      */
-    public D readDataItem(final long dataLocation) throws IOException {
-        long serializationVersion = metadata.getSerializationVersion();
-        final ByteBuffer data = readDataItemBytes(dataLocation);
-        return dataItemSerializer.deserialize(data, serializationVersion);
-    }
-
     public ByteBuffer readDataItemBytes(final long dataLocation) throws IOException {
         final long serializationVersion = metadata.getSerializationVersion();
         final long byteOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
@@ -199,6 +193,12 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
             bytesToRead = dataItemSerializer.getSerializedSizeForVersion(serializationVersion);
         }
         return read(byteOffset, bytesToRead);
+    }
+
+    // For testing purposes
+    D readDataItem(final long dataLocation) throws IOException {
+        final ByteBuffer dataItemBytes = readDataItemBytes(dataLocation);
+        return dataItemSerializer.deserialize(dataItemBytes, dataItemSerializer.getCurrentDataVersion());
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
@@ -17,11 +17,13 @@
 package com.swirlds.virtualmap.internal;
 
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.cache.VirtualNodeCache;
+import java.io.IOException;
 import java.io.UncheckedIOException;
 
 /**
@@ -82,6 +84,20 @@ public interface RecordAccessor<K extends VirtualKey, V extends VirtualValue> {
      * 		an UncheckedIOException is thrown.
      */
     VirtualLeafRecord<K, V> findLeafRecord(final long path, final boolean copy);
+
+    /**
+     * Locates a leaf node based on the path and writes it to the provided output stream. The
+     * written bytes must be binary compatible with virtual leaf record self-serialization
+     * format.
+     *
+     * @param path
+     * 		The virtual leaf node path
+     * @param out
+     *      The output stream to write the node to
+     * @throws IOException
+     *      If an I/O error occurred
+     */
+    void findAndWriteLeafRecord(final long path, final SerializableDataOutputStream out) throws IOException;
 
     /**
      * Finds the path of the given key.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
@@ -20,6 +20,7 @@ import static com.swirlds.virtualmap.internal.Path.INVALID_PATH;
 import static com.swirlds.virtualmap.internal.Path.ROOT_PATH;
 
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
@@ -153,6 +154,17 @@ public class RecordAccessorImpl<K extends VirtualKey, V extends VirtualValue> im
         }
 
         return rec == VirtualNodeCache.DELETED_LEAF_RECORD ? null : rec;
+    }
+
+    @Override
+    public void findAndWriteLeafRecord(final long path, final SerializableDataOutputStream out) throws IOException {
+        final VirtualLeafRecord<K, V> rec = cache.lookupLeafByPath(path, false);
+        if (rec != null) {
+            out.writeSerializable(rec, false);
+            return;
+        }
+        final boolean written = dataSource.loadAndWriteLeafRecord(path, out);
+        assert written : "Leaf record is not found / processed " + path;
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTeacherTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTeacherTreeView.java
@@ -30,7 +30,6 @@ import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
-import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.ConcurrentNodeStatusTracker;
 import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.VirtualStateAccessor;
@@ -207,9 +206,7 @@ public final class VirtualTeacherTreeView<K extends VirtualKey, V extends Virtua
     @Override
     public void serializeLeaf(final SerializableDataOutputStream out, final Long leaf) throws IOException {
         checkValidLeaf(leaf, reconnectState);
-        final VirtualLeafRecord<K, V> leafRecord = records.findLeafRecord(leaf, false);
-        assert leafRecord != null : "Unexpected null leaf record at path=" + leaf;
-        out.writeSerializable(leafRecord, false);
+        records.findAndWriteLeafRecord(leaf, out);
     }
 
     /**


### PR DESCRIPTION
Fix summary:

* A new method is introduced to `VirtualDataSource` interface, `loadAndWriteLeafRecord()`, to find a leaf record in the database and write it to the given output stream
* By default, this method is implemented as reading the record and then serializing it to the stream. MerkleDb data source provides more efficient implementation: it reads virtual leaf record bytes and writes them to the stream, bypassing (de)serialization
* This new method is used by `VirtualTeacherTreeView`

Fixes: https://github.com/hashgraph/hedera-services/issues/9225
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
