### PR TITLE
Cherry-pick : Fix NPE in `TokenWipe` when using missing alias for an account

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessor.java
@@ -454,7 +454,11 @@ public class SignedTxnAccessor implements TxnAccessor {
     }
 
     protected EntityNum lookUpAlias(final ByteString alias) {
-        return view.aliases().get(alias);
+        final var entityNum = view.aliases().get(alias);
+        if (entityNum == null) {
+            return EntityNum.MISSING_NUM;
+        }
+        return entityNum;
     }
 
     protected EntityNum unaliased(final AccountID idOrAlias) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessorTest.java
@@ -978,6 +978,23 @@ class SignedTxnAccessorTest {
         assertEquals(EntityNum.fromLong(10L), subject.unaliased(asAliasAccount(alias)));
     }
 
+    @Test
+    void lookUpMissingAliasDoesntReturnNull() {
+        final var stateView = mock(StateView.class);
+        final var alias = ByteString.copyFromUtf8("someString");
+        final Map<ByteString, EntityNum> accountsMap = new HashMap<>();
+        given(stateView.aliases()).willReturn(accountsMap);
+
+        final var op = ContractCallTransactionBody.newBuilder().build();
+        final var txn = buildTransactionFrom(
+                TransactionBody.newBuilder().setContractCall(op).build());
+        final var subject = SignedTxnAccessor.uncheckedFrom(txn);
+        subject.setStateView(stateView);
+
+        assertEquals(EntityNum.MISSING_NUM, subject.lookUpAlias(alias));
+        assertEquals(EntityNum.MISSING_NUM, subject.unaliased(asAliasAccount(alias)));
+    }
+
     private Transaction signedCryptoCreateTxn() {
         return buildTransactionFrom(cryptoCreateOp());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -294,6 +294,10 @@ public class TxnVerbs {
         return new HapiTokenWipe(token, account, amount);
     }
 
+    public static HapiTokenWipe wipeTokenAccountWithAlias(String token, ByteString alias, long amount) {
+        return new HapiTokenWipe(token, alias, amount);
+    }
+
     public static HapiTokenWipe wipeTokenAccount(String token, String account, List<Long> serialNumbers) {
         return new HapiTokenWipe(token, account, serialNumbers);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -36,10 +36,12 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenFreeze;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUnfreeze;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccount;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccountWithAlias;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
@@ -66,7 +68,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
+import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
@@ -75,7 +77,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
-@HapiTestSuite
+ @HapiTestSuite
 public class TokenManagementSpecs extends HapiSuite {
 
     private static final Logger log = LogManager.getLogger(TokenManagementSpecs.class);
@@ -293,6 +295,7 @@ public class TokenManagementSpecs extends HapiSuite {
         return defaultHapiSpec("WipeAccountFailureCasesWork")
                 .given(
                         newKeyNamed(multiKey),
+                        newKeyNamed("alias").type(KeyFactory.KeyType.SIMPLE),
                         cryptoCreate("misc").balance(0L),
                         cryptoCreate(TOKEN_TREASURY).balance(0L))
                 .when(
@@ -324,7 +327,16 @@ public class TokenManagementSpecs extends HapiSuite {
                         wipeTokenAccount(wipeableToken, TOKEN_TREASURY, 1)
                                 .hasKnownStatus(CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT),
                         wipeTokenAccount(anotherWipeableToken, "misc", 501).hasKnownStatus(INVALID_WIPING_AMOUNT),
-                        wipeTokenAccount(anotherWipeableToken, "misc", -1).hasPrecheck(INVALID_WIPING_AMOUNT));
+                        wipeTokenAccount(anotherWipeableToken, "misc", -1).hasPrecheck(INVALID_WIPING_AMOUNT),
+                        withOpContext((spec, opLog) -> {
+                            final var key = spec.registry().getKey("alias");
+                            final var alias = key.hasECDSASecp256K1() ? key.getECDSASecp256K1() : key.getEd25519();
+                            allRunFor(
+                                    spec,
+                                    wipeTokenAccountWithAlias(unwipeableToken, alias, 1)
+                                            .signedBy(GENESIS)
+                                            .hasKnownStatus(INVALID_ACCOUNT_ID));
+                        }));
     }
 
     @HapiTest
@@ -451,7 +463,7 @@ public class TokenManagementSpecs extends HapiSuite {
                 .then(
                         getTxnRecord(SHOULD_NOT_APPEAR).showsNoTransfers(),
                         getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 0),
-                        UtilVerbs.withOpContext((spec, opLog) -> {
+                        withOpContext((spec, opLog) -> {
                             var mintNFT = getTxnRecord(SHOULD_NOT_APPEAR);
                             allRunFor(spec, mintNFT);
                             var receipt = mintNFT.getResponseRecord().getReceipt();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -77,7 +77,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
- @HapiTestSuite
+@HapiTestSuite
 public class TokenManagementSpecs extends HapiSuite {
 
     private static final Logger log = LogManager.getLogger(TokenManagementSpecs.class);


### PR DESCRIPTION
Cherry-pick #9640 

Fixes https://github.com/hashgraph/hedera-services/issues/9639