### PR TITLE
Invoke `leakCapacityForNOfUnscaled(numImplicitCreations, CryptoCreate)` on failed self-submitted auto-creation

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottle.java
@@ -120,6 +120,15 @@ public class BucketThrottle {
         return allowInstantaneous(n);
     }
 
+    /**
+     * Leaks the given number of capacity units from the bucket.
+     *
+     * @param capacity the number of capacity units to leak
+     */
+    void leakCapacity(final long capacity) {
+        bucket.leak(capacity);
+    }
+
     void leakFor(final long elapsedNanos) {
         final var leakedUnits = effectiveLeak(elapsedNanos);
         bucket.leak(leakedUnits);

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottle.java
@@ -113,6 +113,16 @@ public class DeterministicThrottle implements CongestibleThrottle {
         return delegate.allow(n, elapsedNanos);
     }
 
+    /**
+     * Leaks a given amount of capacity from the bucket. Useful for refunding capacity from an operation
+     * that was allowed through a throttle; but then failed later.
+     *
+     * @param amount the amount of capacity to leak
+     */
+    public void leakCapacity(final long amount) {
+        delegate.leakCapacity(amount);
+    }
+
     public void leakUntil(final Instant now) {
         final var elapsedNanos = elapsedNanosBetween(lastDecisionTime, now);
         lastDecisionTime = now;

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
@@ -251,7 +251,6 @@ class DeterministicThrottleTest {
         subject.allow(1, originalDecision);
         final var preLeakState = subject.usageSnapshot();
         subject.leakCapacity(preLeakState.used() / 2);
-        ;
         final var postLeakState = subject.usageSnapshot();
         assertEquals(preLeakState.used() / 2, postLeakState.used());
     }

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
@@ -241,6 +241,22 @@ class DeterministicThrottleTest {
     }
 
     @Test
+    void canLeakSpecificAmounts() {
+        final int mtps = 333;
+        final int burstPeriod = 6;
+        final var originalDecision = Instant.ofEpochSecond(1_234_567L, 0);
+        final var subject = DeterministicThrottle.withMtpsAndBurstPeriod(mtps, burstPeriod);
+        final var capacity = subject.capacity();
+
+        subject.allow(1, originalDecision);
+        final var preLeakState = subject.usageSnapshot();
+        subject.leakCapacity(preLeakState.used() / 2);
+        ;
+        final var postLeakState = subject.usageSnapshot();
+        assertEquals(preLeakState.used() / 2, postLeakState.used());
+    }
+
+    @Test
     void returnsExpectedInstantaneousState() {
         final int mtps = 333;
         final int burstPeriod = 666;

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockTransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockTransactionContext.java
@@ -43,6 +43,11 @@ import javax.inject.Singleton;
 
 @Singleton
 public class MockTransactionContext implements TransactionContext {
+    @Override
+    public boolean isSelfSubmitted() {
+        return false;
+    }
+
     private Instant now = Constructables.SOME_TIME;
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/BasicTransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/BasicTransactionContext.java
@@ -189,6 +189,11 @@ public class BasicTransactionContext implements TransactionContext {
     }
 
     @Override
+    public boolean isSelfSubmitted() {
+        return nodeInfo.selfId() == submittingMember;
+    }
+
+    @Override
     public AccountID submittingNodeAccount() {
         try {
             return nodeInfo.accountOf(submittingMember);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/NodeInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/NodeInfo.java
@@ -160,6 +160,15 @@ public class NodeInfo {
         return accountOf(selfId);
     }
 
+    /**
+     * Returns this node's id.
+     *
+     * @return this node's id
+     */
+    public long selfId() {
+        return selfId;
+    }
+
     private boolean isIndexOutOfBounds(int index) {
         return index < 0 || index >= numberOfNodes;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/TransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/TransactionContext.java
@@ -84,6 +84,25 @@ public interface TransactionContext {
      */
     AccountID activePayer();
 
+    /**
+     * Returns whether the current transaction being processed was submitted by this node.
+     *
+     * @return true if the current transaction was submitted by this node
+     */
+    boolean isSelfSubmitted();
+
+    /**
+     * Returns the number of auto-creation attempts that are implied by this transaction.
+     *
+     * @return the number of auto-creation attempts
+     */
+    default int numImplicitCreations() {
+        if (!accessor().areImplicitCreationsCounted()) {
+            throw new IllegalStateException("Implicit creations requested before being counted");
+        }
+        return accessor().getNumImplicitCreations();
+    }
+
     default AccountID effectivePayer() {
         return isPayerSigKnownActive() ? activePayer() : submittingNodeAccount();
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransferLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransferLogic.java
@@ -146,9 +146,6 @@ public class TransferLogic {
                 break;
             }
         }
-        if (failedAutoCreation && txnCtx.isSelfSubmitted()) {
-            cryptoCreateThrottleReclaimer.accept(txnCtx.numImplicitCreations());
-        }
 
         if (validity == OK && autoCreationFee > 0) {
             updatedPayerBalance = (updatedPayerBalance == Long.MIN_VALUE)
@@ -169,6 +166,9 @@ public class TransferLogic {
             dropTokenChanges(sideEffectsTracker, nftsLedger, accountsLedger, tokenRelsLedger);
             if (autoCreationLogic != null && autoCreationLogic.reclaimPendingAliases()) {
                 accountsLedger.undoCreations();
+            }
+            if (failedAutoCreation && txnCtx.isSelfSubmitted()) {
+                cryptoCreateThrottleReclaimer.accept(txnCtx.numImplicitCreations());
             }
             throw new InvalidTransactionException(validity);
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactory.java
@@ -240,7 +240,10 @@ public class InfrastructureFactory {
                 recordsHistorian,
                 txnCtx,
                 aliasManager,
-                feeDistribution);
+                feeDistribution,
+                // No-op, we won't have used any frontend throttle capacity for an auto-creation
+                // attempted during an EVM transaction
+                n -> {});
     }
 
     public ApproveAllowanceLogic newApproveAllowanceLogic(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottling.java
@@ -41,6 +41,7 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,6 +49,7 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.IntSupplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -271,6 +273,12 @@ public class DeterministicThrottling implements TimedFunctionalityThrottling {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public void leakCapacityForNOfUnscaled(final int n, @NonNull final HederaFunctionality function) {
+        final var manager = Objects.requireNonNull(functionReqs.get(function));
+        manager.undoClaimedReqsFor(n);
     }
 
     private void logResolvedDefinitions() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/FunctionalityThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/FunctionalityThrottling.java
@@ -80,4 +80,13 @@ public interface FunctionalityThrottling {
      * @throws UnsupportedOperationException if this throttle cannot provide a meaningful answer
      */
     boolean wasLastTxnGasThrottled();
+
+    /**
+     * Leaks the capacity for the given number of the given function. (We don't need to pass
+     * a time because the amount leaked is going to be constant.)
+     *
+     * @param n - the number of the given function
+     * @param function - the function
+     */
+    void leakCapacityForNOfUnscaled(int n, HederaFunctionality function);
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/HapiThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/HapiThrottling.java
@@ -22,6 +22,7 @@ import com.hedera.node.app.hapi.utils.throttles.GasLimitDeterministicThrottle;
 import com.hedera.node.app.service.mono.utils.accessors.TxnAccessor;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
 
@@ -99,5 +100,10 @@ public class HapiThrottling implements FunctionalityThrottling {
     @Override
     public boolean wasLastTxnGasThrottled() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void leakCapacityForNOfUnscaled(final int n, @NonNull final HederaFunctionality function) {
+        delegate.leakCapacityForNOfUnscaled(n, function);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManager.java
@@ -58,8 +58,8 @@ public class ThrottleReqsManager {
      */
     public void undoClaimedReqsFor(int nTransactions) {
         for (int i = 0; i < passedReq.length; i++) {
-            var req = allReqs.get(i);
-            var opsRequired = req.getRight();
+            final var req = allReqs.get(i);
+            final var opsRequired = req.getRight();
             final var bucket = req.getLeft();
             bucket.leakCapacity(nTransactions * opsRequired * BucketThrottle.capacityUnitsPerTxn());
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TimedFunctionalityThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TimedFunctionalityThrottling.java
@@ -39,6 +39,16 @@ public interface TimedFunctionalityThrottling extends FunctionalityThrottling {
         return shouldThrottleQuery(queryFunction, Instant.now(), query);
     }
 
+    /**
+     * Verifies if the frontend throttle has enough capacity to handle the given number of the
+     * given function at the given time. (The time matters because we want to consider how much
+     * will have leaked between now and that time.)
+     *
+     * @param n - the number of the given function
+     * @param function - the function
+     * @param now - the instant for which throttling should be calculated
+     * @return true if the system should throttle the given number of the given function at the
+     */
     boolean shouldThrottleNOfUnscaled(int n, HederaFunctionality function, Instant now);
 
     /**

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottling.java
@@ -23,6 +23,7 @@ import com.hedera.node.app.service.mono.context.TransactionContext;
 import com.hedera.node.app.service.mono.utils.accessors.TxnAccessor;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
 public class TxnAwareHandleThrottling implements FunctionalityThrottling {
@@ -32,6 +33,11 @@ public class TxnAwareHandleThrottling implements FunctionalityThrottling {
     public TxnAwareHandleThrottling(TransactionContext txnCtx, TimedFunctionalityThrottling delegate) {
         this.txnCtx = txnCtx;
         this.delegate = delegate;
+    }
+
+    @Override
+    public void leakCapacityForNOfUnscaled(final int n, @NonNull final HederaFunctionality function) {
+        delegate.leakCapacityForNOfUnscaled(n, function);
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/NodeInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/NodeInfoTest.java
@@ -73,6 +73,11 @@ class NodeInfoTest {
     }
 
     @Test
+    void getsSelfId() {
+        assertEquals(nodeId, subject.selfId());
+    }
+
+    @Test
     void understandsZeroStake() {
         givenEntryWithWeight(nodeId, 0L);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransferLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransferLogicTest.java
@@ -73,6 +73,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.IntConsumer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,10 @@ class TransferLogicTest {
     @Mock
     private AliasManager aliasManager;
 
-    private FeeDistribution feeDistribution = new FeeDistribution(accountNums, dynamicProperties);
+    @Mock
+    private IntConsumer cryptoCreateThrottleReclaimer;
+
+    private final FeeDistribution feeDistribution = new FeeDistribution(accountNums, dynamicProperties);
 
     private TransferLogic subject;
 
@@ -165,7 +169,8 @@ class TransferLogicTest {
                 recordsHistorian,
                 txnCtx,
                 aliasManager,
-                feeDistribution);
+                feeDistribution,
+                cryptoCreateThrottleReclaimer);
     }
 
     @Test
@@ -190,7 +195,8 @@ class TransferLogicTest {
                 recordsHistorian,
                 txnCtx,
                 aliasManager,
-                feeDistribution);
+                feeDistribution,
+                cryptoCreateThrottleReclaimer);
 
         final var triggerList = List.of(inappropriateTrigger);
         assertThrows(IllegalStateException.class, () -> subject.doZeroSum(triggerList));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottlingTest.java
@@ -850,6 +850,20 @@ class DeterministicThrottlingTest {
     }
 
     @Test
+    void canLeakCapacityForNOfManaged() throws IOException {
+        var defs = SerdeUtils.pojoDefs("bootstrap/throttles.json");
+
+        subject.rebuildFor(defs);
+
+        subject.shouldThrottleNOfUnscaled(1, TokenMint, consensusNow);
+        final var oneUsed = subject.activeThrottlesFor(TokenMint).get(0).used();
+        subject.shouldThrottleNOfUnscaled(43, TokenMint, consensusNow);
+        subject.leakCapacityForNOfUnscaled(2, TokenMint);
+        final var fortyTwoUsed = subject.activeThrottlesFor(TokenMint).get(0).used();
+        assertEquals(42 * oneUsed, fortyTwoUsed);
+    }
+
+    @Test
     void whenThrottlesUsesNoCapacity() throws IOException {
         var defs = SerdeUtils.pojoDefs("bootstrap/throttles.json");
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/HapiThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/HapiThrottlingTest.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.throttling;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCallLocal;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoCreate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,6 +66,12 @@ class HapiThrottlingTest {
         assertTrue(ans);
         // and:
         verify(delegate).shouldThrottleQuery(eq(ContractCallLocal), any(), any());
+    }
+
+    @Test
+    void delegatesCapacityLeak() {
+        subject.leakCapacityForNOfUnscaled(2, CryptoCreate);
+        verify(delegate).leakCapacityForNOfUnscaled(2, CryptoCreate);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManagerTest.java
@@ -91,6 +91,26 @@ class ThrottleReqsManagerTest {
     }
 
     @Test
+    void undoingClaimedReqsResetsUsageSnapshotToZero() {
+        // when:
+        var result = subject.allReqsMetAt(now);
+
+        // then:
+        assertTrue(result);
+        // and:
+        assertEquals(
+                aReq * BucketThrottle.capacityUnitsPerTxn(), a.usageSnapshot().used());
+        assertEquals(
+                bReq * BucketThrottle.capacityUnitsPerTxn(), b.usageSnapshot().used());
+
+        // and when:
+        subject.undoClaimedReqsFor(1);
+
+        assertEquals(0, a.usageSnapshot().used());
+        assertEquals(0, b.usageSnapshot().used());
+    }
+
+    @Test
     void usesExpectedCapacityWithOnlyOneReqMet() {
         // given:
         a.allow(aReq, lastDecision);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottlingTest.java
@@ -69,6 +69,12 @@ class TxnAwareHandleThrottlingTest {
     }
 
     @Test
+    void delegatesCapacityLeak() {
+        subject.leakCapacityForNOfUnscaled(2, CryptoCreate);
+        verify(delegate).leakCapacityForNOfUnscaled(2, CryptoCreate);
+    }
+
+    @Test
     void delegatesSnapshotActions() {
         final List<DeterministicThrottle.UsageSnapshot> pretend = List.of();
         given(delegate.getUsageSnapshots()).willReturn(pretend);


### PR DESCRIPTION
**Description**:
 - Upon a failed auto-creation in `TransferLogic`, makes the node that submitted the failed auto-creation leak the reserved `CryptoCreate` capacity from its frontend throttle.