### PR TITLE
Fix `uniqueTokenManagementSpecs` leftover tests

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -76,8 +76,6 @@ public class BaseTokenHandler {
             @NonNull final WritableTokenRelationStore tokenRelationStore) {
         requireNonNull(token);
         requireNonNull(treasuryRel);
-
-        validateTrue(amount >= 0, INVALID_TOKEN_MINT_AMOUNT);
         // validate token supply key exists for mint or burn.
         // But this flag is not set when mint is called on token creation with initial supply.
         // We don't need to check the supply key ONLY in that case

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -153,9 +153,10 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
             newAccountBalance = validated.accountTokenRel().balance() - fungibleWipeCount;
             validateTrue(newAccountBalance >= 0, INVALID_WIPING_AMOUNT);
         } else {
-            // Validate that there is at least one NFT to wipe
-            validateFalse(nftSerialNums.isEmpty(), FAIL_INVALID);
-
+            // Check if nft serial numbers are zero, but fungible count is more than zero
+            validateFalse(nftSerialNums.isEmpty() && fungibleWipeCount > 0, FAIL_INVALID);
+            // Check if nft serial numbers are zero
+            validateFalse(nftSerialNums.isEmpty(), INVALID_WIPING_AMOUNT);
             // Check that the new total supply will not be negative
             newTotalSupply = token.totalSupply() - nftSerialNums.size();
             validateTrue(newTotalSupply >= 0, INVALID_WIPING_AMOUNT);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.token.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_DOES_NOT_OWN_WIPED_NFT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
@@ -149,12 +150,12 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
             newAccountBalance = validated.accountTokenRel().balance() - fungibleWipeCount;
             validateTrue(newAccountBalance >= 0, INVALID_WIPING_AMOUNT);
         } else {
+            // Validate that there is at least one NFT to wipe
+            validateFalse(nftSerialNums.isEmpty(), FAIL_INVALID);
+
             // Check that the new total supply will not be negative
             newTotalSupply = token.totalSupply() - nftSerialNums.size();
             validateTrue(newTotalSupply >= 0, INVALID_WIPING_AMOUNT);
-
-            // Validate that there is at least one NFT to wipe
-            validateFalse(nftSerialNums.isEmpty(), INVALID_WIPING_AMOUNT);
 
             // Load and validate the nfts
             for (final Long nftSerial : nftSerialNums) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -142,6 +142,9 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
         final long newAccountBalance;
         final Account.Builder updatedAcctBuilder = acct.copyBuilder();
         if (token.tokenType() == TokenType.FUNGIBLE_COMMON) {
+            // Validate that there is at least one fungible token to wipe
+            validateTrue(fungibleWipeCount >= 0 && nftSerialNums.isEmpty(), INVALID_WIPING_AMOUNT);
+
             // Check that the new total supply will not be negative
             newTotalSupply = token.totalSupply() - fungibleWipeCount;
             validateTrue(newTotalSupply >= 0, INVALID_WIPING_AMOUNT);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
@@ -117,6 +117,7 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
         }
 
         if (token.tokenType() == TokenType.FUNGIBLE_COMMON) {
+            validateTrue(fungibleBurnCount >= 0 && nftSerialNums.isEmpty(), INVALID_TOKEN_BURN_AMOUNT);
             final var newTotalSupply = changeSupply(
                     validated.token(),
                     treasuryRel,

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -134,6 +134,8 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
         }
 
         if (token.tokenType() == TokenType.FUNGIBLE_COMMON) {
+
+            validateTrue(op.amount() >= 0 && op.metadata().isEmpty(), INVALID_TOKEN_MINT_AMOUNT);
             // we need to know if treasury mint while creation to ignore supply key exist or not.
             long newTotalSupply =
                     mintFungible(token, treasuryRel, op.amount(), false, accountStore, tokenStore, tokenRelStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -632,7 +632,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
             assertThatThrownBy(() -> subject.handle(context))
                     .isInstanceOf(HandleException.class)
-                    .has(responseCode(FAIL_INVALID));
+                    .has(responseCode(INVALID_WIPING_AMOUNT));
         }
 
         @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.token.impl.test.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_DOES_NOT_OWN_WIPED_NFT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
@@ -631,7 +632,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
             assertThatThrownBy(() -> subject.handle(context))
                     .isInstanceOf(HandleException.class)
-                    .has(responseCode(INVALID_WIPING_AMOUNT));
+                    .has(responseCode(FAIL_INVALID));
         }
 
         @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -19,7 +19,6 @@ package com.hedera.node.app.service.token.impl.test.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_DOES_NOT_OWN_WIPED_NFT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -752,7 +752,6 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                         getAccountBalance(ACCOUNT).hasTokenBalance(NFT, 1));
     }
 
-    @HapiTest
     private HapiSpec uniqueWipeFailsWhenInvokedOnFungibleToken() { // invokes unique wipe on fungible tokens
         return defaultHapiSpec("UniqueWipeFailsWhenInvokedOnFungibleToken")
                 .given(
@@ -771,7 +770,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                                 .hasKnownStatus(INVALID_WIPING_AMOUNT)
                                 .via("wipeTx"),
                         wipeTokenAccount(A_TOKEN, ACCOUNT, List.of())
-                                .hasPrecheck(OK)
+                                .hasKnownStatus(OK)
                                 .via("wipeEmptySerialTx"))
                 .then(
                         getTokenInfo(A_TOKEN).hasTotalSupply(10),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -140,6 +140,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
         });
     }
 
+    @HapiTest
     private HapiSpec populatingMetadataForFungibleDoesNotWork() {
         return defaultHapiSpec("PopulatingMetadataForFungibleDoesNotWork")
                 .given(
@@ -232,6 +233,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                         }));
     }
 
+    @HapiTest
     private HapiSpec serialNumbersOnlyOnFungibleBurnFails() {
         return defaultHapiSpec("SerialNumbersOnlyOnFungibleBurnFails")
                 .given(
@@ -718,6 +720,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                         .hasPrecheck(BATCH_SIZE_LIMIT_EXCEEDED));
     }
 
+    @HapiTest
     private HapiSpec commonWipeFailsWhenInvokedOnUniqueToken() {
         return defaultHapiSpec("CommonWipeFailsWhenInvokedOnUniqueToken")
                 .given(
@@ -749,6 +752,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                         getAccountBalance(ACCOUNT).hasTokenBalance(NFT, 1));
     }
 
+    @HapiTest
     private HapiSpec uniqueWipeFailsWhenInvokedOnFungibleToken() { // invokes unique wipe on fungible tokens
         return defaultHapiSpec("UniqueWipeFailsWhenInvokedOnFungibleToken")
                 .given(
@@ -767,7 +771,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                                 .hasKnownStatus(INVALID_WIPING_AMOUNT)
                                 .via("wipeTx"),
                         wipeTokenAccount(A_TOKEN, ACCOUNT, List.of())
-                                .hasKnownStatus(OK)
+                                .hasPrecheck(OK)
                                 .via("wipeEmptySerialTx"))
                 .then(
                         getTokenInfo(A_TOKEN).hasTotalSupply(10),


### PR DESCRIPTION
**Description**:
This PR fixes tests from the `uniqueTokenManagementSpecs`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
One of the tests was change to expect `OK` status on precheck instead, because `OK` is only being used on precheck step.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
