### PR TITLE
08813: ContractCallLocalSuiteTests (#9672)

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
@@ -33,6 +33,7 @@ import com.hedera.hapi.node.transaction.FixedFee;
 import com.hedera.hapi.node.transaction.FractionalFee;
 import com.hedera.hapi.node.transaction.RoyaltyFee;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.hapi.node.state.token.Account;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
@@ -60,7 +61,7 @@ public class TokenTupleUtils {
         return Tuple.of(
                 token.expirationSecond(),
                 headlongAddressOf(token.autoRenewAccountIdOrElse(ZERO_ACCOUNT_ID)),
-                token.autoRenewSeconds());
+                (token.autoRenewSeconds() > 0 ? token.autoRenewSeconds() : 0));
     }
 
     /**
@@ -230,14 +231,15 @@ public class TokenTupleUtils {
             @NonNull final Token token,
             @NonNull final Nft nft,
             final long serialNumber,
-            @NonNull final String ledgerId) {
+            @NonNull final String ledgerId,
+            Account ownerAccount) {
 
         final var nftMetaData = nft.metadata() != null ? nft.metadata().toByteArray() : Bytes.EMPTY.toByteArray();
 
         return Tuple.of(
                 tokenInfoTupleFor(token, ledgerId),
                 serialNumber,
-                headlongAddressOf(nft.ownerIdOrElse(ZERO_ACCOUNT_ID)),
+                headlongAddressOf(ownerAccount),
                 nft.mintTimeOrElse(new Timestamp(0, 0)).seconds(),
                 nftMetaData,
                 headlongAddressOf(nft.spenderIdOrElse(ZERO_ACCOUNT_ID)));

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -173,6 +173,10 @@ public class ConversionUtils {
      */
     public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(@NonNull final AccountID accountID) {
         requireNonNull(accountID);
+        if (accountID.account().kind() == AccountID.AccountOneOfType.UNSET) {
+            return asHeadlongAddress(Bytes.EMPTY.toArray());
+        }
+
         final var integralAddress = accountID.hasAccountNum()
                 ? asEvmAddress(accountID.accountNum())
                 : accountID.alias().toByteArray();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
@@ -359,6 +359,9 @@ public class TestHelpers {
     public static final AccountID OPERATOR_ACCOUNT_ID =
             AccountID.newBuilder().accountNum(7777777L).build();
 
+    public static final Account A_NEW_ACCOUNT = Account.newBuilder().accountId(A_NEW_ACCOUNT_ID).build();
+    public static final Account B_NEW_ACCOUNT = Account.newBuilder().accountId(B_NEW_ACCOUNT_ID).build();
+
     public static final Nft TREASURY_OWNED_NFT = Nft.newBuilder()
             .metadata(Bytes.wrap("Unsold"))
             .nftId(NftID.newBuilder().tokenId(NON_FUNGIBLE_TOKEN_ID).serialNumber(NFT_SERIAL_NO))

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCallTest.java
@@ -16,31 +16,18 @@
 
 package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.nfttokeninfo;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes.ZERO_ACCOUNT_ID;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CIVILIAN_OWNED_NFT;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EXPECTED_FIXED_CUSTOM_FEES;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EXPECTED_FRACTIONAL_CUSTOM_FEES;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EXPECTED_ROYALTY_CUSTOM_FEES;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EXPECTE_DEFAULT_KEYLIST;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EXPECTE_KEYLIST;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_EVERYTHING_TOKEN;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.LEDGER_ID;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SENDER_ID;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.revertOutputFor;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.*;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.*;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.headlongAddressOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.nfttokeninfo.NftTokenInfoCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.nfttokeninfo.NftTokenInfoTranslator;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
 import com.hedera.node.config.data.LedgerConfig;
 import com.swirlds.config.api.Configuration;
-import java.util.Collections;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -59,14 +46,14 @@ class NftTokenInfoCallTest extends HtsCallTestBase {
     @Test
     void returnsNftTokenInfoStatusForPresentToken() {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
-        final var expectedLedgerId = com.hedera.pbj.runtime.io.buffer.Bytes.fromHex(LEDGER_ID);
-        when(ledgerConfig.id()).thenReturn(expectedLedgerId);
+        when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex(LEDGER_ID));
         when(nativeOperations.getNft(FUNGIBLE_EVERYTHING_TOKEN.tokenId().tokenNum(), 2L))
                 .thenReturn(CIVILIAN_OWNED_NFT);
+        when(nativeOperations.getAccount(A_NEW_ACCOUNT_ID.accountNum())).thenReturn(A_NEW_ACCOUNT);
 
         final var subject =
                 new NftTokenInfoCall(gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN, 2L, config);
-
+        String ledgerIdBytes =  com.hedera.pbj.runtime.io.buffer.Bytes.fromHex(LEDGER_ID).toString();
         final var result = subject.execute().fullResult().result();
 
         assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
@@ -94,66 +81,31 @@ class NftTokenInfoCallTest extends HtsCallTestBase {
                                                 EXPECTED_FIXED_CUSTOM_FEES.toArray(new Tuple[0]),
                                                 EXPECTED_FRACTIONAL_CUSTOM_FEES.toArray(new Tuple[0]),
                                                 EXPECTED_ROYALTY_CUSTOM_FEES.toArray(new Tuple[0]),
-                                                Bytes.wrap(expectedLedgerId.toByteArray())
-                                                        .toString()),
+                                                ledgerIdBytes),
                                         2L,
-                                        headlongAddressOf(CIVILIAN_OWNED_NFT.ownerId()),
+                                        headlongAddressOf(A_NEW_ACCOUNT),
                                         1000000L,
                                         com.hedera.pbj.runtime.io.buffer.Bytes.wrap("SOLD")
                                                 .toByteArray(),
-                                        headlongAddressOf(CIVILIAN_OWNED_NFT.spenderId())))
+                                        headlongAddressOf(B_NEW_ACCOUNT)))
                         .array()),
                 result.getOutput());
     }
 
     @Test
-    void returnsNftTokenInfoStatusForMissingToken() {
+    void revertsWhenTryingToFetchMissingTokenNonStaticCall() {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
-        final var expectedLedgerId = com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01");
-        when(ledgerConfig.id()).thenReturn(expectedLedgerId);
+        when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01"));
 
         final var subject = new NftTokenInfoCall(gasCalculator, mockEnhancement(), false, null, 0L, config);
-
         final var result = subject.execute().fullResult().result();
 
-        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
-        assertEquals(
-                Bytes.wrap(NftTokenInfoTranslator.NON_FUNGIBLE_TOKEN_INFO
-                        .getOutputs()
-                        .encodeElements(
-                                INVALID_TOKEN_ID.protoOrdinal(),
-                                Tuple.of(
-                                        Tuple.of(
-                                                Tuple.of(
-                                                        "",
-                                                        "",
-                                                        headlongAddressOf(ZERO_ACCOUNT_ID),
-                                                        "",
-                                                        false,
-                                                        0L,
-                                                        false,
-                                                        EXPECTE_DEFAULT_KEYLIST.toArray(new Tuple[0]),
-                                                        Tuple.of(0L, headlongAddressOf(ZERO_ACCOUNT_ID), 0L)),
-                                                0L,
-                                                false,
-                                                false,
-                                                false,
-                                                Collections.emptyList().toArray(new Tuple[0]),
-                                                Collections.emptyList().toArray(new Tuple[0]),
-                                                Collections.emptyList().toArray(new Tuple[0]),
-                                                Bytes.wrap(expectedLedgerId.toByteArray())
-                                                        .toString()),
-                                        0L,
-                                        headlongAddressOf(ZERO_ACCOUNT_ID),
-                                        new Timestamp(0, 0).seconds(),
-                                        com.hedera.pbj.runtime.io.buffer.Bytes.EMPTY.toByteArray(),
-                                        headlongAddressOf(ZERO_ACCOUNT_ID)))
-                        .array()),
-                result.getOutput());
+        assertEquals(MessageFrame.State.REVERT, result.getState());
+        assertEquals(revertOutputFor(INVALID_TOKEN_ID), result.getOutput());
     }
 
     @Test
-    void returnsNftTokenInfoStatusForMissingTokenStaticCall() {
+    void revertsWhenTryingToFetchMissingTokenStaticCall() {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
         when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01"));
 
@@ -163,5 +115,20 @@ class NftTokenInfoCallTest extends HtsCallTestBase {
 
         assertEquals(MessageFrame.State.REVERT, result.getState());
         assertEquals(revertOutputFor(INVALID_TOKEN_ID), result.getOutput());
+    }
+
+    @Test
+    void revertsWhenFetchingTokenWithNoOwnerAccount() {
+        when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
+        when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex(LEDGER_ID));
+        when(nativeOperations.getNft(FUNGIBLE_EVERYTHING_TOKEN.tokenId().tokenNum(), 2L))
+                .thenReturn(CIVILIAN_OWNED_NFT);
+
+        final var subject =
+                new NftTokenInfoCall(gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN, 2L, config);
+        final var result = subject.execute().fullResult().result();
+
+        assertEquals(MessageFrame.State.REVERT, result.getState());
+        assertEquals(revertOutputFor(INVALID_ACCOUNT_ID), result.getOutput());
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -107,6 +107,7 @@ public class ContractCallLocalSuite extends HapiSuite {
                 htsOwnershipCheckWorksWithAliasAddress());
     }
 
+    @HapiTest
     private HapiSpec htsOwnershipCheckWorksWithAliasAddress() {
         final AtomicReference<AccountID> ecdsaAccountId = new AtomicReference<>();
         final AtomicReference<ByteString> ecdsaAccountIdLongZeroAddress = new AtomicReference<>();


### PR DESCRIPTION
Description:

Purpose of the PR is fixing the htsOwnershipCheckWorksWithAliasAddress in the ContractCallLocalSuite. It fixes some problems in the NftTokenInfoCall and covers some unhandled cases.

Related issue(s):
https://github.com/hashgraph/hedera-services/issues/8813

Fixes #9617 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
