### PR TITLE
use Bytes.EMPTY instead of null to indicate empty keys/values

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/IterableStorageManager.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/IterableStorageManager.java
@@ -28,7 +28,6 @@ import com.hedera.node.app.service.contract.impl.state.StorageAccesses;
 import com.hedera.node.app.service.contract.impl.state.StorageSizeChange;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,10 +109,12 @@ public class IterableStorageManager {
      * @param contractNumber the contract number
      * @return the first storage key for the contract or null if none exists.
      */
-    @Nullable
+    @NonNull
     private Bytes contractFirstKeyOf(@NonNull final Enhancement enhancement, long contractNumber) {
         final var account = enhancement.nativeOperations().getAccount(contractNumber);
-        return account != null && account.firstContractStorageKey() != null ? account.firstContractStorageKey() : null;
+        return account != null && account.firstContractStorageKey() != null
+                ? account.firstContractStorageKey()
+                : Bytes.EMPTY;
     }
 
     /**
@@ -125,10 +126,10 @@ public class IterableStorageManager {
      * @param key The slot key to remove
      * @return the new first key in the linked list of storage for the given contract
      */
-    @Nullable
+    @NonNull
     private Bytes removeAccessedValue(
             @NonNull final ContractStateStore store,
-            @Nullable final Bytes firstContractKey,
+            @NonNull final Bytes firstContractKey,
             long contractNumber,
             @NonNull final Bytes key) {
         try {
@@ -139,7 +140,7 @@ public class IterableStorageManager {
             final var nextKey = slotValue.nextKey();
             final var prevKey = slotValue.previousKey();
 
-            if (nextKey != null) {
+            if (!nextKey.equals(Bytes.EMPTY)) {
                 // Look up the next slot value
                 final var nextSlotKey = newSlotKeyFor(contractNumber, nextKey);
                 final var nextValue = slotValueFor(store, true, nextSlotKey, "Missing next key ");
@@ -149,7 +150,7 @@ public class IterableStorageManager {
                         nextValue.copyBuilder().previousKey(prevKey).build();
                 store.putSlot(nextSlotKey, newNextValue);
             }
-            if (prevKey != null) {
+            if (!prevKey.equals(Bytes.EMPTY)) {
                 // Look up the previous slot value
                 final var prevSlotKey = newSlotKeyFor(contractNumber, prevKey);
                 final var prevValue = slotValueFor(store, true, prevSlotKey, "Missing previous key ");
@@ -181,10 +182,10 @@ public class IterableStorageManager {
      * @param newKey The slot key to insert
      * @return the new first key in the linked list of storage for the given contract
      */
-    @Nullable
+    @NonNull
     private Bytes insertAccessedValue(
             @NonNull final ContractStateStore store,
-            @Nullable final Bytes firstContractKey,
+            @NonNull final Bytes firstContractKey,
             @NonNull final Bytes newValue,
             long contractNumber,
             @NonNull final Bytes newKey) {
@@ -196,7 +197,7 @@ public class IterableStorageManager {
             final var newSlotKey = newSlotKeyFor(contractNumber, newKey);
             final var newSlotValue = SlotValue.newBuilder()
                     .value(newValue)
-                    .previousKey(null)
+                    .previousKey(Bytes.EMPTY)
                     .nextKey(firstContractKey)
                     .build();
             store.putSlot(newSlotKey, newSlotValue);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/IterableStorageManager.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/IterableStorageManager.java
@@ -98,7 +98,9 @@ public class IterableStorageManager {
                 enhancement
                         .operations()
                         .updateStorageMetadata(
-                                change.contractNumber(), firstKeys.get(change.contractNumber()), change.netChange());
+                                change.contractNumber(),
+                                firstKeys.getOrDefault(change.contractNumber(), Bytes.EMPTY),
+                                change.netChange());
             }
         });
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageAccess.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageAccess.java
@@ -30,7 +30,7 @@ import org.apache.tuweni.units.bigints.UInt256;
  *
  * @param key the key of the access
  * @param value the value read or overwritten
- * @param writtenValue if not null, the overwriting value
+ * @param writtenValue if not Bytes.EMPTY, the overwriting value
  */
 public record StorageAccess(@NonNull UInt256 key, @NonNull UInt256 value, @Nullable UInt256 writtenValue) {
     public StorageAccess {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -250,7 +250,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
      */
     @Override
     public void updateStorageMetadata(
-            @NonNull final AccountID accountId, @Nullable final Bytes firstKey, final int netChangeInSlotsUsed) {
+            @NonNull final AccountID accountId, @NonNull final Bytes firstKey, final int netChangeInSlotsUsed) {
         requireNonNull(firstKey);
         requireNonNull(accountId);
         final var target = requireNonNull(accountStore.get(accountId));

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
@@ -140,10 +140,10 @@ public interface TokenServiceApi {
      * Updates the storage metadata for the given contract.
      *
      * @param accountId the id of the contract
-     * @param firstKey       the first key in the storage linked list, null if the storage is empty
+     * @param firstKey       the first key in the storage linked list, empty if the storage is empty
      * @param netChangeInSlotsUsed      the net change in the number of storage slots used by the contract
      */
-    void updateStorageMetadata(@NonNull AccountID accountId, @Nullable Bytes firstKey, int netChangeInSlotsUsed);
+    void updateStorageMetadata(@NonNull AccountID accountId, @NonNull Bytes firstKey, int netChangeInSlotsUsed);
 
     /**
      * Charges the payer the given network fee, and records that fee in the given record builder.


### PR DESCRIPTION
**Description**:
Fix broken HAPI tests by using Bytes.EMPTY instead of null

**Related issue(s)**:

Fixes #9517

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
