### PR TITLE
fix: resolve ci issues and maven central publish issues

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -63,7 +63,7 @@ jobs:
       enable-e2e-tests: false
       enable-integration-tests: false
       enable-hapi-tests: false
-      enable-sonar-analysis: true
+      enable-sonar-analysis: false
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -825,7 +825,7 @@ jobs:
                           },
                           {
                             "type": "mrkdwn",
-                            "text": ${{ steps.parameters.outputs.artifact-registry }}"
+                            "text": "${{ steps.parameters.outputs.artifact-registry }}"
                           },
                           {
                             "type": "mrkdwn",

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -322,7 +322,7 @@ jobs:
           }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: sonar --info --scan ${{ steps.sonar-cloud.outputs.options }}
+          arguments: sonar --info --scan --no-parallel ${{ steps.sonar-cloud.outputs.options }}
 
       - name: Setup Snyk
         env:

--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,12 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.0
-ignore: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-IONETTY-5953332:
+    - '*':
+        reason: No matching gRPC version is available at this time
+        expires: 2024-01-01T00:00:00.000Z
+        created: 2023-10-20T01:20:35.772Z
 patch: {}
 exclude:
   global:

--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -37,5 +37,5 @@ dependencies {
     implementation("org.gradlex:java-ecosystem-capabilities:1.3.1")
     implementation("org.gradlex:java-module-dependencies:1.4.1")
     implementation("org.owasp:dependency-check-gradle:8.4.0")
-    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.3.1.3277")
+    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
 }

--- a/build-logic/project-plugins/src/main/kotlin/Utils.kt
+++ b/build-logic/project-plugins/src/main/kotlin/Utils.kt
@@ -39,7 +39,7 @@ class Utils {
         @JvmStatic
         fun generateProjectVersionReport(rootProject: Project, ostream: OutputStream) {
             val writer = PrintStream(ostream, false, Charsets.UTF_8)
-            val version = rootProject.layout.projectDirectory.versionTxt().asFile.readText()
+            val version = rootProject.layout.projectDirectory.versionTxt().asFile.readText().trim()
 
             ostream.use {
                 writer.use {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.aggregate-reports.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.aggregate-reports.gradle.kts
@@ -35,7 +35,10 @@ sonarqube {
             "sonar.projectDescription",
             "Hedera Services (crypto, file, contract, consensus) on the Platform"
         )
-        property("sonar.projectVersion", layout.projectDirectory.versionTxt().asFile.readText().trim())
+        property(
+            "sonar.projectVersion",
+            layout.projectDirectory.versionTxt().asFile.readText().trim()
+        )
         property("sonar.links.homepage", "https://github.com/hashgraph/hedera-services")
         property("sonar.links.ci", "https://github.com/hashgraph/hedera-services/actions")
         property("sonar.links.issue", "https://github.com/hashgraph/hedera-services/issues")

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.aggregate-reports.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.aggregate-reports.gradle.kts
@@ -35,7 +35,7 @@ sonarqube {
             "sonar.projectDescription",
             "Hedera Services (crypto, file, contract, consensus) on the Platform"
         )
-        property("sonar.projectVersion", layout.projectDirectory.versionTxt().asFile.readText())
+        property("sonar.projectVersion", layout.projectDirectory.versionTxt().asFile.readText().trim())
         property("sonar.links.homepage", "https://github.com/hashgraph/hedera-services")
         property("sonar.links.ci", "https://github.com/hashgraph/hedera-services/actions")
         property("sonar.links.issue", "https://github.com/hashgraph/hedera-services/issues")

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.evm-maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.evm-maven-publish.gradle.kts
@@ -22,6 +22,9 @@ plugins {
 publishing {
     publications {
         named<MavenPublication>("maven") {
+            groupId = "com.hedera.evm"
+            artifactId = "hedera-evm"
+
             pom.developers {
                 developer {
                     name.set("Hedera Base Team")

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -31,7 +31,8 @@ plugins {
     id("com.hedera.hashgraph.spotless-kotlin-conventions")
 }
 
-version = providers.fileContents(rootProject.layout.projectDirectory.versionTxt()).asText.get().trim()
+version =
+    providers.fileContents(rootProject.layout.projectDirectory.versionTxt()).asText.get().trim()
 
 java {
     toolchain {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("com.hedera.hashgraph.spotless-kotlin-conventions")
 }
 
-version = providers.fileContents(rootProject.layout.projectDirectory.versionTxt()).asText.get()
+version = providers.fileContents(rootProject.layout.projectDirectory.versionTxt()).asText.get().trim()
 
 java {
     toolchain {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 ##
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
-org.gradle.jvmargs=-Xmx3072m
+org.gradle.jvmargs=-Xmx6144m
 
 # Enable Gradle caching
 org.gradle.caching=true

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -93,7 +93,7 @@ moduleInfo {
     version("org.hyperledger.besu.datatypes", besuVersion)
     version("org.hyperledger.besu.evm", besuVersion)
     version("org.hyperledger.besu.secp256k1", besuNativeVersion)
-    version("org.json", "20230227")
+    version("org.json", "20231013")
     version("org.junit.jupiter.api", "5.9.1")
     version("org.junit.platform.engine", "1.9.1")
     version("org.junitpioneer", "2.0.1")


### PR DESCRIPTION
## Description

This pull request changes the following:

- Fixes the artifact name used during the Maven Central publish for the Hedera EVM.
- Fixes breakages caused by whitespace in the `version.txt` file.
- Fixes breakage in the CI pipeline due to invalid JSON.
- Temporarily disables Sonar analysis.
- Resolves JSON library vulnerability.

### Related Issues

- Closes #9366 