### PR TITLE
Bump hapi version in use to 0.44.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -141,8 +141,8 @@ fun includeAllProjects(containingFolder: String) {
 
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
-val hapiProtoVersion = "0.43.0-rc-SNAPSHOT"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state"
+val hapiProtoVersion = "0.44.0"
+val hapiProtoBranchOrTag = "v0.44.0"
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
**Description**:
Use hedera-protobufs version 0.44.0

**Related issue(s)**:
Partially fixes #9363 

