### PR TITLE
9512 Prevented MerkleDbStatistics from throwing exceptions if its methods called before `registerMetrics`

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -444,6 +444,9 @@ public class MerkleDbStatistics {
      */
     public void setHashesStoreCompactionTimeMs(final Integer compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
+        if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            return;
+        }
         hashesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
     }
 
@@ -455,6 +458,9 @@ public class MerkleDbStatistics {
      */
     public void setHashesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
+        if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            return;
+        }
         hashesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
     }
 
@@ -466,6 +472,9 @@ public class MerkleDbStatistics {
      */
     public void setLeavesStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
+        if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            return;
+        }
         leavesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
     }
 
@@ -476,6 +485,9 @@ public class MerkleDbStatistics {
      */
     public void setLeavesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
+        if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            return;
+        }
         leavesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
     }
 
@@ -487,6 +499,9 @@ public class MerkleDbStatistics {
      */
     public void setLeafKeysStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
+        if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            return;
+        }
         leafKeysStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
     }
 
@@ -498,6 +513,9 @@ public class MerkleDbStatistics {
      */
     public void setLeafKeysStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
+        if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            return;
+        }
         leafKeysStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -445,7 +445,6 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionTimeMs(final Integer compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
-            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         hashesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -459,8 +458,7 @@ public class MerkleDbStatistics {
      */
     public void setHashesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
-        if (hashesStoreCompactionTimeMsList.isEmpty()) {
-            // if the method called before the metrics are registered, there is nothing to do
+        if (hashesStoreCompactionSavedSpaceMbList.isEmpty()) {
             return;
         }
         hashesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
@@ -474,8 +472,7 @@ public class MerkleDbStatistics {
      */
     public void setLeavesStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
-        if (hashesStoreCompactionTimeMsList.isEmpty()) {
-            // if the method called before the metrics are registered, there is nothing to do
+        if (leavesStoreCompactionTimeMsList.isEmpty()) {
             return;
         }
         leavesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -488,8 +485,7 @@ public class MerkleDbStatistics {
      */
     public void setLeavesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
-        if (hashesStoreCompactionTimeMsList.isEmpty()) {
-            // if the method called before the metrics are registered, there is nothing to do
+        if (leavesStoreCompactionSavedSpaceMbList.isEmpty()) {
             return;
         }
         leavesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
@@ -503,8 +499,7 @@ public class MerkleDbStatistics {
      */
     public void setLeafKeysStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
-        if (hashesStoreCompactionTimeMsList.isEmpty()) {
-            // if the method called before the metrics are registered, there is nothing to do
+        if (leafKeysStoreCompactionTimeMsList.isEmpty()) {
             return;
         }
         leafKeysStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -518,8 +513,7 @@ public class MerkleDbStatistics {
      */
     public void setLeafKeysStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
-        if (hashesStoreCompactionTimeMsList.isEmpty()) {
-            // if the method called before the metrics are registered, there is nothing to do
+        if (leafKeysStoreCompactionSavedSpaceMbList.isEmpty()) {
             return;
         }
         leafKeysStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -445,6 +445,7 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionTimeMs(final Integer compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         hashesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -459,6 +460,7 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         hashesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
@@ -473,6 +475,7 @@ public class MerkleDbStatistics {
     public void setLeavesStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leavesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -486,6 +489,7 @@ public class MerkleDbStatistics {
     public void setLeavesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leavesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
@@ -500,6 +504,7 @@ public class MerkleDbStatistics {
     public void setLeafKeysStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leafKeysStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -514,6 +519,7 @@ public class MerkleDbStatistics {
     public void setLeafKeysStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leafKeysStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -445,6 +445,7 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionTimeMs(final Integer compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         hashesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -459,6 +460,7 @@ public class MerkleDbStatistics {
     public void setHashesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (hashesStoreCompactionSavedSpaceMbList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         hashesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
@@ -473,6 +475,7 @@ public class MerkleDbStatistics {
     public void setLeavesStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (leavesStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leavesStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -486,6 +489,7 @@ public class MerkleDbStatistics {
     public void setLeavesStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (leavesStoreCompactionSavedSpaceMbList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leavesStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);
@@ -500,6 +504,7 @@ public class MerkleDbStatistics {
     public void setLeafKeysStoreCompactionTimeMs(final int compactionLevel, final long value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (leafKeysStoreCompactionTimeMsList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leafKeysStoreCompactionTimeMsList.get(compactionLevel - 1).update(value);
@@ -514,6 +519,7 @@ public class MerkleDbStatistics {
     public void setLeafKeysStoreCompactionSavedSpaceMb(final int compactionLevel, final double value) {
         assert compactionLevel >= 1 && compactionLevel <= config.maxCompactionLevel();
         if (leafKeysStoreCompactionSavedSpaceMbList.isEmpty()) {
+            // if the method called before the metrics are registered, there is nothing to do
             return;
         }
         leafKeysStoreCompactionSavedSpaceMbList.get(compactionLevel - 1).update(value);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
@@ -67,6 +67,16 @@ class MerkleDbStatisticsTest {
 
     @Test
     void testInitialState() {
+        verifyMetricsDoesntThrow(statistics);
+    }
+
+    @Test
+    public void testMetricsDoesntThrowBeforeRegister() {
+        MerkleDbStatistics notRegisteredStatistics = new MerkleDbStatistics(LABEL);
+        verifyMetricsDoesntThrow(notRegisteredStatistics);
+    }
+
+    private void verifyMetricsDoesntThrow(MerkleDbStatistics statistics) {
         assertDoesNotThrow(statistics::countHashReads);
         assertDoesNotThrow(statistics::countLeafReads);
         assertDoesNotThrow(statistics::countLeafKeyReads);
@@ -82,7 +92,7 @@ class MerkleDbStatisticsTest {
         assertDoesNotThrow(() -> statistics.setLeavesStoreCompactionTimeMs(compactionLevel, 314));
         assertDoesNotThrow(() -> statistics.setLeavesStoreCompactionSavedSpaceMb(compactionLevel, Math.PI));
         assertDoesNotThrow(() -> statistics.setLeafKeysStoreCompactionTimeMs(compactionLevel, 314));
-        assertDoesNotThrow(() -> statistics.setLeafKeysStoreCompactionSavedSpaceMb(1, Math.PI));
+        assertDoesNotThrow(() -> statistics.setLeafKeysStoreCompactionSavedSpaceMb(compactionLevel, Math.PI));
         assertDoesNotThrow(() -> statistics.setOffHeapHashesIndexMb(42));
         assertDoesNotThrow(() -> statistics.setOffHeapLeavesIndexMb(42));
         assertDoesNotThrow(() -> statistics.setOffHeapLongKeysIndexMb(42));


### PR DESCRIPTION
**Description**:

This is a fix for the test failure described in #9512 and is a follow up for https://github.com/hashgraph/hedera-services/pull/9060

**Related issue(s)**:

Fixes #9512 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
