### PR TITLE
Add support for underscored numerical literals in Configuration Converters

### DIFF
--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/IntegerConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/IntegerConverter.java
@@ -32,6 +32,6 @@ public final class IntegerConverter implements ConfigConverter<Integer> {
         if (value == null) {
             throw new NullPointerException("null can not be converted");
         }
-        return Integer.valueOf(value);
+        return Integer.valueOf(value.replace("_", ""));
     }
 }

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/LongConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/LongConverter.java
@@ -32,6 +32,6 @@ public final class LongConverter implements ConfigConverter<Long> {
         if (value == null) {
             throw new NullPointerException("null can not be converted");
         }
-        return Long.valueOf(value);
+        return Long.valueOf(value.replace("_", ""));
     }
 }

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/IntegerConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/IntegerConverterTest.java
@@ -79,6 +79,8 @@ class IntegerConverterTest {
                 Arguments.of("-7", -7),
                 Arguments.of("7", 7),
                 Arguments.of("0", 0),
+                Arguments.of("10_000", 10000),
+                Arguments.of("-10_000", -10000),
                 Arguments.of(Integer.MAX_VALUE + "", Integer.MAX_VALUE),
                 Arguments.of(Integer.MIN_VALUE + "", Integer.MIN_VALUE));
     }

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/LongConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/LongConverterTest.java
@@ -121,4 +121,31 @@ class LongConverterTest {
                 () -> converter.convert(rawValue),
                 "Only valid long values must be supported");
     }
+
+    @Test
+    public void convertNumericalLiteral() {
+        // given
+        final LongConverter converter = new LongConverter();
+        final String rawValue = "21_000";
+
+        // when
+        final long value = converter.convert(rawValue);
+
+        // then
+        Assertions.assertEquals(21000L, value, "Numerical literals must be supported");
+    }
+
+    @Test
+    public void convertNumericalLiteralNegative() {
+        // given
+        final LongConverter converter = new LongConverter();
+        final String rawValue = "-781_000";
+
+        // when
+        final long value = converter.convert(rawValue);
+
+        // then
+        Assertions.assertEquals(-781000L, value, "Negative numerical literals must be supported");
+    }
+
 }

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/LongConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/LongConverterTest.java
@@ -147,5 +147,4 @@ class LongConverterTest {
         // then
         Assertions.assertEquals(-781000L, value, "Negative numerical literals must be supported");
     }
-
 }


### PR DESCRIPTION
**Description**:
This PR adds support for numerical literals in the ConfigConvertors for `IntegerConverter` & `LongConvertors`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
