### PR TITLE
Fix failing HAPI tests in mono repo

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
@@ -43,6 +44,7 @@ public class Issue1648Suite extends HapiSuite {
         return List.of(recordStorageFeeIncreasesWithNumTransfers());
     }
 
+    @HapiTest
     public static HapiSpec recordStorageFeeIncreasesWithNumTransfers() {
         return defaultHapiSpec("RecordStorageFeeIncreasesWithNumTransfers")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
@@ -46,12 +46,17 @@ public class Issue1648Suite extends HapiSuite {
     public static HapiSpec recordStorageFeeIncreasesWithNumTransfers() {
         return defaultHapiSpec("RecordStorageFeeIncreasesWithNumTransfers")
                 .given(
-                        UtilVerbs.inParallel(
-                                cryptoCreate("A"), cryptoCreate("B"), cryptoCreate("C"), cryptoCreate("D")),
-                        UtilVerbs.inParallel(
-                                cryptoTransfer(tinyBarsFromTo("A", "B", 1L)).via("txn1"),
-                                cryptoTransfer(tinyBarsFromTo("A", "B", 1L), tinyBarsFromTo("C", "D", 1L))
-                                        .via("txn2")))
+                        cryptoCreate("civilian").balance(10 * ONE_HUNDRED_HBARS),
+                        cryptoCreate("A"),
+                        cryptoCreate("B"),
+                        cryptoCreate("C"),
+                        cryptoCreate("D"),
+                        cryptoTransfer(tinyBarsFromTo("A", "B", 1L))
+                                .payingWith("civilian")
+                                .via("txn1"),
+                        cryptoTransfer(tinyBarsFromTo("A", "B", 1L), tinyBarsFromTo("C", "D", 1L))
+                                .payingWith("civilian")
+                                .via("txn2"))
                 .when(UtilVerbs.recordFeeAmount("txn1", "feeForOne"), UtilVerbs.recordFeeAmount("txn2", "feeForTwo"))
                 .then(UtilVerbs.assertionsHold((spec, assertLog) -> {
                     long feeForOne = spec.registry().getAmount("feeForOne");

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
@@ -55,11 +55,10 @@ public class Issue1742Suite extends HapiSuite {
         return defaultHapiSpec("CryptoTransferListShowsOnlyFeesAfterIAB")
                 .given(cryptoCreate("payer").balance(PAYER_BALANCE))
                 .when()
-                .then(
-                        cryptoTransfer(tinyBarsFromTo("payer", GENESIS, PAYER_BALANCE))
-                                .payingWith("payer")
-                                .via("txn")
-                                .hasPrecheck(INSUFFICIENT_PAYER_BALANCE));
+                .then(cryptoTransfer(tinyBarsFromTo("payer", GENESIS, PAYER_BALANCE))
+                        .payingWith("payer")
+                        .via("txn")
+                        .hasPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
@@ -22,6 +22,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -47,6 +48,7 @@ public class Issue1742Suite extends HapiSuite {
         return false;
     }
 
+    @HapiTest
     public static HapiSpec cryptoTransferListShowsOnlyFeesAfterIAB() {
         final long PAYER_BALANCE = 1_000_000L;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
@@ -20,9 +20,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.takeBalanceSnapshots;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateTransferListForBalances;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -53,14 +51,13 @@ public class Issue1742Suite extends HapiSuite {
         final long PAYER_BALANCE = 1_000_000L;
 
         return defaultHapiSpec("CryptoTransferListShowsOnlyFeesAfterIAB")
-                .given(flattened(
-                        cryptoCreate("payer").balance(PAYER_BALANCE),
-                        takeBalanceSnapshots(FUNDING, NODE, GENESIS, "payer")))
-                .when(cryptoTransfer(tinyBarsFromTo("payer", GENESIS, PAYER_BALANCE))
-                        .payingWith("payer")
-                        .via("txn")
-                        .hasKnownStatus(INSUFFICIENT_ACCOUNT_BALANCE))
-                .then(validateTransferListForBalances("txn", List.of(FUNDING, NODE, GENESIS, "payer")));
+                .given(cryptoCreate("payer").balance(PAYER_BALANCE))
+                .when()
+                .then(
+                        cryptoTransfer(tinyBarsFromTo("payer", GENESIS, PAYER_BALANCE))
+                                .payingWith("payer")
+                                .via("txn")
+                                .hasPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
@@ -27,8 +27,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
@@ -24,9 +24,11 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
@@ -83,25 +85,28 @@ public class Issue2051Spec extends HapiSuite {
                                 .transfer(TRANSFER)
                                 .hasKnownStatus(ACCOUNT_DELETED),
                         getTxnRecord(DELETE_TXN).logged(),
-                        getAccountBalance(PAYER).hasTinyBars(approxChangeFromSnapshot(SNAPSHOT, -9295610, 1000)));
+                        getAccountBalance(PAYER).hasTinyBars(approxChangeFromSnapshot(SNAPSHOT, -9384399, 1000)));
     }
 
     private HapiSpec transferAccountCannotBeDeletedForContractTarget() {
         return defaultHapiSpec("TransferAccountCannotBeDeletedForContractTarget")
-                .given(cryptoCreate(TRANSFER), contractCreate("tbd"), contractCreate(TRANSFER_CONTRACT))
-                .when(cryptoDelete(TRANSFER), contractDelete(TRANSFER_CONTRACT))
+                .given(
+                        uploadInitCode("CreateTrivial"),
+                        uploadInitCode("PayReceivable"),
+                        cryptoCreate(TRANSFER),
+                        contractCreate("CreateTrivial"),
+                        contractCreate("PayReceivable"))
+                .when(cryptoDelete(TRANSFER), contractDelete("PayReceivable"))
                 .then(
                         balanceSnapshot(SNAPSHOT, GENESIS),
-                        contractDelete("tbd")
+                        contractDelete("CreateTrivial")
                                 .via(DELETE_TXN)
                                 .transferAccount(TRANSFER)
-                                .hasKnownStatus(ACCOUNT_DELETED),
-                        contractDelete("tbd")
+                                .hasKnownStatus(OBTAINER_DOES_NOT_EXIST),
+                        contractDelete("CreateTrivial")
                                 .via(DELETE_TXN)
-                                .transferContract(TRANSFER_CONTRACT)
-                                .hasKnownStatus(CONTRACT_DELETED),
-                        getTxnRecord(DELETE_TXN).logged(),
-                        getAccountBalance(GENESIS).hasTinyBars(approxChangeFromSnapshot(SNAPSHOT, -18985232, 1000)));
+                                .transferContract("PayReceivable")
+                                .hasKnownStatus(INVALID_CONTRACT_ID));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
@@ -78,7 +78,7 @@ public class Issue2098Spec extends HapiSuite {
                         .payingWith(ADDRESS_BOOK_CONTROL)
                         .erasingProps(Set.of(GET_TOPIC_INFO)))
                 .then(
-                        getTopicInfo("misc").payingWith(CIVILIAN).hasCostAnswerPrecheck(NOT_SUPPORTED),
+                        getTopicInfo("misc").payingWith(CIVILIAN).hasAnswerOnlyPrecheck(NOT_SUPPORTED),
                         fileUpdate(API_PERMISSIONS)
                                 .payingWith(ADDRESS_BOOK_CONTROL)
                                 .overridingProps(Map.of(GET_TOPIC_INFO, "0-*")),
@@ -92,7 +92,7 @@ public class Issue2098Spec extends HapiSuite {
                         .payingWith(ADDRESS_BOOK_CONTROL)
                         .erasingProps(Set.of(GET_TOPIC_INFO)))
                 .then(
-                        getTopicInfo("misc").payingWith(CIVILIAN).hasCostAnswerPrecheck(NOT_SUPPORTED),
+                        getTopicInfo("misc").payingWith(CIVILIAN).hasAnswerOnlyPrecheck(NOT_SUPPORTED),
                         getTopicInfo("misc"),
                         fileUpdate(API_PERMISSIONS)
                                 .payingWith(ADDRESS_BOOK_CONTROL)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
@@ -82,8 +82,8 @@ public class Issue305Spec extends HapiSuite {
                 }))
                 .then(
                         fileCreate("tbd").key(KEY).deferStatusResolution(),
-                        fileDelete(nextFileId::get).signedBy(GENESIS, KEY).logged(),
-                        getFileInfo(nextFileId::get).logged());
+                        fileDelete(nextFileId::get).signedBy(GENESIS, KEY),
+                        getFileInfo(nextFileId::get).hasDeleted(true));
     }
 
     private HapiSpec congestionMultipliersRefreshOnPropertyUpdate() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
@@ -31,6 +31,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -64,6 +65,7 @@ public class Issue305Spec extends HapiSuite {
         return repeatedSpecs;
     }
 
+    @HapiTest
     private HapiSpec createDeleteInSameRoundWorks() {
         AtomicReference<String> nextFileId = new AtomicReference<>();
         return defaultHapiSpec("CreateDeleteInSameRoundWorks")


### PR DESCRIPTION
**Description**:
Applies the fixes proposed by @tinker-michaelj  to the following failing tests against the mono repo:

- Issue2098Spec → QueryApiPermissionsChangeImmediately
- Issue2098Spec → AdminsCanQueryNoMatterPermissions
- Issue1648Suite → RecordStorageFeeIncreasesWithNumTransfers
- Issue1742Suite → CryptoTransferListShowsOnlyFeesAfterIAB
- Issue2051Spec → TransferAccountCannotBeDeleted
- Issue2051Spec → TransferAccountCannotBeDeletedForContractTarget
- Issue305Spec → CreateDeleteInSameRoundWorks

Adds the `@HapiTest` annotation to tests that pass without any other changes.

**Related issue(s)**:

Fixes #9314 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
