### PR TITLE
9514: Reduce Java allocations when sending internal node hashes during reconnect

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Serializable {
     private static final int SHORT_STRING_BYTES = 4;
     public static final long CLASS_ID = 0xf422da83a251741eL;
-    private static final int CLASS_VERSION = 1;
+    public static final int CLASS_VERSION = 1;
 
     private byte[] value;
     private DigestType digestType;

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/InternalDataLesson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/InternalDataLesson.java
@@ -105,7 +105,7 @@ public class InternalDataLesson<T> implements SelfSerializable {
     @Override
     public void serialize(final SerializableDataOutputStream out) throws IOException {
         teacherTreeView.serializeInternal(out, internal);
-        out.writeSerializableList(teacherTreeView.getChildHashes(internal), false, true);
+        teacherTreeView.writeChildHashes(internal, out);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/StandardTeacherTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/StandardTeacherTreeView.java
@@ -189,11 +189,7 @@ public class StandardTeacherTreeView implements TeacherTreeView<NodeToSend> {
         return merkleNode != null && merkleNode.hasCustomReconnectView();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public List<Hash> getChildHashes(final NodeToSend parent) {
+    private List<Hash> getChildHashes(final NodeToSend parent) {
 
         final MerkleNode node = parent.getNode();
 
@@ -226,6 +222,11 @@ public class StandardTeacherTreeView implements TeacherTreeView<NodeToSend> {
         }
 
         return hashes;
+    }
+
+    @Override
+    public void writeChildHashes(final NodeToSend parent, final SerializableDataOutputStream out) throws IOException {
+        out.writeSerializableList(getChildHashes(parent), false, true);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
@@ -64,7 +64,14 @@ public interface TeacherTreeView<T>
      */
     void serializeInternal(SerializableDataOutputStream out, T internal) throws IOException;
 
-    // Must be binary compatible with out.writeSerializableList(hashesList, false, true);
+    /**
+     * Serialize all child hashes for a given node into a stream. Serialized bytes must be
+     * identical to what out.writeSerializableList(hashesList, false, true) method writes.
+     *
+     * @param parent Merkle node
+     * @param out The output stream
+     * @throws IOException If an I/O error occurred
+     */
     void writeChildHashes(T parent, SerializableDataOutputStream out) throws IOException;
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
@@ -16,11 +16,9 @@
 
 package com.swirlds.common.merkle.synchronization.views;
 
-import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * A "view" into a merkle tree (or subtree) used to perform a reconnect operation. This view is used to access
@@ -66,17 +64,8 @@ public interface TeacherTreeView<T>
      */
     void serializeInternal(SerializableDataOutputStream out, T internal) throws IOException;
 
-    /**
-     * Get the hashes of the children. Hashes should be in the same order as the children. Null children should
-     * cause the null hash to be in the returned list.
-     *
-     * @param parent
-     * 		the parent in question
-     * @return a list of the parent's child hashes
-     * @throws MerkleSynchronizationException
-     * 		if the parent is actually a leaf node or if any of the children don't have a hash
-     */
-    List<Hash> getChildHashes(T parent);
+    // Must be binary compatible with out.writeSerializableList(hashesList, false, true);
+    void writeChildHashes(T parent, SerializableDataOutputStream out) throws IOException;
 
     /**
      * Check if a node is the root of the tree with a custom view.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -29,6 +29,7 @@ import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.common.units.UnitConstants;
@@ -61,6 +62,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -711,6 +713,45 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         }
 
         return hash;
+    }
+
+    @Override
+    public boolean loadAndWriteHash(long path, SerializableDataOutputStream out) throws IOException {
+        if (path < 0) {
+            throw new IllegalArgumentException("path is less than 0");
+        }
+        long lastLeaf = validLeafPathRange.getMaxValidKey();
+        if (path > lastLeaf) {
+            return false;
+        }
+        if (path < tableConfig.getHashesRamToDiskThreshold()) {
+            final Hash hash = hashStoreRam.get(path);
+            if (hash == null) {
+                return false;
+            }
+            hash.serialize(out);
+        } else {
+            // hashBytes here is path (8 bytes) + hash (48 bytes)
+            final ByteBuffer hashBytes = hashStoreDisk.getBytes(path);
+            if (hashBytes == null) {
+                return false;
+            }
+            // Hash.serialize() format is: digest ID (4 bytes) + size (4 bytes) + hash (48 bytes)
+            out.writeInt(DigestType.SHA_384.id());
+            final byte[] bytes;
+            if (hashBytes.hasArray()) {
+                bytes = hashBytes.array();
+            } else {
+                bytes = new byte[hashBytes.remaining()];
+                hashBytes.get(bytes);
+            }
+            final int off = Long.BYTES; // skip the path
+            final int len = bytes.length - off;
+            // Simulate SerializableDataOutputStream.writeByteArray(), which writes size, then array
+            out.writeInt(len);
+            out.write(bytes, off, len);
+        }
+        return true;
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -681,11 +681,7 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
     }
 
     /**
-     * Load hash for a leaf node with given path
-     *
-     * @param path the path to get hash for
-     * @return loaded hash or null if hash is not stored
-     * @throws IOException if there was a problem loading hash
+     * {@inheritDoc}
      */
     @Override
     public Hash loadHash(final long path) throws IOException {
@@ -715,6 +711,9 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         return hash;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean loadAndWriteHash(long path, SerializableDataOutputStream out) throws IOException {
         if (path < 0) {
@@ -724,6 +723,10 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
         if (path > lastLeaf) {
             return false;
         }
+        // This method must write hashes in the same binary format as Hash.(de)serialize(). If a
+        // hash comes from hashStoreRam, it's enough to just serialize it to the output stream.
+        // However, if a hash is stored in the files as a VirtualHashRecord, its bytes are
+        // slightly different, so additional processing is required
         if (path < tableConfig.getHashesRamToDiskThreshold()) {
             final Hash hash = hashStoreRam.get(path);
             if (hash == null) {

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -26,6 +26,7 @@ import static com.swirlds.merkledb.files.DataFileCommon.isFullyWrittenDataFile;
 import static com.swirlds.merkledb.files.DataFileCompactor.INITIAL_COMPACTION_LEVEL;
 import static java.util.Collections.singletonList;
 
+import com.swirlds.base.function.CheckedFunction;
 import com.swirlds.merkledb.KeyRange;
 import com.swirlds.merkledb.Snapshotable;
 import com.swirlds.merkledb.collections.CASableLongIndex;
@@ -410,26 +411,7 @@ public class DataFileCollection<D> implements Snapshotable {
         return dataReader;
     }
 
-    /**
-     * Read a data item from any file that has finished being written. This is not 100% thread safe
-     * with concurrent merging, it is possible it will throw a ClosedChannelException or return
-     * null. So it should be retried if those happen.
-     *
-     * @param dataLocation the location of the data item to read. This contains both the file and
-     *     the location within the file.
-     * @return Data item if the data location was found in files. <br>
-     *     <br>
-     *     A null is returned :
-     *     <ol>
-     *       <li>if not found
-     *       <li>if deserialize flag is false
-     *     </ol>
-     *
-     * @throws IOException If there was a problem reading the data item.
-     * @throws ClosedChannelException In the very rare case merging closed the file between us
-     *     checking if file is open and reading
-     */
-    protected D readDataItem(final long dataLocation) throws IOException {
+    private DataFileReader<D> readerForDataLocation(final long dataLocation) throws IOException {
         // check if found
         if (dataLocation == 0) {
             return null;
@@ -452,7 +434,7 @@ public class DataFileCollection<D> implements Snapshotable {
         }
         // read data, check at last second that file is not closed
         if (file.isOpen()) {
-            return file.readDataItem(dataLocation);
+            return file;
         } else {
             // Let's log this as it should happen very rarely but if we see it a lot then we should
             // have a rethink.
@@ -463,22 +445,36 @@ public class DataFileCollection<D> implements Snapshotable {
     }
 
     /**
-     * Read a data item from any file that has finished being written. Uses a LongList that maps
-     * key-&gt;dataLocation, this allows for multiple retries going back to the index each time. The
-     * allows us to cover the cracks where threads can slip though.
+     * Read data item bytes from any file that has finished being written. This is not 100% thread
+     * safe, for example, it is possible that the data file is deleted by compaction running in parallel.
+     * This is why this method is retried multiple times from {@link #readDataItemBytesUsingIndex},
+     * assuming that during compaction the index is updated to point to a new data file.
      *
-     * This depends on the fact that LongList has a nominal value of
-     * LongList.IMPERMISSIBLE_VALUE=0 for non-existent values.
-     *
-     * @param index key-&gt;dataLocation index
-     * @param keyIntoIndex The key to lookup in index
-     * @return Data item if the data location was found in files. If contained in the index but not
-     *     in files after a number of retries then an exception is thrown. <br>
-     *     A null is returned if not found in index
+     * @param dataLocation the location of the data item to read. This contains both the file and
+     *     the location within the file.
+     * @return Data item bytes if the data location was found in files
      *
      * @throws IOException If there was a problem reading the data item.
+     * @throws ClosedChannelException In the very rare case merging closed the file between us
+     *     checking if file is open and reading
      */
-    public D readDataItemUsingIndex(final LongList index, final long keyIntoIndex) throws IOException {
+    protected ByteBuffer readDataItemBytes(final long dataLocation) throws IOException {
+        final DataFileReader<D> file = readerForDataLocation(dataLocation);
+        return (file != null) ? file.readDataItemBytes(dataLocation) : null;
+    }
+
+    protected D readDataItem(final long dataLocation) throws IOException {
+        final DataFileReader<D> file = readerForDataLocation(dataLocation);
+        if (file == null) {
+            return null;
+        }
+        final ByteBuffer dataItemBytes = file.readDataItemBytes(dataLocation);
+        return dataItemSerializer.deserialize(dataItemBytes, file.getMetadata().getSerializationVersion());
+    }
+
+    private <T> T retryReadUsingIndex(
+            final LongList index, final long keyIntoIndex, final CheckedFunction<Long, T, IOException> reader)
+            throws IOException {
         // Try reading up to 5 times, 99.999% should work first try but there is a small chance the
         // file was closed by
         // merging when we are half way though reading, and we will see  file.isOpen() = false or a
@@ -494,10 +490,10 @@ public class DataFileCollection<D> implements Snapshotable {
             }
             // read data
             try {
-                final D readData = readDataItem(dataLocation);
+                final T readData = reader.apply(dataLocation);
                 // check we actually read data, this could be null if the file was closed half way
                 // though us reading
-                if ((readData != null)) {
+                if (readData != null) {
                     return readData;
                 }
             } catch (final IOException e) {
@@ -542,6 +538,44 @@ public class DataFileCollection<D> implements Snapshotable {
             }
         }
         throw new IOException("Read failed after 5 retries");
+    }
+
+    /**
+     * Read a data item bytes from any file that has finished being written. Uses a LongList that maps
+     * key-&gt;dataLocation, this allows for multiple retries going back to the index each time. The
+     * allows us to cover the cracks where threads can slip though.
+     *
+     * <p>This depends on the fact that LongList has a nominal value of
+     * LongList.IMPERMISSIBLE_VALUE=0 for non-existent values.
+     *
+     * @param index key-&gt;dataLocation index
+     * @param keyIntoIndex The key to lookup in index
+     * @return Data item bytes if the data location was found in files. If contained in the index but not in
+     *     files after a number of retries then an exception is thrown. A null is returned if not found in index
+     *
+     * @throws IOException If there was a problem reading the data item.
+     */
+    public ByteBuffer readDataItemBytesUsingIndex(final LongList index, final long keyIntoIndex) throws IOException {
+        return retryReadUsingIndex(index, keyIntoIndex, this::readDataItemBytes);
+    }
+
+    /**
+     * Read a data item from any file that has finished being written. Uses a LongList that maps
+     * key-&gt;dataLocation, this allows for multiple retries going back to the index each time. The
+     * allows us to cover the cracks where threads can slip though.
+     *
+     * <p>This depends on the fact that LongList has a nominal value of
+     * LongList.IMPERMISSIBLE_VALUE=0 for non-existent values.
+     *
+     * @param index key-&gt;dataLocation index
+     * @param keyIntoIndex The key to lookup in index
+     * @return Data item if the data location was found in files. If contained in the index but not in files
+     *     after a number of retries then an exception is thrown. A null is returned if not found in index
+     *
+     * @throws IOException If there was a problem reading the data item.
+     */
+    public D readDataItemUsingIndex(final LongList index, final long keyIntoIndex) throws IOException {
+        return retryReadUsingIndex(index, keyIntoIndex, this::readDataItem);
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -453,7 +453,7 @@ public class DataFileCollection<D> implements Snapshotable {
 
     /**
      * Read data item bytes at a given location (file index + offset). If the file is not found or
-     * alread closed, this method returns {@code null}. This may happen, if the index, where the data
+     * already closed, this method returns {@code null}. This may happen, if the index, where the data
      * location originated from, has just been updated in a parallel compaction thread.
      *
      * <p>NOTE: this method may not be used for data types, which can be of multiple different

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -171,16 +171,15 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
     }
 
     /**
-     * Read data item bytes from file at dataLocation and deserialize them into the Java object, if
-     * requested.
+     * Read data item bytes from file at dataLocation.
      *
      * @param dataLocation The file index combined with the offset for the starting block of the
      *     data in the file
-     * @return Deserialized data item
+     * @return Data item bytes
      * @throws IOException If there was a problem reading from data file
      * @throws ClosedChannelException if the data file was closed
      */
-    public ByteBuffer readDataItemBytes(final long dataLocation) throws IOException {
+    ByteBuffer readDataItemBytes(final long dataLocation) throws IOException {
         final long serializationVersion = metadata.getSerializationVersion();
         final long byteOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
         final int bytesToRead;
@@ -195,7 +194,14 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
         return read(byteOffset, bytesToRead);
     }
 
-    // For testing purposes
+    /**
+     * Read data item from file at dataLocation and deserialize it to a Java object.
+     *
+     * @param dataLocation Data item location, which combines data file index and offset in the file
+     * @return Deserialized data item
+     * @throws IOException If there was a problem reading from data file
+     * @throws ClosedChannelException if the data file was closed
+     */
     D readDataItem(final long dataLocation) throws IOException {
         final ByteBuffer dataItemBytes = readDataItemBytes(dataLocation);
         return dataItemSerializer.deserialize(dataItemBytes, metadata.getSerializationVersion());

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -176,16 +176,10 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
      *
      * @param dataLocation The file index combined with the offset for the starting block of the
      *     data in the file
-     * @return Deserialized data item, or {@code null} if deserialization is not requested
+     * @return Deserialized data item
      * @throws IOException If there was a problem reading from data file
      * @throws ClosedChannelException if the data file was closed
      */
-    public D readDataItem(final long dataLocation) throws IOException {
-        long serializationVersion = metadata.getSerializationVersion();
-        final ByteBuffer data = readDataItemBytes(dataLocation);
-        return dataItemSerializer.deserialize(data, serializationVersion);
-    }
-
     public ByteBuffer readDataItemBytes(final long dataLocation) throws IOException {
         final long serializationVersion = metadata.getSerializationVersion();
         final long byteOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
@@ -199,6 +193,12 @@ public final class DataFileReader<D> implements AutoCloseable, Comparable<DataFi
             bytesToRead = dataItemSerializer.getSerializedSizeForVersion(serializationVersion);
         }
         return read(byteOffset, bytesToRead);
+    }
+
+    // For testing purposes
+    D readDataItem(final long dataLocation) throws IOException {
+        final ByteBuffer dataItemBytes = readDataItemBytes(dataLocation);
+        return dataItemSerializer.deserialize(dataItemBytes, metadata.getSerializationVersion());
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStore.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStore.java
@@ -201,6 +201,17 @@ public class MemoryIndexDiskKeyValueStore<D> implements AutoCloseable, Snapshota
         return fileCollection.readDataItemUsingIndex(index, key);
     }
 
+    /**
+     * Get raw value bytes by reading it from disk.
+     *
+     * <p>NOTE: this method may not be used for data types, which can be of multiple different
+     * versions. This is because there is no way for a caller to know the version of the returned
+     * bytes.
+     *
+     * @param key The key to find and read value for
+     * @return Array of serialization version for data if the value was read or null if not found
+     * @throws IOException If there was a problem reading the value from file
+     */
     public ByteBuffer getBytes(final long key) throws IOException {
         if (!checkKeyInRange(key)) {
             return null;

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStore.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStore.java
@@ -26,6 +26,7 @@ import com.swirlds.merkledb.files.DataFileCollection.LoadedDataCallback;
 import com.swirlds.merkledb.serialize.DataItemSerializer;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LongSummaryStatistics;
@@ -170,14 +171,7 @@ public class MemoryIndexDiskKeyValueStore<D> implements AutoCloseable, Snapshota
         return dataFileReader;
     }
 
-    /**
-     * Get a value by reading it from disk.
-     *
-     * @param key The key to find and read value for
-     * @return Array of serialization version for data if the value was read or null if not found
-     * @throws IOException If there was a problem reading the value from file
-     */
-    public D get(final long key) throws IOException {
+    private boolean checkKeyInRange(final long key) {
         // Check if out of range
         final KeyRange keyRange = fileCollection.getValidKeyRange();
         if (!keyRange.withinRange(key)) {
@@ -187,10 +181,32 @@ public class MemoryIndexDiskKeyValueStore<D> implements AutoCloseable, Snapshota
             if (key != 0) {
                 logger.trace(MERKLE_DB.getMarker(), "Key [{}] is outside valid key range of {}", key, keyRange);
             }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get a value by reading it from disk.
+     *
+     * @param key The key to find and read value for
+     * @return Array of serialization version for data if the value was read or null if not found
+     * @throws IOException If there was a problem reading the value from file
+     */
+    public D get(final long key) throws IOException {
+        if (!checkKeyInRange(key)) {
             return null;
         }
         // read from files via index lookup
         return fileCollection.readDataItemUsingIndex(index, key);
+    }
+
+    public ByteBuffer getBytes(final long key) throws IOException {
+        if (!checkKeyInRange(key)) {
+            return null;
+        }
+        // read from files via index lookup
+        return fileCollection.readDataItemBytesUsingIndex(index, key);
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
@@ -20,6 +20,7 @@ import static com.swirlds.common.units.UnitConstants.BYTES_TO_BITS;
 import static com.swirlds.common.units.UnitConstants.MEBIBYTES_TO_BYTES;
 
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.merkledb.files.hashmap.HalfDiskVirtualKeySet;
 import com.swirlds.virtual.merkle.TestKey;
@@ -93,6 +94,11 @@ public final class BreakableDataSource implements VirtualDataSource<TestKey, Tes
     @Override
     public Hash loadHash(final long path) throws IOException {
         return delegate.loadHash(path);
+    }
+
+    @Override
+    public boolean loadAndWriteHash(long path, SerializableDataOutputStream out) throws IOException {
+        return delegate.loadAndWriteHash(path, out);
     }
 
     @Override

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenVirtualMapTeacherView.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenVirtualMapTeacherView.java
@@ -16,12 +16,10 @@
 
 package com.swirlds.virtual.merkle.reconnect;
 
-import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.synchronization.views.TeacherTreeView;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * An intentionally broken teacher tree view. Throws an IO exception after a certain number of nodes have been
@@ -120,8 +118,8 @@ public class BrokenVirtualMapTeacherView implements TeacherTreeView<Long> {
     }
 
     @Override
-    public List<Hash> getChildHashes(final Long parent) {
-        return baseView.getChildHashes(parent);
+    public void writeChildHashes(final Long parent, final SerializableDataOutputStream out) throws IOException {
+        baseView.writeChildHashes(parent, out);
     }
 
     @Override

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.swirlds.common.config.sources.SimpleConfigSource;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
@@ -34,7 +35,7 @@ import com.swirlds.common.merkle.synchronization.internal.QueryResponse;
 import com.swirlds.common.test.merkle.dummy.DummyMerkleInternal;
 import com.swirlds.common.test.merkle.dummy.DummyMerkleLeaf;
 import com.swirlds.common.test.merkle.util.MerkleTestUtils;
-import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.MerkleDbTableConfig;
@@ -84,8 +85,13 @@ public class VirtualMapReconnectTestBase {
     protected static final TestValue FOX = new TestValue("FOX");
     protected static final TestValue GOOSE = new TestValue("GOOSE");
 
-    protected final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
-    protected final ReconnectConfig reconnectConfig = configuration.getConfigData(ReconnectConfig.class);
+    // Custom reconnect config to make tests with timeouts faster
+    protected static ReconnectConfig reconnectConfig = ConfigurationBuilder.create()
+            .withSources(new SimpleConfigSource("reconnect.asyncStreamTimeout", "5s"))
+            .withConfigDataType(ReconnectConfig.class)
+            .build()
+            .getConfigData(ReconnectConfig.class);
+
     protected VirtualMap<TestKey, TestValue> teacherMap;
     protected VirtualMap<TestKey, TestValue> learnerMap;
     protected BrokenBuilder teacherBuilder;
@@ -101,6 +107,7 @@ public class VirtualMapReconnectTestBase {
                 (short) 1, DigestType.SHA_384,
                 (short) 1, new TestKeySerializer(),
                 (short) 1, new TestValueSerializer());
+        tableConfig.hashesRamToDiskThreshold(0);
         return new MerkleDbDataSourceBuilder<>(tableConfig);
     }
 
@@ -177,6 +184,19 @@ public class VirtualMapReconnectTestBase {
      */
     protected void reconnectMultipleTimes(
             final int attempts, final Function<VirtualMap<TestKey, TestValue>, MerkleNode> brokenTeacherMapBuilder) {
+
+        final VirtualRootNode<TestKey, TestValue> virtualRootNode =
+                teacherMap.asInternal().getChild(1);
+        virtualRootNode.enableFlush();
+
+        final VirtualMap<TestKey, TestValue> teacherCopy = teacherMap.copy();
+        teacherMap.release();
+        try {
+            virtualRootNode.waitUntilFlushed();
+        } catch (final InterruptedException z) {
+            throw new RuntimeException("Interrrupted exception while waiting for virtual map to flush");
+        }
+        teacherMap = teacherCopy;
 
         final MerkleInternal teacherTree = createTreeForMap(teacherMap);
         final VirtualMap<TestKey, TestValue> copy = teacherMap.copy();

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -185,6 +185,8 @@ public class VirtualMapReconnectTestBase {
     protected void reconnectMultipleTimes(
             final int attempts, final Function<VirtualMap<TestKey, TestValue>, MerkleNode> brokenTeacherMapBuilder) {
 
+        // Make sure virtual map data is flushed to disk (data source), otherwise all
+        // data for reconnects would be loaded from virtual node cache
         final VirtualRootNode<TestKey, TestValue> virtualRootNode =
                 teacherMap.asInternal().getChild(1);
         virtualRootNode.enableFlush();
@@ -194,7 +196,7 @@ public class VirtualMapReconnectTestBase {
         try {
             virtualRootNode.waitUntilFlushed();
         } catch (final InterruptedException z) {
-            throw new RuntimeException("Interrrupted exception while waiting for virtual map to flush");
+            throw new RuntimeException("Interrupted exception while waiting for virtual map to flush");
         }
         teacherMap = teacherCopy;
 

--- a/platform-sdk/swirlds-virtualmap/build.gradle.kts
+++ b/platform-sdk/swirlds-virtualmap/build.gradle.kts
@@ -27,7 +27,6 @@ jmhModuleInfo {
 
 testModuleInfo {
     requires("com.swirlds.common.test.fixtures")
-    requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.common.testing")
     requires("com.swirlds.config.api.test.fixtures")
     requires("com.swirlds.test.framework")

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
@@ -17,6 +17,7 @@
 package com.swirlds.virtualmap.datasource;
 
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.metrics.Metrics;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
@@ -130,6 +131,15 @@ public interface VirtualDataSource<K extends VirtualKey, V extends VirtualValue>
      * 		If there was a problem loading the leaf's hash from data source
      */
     Hash loadHash(final long path) throws IOException;
+
+    default boolean loadAndWriteHash(final long path, final SerializableDataOutputStream out) throws IOException {
+        final Hash hash = loadHash(path);
+        if (hash == null) {
+            return false;
+        }
+        hash.serialize(out);
+        return true;
+    }
 
     /**
      * Write a snapshot of the current state of the database at this moment in time. This will need to be called between

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
@@ -122,8 +122,6 @@ public interface VirtualDataSource<K extends VirtualKey, V extends VirtualValue>
     /**
      * Load a virtual node hash by path.
      *
-     * NOTE: Called during the hashing phase ONLY. Never called on non-existent nodes.
-     *
      * @param path virtual node path
      * @return The node's record if one was stored for the given path; {@code null} if not stored or
      * 	  		deserialization is not requested
@@ -132,6 +130,20 @@ public interface VirtualDataSource<K extends VirtualKey, V extends VirtualValue>
      */
     Hash loadHash(final long path) throws IOException;
 
+    /**
+     * Load a virtual node hash by path and, if found, write it to the specified output stream. This
+     * method helps avoid (de)serialization overhead during reconnects on the teacher side. Instead of
+     * loading bytes from disk, then deserializing them into {@link Hash} objects, and then serializing
+     * again to socket output stream, this method can write the bytes directly to the stream.
+     *
+     * <p>Written bytes must be 100% identical to how hashes are serialized using {@link
+     * Hash#serialize(SerializableDataOutputStream)} method.
+     *
+     * @param path Virtual node path
+     * @param out Output stream to write the hash, if found
+     * @return If the hash was found and written to the stream
+     * @throws IOException If an I/O error occurred
+     */
     default boolean loadAndWriteHash(final long path, final SerializableDataOutputStream out) throws IOException {
         final Hash hash = loadHash(path);
         if (hash == null) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
@@ -49,6 +49,18 @@ public interface RecordAccessor<K extends VirtualKey, V extends VirtualValue> {
      */
     Hash findHash(long path);
 
+    /**
+     * Looks up a virtual node hash for a given path. If the hash is found, writes it to a
+     * specified output stream.
+     *
+     * <p>Written bytes must be 100% identical to how hashes are serialized using {@link
+     * Hash#serialize(SerializableDataOutputStream)} method.
+     *
+     * @param path Virtual node path
+     * @param out Output stream to write the hash to
+     * @return If the hash is found and written to the stream
+     * @throws IOException If an I/O error occurred
+     */
     boolean findAndWriteHash(long path, SerializableDataOutputStream out) throws IOException;
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
@@ -17,11 +17,13 @@
 package com.swirlds.virtualmap.internal;
 
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.cache.VirtualNodeCache;
+import java.io.IOException;
 import java.io.UncheckedIOException;
 
 /**
@@ -46,6 +48,8 @@ public interface RecordAccessor<K extends VirtualKey, V extends VirtualValue> {
      * 		an UncheckedIOException is thrown.
      */
     Hash findHash(long path);
+
+    boolean findAndWriteHash(long path, SerializableDataOutputStream out) throws IOException;
 
     /**
      * Locates and returns a leaf node based on the given key. If the leaf

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
@@ -107,6 +107,9 @@ public class RecordAccessorImpl<K extends VirtualKey, V extends VirtualValue> im
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean findAndWriteHash(long path, SerializableDataOutputStream out) throws IOException {
         assert path >= 0;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
@@ -20,6 +20,7 @@ import static com.swirlds.virtualmap.internal.Path.INVALID_PATH;
 import static com.swirlds.virtualmap.internal.Path.ROOT_PATH;
 
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
@@ -104,6 +105,20 @@ public class RecordAccessorImpl<K extends VirtualKey, V extends VirtualValue> im
         } catch (final IOException e) {
             throw new UncheckedIOException("Failed to read node hash from data source by path", e);
         }
+    }
+
+    @Override
+    public boolean findAndWriteHash(long path, SerializableDataOutputStream out) throws IOException {
+        assert path >= 0;
+        final Hash hash = cache.lookupHashByPath(path, false);
+        if (hash == VirtualNodeCache.DELETED_HASH) {
+            return false;
+        }
+        if (hash != null) {
+            hash.serialize(out);
+            return true;
+        }
+        return dataSource.loadAndWriteHash(path, out);
     }
 
     /**


### PR DESCRIPTION
Fix summary:

* `getChildHashes()` method in `TeacherTreeView` is replaced with another method, `writeChildHashes()`. This new method is expected to write child hashes to the specified output stream in binary format, identical to how list of `Hash` objects was previously written
* In `StandardTeacherTreeView` this method is implemented using the old `getChildHashes()` and serializing them with `SerializableDataOutputStream.writeSerializableList()`
* In `VirtualTeacherTreeView` this new method delegates to the underlying data source
* In `VirtualDataSource` a new method is added for this purpose, `loadAndWriteHash()`
* This new method in `MerkleDbDataSource` loads hash bytes from disk and serializes them to the output stream, bypassing deserialization to `Hash`

Testing:

* Existing virtual map reconnect tests in `swirlds-merkle` are used
* I found that these tests use MerkleDb, but the data source is not actually used, all nodes are loaded from virtual node cache. Fixed that
* Then I had to set hashes RAM to disk threshold to 0 to load hashes from disk, not from data source cache
* Then I found that one of the reconnect tests take 5 mins to complete because of recent async timeout update. Changed the test to use custom timeout (5s)

Fixes: https://github.com/hashgraph/hedera-services/issues/9514
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
