### PR TITLE
Fix NPE in `TokenWipe` when using missing alias for an account

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessor.java
@@ -454,7 +454,11 @@ public class SignedTxnAccessor implements TxnAccessor {
     }
 
     protected EntityNum lookUpAlias(final ByteString alias) {
-        return view.aliases().get(alias);
+        final var entityNum = view.aliases().get(alias);
+        if (entityNum == null) {
+            return EntityNum.MISSING_NUM;
+        }
+        return entityNum;
     }
 
     protected EntityNum unaliased(final AccountID idOrAlias) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessorTest.java
@@ -978,6 +978,23 @@ class SignedTxnAccessorTest {
         assertEquals(EntityNum.fromLong(10L), subject.unaliased(asAliasAccount(alias)));
     }
 
+    @Test
+    void lookUpMissingAliasDoesntReturnNull() {
+        final var stateView = mock(StateView.class);
+        final var alias = ByteString.copyFromUtf8("someString");
+        final Map<ByteString, EntityNum> accountsMap = new HashMap<>();
+        given(stateView.aliases()).willReturn(accountsMap);
+
+        final var op = ContractCallTransactionBody.newBuilder().build();
+        final var txn = buildTransactionFrom(
+                TransactionBody.newBuilder().setContractCall(op).build());
+        final var subject = SignedTxnAccessor.uncheckedFrom(txn);
+        subject.setStateView(stateView);
+
+        assertEquals(EntityNum.MISSING_NUM, subject.lookUpAlias(alias));
+        assertEquals(EntityNum.MISSING_NUM, subject.unaliased(asAliasAccount(alias)));
+    }
+
     private Transaction signedCryptoCreateTxn() {
         return buildTransactionFrom(cryptoCreateOp());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -292,6 +292,10 @@ public class TxnVerbs {
         return new HapiTokenWipe(token, account, amount);
     }
 
+    public static HapiTokenWipe wipeTokenAccountWithAlias(String token, ByteString alias, long amount) {
+        return new HapiTokenWipe(token, alias, amount);
+    }
+
     public static HapiTokenWipe wipeTokenAccount(String token, String account, List<Long> serialNumbers) {
         return new HapiTokenWipe(token, account, serialNumbers);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -286,8 +286,8 @@ public class TokenManagementSpecs extends HapiSuite {
 
         return defaultHapiSpec("WipeAccountFailureCasesWork")
                 .given(
-                        newKeyNamed(multiKey).type(KeyFactory.KeyType.SIMPLE),
-                        newKeyNamed("alias"),
+                        newKeyNamed(multiKey),
+                        newKeyNamed("alias").type(KeyFactory.KeyType.SIMPLE),
                         cryptoCreate("misc").balance(0L),
                         cryptoCreate(TOKEN_TREASURY).balance(0L))
                 .when(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.token;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -285,7 +284,7 @@ public class TokenManagementSpecs extends HapiSuite {
         var multiKey = "wipeAndSupplyKey";
         var someMeta = ByteString.copyFromUtf8("HEY");
 
-        return onlyDefaultHapiSpec("WipeAccountFailureCasesWork")
+        return defaultHapiSpec("WipeAccountFailureCasesWork")
                 .given(
                         newKeyNamed(multiKey).type(KeyFactory.KeyType.SIMPLE),
                         newKeyNamed("alias"),


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/9639