### PR TITLE
9066 Enable Some ScheduleService HAPI tests

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyComparator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyComparator.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.spi.key;
+
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.Key.KeyOneOfType;
+import com.hedera.hapi.node.base.KeyList;
+import com.hedera.hapi.node.base.ThresholdKey;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Comparator used to impose a deterministic ordering on collections of Key objects.
+ * <br>These include maps, sets, lists, arrays, etc...
+ * <br>The methods in this class are used in hot spot code, so allocation must be kept to a bare
+ * minimum, and anything likely to have performance questions
+ * <br>Note that comparing keys is unavoidably costly.  We try to exit as early as possible throughout
+ * this class, but worst case we're comparing every simple key byte-by-byte for the entire tree, which
+ * may be up to 15 levels deep with any number of keys per level.  We haven't seen a key with
+ * several million "simple" keys included, but that does not mean nobody will create one.
+ */
+public class KeyComparator implements Comparator<Key> {
+    @Override
+    public int compare(final Key first, final Key second) {
+        if (first == second) return 0;
+        else if (first == null) return -1;
+        else if (second == null) return 1;
+        else if (first.key() == null) return second.key() == null ? 0 : -1;
+        else if (second.key() == null) return 1;
+
+        final KeyOneOfType firstKeyType = first.key().kind();
+        final KeyOneOfType secondKeyType = second.key().kind();
+        if (firstKeyType != secondKeyType) return compareCrossType(firstKeyType, secondKeyType);
+        else {
+            // both keys are the same type; so compare the details.
+            return switch (firstKeyType) {
+                case UNSET -> 0; // both unset compares equal.
+                case CONTRACT_ID -> compareContractId(first, second);
+                case DELEGATABLE_CONTRACT_ID -> compareDelegateable(first, second);
+                case ED25519 -> compareEdwards(first, second);
+                case ECDSA_SECP256K1 -> compareSecp256k(first, second);
+                case THRESHOLD_KEY -> compareThreshold(first, second);
+                case KEY_LIST -> compareKeyList(first, second);
+                    // The next two are not currently supported key types.
+                case RSA_3072 -> compareRsa(first, second);
+                case ECDSA_384 -> compareEcdsa(first, second);
+            };
+        }
+    }
+
+    private int compareContractId(final Key first, final Key second) {
+        final ContractID lhs = first.contractID();
+        final ContractID rhs = second.contractID();
+        if (lhs == rhs) return 0;
+        else if (lhs == null) return -1;
+        else if (rhs == null) return 1;
+        else return compareId(lhs, rhs);
+    }
+
+    private int compareDelegateable(final Key first, final Key second) {
+        final ContractID lhs = first.delegatableContractId();
+        final ContractID rhs = second.delegatableContractId();
+        if (lhs == rhs) return 0;
+        else if (lhs == null) return -1;
+        else if (rhs == null) return 1;
+        else return compareId(lhs, rhs);
+    }
+
+    private int compareId(final ContractID leftId, final ContractID rightId) {
+        final long realmOne = leftId.realmNum();
+        final long realmTwo = rightId.realmNum();
+        final long shardOne = leftId.shardNum();
+        final long shardTwo = rightId.shardNum();
+        final Bytes evmOne = leftId.evmAddress();
+        final Bytes evmTwo = rightId.evmAddress();
+        final Long leftNum = leftId.contractNum();
+        final Long rightNum = rightId.contractNum();
+        final long firstId = leftNum != null ? leftNum.longValue() : 0L;
+        final long secondId = rightNum != null ? rightNum.longValue() : 0L;
+        if (realmOne == realmTwo) {
+            if (shardOne == shardTwo) {
+                if (firstId == secondId) {
+                    return compareBytes(evmOne, evmTwo);
+                } else {
+                    return firstId > secondId ? -1 : 1;
+                }
+            } else {
+                return shardOne > shardTwo ? -1 : 1;
+            }
+        } else {
+            return realmOne > realmTwo ? -1 : 1;
+        }
+    }
+
+    private int compareEdwards(final Key first, final Key second) {
+        final Bytes lhs = first.ed25519();
+        final Bytes rhs = second.ed25519();
+        return compareBytes(lhs, rhs);
+    }
+
+    private int compareSecp256k(final Key first, final Key second) {
+        final Bytes lhs = first.ecdsaSecp256k1();
+        final Bytes rhs = second.ecdsaSecp256k1();
+        return compareBytes(lhs, rhs);
+    }
+
+    private int compareThreshold(final Key first, final Key second) {
+        final ThresholdKey lhs = first.thresholdKey();
+        final ThresholdKey rhs = second.thresholdKey();
+        if (lhs == rhs) return 0;
+        else if (lhs == null) return -1;
+        else if (rhs == null) return 1;
+
+        final int leftThreshold = lhs.threshold();
+        final int rightThreshold = rhs.threshold();
+        if (leftThreshold != rightThreshold) return leftThreshold - rightThreshold;
+
+        final KeyList leftList = lhs.keys();
+        final KeyList rightList = rhs.keys();
+        if (leftList == rightList) return 0;
+        else if (leftList == null) return -1;
+        else if (rightList == null) return 1;
+        else return compareListOfKeys(leftList.keys(), rightList.keys());
+    }
+
+    private int compareKeyList(final Key first, final Key second) {
+        final KeyList lhs = first.keyList();
+        final KeyList rhs = second.keyList();
+        if (lhs == rhs) return 0;
+        else if (lhs == null) return -1;
+        else if (rhs == null) return 1;
+        return compareListOfKeys(lhs.keys(), rhs.keys());
+    }
+
+    private int compareEcdsa(final Key first, final Key second) {
+        throw new UnsupportedOperationException("Key Type ECDSA 384 is not supported");
+    }
+
+    private int compareRsa(final Key first, final Key second) {
+        throw new UnsupportedOperationException("Key Type RSA 3072 is not supported");
+    }
+
+    // IMPORTANT NOTE: This method relies on the order of each List to be consistent across all
+    //     nodes in the network, and *List Order Is Significant*.  This is currently true, but
+    //     if it ever changes, then this method must change to perform an exhaustive comparison
+    //     (nested loops) of the two lists (making order within the lists not need to match).
+    private int compareListOfKeys(final List<Key> lhs, final List<Key> rhs) {
+        if (lhs == rhs) return 0;
+        else if (lhs == null) return -1;
+        else if (rhs == null) return 1;
+
+        final int leftLength = lhs.size();
+        final int rightLength = rhs.size();
+        if (leftLength != rightLength) return leftLength - rightLength;
+        else
+            for (int i = 0; i < leftLength; i++) {
+                final int comparison = compare(lhs.get(i), rhs.get(i));
+                if (comparison != 0) return comparison;
+            }
+        // nothing differed between the two lists; they are equal.
+        return 0;
+    }
+
+    private int compareBytes(final Bytes lhs, final Bytes rhs) {
+        if (lhs == rhs) return 0;
+        else if (lhs == null) return -1;
+        else if (rhs == null) return 1;
+
+        final long leftLength = lhs.length();
+        final long rightLength = rhs.length();
+        if (leftLength != rightLength) return leftLength > rightLength ? -1 : 1;
+        else {
+            // left and right length are equal.
+            for (long offset = 0L; offset < leftLength; offset++) {
+                // cast because java hates byte (it promotes to int for everything anyway)
+                final int left = (int) lhs.getByte(offset);
+                final int right = (int) rhs.getByte(offset);
+                if (left != right) return left - right;
+            }
+        }
+        // nothing differed, so these are equal.
+        return 0;
+    }
+
+    /**
+     * Compare two keys of different types for sort ordering.
+     * The "natural" order, in this case, is just the type order in the proto file.
+     * @param firstKeyType The OneOfType for the first (left hand) key.
+     * @param secondKeyType The OneOfType for the second (right hand) key.
+     * @return a value less than, equal to, or greater than 0 indicating if the first key type should be
+     *   sorted before, the same, or after, the second key type.
+     */
+    private int compareCrossType(final KeyOneOfType firstKeyType, final KeyOneOfType secondKeyType) {
+        return firstKeyType.protoOrdinal() - secondKeyType.protoOrdinal();
+    }
+}

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
@@ -41,12 +41,7 @@ final class ScheduleStoreUtility {
         if (scheduleToHash.adminKey() != null) {
             addToHash(hasher, scheduleToHash.adminKey());
         }
-        if (scheduleToHash.payerAccountId() != null) {
-            addToHash(hasher, scheduleToHash.payerAccountId());
-        }
-        if (scheduleToHash.schedulerAccountId() != null) {
-            addToHash(hasher, scheduleToHash.schedulerAccountId());
-        }
+        // @note We should check scheduler here, but mono doesn't, so we cannot either, yet.
         if (scheduleToHash.scheduledTransaction() != null) {
             addToHash(hasher, scheduleToHash.scheduledTransaction());
         }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -28,6 +28,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.schedule.ReadableScheduleStore;
 import com.hedera.node.app.service.schedule.ScheduleRecordBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.app.spi.key.KeyComparator;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -38,15 +39,12 @@ import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Provides some implementation support needed for both the {@link ScheduleCreateHandler} and {@link
@@ -84,21 +82,31 @@ abstract class AbstractScheduleHandler {
             final TransactionBody scheduledAsOrdinary = HandlerUtility.childAsOrdinary(scheduleInState);
             final TransactionKeys keyStructure = context.allKeysForTransaction(scheduledAsOrdinary, payer);
             final Set<Key> scheduledRequiredKeys = getKeySetFromTransactionKeys(keyStructure);
-            final Set<Key> currentSignatories = setOfKeys(scheduleInState.signatories());
-            scheduledRequiredKeys.removeAll(currentSignatories);
             // Ensure the payer is required, some rare corner cases may not require it otherwise.
             final Key payerKey = getKeyForAccount(context, payer);
             if (payerKey != null) scheduledRequiredKeys.add(payerKey);
-            final Set<Key> remainingRequiredKeys = scheduledRequiredKeys.parallelStream()
-                    .map(new ValidatedKeysMapping(context, currentSignatories))
-                    .flatMap(Set::stream)
-                    .collect(Collectors.toSet());
-            // This works ONLY because ValidatedKeysMapping observes the validation process and
-            // modifies currentSignatories to add any newly validated primitive keys.
+            final Set<Key> currentSignatories = setOfKeys(scheduleInState.signatories());
+            scheduledRequiredKeys.removeAll(currentSignatories);
+            final Set<Key> remainingRequiredKeys =
+                    filterRemainingRequiredKeys(context, scheduledRequiredKeys, currentSignatories);
+            // Mono doesn't store extra signatures, so for now we mustn't either.
+            // This is structurally wrong for long term schedules, so we must remove this later.
+            // @todo('long term schedule') remove this "trim" when enabling long term schedules.
+            trimSignatories(currentSignatories, scheduledRequiredKeys);
             return new ScheduleKeysResult(currentSignatories, remainingRequiredKeys);
         } catch (final PreCheckException translated) {
             throw new HandleException(translated.responseCode());
         }
+    }
+
+    // Remove any keys in signatores that are currently neither required nor optional.
+    // This is temporary, to match mono-service behavior
+    @NonNull
+    protected void trimSignatories(@NonNull final Set<Key> signatories, @NonNull final Set<Key> requiredKeys) {
+        Objects.requireNonNull(signatories);
+        Objects.requireNonNull(requiredKeys);
+        final int preFilterCount = signatories.size();
+        signatories.retainAll(requiredKeys); // Set intersection
     }
 
     @Nullable
@@ -267,44 +275,52 @@ abstract class AbstractScheduleHandler {
     }
 
     @NonNull
-    private Set<Key> getKeySetFromTransactionKeys(final TransactionKeys requiredKeys) {
-        final Set<Key> scheduledRequiredKeys = new ConcurrentSkipListSet<>(new RecordIdentityComparator());
+    private SortedSet<Key> getKeySetFromTransactionKeys(final TransactionKeys requiredKeys) {
+        final SortedSet<Key> scheduledRequiredKeys = new ConcurrentSkipListSet<>(new KeyComparator());
         scheduledRequiredKeys.addAll(requiredKeys.requiredNonPayerKeys());
         scheduledRequiredKeys.addAll(requiredKeys.optionalNonPayerKeys());
         scheduledRequiredKeys.add(requiredKeys.payerKey());
         return scheduledRequiredKeys;
     }
 
+    private SortedSet<Key> filterRemainingRequiredKeys(
+            final HandleContext context, final Set<Key> scheduledRequiredKeys, final Set<Key> currentSignatories) {
+        // the final output must be a sorted/ordered set.
+        final SortedSet<Key> remainingKeys = new ConcurrentSkipListSet<>(new KeyComparator());
+        final Set<Key> currentUnverifiedKeys = new HashSet<>(1);
+        final var assistant = new ScheduleVerificationAssistant(currentSignatories, currentUnverifiedKeys);
+        for (final Key next : scheduledRequiredKeys) {
+            // The schedule verification assistant observes each primitive key in the tree
+            final SignatureVerification isVerified = context.verificationFor(next, assistant);
+            // unverified primitive keys only count if the top-level key failed verification.
+            if (!isVerified.passed()) {
+                remainingKeys.addAll(currentUnverifiedKeys);
+            }
+            currentUnverifiedKeys.clear();
+        }
+        return remainingKeys;
+    }
+
     /**
-     * Given an arbitrary {@link Iterable<Key>}, return a <strong>modifiable</strong> {@link Set<Key>} containing
+     * Given an arbitrary {@link Iterable<Key>}, return a <strong>modifiable</strong> {@link SortedSet<Key>} containing
      * the same objects as the input.
      * If there are any duplicates in the input, only one of each will be in the result.
      * If there are any null values in the input, those values will be excluded from the result.
-     * Note: The return value of this method is always safe to be read and written by multiple threads
-     *     concurrently, and operates as close to lock-free as possible.
-     * Implementation Note: we use ConcurrentSkipListSet that orders the entries by hash code.  This means that
-     *   object order will be very different from a reasonable natural ordering, but it should (if hashCode is defined
-     *   properly) be consistent with equals, and have sufficient diffusion to work well with the random
-     *   functions inherent in the Skip List data structure. Order is not important, so this approach is reasonable.
-     *   The alternative is a CopyOnWriteArraySet, which has significant GC performance issues.
      * @param keyCollection an Iterable of Key values.
-     * @return a {@link Set<Key>} containing the same contents as the input.  Duplicates and null values are excluded
-     * from this Set.  This Set is always a modifiable set.
+     * @return a {@link SortedSet<Key>} containing the same contents as the input.
+     * Duplicates and null values are excluded from this Set.  This Set is always a modifiable set.
      */
     @NonNull
-    private Set<Key> setOfKeys(@Nullable final Iterable<Key> keyCollection) {
-        // We only permit Concurrent sets for this method.
-        if (keyCollection instanceof ConcurrentSkipListSet<Key>) {
-            return (Set<Key>) keyCollection;
-        } else if (keyCollection != null) {
-            final Set<Key> results = new ConcurrentSkipListSet<>(new RecordIdentityComparator());
+    private SortedSet<Key> setOfKeys(@Nullable final Iterable<Key> keyCollection) {
+        if (keyCollection != null) {
+            final SortedSet<Key> results = new ConcurrentSkipListSet<>(new KeyComparator());
             for (final Key next : keyCollection) {
                 if (next != null) results.add(next);
             }
             return results;
         } else {
             // cannot use Set.of() or Collections.emptySet() here because those are unmodifiable.
-            return new ConcurrentSkipListSet<>(new RecordIdentityComparator());
+            return new ConcurrentSkipListSet<>(new KeyComparator());
         }
     }
 
@@ -317,70 +333,5 @@ abstract class AbstractScheduleHandler {
                 && (!isLongTermEnabled
                         || (scheduleToExecute.waitForExpiry()
                                 && validationResult == ResponseCodeEnum.SCHEDULE_PENDING_EXPIRATION));
-    }
-
-    /**
-     * A mapping function implementation that validates a single account key and maps that to a
-     * set of "primitive" keys that are needed (in whole or in part) to meet the full signature
-     * requirements of that key.  This function, as a side effect, adds additional "primitive"
-     * keys to the existing signatories set for each such key that has a valid signature for the
-     * current transaction.
-     */
-    private static class ValidatedKeysMapping implements Function<Key, Set<Key>> {
-        private final HandleContext context;
-        private final Set<Key> signatories;
-
-        /**
-         * Create a mapping function with a given context and set of signatories.
-         *
-         * @param context a HandleContext for a particular ScheduleCreate or ScheduleSign transaction.
-         * @param signatories a Set of "primitive" keys that were previously validated, and therefore
-         *     are "deemed" to have signed the child transaction.  <strong>This set is modified by the
-         *     apply method</strong> of the object created, so it must not be an unmodifiable set.
-         */
-        protected ValidatedKeysMapping(@NonNull final HandleContext context, @NonNull final Set<Key> signatories) {
-            this.context = context;
-            this.signatories = signatories;
-        }
-
-        /**
-         * Apply the mapping function to a particular Account key.
-         * The function here checks if the key is valid while providing a verification assistant that
-         * considers all keys in "signatories" to be valid.  The mapping, as a side effect, also
-         * records all newly validated "primitive" keys and adds those to "signatories".  If the
-         * Account key is still not validated, then all remaining required "primitive" keys are
-         * returned.
-         *
-         * Note, it is possible that not all values in the returned key set are required, particularly
-         * in the case of threshold keys, it may be that only some of the keys are required, but all
-         * of the keys returned <strong>can</strong> be used to meet the signature requirements for
-         * the Account key.
-         *
-         * @param key a single Account key to validate against the signatures on the current transaction
-         *     as well as the "signatories" set of previously validated signatures.
-         * @return a {@link Set<Key>} of "primitive" keys that still must be validated
-         *     (in whole or in part) to consider the Account key fully validated.
-         */
-        @Override
-        public Set<Key> apply(final Key key) {
-            final Set<Key> remainingUnverifiedKeys = new LinkedHashSet<>();
-            final var assistant = new ScheduleVerificationAssistant(signatories, remainingUnverifiedKeys);
-            final SignatureVerification isVerified = context.verificationFor(key, assistant);
-            // unverified primitive keys only count if the top-level key failed verification.
-            return isVerified.passed() ? Collections.emptySet() : remainingUnverifiedKeys;
-        }
-    }
-
-    /**
-     * Comparator implementation for Records that orders by hash code.  This is not useful if order actually
-     * matters, but it is useful to use an ordered set when order does not matter and performance does.
-     * We use this to enable storing a Record (Key) in a ConcurrentSkipListSet which is used in a highly
-     * parallel operation that both reads and modifies the set on, ideally, several threads at once.
-     */
-    private static class RecordIdentityComparator implements Comparator<Record> {
-        @Override
-        public int compare(final Record left, final Record right) {
-            return Objects.hashCode(left) - Objects.hashCode(right);
-        }
     }
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
@@ -35,6 +35,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.SchedulingConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -79,15 +80,22 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         Objects.requireNonNull(context, NULL_CONTEXT_MESSAGE);
         final TransactionBody currentTransaction = context.body();
-        final LedgerConfig config = context.configuration().getConfigData(LedgerConfig.class);
+        final LedgerConfig ledgerConfig = context.configuration().getConfigData(LedgerConfig.class);
+        final HederaConfig hederaConfig = context.configuration().getConfigData(HederaConfig.class);
         final SchedulingConfig schedulingConfig = context.configuration().getConfigData(SchedulingConfig.class);
         final long maxExpireConfig = schedulingConfig.longTermEnabled()
                 ? schedulingConfig.maxExpirationFutureSeconds()
-                : config.scheduleTxExpiryTimeSecs();
+                : ledgerConfig.scheduleTxExpiryTimeSecs();
         final ScheduleCreateTransactionBody scheduleBody = getValidScheduleCreateBody(currentTransaction);
-        checkSchedulableWhitelist(scheduleBody, schedulingConfig);
+        if (scheduleBody.memo() != null && scheduleBody.memo().length() > hederaConfig.transactionMaxMemoUtf8Bytes())
+            throw new PreCheckException(ResponseCodeEnum.MEMO_TOO_LONG);
+        // @todo('future') add whitelist check here; mono checks very late, so we cannot check that here yet.
         // validate the schedulable transaction
         getSchedulableTransaction(currentTransaction);
+        // @todo('future') This key/account validation should move to handle once we finish and validate
+        //                 modularization; mono does this check too early, and may reject transactions
+        //                 that should succeed.
+        validatePayerAndScheduler(context, scheduleBody);
         // If we have an explicit payer account for the scheduled child transaction,
         //   add it to optional keys (it might not have signed yet).
         final Key payerKey = getKeyForPayerAccount(scheduleBody, context);
@@ -96,6 +104,7 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
             // If an admin key is present, it must sign the create transaction.
             context.requireKey(scheduleBody.adminKeyOrThrow());
         }
+        checkSchedulableWhitelist(scheduleBody, schedulingConfig);
         final TransactionID transactionId = currentTransaction.transactionID();
         if (transactionId != null) {
             final Schedule provisionalSchedule =
@@ -133,7 +142,7 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
                     validate(provisionalSchedule, currentConsensusTime, isLongTermEnabled);
             if (validationOk(validationResult)) {
                 final List<Schedule> possibleDuplicates = scheduleStore.getByEquality(provisionalSchedule);
-                if (isPresentIn(possibleDuplicates, provisionalSchedule)) {
+                if (isPresentIn(context, possibleDuplicates, provisionalSchedule)) {
                     throw new HandleException(ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED);
                 }
                 if (scheduleStore.numSchedulesInState() + 1 > schedulingConfig.maxNumber()) {
@@ -143,8 +152,9 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
                 final ScheduleKeysResult requiredKeysResult = allKeysForTransaction(provisionalSchedule, context);
                 final Set<Key> allRequiredKeys = requiredKeysResult.remainingRequiredKeys();
                 final Set<Key> updatedSignatories = requiredKeysResult.updatedSignatories();
-                Schedule finalSchedule = HandlerUtility.completeProvisionalSchedule(
-                        provisionalSchedule, context.newEntityNum(), updatedSignatories);
+                final long nextId = getNextId(context);
+                Schedule finalSchedule =
+                        HandlerUtility.completeProvisionalSchedule(provisionalSchedule, nextId, updatedSignatories);
                 if (tryToExecuteSchedule(
                         context,
                         finalSchedule,
@@ -165,13 +175,34 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
         }
     }
 
+    /*
+     Note: This method should not be needed, but HapiTests don't work properly in this regard
+      (genesis doesn't fill in the next entity state).  This ensures the next entity is not a system entity before
+      returning the value.
+      This is temporary until we can fix the genesis state handling for newEntityNum...
+    */
+    private long getNextId(final HandleContext context) {
+        final LedgerConfig config = context.configuration().getConfigData(LedgerConfig.class);
+        long minEntity = config.numReservedSystemEntities();
+        long nextId;
+        do {
+            nextId = context.newEntityNum();
+        } while (nextId <= minEntity);
+        return nextId;
+    }
+
     private boolean isPresentIn(
-            @Nullable final List<Schedule> possibleDuplicates, @NonNull final Schedule provisionalSchedule) {
-        if (possibleDuplicates != null) {
+            @NonNull final HandleContext context,
+            @Nullable final List<Schedule> possibleDuplicates,
+            @NonNull final Schedule provisionalSchedule) {
+        if (possibleDuplicates != null)
             for (final Schedule candidate : possibleDuplicates) {
-                if (compareForDuplicates(candidate, provisionalSchedule)) return true;
+                if (compareForDuplicates(candidate, provisionalSchedule)) {
+                    // Do not forget to set the ID of the existing duplicate in the receipt...
+                    context.recordBuilder(ScheduleRecordBuilder.class).scheduleID(candidate.scheduleId());
+                    return true;
+                }
             }
-        }
         return false;
     }
 
@@ -180,6 +211,7 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
                 && candidate.providedExpirationSecond() == requested.providedExpirationSecond()
                 && Objects.equals(candidate.memo(), requested.memo())
                 && Objects.equals(candidate.adminKey(), requested.adminKey())
+                // @note We should check scheduler here, but mono doesn't, so we cannot either, yet.
                 && Objects.equals(candidate.scheduledTransaction(), requested.scheduledTransaction());
     }
 
@@ -238,11 +270,29 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
         }
     }
 
+    private void validatePayerAndScheduler(
+            final PreHandleContext context, final ScheduleCreateTransactionBody scheduleBody) throws PreCheckException {
+        final ReadableAccountStore accountStore = context.createStore(ReadableAccountStore.class);
+        final AccountID payerForSchedule = scheduleBody.payerAccountID();
+        if (payerForSchedule != null) {
+            final Account payer = accountStore.getAccountById(payerForSchedule);
+            if (payer == null) {
+                throw new PreCheckException(ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST);
+            }
+        }
+        final AccountID schedulerId = context.payer();
+        if (schedulerId != null) {
+            final Account scheduler = accountStore.getAccountById(schedulerId);
+            if (scheduler == null) {
+                throw new PreCheckException(ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST);
+            }
+        }
+    }
+
     private void checkSchedulableWhitelist(
             @NonNull final ScheduleCreateTransactionBody scheduleCreate, @NonNull final SchedulingConfig config)
             throws PreCheckException {
         final Set<HederaFunctionality> whitelist = config.whitelist().functionalitySet();
-        // Argh. Spotless is forced wrapping of fluent expressions at 73 characters.
         final DataOneOfType transactionType =
                 scheduleCreate.scheduledTransactionBody().data().kind();
         final HederaFunctionality functionType = HandlerUtility.functionalityForType(transactionType);

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtilityTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtilityTest.java
@@ -68,18 +68,6 @@ class ScheduleStoreUtilityTest extends ScheduleTestBase {
         assertThat(hashValue).isEqualTo(SCHEDULE_IN_STATE_ALTERNATE_SCHEDULED_SHA256);
         testSchedule.scheduledTransaction(scheduleInState.scheduledTransaction());
 
-        testSchedule.payerAccountId(admin);
-        hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());
-        assertThat(hashValue).isNotEqualTo(SCHEDULE_IN_STATE_SHA256);
-        assertThat(hashValue).isEqualTo(SCHEDULE_IN_STATE_ADMIN_IS_PAYER_SHA256);
-        testSchedule.payerAccountId(scheduleInState.payerAccountId());
-
-        testSchedule.schedulerAccountId(payer);
-        hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());
-        assertThat(hashValue).isNotEqualTo(SCHEDULE_IN_STATE_SHA256);
-        assertThat(hashValue).isEqualTo(SCHEDULE_IN_STATE_PAYER_IS_SCHEDULER_SHA256);
-        testSchedule.schedulerAccountId(scheduleInState.schedulerAccountId());
-
         testSchedule.memo(ODD_MEMO);
         hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());
         assertThat(hashValue).isNotEqualTo(SCHEDULE_IN_STATE_SHA256);
@@ -119,6 +107,16 @@ class ScheduleStoreUtilityTest extends ScheduleTestBase {
         hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());
         assertThat(hashValue).isEqualTo(SCHEDULE_IN_STATE_SHA256);
         testSchedule.executed(scheduleInState.executed());
+
+        testSchedule.payerAccountId(admin);
+        hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());
+        assertThat(hashValue).isEqualTo(SCHEDULE_IN_STATE_SHA256);
+        testSchedule.payerAccountId(scheduleInState.payerAccountId());
+
+        testSchedule.schedulerAccountId(payer);
+        hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());
+        assertThat(hashValue).isEqualTo(SCHEDULE_IN_STATE_SHA256);
+        testSchedule.schedulerAccountId(scheduleInState.schedulerAccountId());
 
         testSchedule.resolutionTime(modifiedResolutionTime);
         hashValue = ScheduleStoreUtility.calculateStringHash(testSchedule.build());

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
@@ -134,21 +134,17 @@ public class ScheduleTestBase {
             Bytes.fromHex("983470192754092657adbdbeef61948794713207439248567184729049081327");
     // A few random values for fake schedule hashes
     protected static final String SCHEDULE_IN_STATE_SHA256 =
-            "6d850a46e97dd8a4eafd3d7c114d0d151349e4f8531301b22c5fe508f712b6e4";
+            "5a89e2e2ef363aa047e2ca032cc8fbff02cf64f5536e350bc252dcbc6e76fd76";
     protected static final String SCHEDULE_IN_STATE_0_EXPIRE_SHA256 =
-            "d08c66b1aea67d7b26d12f3eb049c9cd5c62a704355ae9e4afcc20220242aeb8";
+            "4a9a1bd0a6487bac0924da771d4bb62ed72391c15602eaee394991929bdde427";
     protected static final String SCHEDULE_IN_STATE_PAYER_IS_ADMIN_SHA256 =
-            "eb2a14bfa714e03b8b638d0a869307c40edcc582d1e422f7e7cbdfae9e94e179";
+            "ef76f6e13f805b9ab5ae0e6fd9fd5976aba14e1b1f7cb4ecbd07fbc298f90ee5";
     protected static final String SCHEDULE_IN_STATE_ALTERNATE_SCHEDULED_SHA256 =
-            "a8faabddb49666f87fe5b392f617898437efe55ed43e03f5939583a44dbf0394";
-    protected static final String SCHEDULE_IN_STATE_ADMIN_IS_PAYER_SHA256 =
-            "a90f258d2f17458813e94ee8300d9e14573879e4c7a6b7a8d7787c2b294e5aa2";
-    protected static final String SCHEDULE_IN_STATE_PAYER_IS_SCHEDULER_SHA256 =
-            "8bb64547bbe47ff03ce476eef60746935367c5e9eaa47c02e16d3d697ee4e409";
+            "1e2ec1fa33fce66166497aeffa8a0af690e257cafad02063a13191cabc2c2de3";
     protected static final String SCHEDULE_IN_STATE_ODD_MEMO_SHA256 =
-            "f545d65f1351319764fb2934dcc2db44775c8e42291d41168f32fe0e217d51ca";
+            "7788f7de741c9ef2e7bf371095ea497a0eaed1ad9b6cba2489f34f565ee70556";
     protected static final String SCHEDULE_IN_STATE_WAIT_EXPIRE_SHA256 =
-            "8b91851ebd425c9e658fd3ad6d0ad72e6e4cedab58c518485ae3876f551bb001";
+            "87cfae9fd8f15126af9ba8be0155c57f1cf0838c4915f4e0ea297a15d5d3a3b9";
     protected static final String SCHEDULED_TRANSACTION_MEMO = "Les ħ2ᛏᚺᛂ🌕 goo";
     protected static final String ODD_MEMO = "she had marvelous judgement, Don... if not particularly good taste.";
     // a few typed null values to avoid casting null

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandlerTest.java
@@ -112,7 +112,7 @@ class ScheduleCreateHandlerTest extends ScheduleHandlerTestBase {
         final TransactionBody createBody = scheduleCreateTransaction(payer);
         realPreContext = new PreHandleContextImpl(mockStoreFactory, createBody, testConfig, mockDispatcher);
         Assertions.assertThrowsPreCheck(
-                () -> subject.preHandle(realPreContext), ResponseCodeEnum.INVALID_SCHEDULE_PAYER_ID);
+                () -> subject.preHandle(realPreContext), ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleDeleteSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleDeleteSpecs.java
@@ -25,7 +25,9 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.submitMessageTo;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.schedule.ScheduleLongTermExecutionSpecs.withAndWithoutLongTermEnabled;
+import static com.hedera.services.bdd.suites.schedule.ScheduleLongTermSignSpecs.SCHEDULING_WHITELIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SCHEDULE_ALREADY_DELETED;
@@ -67,9 +69,11 @@ public class ScheduleDeleteSpecs extends HapiSuite {
                 deletingExecutedIsPointless()));
     }
 
+    @HapiTest
     private HapiSpec deleteWithNoAdminKeyFails() {
         return defaultHapiSpec("DeleteWithNoAdminKeyFails")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,CryptoCreate"),
                         cryptoCreate(SENDER),
                         cryptoCreate(RECEIVER),
                         scheduleCreate(VALID_SCHEDULED_TXN, cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1))))
@@ -77,9 +81,11 @@ public class ScheduleDeleteSpecs extends HapiSuite {
                 .then(scheduleDelete(VALID_SCHEDULED_TXN).hasKnownStatus(SCHEDULE_IS_IMMUTABLE));
     }
 
+    @HapiTest
     private HapiSpec unauthorizedDeletionFails() {
         return defaultHapiSpec("UnauthorizedDeletionFails")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,CryptoCreate"),
                         newKeyNamed(ADMIN),
                         newKeyNamed("non-admin-key"),
                         cryptoCreate(SENDER),
@@ -92,9 +98,11 @@ public class ScheduleDeleteSpecs extends HapiSuite {
                         .hasKnownStatus(INVALID_SIGNATURE));
     }
 
+    @HapiTest
     private HapiSpec deletingAlreadyDeletedIsObvious() {
         return defaultHapiSpec("DeletingAlreadyDeletedIsObvious")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,CryptoCreate"),
                         cryptoCreate(SENDER),
                         cryptoCreate(RECEIVER),
                         newKeyNamed(ADMIN),
@@ -121,6 +129,7 @@ public class ScheduleDeleteSpecs extends HapiSuite {
     private HapiSpec deletingExecutedIsPointless() {
         return defaultHapiSpec("DeletingExecutedIsPointless")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,CryptoCreate,ConsensusSubmitMessage"),
                         createTopic("ofGreatInterest"),
                         newKeyNamed(ADMIN),
                         scheduleCreate(VALID_SCHEDULED_TXN, submitMessageTo("ofGreatInterest"))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleRecordSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleRecordSpecs.java
@@ -274,9 +274,11 @@ public class ScheduleRecordSpecs extends HapiSuite {
                 .then(cryptoCreate("nope").txnId("withScheduled").hasPrecheck(TRANSACTION_ID_FIELD_NOT_ALLOWED));
     }
 
+    @HapiTest
     public HapiSpec executionTimeIsAvailable() {
         return defaultHapiSpec("ExecutionTimeIsAvailable")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,ContractCall"),
                         cryptoCreate(PAYER),
                         cryptoCreate(RECEIVER).receiverSigRequired(true).balance(0L))
                 .when(
@@ -291,9 +293,11 @@ public class ScheduleRecordSpecs extends HapiSuite {
                 .then(getScheduleInfo("tb").logged().wasExecutedBy(TRIGGER));
     }
 
+    @HapiTest
     public HapiSpec deletionTimeIsAvailable() {
         return defaultHapiSpec("DeletionTimeIsAvailable")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,ContractCall"),
                         newKeyNamed(ADMIN),
                         cryptoCreate(PAYER),
                         cryptoCreate(RECEIVER).receiverSigRequired(true).balance(0L))
@@ -312,6 +316,7 @@ public class ScheduleRecordSpecs extends HapiSuite {
     public HapiSpec allRecordsAreQueryable() {
         return defaultHapiSpec("AllRecordsAreQueryable")
                 .given(
+                        overriding(SCHEDULING_WHITELIST, "CryptoTransfer,ContractCall"),
                         cryptoCreate(PAYER),
                         cryptoCreate(RECEIVER).receiverSigRequired(true).balance(0L))
                 .when(


### PR DESCRIPTION
 * Fixed poor exception handling that caused massive runaway and time expansion when the hapi node fails.
 * Added HapiTest annotation for many schedule tests
 * Began working through issus in ScheduleCreate spec
 * Modifications to schedule handlers to increase passing tests
 * Added a `KeyComparator` class to compare Key objects and impose a total order on collections of Keys.
   * This is necessary to have deterministic order of key collections (particularly sets and maps) across nodes.
