### PR TITLE
Enable Gradle Configuration Cache

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -776,7 +776,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.sdk-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "release${{ inputs.sdk-release-profile }} --scan -PpublishSigningEnabled=true"
+          arguments: "release${{ inputs.sdk-release-profile }} --scan -PpublishSigningEnabled=true --no-configuration-cache"
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.adarshr:gradle-test-logger-plugin:3.2.0")
+    implementation("com.adarshr:gradle-test-logger-plugin:4.0.0")
     implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.25.0")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.22.0")
     implementation("com.github.johnrengelman:shadow:8.1.1")

--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -26,11 +26,9 @@ dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.22.0")
     implementation("com.github.johnrengelman:shadow:8.1.1")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
-    implementation("com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1")
     implementation(
         "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.1"
     )
-    implementation("gradle.plugin.lazy.zoo.gradle:git-data-plugin:1.2.2")
     implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.1")
     implementation("net.swiftzer.semver:semver:1.3.0")
     implementation("org.gradlex:extra-java-module-info:1.5")

--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(
         "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.1"
     )
-    implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.1")
+    implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
     implementation("org.gradlex:extra-java-module-info:1.5")
     implementation("org.gradlex:java-ecosystem-capabilities:1.3.1")

--- a/build-logic/project-plugins/src/main/kotlin/Utils.kt
+++ b/build-logic/project-plugins/src/main/kotlin/Utils.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import net.swiftzer.semver.SemVer
-import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import java.io.OutputStream
@@ -32,14 +30,8 @@ class Utils {
             file("version.txt").let { if (it.asFile.exists()) it else this.dir("..").versionTxt() }
 
         @JvmStatic
-        fun updateVersion(project: Project, newVersion: SemVer) {
-            project.layout.projectDirectory.versionTxt().asFile.writeText(newVersion.toString())
-        }
-
-        @JvmStatic
-        fun generateProjectVersionReport(rootProject: Project, ostream: OutputStream) {
+        fun generateProjectVersionReport(version: String, ostream: OutputStream) {
             val writer = PrintStream(ostream, false, Charsets.UTF_8)
-            val version = rootProject.layout.projectDirectory.versionTxt().asFile.readText().trim()
 
             ostream.use {
                 writer.use {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.application.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.application.gradle.kts
@@ -17,12 +17,9 @@
 plugins {
     id("application")
     id("com.hedera.hashgraph.java")
-    id("com.gorylenko.gradle-git-properties")
 }
 
 group = "com.swirlds"
-
-gitProperties { keys = listOf("git.build.version", "git.commit.id", "git.commit.id.abbrev") }
 
 // Find the central SDK deployment dir by searching up the folder hierarchy
 fun sdkDir(dir: Directory): Directory =
@@ -38,9 +35,11 @@ val copyLib =
 // Copy built jar into `data/apps` and rename
 val copyApp =
     tasks.register<Copy>("copyApp") {
+        inputs.property("projectName", project.name)
+
         from(tasks.jar)
         into(sdkDir(layout.projectDirectory).dir("data/apps"))
-        rename { "${project.name}.jar" }
+        rename { "${inputs.properties["projectName"]}.jar" }
     }
 
 tasks.assemble {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.hapi.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.hapi.gradle.kts
@@ -49,12 +49,3 @@ sourceSets.all {
         }
     }
 }
-
-tasks.withType<Jar>().configureEach {
-    dependsOn(tasks.named("generatePbjSource"))
-    dependsOn(tasks.named("generateTestPbjSource"))
-    dependsOn(tasks.named("generateTestFixturesPbjSource"))
-    dependsOn(tasks.named("generateItestPbjSource"))
-    dependsOn(tasks.named("generateEetPbjSource"))
-    dependsOn(tasks.named("generateXtestPbjSource"))
-}

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -70,6 +70,33 @@ sourceSets.all {
     }
 }
 
+val writeGitProperties =
+    tasks.register<WriteProperties>("writeGitProperties") {
+        property("git.build.version", project.version)
+        @Suppress("UnstableApiUsage")
+        property(
+            "git.commit.id",
+            providers
+                .exec { commandLine("git", "rev-parse", "HEAD") }
+                .standardOutput
+                .asText
+                .map { it.trim() }
+        )
+        @Suppress("UnstableApiUsage")
+        property(
+            "git.commit.id.abbrev",
+            providers
+                .exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+                .standardOutput
+                .asText
+                .map { it.trim() }
+        )
+
+        destinationFile.set(layout.buildDirectory.file("generated/git/git.properties"))
+    }
+
+tasks.processResources { from(writeGitProperties) }
+
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -22,12 +22,6 @@ plugins {
 }
 
 dependencies.components {
-    // TODO remove, once a new version of 'com.hedera.pbj.runtime' has been
-    //  published with fix from https://github.com/hashgraph/pbj/pull/92
-    withModule("com.hedera.pbj:pbj-runtime") {
-        allVariants { withDependencies { removeAll { it.name != "antlr4-runtime" } } }
-    }
-
     withModule<IoGrpcDependencyMetadataRule>("io.grpc:grpc-netty")
     withModule<IoGrpcDependencyMetadataRule>("io.grpc:grpc-protobuf")
     withModule<IoGrpcDependencyMetadataRule>("io.grpc:grpc-protobuf-lite")

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.maven-publish.gradle.kts
@@ -18,7 +18,6 @@ plugins {
     id("java")
     id("maven-publish")
     id("signing")
-    id("com.google.cloud.artifactregistry.gradle-plugin")
 }
 
 java {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.platform-maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.platform-maven-publish.gradle.kts
@@ -19,6 +19,14 @@ plugins {
     id("com.hedera.hashgraph.maven-publish")
 }
 
+@Suppress("UnstableApiUsage")
+if (!gradle.startParameter.isConfigurationCacheRequested) {
+    // plugin to support 'artifactregistry' repositories that currently only works without
+    // configuration cache
+    // https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/85
+    apply(plugin = "com.google.cloud.artifactregistry.gradle-plugin")
+}
+
 publishing {
     publications {
         named<MavenPublication>("maven") {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.sdk.conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.sdk.conventions.gradle.kts
@@ -17,7 +17,6 @@
 plugins {
     id("java-library")
     id("com.hedera.hashgraph.java")
-    id("com.gorylenko.gradle-git-properties")
 }
 
 group = "com.swirlds"
@@ -27,8 +26,6 @@ javaModuleDependencies { versionsFromConsistentResolution(":swirlds-platform-cor
 configurations.getByName("mainRuntimeClasspath") {
     extendsFrom(configurations.getByName("internal"))
 }
-
-gitProperties { keys = listOf("git.build.version", "git.commit.id", "git.commit.id.abbrev") }
 
 // !!! Remove the following once 'test' tasks are allowed to run in parallel ===
 val allPlatformSdkProjects =

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.shadow-jar.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.shadow-jar.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.internal.DefaultDependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
@@ -26,11 +27,14 @@ tasks.withType<ShadowJar>().configureEach {
     from(sourceSets.main.get().output)
     mergeServiceFiles()
 
-    // Defer the resolution  of 'runtimeClasspath'. This is an issue in the shadow
-    // plugin that it automatically accesses the files in 'runtimeClasspath' while
-    // Gradle is building the task graph. The three lines below work around that.
+    // There is an issue in the shadow plugin that it automatically accesses the
+    // files in 'runtimeClasspath' while Gradle is building the task graph.
     // See: https://github.com/johnrengelman/shadow/issues/882
-    inputs.files(project.configurations.runtimeClasspath)
-    configurations = emptyList()
-    doFirst { configurations = listOf(inputs.files.filter { it.extension == "jar" }) }
+    dependencyFilter = NoResolveDependencyFilter()
+}
+
+class NoResolveDependencyFilter : DefaultDependencyFilter(project) {
+    override fun resolve(configuration: FileCollection): FileCollection {
+        return configuration
+    }
 }

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.shadow-jar.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.shadow-jar.gradle.kts
@@ -32,5 +32,5 @@ tasks.withType<ShadowJar>().configureEach {
     // See: https://github.com/johnrengelman/shadow/issues/882
     inputs.files(project.configurations.runtimeClasspath)
     configurations = emptyList()
-    doFirst { configurations = listOf(project.configurations.runtimeClasspath.get()) }
+    doFirst { configurations = listOf(inputs.files.filter { it.extension == "jar" }) }
 }

--- a/build-logic/settings-plugins/build.gradle.kts
+++ b/build-logic/settings-plugins/build.gradle.kts
@@ -16,7 +16,4 @@
 
 plugins { `kotlin-dsl` }
 
-dependencies {
-    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.15.1")
-    implementation("me.champeau.gradle.includegit:plugin:0.1.6")
-}
+dependencies { implementation("com.gradle:gradle-enterprise-gradle-plugin:3.15.1") }

--- a/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
+++ b/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
@@ -22,12 +22,7 @@ pluginManagement {
     }
 }
 
-plugins {
-    id("com.gradle.enterprise")
-    // Use GIT plugin to clone HAPI protobuf files
-    // See documentation https://melix.github.io/includegit-gradle-plugin/latest/index.html
-    id("me.champeau.includegit")
-}
+plugins { id("com.gradle.enterprise") }
 
 // Enable Gradle Build Scan
 gradleEnterprise {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx6144m
 
+# Enable Gradle caching
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx6144m
 
-# Enable Gradle caching
+org.gradle.configuration-cache=true
 org.gradle.caching=true
 
 # Enable parallel workers

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -53,7 +53,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.4")
+    version("com.hedera.pbj.runtime", "0.7.6")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)
     version("dagger.compiler", daggerVersion)

--- a/hedera-node/hapi/build.gradle.kts
+++ b/hedera-node/hapi/build.gradle.kts
@@ -26,19 +26,26 @@ description = "Hedera API"
 val hapiProtoBranchOrTag = "add-pbj-types-for-state"
 val hederaProtoDir = layout.projectDirectory.dir("hedera-protobufs")
 
-@Suppress("UnstableApiUsage")
-providers
-    .exec {
-        if (!hederaProtoDir.dir(".git").asFile.exists()) {
-            workingDir = layout.projectDirectory.asFile
-            commandLine("git", "clone", "https://github.com/hashgraph/hedera-protobufs.git", "-q")
-        } else {
-            workingDir = hederaProtoDir.asFile
-            commandLine("git", "fetch", "-q")
+if (!gradle.startParameter.isOffline) {
+    @Suppress("UnstableApiUsage")
+    providers
+        .exec {
+            if (!hederaProtoDir.dir(".git").asFile.exists()) {
+                workingDir = layout.projectDirectory.asFile
+                commandLine(
+                    "git",
+                    "clone",
+                    "https://github.com/hashgraph/hedera-protobufs.git",
+                    "-q"
+                )
+            } else {
+                workingDir = hederaProtoDir.asFile
+                commandLine("git", "fetch", "-q")
+            }
         }
-    }
-    .result
-    .get()
+        .result
+        .get()
+}
 
 @Suppress("UnstableApiUsage")
 providers

--- a/hedera-node/hapi/build.gradle.kts
+++ b/hedera-node/hapi/build.gradle.kts
@@ -61,20 +61,3 @@ tasks.test {
     minHeapSize = "512m"
     maxHeapSize = "4096m"
 }
-
-// ----
-// TODO move the following things to 'hashgraph/pbj' plugin
-tasks.withType<com.hedera.pbj.compiler.PbjCompilerTask> {
-    doFirst {
-        // Clean output directories before generating new code. Belongs into:
-        // 'pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java'
-        delete(javaMainOutputDirectory)
-        delete(javaTestOutputDirectory)
-    }
-}
-
-tasks.withType<com.autonomousapps.tasks.CodeSourceExploderTask>().configureEach {
-    // Wire the source generation so that the source sets know which tasks
-    // generate code for them. Then this additional 'dependsOn' is not necessary.
-    dependsOn(tasks.withType<com.hedera.pbj.compiler.PbjCompilerTask>())
-} // ----

--- a/hedera-node/hapi/build.gradle.kts
+++ b/hedera-node/hapi/build.gradle.kts
@@ -23,6 +23,32 @@ plugins {
 
 description = "Hedera API"
 
+val hapiProtoBranchOrTag = "add-pbj-types-for-state"
+val hederaProtoDir = layout.projectDirectory.dir("hedera-protobufs")
+
+@Suppress("UnstableApiUsage")
+providers
+    .exec {
+        if (!hederaProtoDir.dir(".git").asFile.exists()) {
+            workingDir = layout.projectDirectory.asFile
+            commandLine("git", "clone", "https://github.com/hashgraph/hedera-protobufs.git", "-q")
+        } else {
+            workingDir = hederaProtoDir.asFile
+            commandLine("git", "fetch", "-q")
+        }
+    }
+    .result
+    .get()
+
+@Suppress("UnstableApiUsage")
+providers
+    .exec {
+        workingDir = hederaProtoDir.asFile
+        commandLine("git", "checkout", hapiProtoBranchOrTag, "-q")
+    }
+    .result
+    .get()
+
 testModuleInfo {
     requires("com.hedera.node.hapi")
     // we depend on the protoc compiled hapi during test as we test our pbj generated code

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -127,16 +127,15 @@ tasks.withType<Test> {
 // Add all the libs dependencies into the jar manifest!
 tasks.jar {
     inputs.files(configurations.runtimeClasspath)
-    manifest {
-        attributes(
-            "Main-Class" to "com.hedera.node.app.ServicesMain",
+    manifest { attributes("Main-Class" to "com.hedera.node.app.ServicesMain") }
+    doFirst {
+        manifest.attributes(
             "Class-Path" to
-                configurations.runtimeClasspath.get().elements.map { entry ->
-                    entry
-                        .map { "../../data/lib/" + it.asFile.name }
-                        .sorted()
-                        .joinToString(separator = " ")
-                }
+                inputs.files
+                    .filter { it.extension == "jar" }
+                    .map { "../../data/lib/" + it.name }
+                    .sorted()
+                    .joinToString(separator = " ")
         )
     }
 }

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -146,25 +146,6 @@ val copyLib =
     tasks.register<Sync>("copyLib") {
         from(project.configurations.getByName("runtimeClasspath"))
         into(layout.projectDirectory.dir("../data/lib"))
-
-        doLast {
-            val nonModulalJars =
-                destinationDir
-                    .listFiles()!!
-                    .mapNotNull { jar ->
-                        if (zipTree(jar).none { it.name == "module-info.class" }) {
-                            jar.name
-                        } else {
-                            null
-                        }
-                    }
-                    .sorted()
-            if (nonModulalJars.isNotEmpty()) {
-                throw RuntimeException(
-                    "Jars without 'module-info.class' in 'data/lib'\n${nonModulalJars.joinToString("\n")}"
-                )
-            }
-        }
     }
 
 // Copy built jar into `data/apps` and rename HederaNode.jar

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/ActionsHelperTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/ActionsHelperTest.java
@@ -53,7 +53,7 @@ class ActionsHelperTest {
     @Test
     void prettyPrintsAsExpected() {
         final var expected =
-                "SolidityAction(callType: CALL, callOperationType: OP_CALL, value: 0, gas: 500000, gasUsed: 0, callDepth: 0, callingAccount: <null>, callingContract: ContractID[shardNum=0, realmNum=0, contract=OneOf[kind=CONTRACT_NUM, value=666]], recipientAccount: <null>, recipientContract: ContractID[shardNum=0, realmNum=0, contract=OneOf[kind=CONTRACT_NUM, value=666]], invalidSolidityAddress (aka targetedAddress): <null>, input: Bytes[1,2,3,4,5,6,7,8,9], output: Bytes[9,8,7,6,5,4,3,2,1], revertReason: <null>, error: <null>)";
+                "SolidityAction(callType: CALL, callOperationType: OP_CALL, value: 0, gas: 500000, gasUsed: 0, callDepth: 0, callingAccount: <null>, callingContract: ContractID[shardNum=0, realmNum=0, contract=OneOf[kind=CONTRACT_NUM, value=666]], recipientAccount: <null>, recipientContract: ContractID[shardNum=0, realmNum=0, contract=OneOf[kind=CONTRACT_NUM, value=666]], invalidSolidityAddress (aka targetedAddress): <null>, input: 010203040506070809, output: 090807060504030201, revertReason: <null>, error: <null>)";
         final var actual = subject.prettyPrint(CALL_ACTION);
         assertEquals(expected, actual);
     }

--- a/platform-sdk/swirlds/build.gradle.kts
+++ b/platform-sdk/swirlds/build.gradle.kts
@@ -32,17 +32,18 @@ tasks.copyApp {
 
 tasks.jar {
     // Gradle fails to track 'configurations.runtimeClasspath' as an input to the task if it is
-    // only used in the 'mainfest.attributes'. Hence, we explicitly add it as input.
+    // only used in the 'manifest.attributes'. Hence, we explicitly add it as input.
     inputs.files(configurations.runtimeClasspath)
-    manifest {
-        attributes(
-            "Class-Path" to
-                configurations.runtimeClasspath.get().elements.map { entry ->
-                    entry
-                        .map { "data/lib/" + it.asFile.name }
+    doFirst {
+        manifest {
+            attributes(
+                "Class-Path" to
+                    inputs.files
+                        .filter { it.extension == "jar" }
+                        .map { "data/lib/" + it.name }
                         .sorted()
                         .joinToString(separator = " ")
-                }
-        )
+            )
+        }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import me.champeau.gradle.igp.gitRepositories
-
 pluginManagement { includeBuild("build-logic") }
 
 plugins { id("com.hedera.hashgraph.settings") }
@@ -141,24 +139,8 @@ fun includeAllProjects(containingFolder: String) {
     }
 }
 
-// The HAPI API version to use for Protobuf sources. This can be a tag or branch
-// name from the hedera-protobufs GIT repo.
+// The HAPI API version to use for Protobuf sources.
 val hapiProtoVersion = "0.44.0"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state"
-
-gitRepositories {
-    checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))
-
-    if (!gradle.startParameter.isOffline) {
-        include("hedera-protobufs") {
-            uri.set("https://github.com/hashgraph/hedera-protobufs.git")
-            // HAPI repo version
-            tag.set(hapiProtoBranchOrTag)
-            // do not load project from repo
-            autoInclude.set(false)
-        }
-    }
-}
 
 dependencyResolutionManagement {
     // Protobuf tool versions

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -167,6 +167,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.4")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.6")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -148,8 +148,6 @@ val hapiProtoBranchOrTag = "add-pbj-types-for-state"
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))
-    // check branch in repo for updates every second
-    refreshIntervalMillis.set(1000)
 
     if (!gradle.startParameter.isOffline) {
         include("hedera-protobufs") {


### PR DESCRIPTION
**Description**:

https://docs.gradle.org/current/userguide/configuration_cache.html

For this to work, all external processes that are part of the Gradle configuration need to run through `providers.exec`. Many plugins do not yet do this, hence this PR removes all plugins that call `git` under the hood. Instead we call `git` directly using `providers.exec` where needed. 

Also, the `com.google.cloud.artifactregistry.gradle-plugin` is not compatible with the _configuration cache_ yet (https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/85). But the functionality is only needed for publishing. Until the plugin is fixed, we apply it conditionally when we run without cache for publishing.


