### PR TITLE
Schedule release branch creation for 0.44

### DIFF
--- a/.github/workflows/config/node-release.yaml
+++ b/.github/workflows/config/node-release.yaml
@@ -1,11 +1,11 @@
 release:
   branching:
     execution:
-      time: "19:00:00"
+      time: "17:00:00"
     schedule:
-      - on: "2023-05-30"
-        name: release/0.39
+      - on: "2023-10-27"
+        name: release/0.44
         initial-tag:
-          create: false
-          name: v0.39.0-alpha.2
+          create: true
+          name: v0.44.0-alpha.2
 


### PR DESCRIPTION
**Description**:
Tag `0.44.0-alpha.2` and create `release/0.44` branch. This PR schedules these two tasks to be executed on Oct 27 at 17:00 UTC / noon CDT.

**Related issue(s)**:

Partially fixes #9363 
