### PR TITLE
enable query payment suite

### DIFF
--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/Scenarios.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/Scenarios.java
@@ -303,6 +303,7 @@ public interface Scenarios extends TransactionFactory {
     final TestUser ALICE = new TestUser(
             account1002,
             Account.newBuilder()
+                    .tinybarBalance(100_000_000)
                     .accountId(account1002)
                     .key(FAKE_ECDSA_KEY_INFOS[2].publicKey())
                     .build(),

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
@@ -152,19 +152,23 @@ public class QueryChecker {
                 }
 
                 // The balance only needs to be checked for sent amounts (= negative values)
-                if (amount < 0 && (account.tinybarBalance() - transferTxnFee) < -amount) {
+                if (amount < 0 && (account.tinybarBalance()) < -amount) {
                     // FUTURE: Expiry should probably be checked earlier
                     expiryValidation.checkAccountExpiry(account);
                     throw new InsufficientBalanceException(INSUFFICIENT_PAYER_BALANCE, transferTxnFee);
                 }
 
                 // Make sure the node receives enough
-                if (amount >= 0 && nodeAccountID.equals(transfer.accountIDOrThrow())) {
+                if (amount >= 0 && nodeAccountID.equals(accountID)) {
                     nodeReceivesSome = true;
                     if (amount < nodePayment) {
                         throw new InsufficientBalanceException(INSUFFICIENT_TX_FEE, nodePayment);
                     }
                 }
+            }
+            // this will happen just if it is a payer
+            else if (amount < 0 && (payer.tinybarBalance() - transferTxnFee) < -amount){
+                throw new InsufficientBalanceException(INSUFFICIENT_PAYER_BALANCE, transferTxnFee);
             }
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
@@ -167,7 +167,7 @@ public class QueryChecker {
                 }
             }
             // this will happen just if it is a payer
-            else if (amount < 0 && (payer.tinybarBalance() - transferTxnFee) < -amount){
+            else if (amount < 0 && (payer.tinybarBalance() - transferTxnFee) < -amount) {
                 throw new InsufficientBalanceException(INSUFFICIENT_PAYER_BALANCE, transferTxnFee);
             }
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
@@ -69,7 +69,8 @@ public class HapiTestEnv {
                 final var workingDir = Path.of("./build/hapi-test/" + testName + "/node" + nodeId)
                         .normalize();
                 setupWorkingDirectory(workingDir, configText);
-//                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
+                //                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId *
+                // 2)));
                 if (nodeId == 0) {
                     nodes.add(new InProcessHapiTestNode(workingDir, 0, FIRST_GRPC_PORT));
                 } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
@@ -69,13 +69,7 @@ public class HapiTestEnv {
                 final var workingDir = Path.of("./build/hapi-test/" + testName + "/node" + nodeId)
                         .normalize();
                 setupWorkingDirectory(workingDir, configText);
-                //                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId *
-                // 2)));
-                if (nodeId == 0) {
-                    nodes.add(new InProcessHapiTestNode(workingDir, 0, FIRST_GRPC_PORT));
-                } else {
-                    nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
-                }
+                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
@@ -69,7 +69,12 @@ public class HapiTestEnv {
                 final var workingDir = Path.of("./build/hapi-test/" + testName + "/node" + nodeId)
                         .normalize();
                 setupWorkingDirectory(workingDir, configText);
-                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
+//                nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
+                if (nodeId == 0) {
+                    nodes.add(new InProcessHapiTestNode(workingDir, 0, FIRST_GRPC_PORT));
+                } else {
+                    nodes.add(new SubProcessHapiTestNode(workingDir, nodeId, FIRST_GRPC_PORT + (nodeId * 2)));
+                }
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
@@ -81,18 +81,21 @@ public class QueryPaymentSuite extends HapiSuite {
                 .when()
                 .then(
                         getAccountInfo(GENESIS)
-                                .withPayment(cryptoTransfer(spec ->
-                                        multiAccountPaymentToNode003AndBeneficiary(spec, "a", "b", "c", 1_000L, 2L)).payingWith("a"))
+                                .withPayment(cryptoTransfer(spec -> multiAccountPaymentToNode003AndBeneficiary(
+                                                spec, "a", "b", "c", 1_000L, 2L))
+                                        .payingWith("a"))
                                 .setNode(NODE)
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_TX_FEE),
                         getAccountInfo(GENESIS)
-                                .withPayment(cryptoTransfer(spec ->
-                                        multiAccountPaymentToNode003AndBeneficiary(spec, "d", "b", "c", 5000, 200L)).payingWith("a"))
+                                .withPayment(cryptoTransfer(spec -> multiAccountPaymentToNode003AndBeneficiary(
+                                                spec, "d", "b", "c", 5000, 200L))
+                                        .payingWith("a"))
                                 .setNode(NODE)
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE),
                         getAccountInfo(GENESIS)
                                 .withPayment(cryptoTransfer(spec -> multiAccountPaymentToNode003AndBeneficiary(
-                                        spec, "d", GENESIS, "c", 5000, 200L)).payingWith("a"))
+                                                spec, "d", GENESIS, "c", 5000, 200L))
+                                        .payingWith("a"))
                                 .setNode(NODE)
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
@@ -143,7 +146,8 @@ public class QueryPaymentSuite extends HapiSuite {
                 .when()
                 .then(
                         getAccountInfo(GENESIS).fee(100L).setNode(NODE).hasAnswerOnlyPrecheck(OK),
-                        getAccountInfo(GENESIS).payingWith("a")
+                        getAccountInfo(GENESIS)
+                                .payingWith("a")
                                 .nodePayment(Long.MAX_VALUE)
                                 .setNode(NODE)
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE),
@@ -163,7 +167,8 @@ public class QueryPaymentSuite extends HapiSuite {
                         cryptoCreate("c").balance(1_234L))
                 .when()
                 .then(getAccountInfo(GENESIS)
-                        .withPayment(cryptoTransfer(spec -> invalidPaymentToNode(spec, "a", "b", "c", 1200)).payingWith("a"))
+                        .withPayment(cryptoTransfer(spec -> invalidPaymentToNode(spec, "a", "b", "c", 1200))
+                                .payingWith("a"))
                         .setNode(NODE)
                         .fee(10L)
                         .hasAnswerOnlyPrecheck(INVALID_RECEIVING_NODE_ACCOUNT));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
@@ -70,30 +70,30 @@ public class QueryPaymentSuite extends HapiSuite {
      * 2. TransactionPayer will pay for query payment to node and payer has less balance
      * 3. Transaction payer is not involved in transfers for query payment to node and one or more have less balance
      */
+    @HapiTest
     private HapiSpec queryPaymentsFailsWithInsufficientFunds() {
         return defaultHapiSpec("queryPaymentsFailsWithInsufficientFunds")
                 .given(
-                        cryptoCreate("a").balance(1_234L),
+                        cryptoCreate("a").balance(500_000_000L),
                         cryptoCreate("b").balance(1_234L),
-                        cryptoCreate("c").balance(1_234L))
+                        cryptoCreate("c").balance(1_234L),
+                        cryptoCreate("d").balance(1_234L))
                 .when()
                 .then(
                         getAccountInfo(GENESIS)
                                 .withPayment(cryptoTransfer(spec ->
-                                        multiAccountPaymentToNode003AndBeneficiary(spec, "a", "b", "c", 1_000L, 2L)))
+                                        multiAccountPaymentToNode003AndBeneficiary(spec, "a", "b", "c", 1_000L, 2L)).payingWith("a"))
                                 .setNode(NODE)
-                                .payingWith("a")
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_TX_FEE),
                         getAccountInfo(GENESIS)
                                 .withPayment(cryptoTransfer(spec ->
-                                        multiAccountPaymentToNode003AndBeneficiary(spec, "a", "b", "c", 5000, 200L)))
+                                        multiAccountPaymentToNode003AndBeneficiary(spec, "d", "b", "c", 5000, 200L)).payingWith("a"))
                                 .setNode(NODE)
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE),
                         getAccountInfo(GENESIS)
                                 .withPayment(cryptoTransfer(spec -> multiAccountPaymentToNode003AndBeneficiary(
-                                        spec, "a", GENESIS, "c", 5000, 200L)))
+                                        spec, "d", GENESIS, "c", 5000, 200L)).payingWith("a"))
                                 .setNode(NODE)
-                                .payingWith("a")
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
@@ -133,17 +133,18 @@ public class QueryPaymentSuite extends HapiSuite {
     }
 
     // Check if multiple payers or single payer pay amount to node
+    @HapiTest
     private HapiSpec queryPaymentsSingleBeneficiaryChecked() {
         return defaultHapiSpec("queryPaymentsSingleBeneficiaryChecked")
                 .given(
-                        cryptoCreate("a").balance(1_234L),
+                        cryptoCreate("a").balance(500_000_000L),
                         cryptoCreate("b").balance(1_234L),
                         cryptoCreate("c").balance(1_234L))
                 .when()
                 .then(
                         getAccountInfo(GENESIS).fee(100L).setNode(NODE).hasAnswerOnlyPrecheck(OK),
-                        getAccountInfo(GENESIS)
-                                .fee(Long.MAX_VALUE)
+                        getAccountInfo(GENESIS).payingWith("a")
+                                .nodePayment(Long.MAX_VALUE)
                                 .setNode(NODE)
                                 .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE),
                         getAccountInfo(GENESIS)
@@ -153,17 +154,17 @@ public class QueryPaymentSuite extends HapiSuite {
     }
 
     // Check if payment is not done to node
+    @HapiTest
     private HapiSpec queryPaymentsNotToNodeFails() {
         return defaultHapiSpec("queryPaymentsNotToNodeFails")
                 .given(
-                        cryptoCreate("a").balance(1_234L),
+                        cryptoCreate("a").balance(500_000_000L),
                         cryptoCreate("b").balance(1_234L),
                         cryptoCreate("c").balance(1_234L))
                 .when()
                 .then(getAccountInfo(GENESIS)
-                        .withPayment(cryptoTransfer(spec -> invalidPaymentToNode(spec, "a", "b", "c", 1200)))
+                        .withPayment(cryptoTransfer(spec -> invalidPaymentToNode(spec, "a", "b", "c", 1200)).payingWith("a"))
                         .setNode(NODE)
-                        .payingWith("a")
                         .fee(10L)
                         .hasAnswerOnlyPrecheck(INVALID_RECEIVING_NODE_ACCOUNT));
     }


### PR DESCRIPTION
Enable 3 new tets for query payment that never worked in Mono.
Also fixed the logic in `QueryChecker`

**Related issue(s)**:

Fixes #9176 

