### PR TITLE
Fix `mintUniqueTokenReceiptCheck` in `UniqueTokenManagementSpecs`

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -180,6 +180,8 @@ public class RecordFinalizerBase {
                         persistedNft.hasOwnerId() && !persistedNft.ownerId().equals(AccountID.DEFAULT);
                 // If the NFT did not have an owner before set it to the treasury account
                 senderAccountId = hasOwnerId ? persistedNft.ownerId() : token.treasuryAccountId();
+            } else {
+                senderAccountId = ZERO_ACCOUNT_ID;
             }
 
             // If the NFT has been burned or wiped, modifiedNft will be null. In that case the receiverId

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -173,8 +173,9 @@ public class RecordFinalizerBase {
 
             // The NFT may not have existed before, in which case we'll use a null sender account ID
             AccountID senderAccountId = null;
+            final var token = readableTokenStore.get(nftId.tokenId());
+
             if (persistedNft != null) {
-                final var token = readableTokenStore.get(nftId.tokenId());
                 final boolean hasOwnerId =
                         persistedNft.hasOwnerId() && !persistedNft.ownerId().equals(AccountID.DEFAULT);
                 // If the NFT did not have an owner before set it to the treasury account
@@ -185,7 +186,9 @@ public class RecordFinalizerBase {
             // will be explicitly set as 0.0.0
             final var builder = NftTransfer.newBuilder();
             if (modifiedNft != null) {
-                builder.receiverAccountID(modifiedNft.ownerId());
+                // If ownerId is null, we assume that the receiver is the treasury
+                final var receiverAccountID = modifiedNft.hasOwnerId() ? modifiedNft.ownerId() : token.treasuryAccountId();
+                builder.receiverAccountID(receiverAccountID);
             } else {
                 builder.receiverAccountID(ZERO_ACCOUNT_ID);
             }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -187,7 +187,8 @@ public class RecordFinalizerBase {
             final var builder = NftTransfer.newBuilder();
             if (modifiedNft != null) {
                 // If ownerId is null, we assume that the receiver is the treasury
-                final var receiverAccountID = modifiedNft.hasOwnerId() ? modifiedNft.ownerId() : token.treasuryAccountId();
+                final var receiverAccountID =
+                        modifiedNft.hasOwnerId() ? modifiedNft.ownerId() : token.treasuryAccountId();
                 builder.receiverAccountID(receiverAccountID);
             } else {
                 builder.receiverAccountID(ZERO_ACCOUNT_ID);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeChildRecordHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeChildRecordHandlerTest.java
@@ -509,7 +509,7 @@ class FinalizeChildRecordHandlerTest extends CryptoTokenHandlerTestBase {
                         .token(TOKEN_321)
                         .nftTransfers(NftTransfer.newBuilder()
                                 .serialNumber(1)
-                                .senderAccountID((AccountID) null)
+                                .senderAccountID(ZERO_ACCOUNT_ID)
                                 .receiverAccountID(ACCOUNT_3434_ID)
                                 .build())
                         .build()));

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeParentRecordHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeParentRecordHandlerTest.java
@@ -744,7 +744,7 @@ class FinalizeParentRecordHandlerTest extends CryptoTokenHandlerTestBase {
                         .token(TOKEN_321)
                         .nftTransfers(NftTransfer.newBuilder()
                                 .serialNumber(1)
-                                .senderAccountID((AccountID) null)
+                                .senderAccountID(ZERO_ACCOUNT_ID)
                                 .receiverAccountID(ACCOUNT_3434_ID)
                                 .build())
                         .build()));

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
@@ -131,6 +131,8 @@ public class CryptoTokenHandlerTestBase extends StateBuilderUtil {
     protected final EntityNumber node1Id = EntityNumber.newBuilder().number(1L).build();
 
     /* ---------- Account IDs */
+    protected final AccountID ZERO_ACCOUNT_ID =
+            AccountID.newBuilder().accountNum(0).build();
     protected final AccountID payerId = AccountID.newBuilder().accountNum(3).build();
     protected final AccountID deleteAccountId =
             AccountID.newBuilder().accountNum(3213).build();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -800,6 +800,7 @@ public class UniqueTokenManagementSpecs extends HapiSuite {
                 .then(wipeTokenAccount(NFT, ACCOUNT, List.of(-5L, -6L)).hasPrecheck(INVALID_NFT_ID));
     }
 
+    @HapiTest
     private HapiSpec mintUniqueTokenReceiptCheck() {
         return defaultHapiSpec("mintUniqueTokenReceiptCheck")
                 .given(


### PR DESCRIPTION
**Description**:
This PR fix `mintUniqueTokenReceiptCheck` in `UniqueTokenManagementSpecs` by setting the treasury as owner, if ownerId is null.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
