### PR TITLE
Leftovers in `TraceabilitySuite`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -454,7 +454,7 @@ public class HandleWorkflow {
                             throw new HandleException(INSUFFICIENT_PAYER_BALANCE);
                         }
                     }
-                    
+
                     // Do not override to SUCCESS if there is an error status
                     if (recordBuilder.status() == OK) {
                         recordBuilder.status(SUCCESS);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -454,7 +454,11 @@ public class HandleWorkflow {
                             throw new HandleException(INSUFFICIENT_PAYER_BALANCE);
                         }
                     }
-                    recordBuilder.status(SUCCESS);
+                    
+                    // Do not override to SUCCESS if there is an error status
+                    if (recordBuilder.status() == OK) {
+                        recordBuilder.status(SUCCESS);
+                    }
 
                     // After transaction is successfully handled update the gas throttle by leaking the unused gas
                     if (isGasThrottled(transactionInfo.functionality()) && recordBuilder.hasContractResult()) {

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -36,6 +36,8 @@ public record ContractsConfig(
         @ConfigProperty(value = "localCall.estRetBytes", defaultValue = "32") @NetworkProperty int localCallEstRetBytes,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean allowCreate2,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean allowAutoAssociations,
+        @ConfigProperty(value = "lazyCreation.enabled", defaultValue = "false") @NetworkProperty
+                boolean lazyCreationEnabled,
         // @ConfigProperty(defaultValue =
         // "TokenAssociateToAccount,TokenDissociateFromAccount,TokenFreezeAccount,TokenUnfreezeAccount,TokenGrantKycToAccount,TokenRevokeKycFromAccount,TokenAccountWipe,TokenBurn,TokenDelete,TokenMint,TokenUnpause,TokenPause,TokenCreate,TokenUpdate,ContractCall,CryptoTransfer") Set<HederaFunctionality> allowSystemUseOfHapiSigs,
         @ConfigProperty(defaultValue = "0") @NetworkProperty long maxNumWithHapiSigsAccess,

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -36,8 +36,6 @@ public record ContractsConfig(
         @ConfigProperty(value = "localCall.estRetBytes", defaultValue = "32") @NetworkProperty int localCallEstRetBytes,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean allowCreate2,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean allowAutoAssociations,
-        @ConfigProperty(value = "lazyCreation.enabled", defaultValue = "true") @NetworkProperty
-                boolean lazyCreationEnabled,
         // @ConfigProperty(defaultValue =
         // "TokenAssociateToAccount,TokenDissociateFromAccount,TokenFreezeAccount,TokenUnfreezeAccount,TokenGrantKycToAccount,TokenRevokeKycFromAccount,TokenAccountWipe,TokenBurn,TokenDelete,TokenMint,TokenUnpause,TokenPause,TokenCreate,TokenUpdate,ContractCall,CryptoTransfer") Set<HederaFunctionality> allowSystemUseOfHapiSigs,
         @ConfigProperty(defaultValue = "0") @NetworkProperty long maxNumWithHapiSigsAccess,

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -36,7 +36,7 @@ public record ContractsConfig(
         @ConfigProperty(value = "localCall.estRetBytes", defaultValue = "32") @NetworkProperty int localCallEstRetBytes,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean allowCreate2,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean allowAutoAssociations,
-        @ConfigProperty(value = "lazyCreation.enabled", defaultValue = "false") @NetworkProperty
+        @ConfigProperty(value = "lazyCreation.enabled", defaultValue = "true") @NetworkProperty
                 boolean lazyCreationEnabled,
         // @ConfigProperty(defaultValue =
         // "TokenAssociateToAccount,TokenDissociateFromAccount,TokenFreezeAccount,TokenUnfreezeAccount,TokenGrantKycToAccount,TokenRevokeKycFromAccount,TokenAccountWipe,TokenBurn,TokenDelete,TokenMint,TokenUnpause,TokenPause,TokenCreate,TokenUpdate,ContractCall,CryptoTransfer") Set<HederaFunctionality> allowSystemUseOfHapiSigs,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -146,8 +146,7 @@ public class HandleHederaOperations implements HederaOperations {
      */
     @Override
     public long lazyCreationCostInGas() {
-        // TODO - implement correctly
-        return 500_000L;
+        return context.feeCalculator(SubType.DEFAULT).calculate().totalFee() / gasPriceInTinybars();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -147,7 +147,7 @@ public class HandleHederaOperations implements HederaOperations {
     @Override
     public long lazyCreationCostInGas() {
         // TODO - implement correctly
-        return 1L;
+        return 500_000L;
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -42,6 +42,7 @@ import com.hedera.node.app.service.contract.impl.state.WritableContractStateStor
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
+import com.hedera.node.app.spi.fees.*;
 import com.hedera.node.app.spi.records.BlockRecordInfo;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -78,6 +79,12 @@ class HandleHederaOperationsTest {
 
     @Mock
     private TinybarValues tinybarValues;
+
+    @Mock
+    private FeeCalculator feeCalculator;
+
+    @Mock
+    private Fees fees;
 
     private HandleHederaOperations subject;
 
@@ -155,6 +162,11 @@ class HandleHederaOperationsTest {
     @Test
     void lazyCreationCostInGasHardcoded() {
         assertEquals(1L, subject.lazyCreationCostInGas());
+        given(context.feeCalculator(SubType.DEFAULT)).willReturn(feeCalculator);
+        given(feeCalculator.calculate()).willReturn(fees);
+        given(fees.totalFee()).willReturn(20_000_000L);
+        given(tinybarValues.topLevelTinybarGasPrice()).willReturn(50L);
+        assertEquals(400_000L, subject.lazyCreationCostInGas());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -161,7 +161,6 @@ class HandleHederaOperationsTest {
 
     @Test
     void lazyCreationCostInGasHardcoded() {
-        assertEquals(1L, subject.lazyCreationCostInGas());
         given(context.feeCalculator(SubType.DEFAULT)).willReturn(feeCalculator);
         given(feeCalculator.calculate()).willReturn(fees);
         given(fees.totalFee()).willReturn(20_000_000L);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -130,7 +130,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.jupiter.api.Order;
 
 @HapiTestSuite
 public class TraceabilitySuite extends HapiSuite {
@@ -227,7 +226,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(1)
     private HapiSpec traceabilityE2EScenario1() {
         return defaultHapiSpec("traceabilityE2EScenario1")
                 .given(
@@ -597,7 +595,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(2)
     private HapiSpec traceabilityE2EScenario2() {
         return defaultHapiSpec("traceabilityE2EScenario2")
                 .given(
@@ -1002,7 +999,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(3)
     private HapiSpec traceabilityE2EScenario3() {
         return defaultHapiSpec("traceabilityE2EScenario3")
                 .given(
@@ -1410,7 +1406,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(4)
     private HapiSpec traceabilityE2EScenario4() {
         return defaultHapiSpec("traceabilityE2EScenario4")
                 .given(
@@ -1701,7 +1696,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(5)
     private HapiSpec traceabilityE2EScenario5() {
         return defaultHapiSpec("traceabilityE2EScenario5")
                 .given(
@@ -2004,7 +1998,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(6)
     private HapiSpec traceabilityE2EScenario6() {
         return defaultHapiSpec("traceabilityE2EScenario6")
                 .given(
@@ -2339,7 +2332,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(7)
     private HapiSpec traceabilityE2EScenario7() {
         return defaultHapiSpec("traceabilityE2EScenario7")
                 .given(
@@ -2730,7 +2722,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(8)
     private HapiSpec traceabilityE2EScenario8() {
         return defaultHapiSpec("traceabilityE2EScenario8")
                 .given(
@@ -3082,7 +3073,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(9)
     private HapiSpec traceabilityE2EScenario9() {
         return defaultHapiSpec("traceabilityE2EScenario9")
                 .given(
@@ -3388,7 +3378,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(10)
     private HapiSpec traceabilityE2EScenario10() {
         return defaultHapiSpec("traceabilityE2EScenario10")
                 .given(
@@ -3730,7 +3719,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(11)
     private HapiSpec traceabilityE2EScenario11() {
         return defaultHapiSpec("traceabilityE2EScenario11")
                 .given(
@@ -4007,7 +3995,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(12)
     private HapiSpec traceabilityE2EScenario12() {
         final var contract = "CreateTrivial";
         final var scenario12 = "traceabilityE2EScenario12";
@@ -4040,7 +4027,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(13)
     private HapiSpec traceabilityE2EScenario13() {
         final AtomicReference<AccountID> accountIDAtomicReference = new AtomicReference<>();
         return propertyPreservingHapiSpec("traceabilityE2EScenario13")
@@ -4086,7 +4072,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(14)
     private HapiSpec traceabilityE2EScenario14() {
         return propertyPreservingHapiSpec("traceabilityE2EScenario14")
                 .preserving(CHAIN_ID_PROPERTY)
@@ -4132,7 +4117,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(15)
     private HapiSpec traceabilityE2EScenario15() {
         final String GET_BYTECODE = "getBytecode";
         final String DEPLOY = "deploy";
@@ -4272,7 +4256,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(16)
     private HapiSpec traceabilityE2EScenario16() {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final String PRECOMPILE_CALLER = "PrecompileCaller";
@@ -4382,7 +4365,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(17)
     private HapiSpec traceabilityE2EScenario17() {
         return defaultHapiSpec("traceabilityE2EScenario17")
                 .given(
@@ -4441,7 +4423,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(18)
     private HapiSpec traceabilityE2EScenario18() {
         return defaultHapiSpec("traceabilityE2EScenario18")
                 .given(uploadInitCode(REVERTING_CONTRACT))
@@ -4466,7 +4447,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(19)
     private HapiSpec traceabilityE2EScenario19() {
         final var RECEIVER = "RECEIVER";
         final var hbarsToSend = 1;
@@ -4512,7 +4492,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(20)
     private HapiSpec traceabilityE2EScenario20() {
         return defaultHapiSpec("traceabilityE2EScenario20")
                 .given(uploadInitCode(REVERTING_CONTRACT))
@@ -4538,7 +4517,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
-    @Order(21)
     private HapiSpec traceabilityE2EScenario21() {
         return defaultHapiSpec("traceabilityE2EScenario21")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4026,7 +4026,8 @@ public class TraceabilitySuite extends HapiSuite {
                         expectContractBytecode(TRACEABILITY_TXN, contract));
     }
 
-    HapiSpec traceabilityE2EScenario13() {
+    @HapiTest
+    private HapiSpec traceabilityE2EScenario13() {
         final AtomicReference<AccountID> accountIDAtomicReference = new AtomicReference<>();
         return defaultHapiSpec("traceabilityE2EScenario13")
                 .given(
@@ -4068,6 +4069,7 @@ public class TraceabilitySuite extends HapiSuite {
                         expectContractBytecodeWithMinimalFieldsSidecarFor(FIRST_CREATE_TXN, PAY_RECEIVABLE_CONTRACT));
     }
 
+    @HapiTest
     private HapiSpec traceabilityE2EScenario14() {
         return defaultHapiSpec("traceabilityE2EScenario14")
                 .given(
@@ -4110,7 +4112,8 @@ public class TraceabilitySuite extends HapiSuite {
                 }));
     }
 
-    HapiSpec traceabilityE2EScenario15() {
+    @HapiTest
+    private HapiSpec traceabilityE2EScenario15() {
         final String GET_BYTECODE = "getBytecode";
         final String DEPLOY = "deploy";
         final var CREATE_2_TXN = "Create2Txn";
@@ -4248,7 +4251,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .then();
     }
 
-    HapiSpec traceabilityE2EScenario16() {
+    @HapiTest
+    private HapiSpec traceabilityE2EScenario16() {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final String PRECOMPILE_CALLER = "PrecompileCaller";
         final String txn = "payTxn";
@@ -4438,7 +4442,8 @@ public class TraceabilitySuite extends HapiSuite {
                                 FIRST_CREATE_TXN, REVERTING_CONTRACT, BigInteger.valueOf(4)));
     }
 
-    HapiSpec traceabilityE2EScenario19() {
+    @HapiTest
+    private HapiSpec traceabilityE2EScenario19() {
         final var RECEIVER = "RECEIVER";
         final var hbarsToSend = 1;
         final var transferTxn = "payTxn";
@@ -4480,6 +4485,7 @@ public class TraceabilitySuite extends HapiSuite {
                 }));
     }
 
+    @HapiTest
     private HapiSpec traceabilityE2EScenario20() {
         return defaultHapiSpec("traceabilityE2EScenario20")
                 .given(uploadInitCode(REVERTING_CONTRACT))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4029,8 +4029,10 @@ public class TraceabilitySuite extends HapiSuite {
     @HapiTest
     private HapiSpec traceabilityE2EScenario13() {
         final AtomicReference<AccountID> accountIDAtomicReference = new AtomicReference<>();
-        return defaultHapiSpec("traceabilityE2EScenario13")
+        return propertyPreservingHapiSpec("traceabilityE2EScenario13")
+                .preserving(CHAIN_ID_PROPERTY)
                 .given(
+                        overriding(CHAIN_ID_PROPERTY, "298"),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
                         cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
@@ -4071,8 +4073,10 @@ public class TraceabilitySuite extends HapiSuite {
 
     @HapiTest
     private HapiSpec traceabilityE2EScenario14() {
-        return defaultHapiSpec("traceabilityE2EScenario14")
+        return propertyPreservingHapiSpec("traceabilityE2EScenario14")
+                .preserving(CHAIN_ID_PROPERTY)
                 .given(
+                        overriding(CHAIN_ID_PROPERTY, "298"),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
                         cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
@@ -4447,8 +4451,10 @@ public class TraceabilitySuite extends HapiSuite {
         final var RECEIVER = "RECEIVER";
         final var hbarsToSend = 1;
         final var transferTxn = "payTxn";
-        return defaultHapiSpec("traceabilityE2EScenario19")
+        return propertyPreservingHapiSpec("traceabilityE2EScenario19")
+                .preserving(CHAIN_ID_PROPERTY)
                 .given(
+                        overriding(CHAIN_ID_PROPERTY, "298"),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RECEIVER).balance(0L),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -4828,6 +4834,7 @@ public class TraceabilitySuite extends HapiSuite {
                 }));
     }
 
+    @HapiTest
     private HapiSpec ethereumLazyCreateExportsExpectedSidecars() {
         final var RECIPIENT_KEY = "lazyAccountRecipient";
         final var RECIPIENT_KEY2 = "lazyAccountRecipient2";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -130,6 +130,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.Order;
 
 @HapiTestSuite
 public class TraceabilitySuite extends HapiSuite {
@@ -226,6 +227,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(1)
     private HapiSpec traceabilityE2EScenario1() {
         return defaultHapiSpec("traceabilityE2EScenario1")
                 .given(
@@ -595,6 +597,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(2)
     private HapiSpec traceabilityE2EScenario2() {
         return defaultHapiSpec("traceabilityE2EScenario2")
                 .given(
@@ -999,6 +1002,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(3)
     private HapiSpec traceabilityE2EScenario3() {
         return defaultHapiSpec("traceabilityE2EScenario3")
                 .given(
@@ -1406,6 +1410,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(4)
     private HapiSpec traceabilityE2EScenario4() {
         return defaultHapiSpec("traceabilityE2EScenario4")
                 .given(
@@ -1696,6 +1701,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(5)
     private HapiSpec traceabilityE2EScenario5() {
         return defaultHapiSpec("traceabilityE2EScenario5")
                 .given(
@@ -1998,6 +2004,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(6)
     private HapiSpec traceabilityE2EScenario6() {
         return defaultHapiSpec("traceabilityE2EScenario6")
                 .given(
@@ -2332,6 +2339,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(7)
     private HapiSpec traceabilityE2EScenario7() {
         return defaultHapiSpec("traceabilityE2EScenario7")
                 .given(
@@ -2722,6 +2730,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(8)
     private HapiSpec traceabilityE2EScenario8() {
         return defaultHapiSpec("traceabilityE2EScenario8")
                 .given(
@@ -3073,6 +3082,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(9)
     private HapiSpec traceabilityE2EScenario9() {
         return defaultHapiSpec("traceabilityE2EScenario9")
                 .given(
@@ -3378,6 +3388,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(10)
     private HapiSpec traceabilityE2EScenario10() {
         return defaultHapiSpec("traceabilityE2EScenario10")
                 .given(
@@ -3719,6 +3730,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(11)
     private HapiSpec traceabilityE2EScenario11() {
         return defaultHapiSpec("traceabilityE2EScenario11")
                 .given(
@@ -3995,6 +4007,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(12)
     private HapiSpec traceabilityE2EScenario12() {
         final var contract = "CreateTrivial";
         final var scenario12 = "traceabilityE2EScenario12";
@@ -4027,6 +4040,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(13)
     private HapiSpec traceabilityE2EScenario13() {
         final AtomicReference<AccountID> accountIDAtomicReference = new AtomicReference<>();
         return propertyPreservingHapiSpec("traceabilityE2EScenario13")
@@ -4072,6 +4086,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(14)
     private HapiSpec traceabilityE2EScenario14() {
         return propertyPreservingHapiSpec("traceabilityE2EScenario14")
                 .preserving(CHAIN_ID_PROPERTY)
@@ -4117,6 +4132,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(15)
     private HapiSpec traceabilityE2EScenario15() {
         final String GET_BYTECODE = "getBytecode";
         final String DEPLOY = "deploy";
@@ -4256,6 +4272,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(16)
     private HapiSpec traceabilityE2EScenario16() {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final String PRECOMPILE_CALLER = "PrecompileCaller";
@@ -4365,6 +4382,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(17)
     private HapiSpec traceabilityE2EScenario17() {
         return defaultHapiSpec("traceabilityE2EScenario17")
                 .given(
@@ -4423,6 +4441,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(18)
     private HapiSpec traceabilityE2EScenario18() {
         return defaultHapiSpec("traceabilityE2EScenario18")
                 .given(uploadInitCode(REVERTING_CONTRACT))
@@ -4447,6 +4466,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(19)
     private HapiSpec traceabilityE2EScenario19() {
         final var RECEIVER = "RECEIVER";
         final var hbarsToSend = 1;
@@ -4492,6 +4512,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(20)
     private HapiSpec traceabilityE2EScenario20() {
         return defaultHapiSpec("traceabilityE2EScenario20")
                 .given(uploadInitCode(REVERTING_CONTRACT))
@@ -4517,6 +4538,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @HapiTest
+    @Order(21)
     private HapiSpec traceabilityE2EScenario21() {
         return defaultHapiSpec("traceabilityE2EScenario21")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4926,7 +4926,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5960")
-    @HapiTest
     private HapiSpec hollowAccountCreate2MergeExportsExpectedSidecars() {
         final var tcValue = 1_234L;
         final var create2Factory = "Create2Factory";
@@ -5093,7 +5092,6 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5960")
-    @HapiTest
     private HapiSpec assertSidecars() {
         return defaultHapiSpec("assertSidecars")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4926,6 +4926,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5960")
+    @HapiTest
     private HapiSpec hollowAccountCreate2MergeExportsExpectedSidecars() {
         final var tcValue = 1_234L;
         final var create2Factory = "Create2Factory";
@@ -5092,6 +5093,7 @@ public class TraceabilitySuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5960")
+    @HapiTest
     private HapiSpec assertSidecars() {
         return defaultHapiSpec("assertSidecars")
                 .given(


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

There are several tests that need to be fixed. Most of them are using Ethereum transactions or contract deployment.

Problematic tests:
- hollowAccountCreate2MergeExportsExpectedSidecars - missing `lazyCreation.enabled` in `ContractsConfig`, added it but still no success
- assertSidecars - `sidecarWatcher.thereAreNoPendingSidecars()` returns false and the `sidecarWatcher` has status `Pending sidecars not yet seen`
- ethereumLazyCreateExportsExpectedSidecars - same as `hollowAccountCreate2MergeExportsExpectedSidecars` test

Done:
- traceabilityE2EScenario13
- traceabilityE2EScenario14
- traceabilityE2EScenario15
- traceabilityE2EScenario16
- traceabilityE2EScenario19
- traceabilityE2EScenario20

**Depends on**:

- https://github.com/hashgraph/hedera-services/pull/9498

**Related issue(s)**:

Fixes #8918 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
