### PR TITLE
Enable `AutoAccountUpdateSuite` test

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -409,7 +409,6 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
                 Math.max(explicitAutoAssocSlotLifetime, oldLifetime),
                 newSlotsUsage,
                 Math.max(explicitAutoAssocSlotLifetime, newLifetime));
-        System.out.println("rbsDelta = " + rbsDelta + ", slotRbsDelta = " + slotRbsDelta + "baseSize = " + baseSize);
         return feeCalculator
                 .addBytesPerTransaction(baseSize)
                 .addRamByteSeconds(rbsDelta > 0 ? rbsDelta : 0)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyFactory.java
@@ -263,6 +263,8 @@ public class KeyFactory implements Serializable {
         private void signRecursively(final Key key, final SigControl controller) throws GeneralSecurityException {
             switch (controller.getNature()) {
                 case SIG_OFF:
+                    keySigs.add(new AbstractMap.SimpleEntry<>(extractPubKey(key), new byte[0]));
+                    break;
                 case CONTRACT_ID:
                 case DELEGATABLE_CONTRACT_ID:
                     break;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
@@ -87,6 +87,7 @@ public class TrieSigMapGenerator implements SigMapGenerator {
 
         final Function<byte[], byte[]> prefixCalc = getPrefixCalcFor(trie);
         return keySigs.stream()
+                .filter(keySig -> keySig.getValue().length > 0)
                 .map(keySig -> {
                     final var key = keySig.getKey();
                     final var wrappedKey = ByteString.copyFrom(key);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -79,8 +80,11 @@ public class TrieSigMapGenerator implements SigMapGenerator {
 
     @Override
     public SignatureMap forPrimitiveSigs(final HapiSpec spec, final List<Map.Entry<byte[], byte[]>> keySigs) {
-        List<byte[]> keys = keySigs.stream().map(Map.Entry::getKey).collect(toList());
-        ByteTrie trie = new ByteTrie(keys);
+        Set<ByteString> keys = keySigs.stream()
+                .map(Map.Entry::getKey)
+                .map(ByteString::copyFrom)
+                .collect(Collectors.toSet());
+        ByteTrie trie = new ByteTrie(keys.stream().map(ByteString::toByteArray).collect(toList()));
 
         final Set<ByteString> alwaysFullPrefixes =
                 (fullPrefixKeys == null) ? Collections.emptySet() : fullPrefixSetFor(spec);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountUpdateSuite.java
@@ -120,7 +120,7 @@ public class AutoAccountUpdateSuite extends HapiSuite {
                                 .has(accountWith().expectedBalanceWithChargedUsd((2 * ONE_HUNDRED_HBARS), 0, 0)));
     }
 
-    //    @HapiTest  disable to unblock other PRs
+    @HapiTest
     private HapiSpec updateKeyOnAutoCreatedAccount() {
         final var complexKey = "complexKey";
 


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/9434

Enable `AutoAccountUpdateSuite` updateKeyOnAutoCreatedAccount test. 
Fixes an issue in client side while generating signatureMaps, and add all the public keys that are needed by the transaction which may or may not have signatures for public key prefix matching.
