### PR TITLE
Make all deprecated queries and methods free of charge

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetByKeyHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetByKeyHandler.java
@@ -25,8 +25,7 @@ import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.transaction.GetByKeyResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
-import com.hedera.node.app.spi.fees.Fees;
-import com.hedera.node.app.spi.workflows.PaidQueryHandler;
+import com.hedera.node.app.spi.workflows.FreeQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -40,7 +39,7 @@ import javax.inject.Singleton;
  * we cannot remove it. However, it should not be used.
  */
 @Singleton
-public class NetworkGetByKeyHandler extends PaidQueryHandler {
+public class NetworkGetByKeyHandler extends FreeQueryHandler {
     @Inject
     public NetworkGetByKeyHandler() {
         // Exists for injection
@@ -71,11 +70,5 @@ public class NetworkGetByKeyHandler extends PaidQueryHandler {
         requireNonNull(context);
         requireNonNull(header);
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext context) {
-        return context.feeCalculator().calculate();
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetExecutionTimeHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetExecutionTimeHandler.java
@@ -25,9 +25,7 @@ import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.network.NetworkGetExecutionTimeResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
-import com.hedera.node.app.service.mono.fees.calculation.meta.queries.GetExecTimeResourceUsage;
-import com.hedera.node.app.spi.fees.Fees;
-import com.hedera.node.app.spi.workflows.PaidQueryHandler;
+import com.hedera.node.app.spi.workflows.FreeQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -41,7 +39,7 @@ import javax.inject.Singleton;
  * we cannot remove it. However, it should not be used.
  */
 @Singleton
-public class NetworkGetExecutionTimeHandler extends PaidQueryHandler {
+public class NetworkGetExecutionTimeHandler extends FreeQueryHandler {
     @Inject
     public NetworkGetExecutionTimeHandler() {
         // Exists for injection
@@ -71,13 +69,5 @@ public class NetworkGetExecutionTimeHandler extends PaidQueryHandler {
         requireNonNull(context);
         requireNonNull(header);
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final var query = queryContext.query();
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> new GetExecTimeResourceUsage()
-                .usageGiven(query));
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
@@ -20,8 +20,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
-import com.hedera.node.app.service.mono.fees.calculation.system.txns.UncheckedSubmitResourceUsage;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -62,11 +60,7 @@ public class NetworkUncheckedSubmitHandler implements TransactionHandler {
 
     @NonNull
     @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-
-        return feeContext
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> UncheckedSubmitResourceUsage.usageGiven());
+    public Fees calculateFees(final FeeContext feeContext) {
+        return Fees.FREE;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
@@ -19,6 +19,8 @@ package com.hedera.node.app.service.contract.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.node.app.spi.fees.FeeContext;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -30,6 +32,9 @@ import javax.inject.Singleton;
 
 /**
  * This class contains all workflow-related functionality regarding {@link HederaFunctionality#SYSTEM_DELETE}.
+ * <p>
+ * This transaction type has been deprecated. Because protobufs promise backwards compatibility,
+ * we cannot remove it. However, it should not be used.
  */
 @Singleton
 public class ContractSystemDeleteHandler implements TransactionHandler {
@@ -45,6 +50,14 @@ public class ContractSystemDeleteHandler implements TransactionHandler {
 
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
+        // this will never actually get called
+        // because preHandle will always throw
         throw new HandleException(NOT_SUPPORTED);
+    }
+
+    @NonNull
+    @Override
+    public Fees calculateFees(final FeeContext feeContext) {
+        return Fees.FREE;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
@@ -19,6 +19,8 @@ package com.hedera.node.app.service.contract.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.node.app.spi.fees.FeeContext;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -30,6 +32,9 @@ import javax.inject.Singleton;
 
 /**
  * This class contains all workflow-related functionality regarding {@link HederaFunctionality#SYSTEM_UNDELETE}.
+ * <p>
+ * This transaction type has been deprecated. Because protobufs promise backwards compatibility,
+ * we cannot remove it. However, it should not be used.
  */
 @Singleton
 public class ContractSystemUndeleteHandler implements TransactionHandler {
@@ -45,6 +50,14 @@ public class ContractSystemUndeleteHandler implements TransactionHandler {
 
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
+        // this will never actually get called
+        // because preHandle will always throw
         throw new HandleException(NOT_SUPPORTED);
+    }
+
+    @NonNull
+    @Override
+    public Fees calculateFees(final FeeContext feeContext) {
+        return Fees.FREE;
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.node.app.spi.fees.FeeContext;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -54,5 +56,11 @@ public class CryptoAddLiveHashHandler implements TransactionHandler {
         // because preHandle will throw a PreCheckException
         // before we get here
         throw new HandleException(ResponseCodeEnum.NOT_SUPPORTED);
+    }
+
+    @NonNull
+    @Override
+    public Fees calculateFees(final FeeContext feeContext) {
+        return Fees.FREE;
     }
 }


### PR DESCRIPTION
**Description**:
Make all deprecated queries and transactions free, so that fees are not calculated.

**Related issue(s)**:

Fixes #9385 
Partially fixes an issue that was causing CongestionPricingSuite to fail.
