### PR TITLE
Disable post-upgrade stake housekeeping

### DIFF
--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -45,7 +45,8 @@ staking.maxStakeRewarded=5000000000000000000
 staking.periodMins=1
 staking.rewardBalanceThreshold=0
 staking.rewardHistory.numStoredPeriods=365
-staking.startupHelper.recompute=NODE_STAKES,PENDING_REWARDS
+# Comma-separated list of { NODE_STAKES, PENDING_REWARDS }
+staking.startupHelper.recompute=
 tokens.storeRelsOnDisk=true
 hedera.workflows.enabled=
 # Dynamic properties

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -45,7 +45,8 @@ staking.maxStakeRewarded=650000000000000000
 staking.periodMins=1440
 staking.rewardBalanceThreshold=8500000000000000
 staking.rewardHistory.numStoredPeriods=365
-staking.startupHelper.recompute=NODE_STAKES,PENDING_REWARDS
+# Comma-separated list of { NODE_STAKES, PENDING_REWARDS }
+staking.startupHelper.recompute=
 tokens.storeRelsOnDisk=true
 hedera.workflows.enabled=
 # Dynamic properties

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -505,7 +505,7 @@ class BootstrapPropertiesTest {
             entry(STAKING_REWARD_BALANCE_THRESHOLD, 0L),
             entry(STAKING_REQUIRE_MIN_STAKE_TO_REWARD, false),
             entry(STAKING_REWARD_HISTORY_NUM_STORED_PERIODS, 365),
-            entry(STAKING_STARTUP_HELPER_RECOMPUTE, EnumSet.allOf(StakeStartupHelper.RecomputeType.class)),
+            entry(STAKING_STARTUP_HELPER_RECOMPUTE, EnumSet.noneOf(StakeStartupHelper.RecomputeType.class)),
             entry(STAKING_PER_HBAR_REWARD_RATE, 6_849L),
             entry(STAKING_START_THRESH, 25000000000000000L),
             entry(STAKING_FEES_NODE_REWARD_PERCENT, 0),

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -45,7 +45,8 @@ staking.maxStakeRewarded=5000000000000000000
 staking.periodMins=1
 staking.rewardBalanceThreshold=0
 staking.rewardHistory.numStoredPeriods=365
-staking.startupHelper.recompute=NODE_STAKES,PENDING_REWARDS
+# Comma-separated list of { NODE_STAKES, PENDING_REWARDS }
+staking.startupHelper.recompute=
 tokens.storeRelsOnDisk=true
 hedera.workflows.enabled=
 # Dynamic properties

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -45,7 +45,8 @@ staking.maxStakeRewarded=5000000000000000000
 staking.periodMins=1440
 staking.rewardBalanceThreshold=0
 staking.rewardHistory.numStoredPeriods=365
-staking.startupHelper.recompute=NODE_STAKES,PENDING_REWARDS
+# Comma-separated list of { NODE_STAKES, PENDING_REWARDS }
+staking.startupHelper.recompute=
 tokens.storeRelsOnDisk=true
 hedera.workflows.enabled=
 # Dynamic properties


### PR DESCRIPTION
**Description**:
 - Closes #9473 by making `staking.startupHelper.recompute` the empty set.