### PR TITLE
chore: fix StatsSigningTestingTool to hash the data for ECDSA signatures

### DIFF
--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
@@ -159,7 +159,7 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
      * {@inheritDoc}
      */
     @Override
-    public synchronized byte[] hash(byte[] buffer, int offset, int len) {
+    public synchronized byte[] hash(final byte[] buffer, final int offset, final int len) {
         return keccak256(buffer, offset, len);
     }
 

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
@@ -159,7 +159,7 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
      * {@inheritDoc}
      */
     @Override
-    public byte[] hash(byte[] buffer, int offset, int len) {
+    public synchronized byte[] hash(byte[] buffer, int offset, int len) {
         return keccak256(buffer, offset, len);
     }
 

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
@@ -22,17 +22,7 @@ import static com.swirlds.logging.LogMarker.STARTUP;
 
 import com.swirlds.common.crypto.SignatureType;
 import java.io.IOException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.PublicKey;
-import java.security.SecureRandom;
-import java.security.Security;
-import java.security.Signature;
-import java.security.SignatureException;
+import java.security.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.ASN1InputStream;
@@ -99,6 +89,11 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
     private boolean algorithmAvailable;
 
     /**
+     * The internal keccak-256 digest instance used to hash the data to be signed.
+     */
+    private MessageDigest keccakDigest;
+
+    /**
      * Constructs a new instance that supports the supplied {@link SignatureType} algorithm.
      *
      * @param signatureType
@@ -134,8 +129,9 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
     @Override
     public byte[] sign(final byte[] buffer, final int offset, final int len) throws SignatureException {
         try {
+            final byte[] dataHash = keccak256(buffer, offset, len);
             signature.initSign(keyPair.getPrivate(), random);
-            signature.update(buffer, offset, len);
+            signature.update(dataHash, 0, dataHash.length);
             return processSignature(signature.sign());
         } catch (InvalidKeyException | IOException e) {
             throw new SignatureException(e);
@@ -148,14 +144,23 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
     @Override
     public ExtendedSignature signEx(final byte[] buffer, final int offset, final int len) throws SignatureException {
         try {
+            final byte[] dataHash = keccak256(buffer, offset, len);
             signature.initSign(keyPair.getPrivate(), random);
-            signature.update(buffer, offset, len);
+            signature.update(dataHash, 0, dataHash.length);
             final byte[] sig = signature.sign();
 
             return new ExtendedSignature(processSignature(sig), rawSignatureRCoord(sig), rawSignatureSCoord(sig));
         } catch (InvalidKeyException | IOException e) {
             throw new SignatureException(e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] hash(byte[] buffer, int offset, int len) {
+        return keccak256(buffer, offset, len);
     }
 
     /**
@@ -182,6 +187,7 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
                     hex(rawPublicKeyYCoord(keyPair.getPublic())));
 
             signature = Signature.getInstance(signatureType.signingAlgorithm(), signatureType.provider());
+            keccakDigest = MessageDigest.getInstance("KECCAK-256");
             algorithmAvailable = true;
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | NoSuchProviderException e) {
             logger.error(
@@ -341,5 +347,11 @@ public abstract class ECSigningAlgorithm implements SigningAlgorithm {
         System.arraycopy(rawY, srcStartY, rawComposite, dstStartY, lenY);
 
         return rawComposite;
+    }
+
+    protected byte[] keccak256(final byte[] buffer, final int offset, final int len) {
+        keccakDigest.reset();
+        keccakDigest.update(buffer, offset, len);
+        return keccakDigest.digest();
     }
 }

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/SigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/SigningAlgorithm.java
@@ -90,6 +90,19 @@ public interface SigningAlgorithm {
     ExtendedSignature signEx(byte[] buffer, int offset, int len) throws SignatureException;
 
     /**
+     * Creates a cryptographic digest compatible with the signature algorithm.
+     *
+     * @param buffer
+     * 		an array containing the data to be signed.
+     * @param offset
+     * 		starting position from which to begin reading in the {@code buffer} array.
+     * @param len
+     * 		the number of array elements to be read.
+     * @return a byte array containing a one-way hash of the data.
+     */
+    byte[] hash(byte[] buffer, int offset, int len);
+
+    /**
      * Called during initialization to ensure that all necessary cryptographic constructs have been created and
      * initialized. This method is only called once; however, implementations should ensure that is idempotent. This
      * method should (in most cases) also create the Public/Private key pair.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/X25519SigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/X25519SigningAlgorithm.java
@@ -148,6 +148,14 @@ public class X25519SigningAlgorithm implements SigningAlgorithm {
      * {@inheritDoc}
      */
     @Override
+    public byte[] hash(byte[] buffer, int offset, int len) {
+        throw new UnsupportedOperationException("External hashing is not supported by this algorithm");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void tryAcquirePrimitives() {
         try {
             final SodiumJava sodium = new SodiumJava();


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates StatsSigningTestingTool (SSTT) to hash data using KECCAK-256 when signing with the ECDSA Secp256k1 algorithm.

### Related Issues

- Closes #9335 

## Verification

- [Failing Test (Prior to the Fix)](https://swirldslabs.slack.com/archives/C03E22UB0A2/p1697642802149709)
- [Passing Test (After the Fix)](https://swirldslabs.slack.com/archives/C03E22UB0A2/p1697647732010719)