### PR TITLE
9559 Increased timeout in the assertions to prevent non-deterministic failures.

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
@@ -293,7 +293,7 @@ class MerkleDbCompactionCoordinatorTest {
                     }
                     verifyNoInteractions(statisticsUpdater);
                 },
-                Duration.ofMillis(100),
+                Duration.ofSeconds(1),
                 "Unexpected mock state");
     }
 
@@ -325,7 +325,7 @@ class MerkleDbCompactionCoordinatorTest {
                         throw new RuntimeException(e);
                     }
                 },
-                Duration.ofMillis(100),
+                Duration.ofSeconds(1),
                 "Unexpected mock state");
     }
 }


### PR DESCRIPTION
**Description**:

Increased a timeout in `MerkleDbCompactionCoordinatorTest#assertCompactable` and `MerkleDbCompactionCoordinatorTest#testCompactionFailed` to prevent non-deterministic failures


**Related issue(s)**:

Fixes #9559 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
