### PR TITLE
Dumper for token associations (tokenrels)

### DIFF
--- a/hedera-node/cli-clients/services-cli.sh
+++ b/hedera-node/cli-clients/services-cli.sh
@@ -195,7 +195,7 @@ run () {
 }
 
 colorize () {
-  java -cp "${JVM_CLASSPATH}" com.swirlds.cli.utility.StdInOutColorize "${PROGRAM_ARGS[@]}"
+  java -cp "${JVM_CLASSPATH}" com.swirlds.cli.logging.StdInOutColorize "${PROGRAM_ARGS[@]}"
 }
 
 if [[ "$COLOR" = true ]]; then

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -93,6 +93,7 @@ public class DumpStateCommand extends AbstractCommand {
     void contractBytecodes(
             @Option(
                             names = {"-o", "--bytecode", "--contract-bytecode"},
+                            required = true,
                             arity = "1",
                             description = "Output file for contracts bytecode dump")
                     @NonNull
@@ -126,6 +127,7 @@ public class DumpStateCommand extends AbstractCommand {
     void contractStores(
             @Option(
                             names = {"-o", "--store"},
+                            required = true,
                             arity = "1",
                             description = "Output file for contracts store dump")
                     @NonNull
@@ -154,6 +156,7 @@ public class DumpStateCommand extends AbstractCommand {
     void accounts(
             @Option(
                             names = {"--account"},
+                            required = true,
                             arity = "1",
                             description = "Output file for accounts dump")
                     @NonNull
@@ -167,7 +170,7 @@ public class DumpStateCommand extends AbstractCommand {
                             names = {"--low"},
                             arity = "0..1",
                             defaultValue = "0",
-                            description = "Lowest acount number (inclusive) to dump")
+                            description = "Lowest account number (inclusive) to dump")
                     int lowLimit,
             @Option(
                             names = {"--high"},
@@ -202,6 +205,7 @@ public class DumpStateCommand extends AbstractCommand {
     void files(
             @Option(
                             names = {"--file"},
+                            required = true,
                             arity = "1",
                             description = "Output file for files dump")
                     @NonNull
@@ -217,7 +221,7 @@ public class DumpStateCommand extends AbstractCommand {
                     final boolean omitContents,
             @Option(
                             names = {"-s", "--summary"},
-                            description = "Emit a summary line")
+                            description = "Emit summary information")
                     final boolean emitSummary) {
         Objects.requireNonNull(filesPath);
         init();
@@ -236,6 +240,7 @@ public class DumpStateCommand extends AbstractCommand {
     void tokens(
             @Option(
                             names = {"--token"},
+                            required = true,
                             arity = "1",
                             description = "Output file for fungibles dump")
                     @NonNull
@@ -251,7 +256,7 @@ public class DumpStateCommand extends AbstractCommand {
                     final boolean doFeeSummary,
             @Option(
                             names = {"-s", "--summary"},
-                            description = "Emit a summary line")
+                            description = "Emit summary information")
                     final boolean emitSummary) {
         Objects.requireNonNull(tokensPath);
         init();
@@ -270,13 +275,14 @@ public class DumpStateCommand extends AbstractCommand {
     void uniques(
             @Option(
                             names = {"--unique"},
+                            required = true,
                             arity = "1",
                             description = "Output file for unique tokens dump")
                     @NonNull
                     final Path uniquesPath,
             @Option(
                             names = {"-s", "--summary"},
-                            description = "Emit a summary line")
+                            description = "Emit a summary information")
                     final boolean emitSummary) {
         Objects.requireNonNull(uniquesPath);
         init();
@@ -286,25 +292,46 @@ public class DumpStateCommand extends AbstractCommand {
         finish();
     }
 
+    @Command(name = "associations", description = "Dump token associations (tokenrels)")
+    void associations(
+            @Option(
+                            names = {"--associations"},
+                            required = true,
+                            arity = "1",
+                            description = "Output file for token associations dump")
+                    @NonNull
+                    final Path associationsPath,
+            @Option(
+                            names = {"-s", "--summary"},
+                            description = "Emit summary information")
+                    final boolean emitSummary) {
+        Objects.requireNonNull(associationsPath);
+        init();
+        System.out.println("=== token associations ===");
+        DumpTokenAssociationsSubcommand.doit(
+                parent.signedState, associationsPath, emitSummary ? EmitSummary.YES : EmitSummary.NO, parent.verbosity);
+        finish();
+    }
+
     /** Setup to run a dump subcommand: If _first_ subcommand being run then open signed state file */
     void init() {
-        if (thisSubcommandisNumber == null) {
-            thisSubcommandisNumber = 0;
+        if (thisSubcommandsNumber == null) {
+            thisSubcommandsNumber = 0;
             subcommandsToRun = getSubcommandsToRun();
             parent.openSignedState();
         } else {
-            thisSubcommandisNumber++;
+            thisSubcommandsNumber++;
         }
     }
 
     /** Cleanup after running a dump subcommand: If _last_ subcommand being run then close signed state file */
     void finish() {
-        if (thisSubcommandisNumber == subcommandsToRun.size() - 1) {
+        if (thisSubcommandsNumber == subcommandsToRun.size() - 1) {
             parent.closeSignedState();
         }
     }
 
-    Integer thisSubcommandisNumber;
+    Integer thisSubcommandsNumber;
     Set<String> subcommandsToRun;
 
     /** We need to find out how many subcommands we're going to run, so that we can manage the signed state file.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokenAssociationsSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokenAssociationsSubcommand.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.service.mono.state.merkle.MerkleTokenRelStatus;
+import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
+import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskTokenRel;
+import com.hedera.node.app.service.mono.utils.EntityNumPair;
+import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import com.hedera.services.cli.utils.Writer;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.base.utility.Pair;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+
+/** Dump all token associations (tokenrels) , from a signed state file, to a text file, in deterministic order */
+@SuppressWarnings("java:S106")
+// S106: "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
+public class DumpTokenAssociationsSubcommand {
+
+    static void doit(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path tokenRelPath,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final Verbosity verbosity) {
+        new DumpTokenAssociationsSubcommand(state, tokenRelPath, emitSummary, verbosity).doit();
+    }
+
+    @NonNull
+    final SignedStateHolder state;
+
+    @NonNull
+    final Path tokenRelPath;
+
+    @NonNull
+    final EmitSummary emitSummary;
+
+    @NonNull
+    final Verbosity verbosity;
+
+    DumpTokenAssociationsSubcommand(
+            @NonNull final SignedStateHolder state,
+            @NonNull final Path tokenRelPath,
+            @NonNull final EmitSummary emitSummary,
+            @NonNull final Verbosity verbosity) {
+        requireNonNull(state, "state");
+        requireNonNull(tokenRelPath, "tokenRelPath");
+        requireNonNull(emitSummary, "emitSummary");
+        requireNonNull(verbosity, "verbosity");
+
+        this.state = state;
+        this.tokenRelPath = tokenRelPath;
+        this.emitSummary = emitSummary;
+        this.verbosity = verbosity;
+    }
+
+    void doit() {
+        final var tokenAssociationsStore = state.getTokenAssociations();
+        System.out.printf(
+                "=== %d token associations (%s) === %n",
+                tokenAssociationsStore.size(), tokenAssociationsStore.areOnDisk() ? "virtual" : "merkle");
+        final var tokenAssociations = gatherTokenAssociations(tokenAssociationsStore);
+
+        int reportSize;
+        try (@NonNull final var writer = new Writer(tokenRelPath)) {
+            if (emitSummary == EmitSummary.YES) reportSummary(writer, tokenAssociations);
+            reportOnTokenAssociations(writer, tokenAssociations);
+            reportSize = writer.getSize();
+        }
+        System.out.printf("=== token association report is %d bytes %n", reportSize);
+    }
+
+    record TokenRel(
+            long account,
+            long tokenId,
+            long balance,
+            boolean isFrozen,
+            boolean isKycGranted,
+            boolean isAutomaticAssociation,
+            long prev,
+            long next) {
+        @NonNull
+        public static TokenRel from(@NonNull final MerkleTokenRelStatus tokenRel) {
+            final var at = toLongsPair(toPair(tokenRel.getKey()));
+            return new TokenRel(
+                    at.left(),
+                    at.right(),
+                    tokenRel.getBalance(),
+                    tokenRel.isFrozen(),
+                    tokenRel.isKycGranted(),
+                    tokenRel.isAutomaticAssociation(),
+                    tokenRel.getPrev(),
+                    tokenRel.getNext());
+        }
+
+        @NonNull
+        public static TokenRel from(@NonNull final OnDiskTokenRel tokenRel) {
+            final var at = toLongsPair(toPair(tokenRel.getKey()));
+            return new TokenRel(
+                    at.left(),
+                    at.right(),
+                    tokenRel.getBalance(),
+                    tokenRel.isFrozen(),
+                    tokenRel.isKycGranted(),
+                    tokenRel.isAutomaticAssociation(),
+                    tokenRel.getPrev(),
+                    tokenRel.getNext());
+        }
+
+        @NonNull
+        public Pair<Long /*accountId*/, Long /*tokenId*/> getKey() {
+            return Pair.of(account, tokenId);
+        }
+    }
+
+    void reportSummary(
+            @NonNull final Writer writer, @NonNull final SortedMap<Pair<Long, Long>, TokenRel> tokenAssociations) {
+        requireNonNull(writer, "writer");
+        requireNonNull(tokenAssociations, "tokenAssociations");
+
+        final var uniqueAccounts = new HashSet<Long>();
+        final var uniqueTokens = new HashSet<Long>();
+        final var tokensByAccounts = new HashMap<Long, Long>();
+        tokenAssociations.keySet().forEach(p -> {
+            uniqueAccounts.add(p.left());
+            uniqueTokens.add(p.right());
+            tokensByAccounts.merge(p.left(), 1L, (a, ignored) -> a + 1);
+        });
+
+        final var totalTokenRelsByUniques =
+                tokensByAccounts.values().stream().mapToLong(i -> i).sum();
+
+        writer.write(
+                "# === %8d token associations (%d the hard way), %7d accounts with associations, %7d token types associated with accounts%n"
+                        .formatted(
+                                tokenAssociations.size(),
+                                totalTokenRelsByUniques,
+                                uniqueAccounts.size(),
+                                uniqueTokens.size()));
+
+        final var tokensByAccountsHistogram = tokensByAccounts.values().stream()
+                .collect(Collectors.groupingBy(n -> 0 == n ? 0 : (int) Math.log10(n), Collectors.counting()));
+        final int maxDigits = tokensByAccountsHistogram.keySet().stream()
+                .max(Comparator.naturalOrder())
+                .orElse(0);
+
+        final var sb = new StringBuilder(1000);
+        sb.append("#   === token associations per account histogram ===%n".formatted());
+        for (int i = 0; i <= maxDigits; i++) {
+            sb.append("# %11s: %8d%n"
+                    .formatted("<=" + (int) Math.pow(10, i), tokensByAccountsHistogram.getOrDefault(i, 0L)));
+        }
+        writer.write(sb);
+        writer.write("");
+    }
+
+    @NonNull
+    String formatHeader() {
+        return "account;token;balance;frozen;kycGranted;automaticAssociation;prev;next";
+    }
+
+    @NonNull
+    String toCsv(final boolean b) {
+        return b ? "T" : "";
+    }
+
+    @NonNull
+    String formatTokenRel(@NonNull final TokenRel t) {
+        return "%d;%d;%d;%s;%s;%s;%d;%d"
+                .formatted(
+                        t.account(),
+                        t.tokenId(),
+                        t.balance(),
+                        toCsv(t.isFrozen()),
+                        toCsv(t.isKycGranted()),
+                        toCsv(t.isAutomaticAssociation()),
+                        t.prev(),
+                        t.next());
+    }
+
+    void reportOnTokenAssociations(
+            @NonNull final Writer writer, @NonNull final SortedMap<Pair<Long, Long>, TokenRel> tokenAssociations) {
+        requireNonNull(writer, "writer");
+        requireNonNull(tokenAssociations, "tokenAssociations");
+        writer.writeln(formatHeader());
+        tokenAssociations.forEach((ignored, value) -> writer.writeln(formatTokenRel(value)));
+        writer.writeln("");
+    }
+
+    @NonNull
+    SortedMap<Pair<Long, Long>, TokenRel> gatherTokenAssociations(@NonNull TokenRelStorageAdapter tokenRelStore) {
+        requireNonNull(tokenRelStore, "tokenRelStore");
+
+        final SortedMap<Pair<Long, Long>, TokenRel> r = new TreeMap<>(getPairOfLongsComparator());
+
+        if (tokenRelStore.areOnDisk()) {
+            final var tokenRels = requireNonNull(tokenRelStore.getOnDiskRels());
+            final var tokenAssociations = new ConcurrentLinkedQueue<TokenRel>();
+            try {
+                final var threadCount = 8; // Good enough for my laptop, why not?
+                tokenRels.extractVirtualMapDataC(
+                        getStaticThreadManager(),
+                        p -> {
+                            final var tokenRel = TokenRel.from(p.value());
+                            tokenAssociations.add(tokenRel);
+                        },
+                        threadCount);
+            } catch (final InterruptedException ex) {
+                System.err.println("*** Traversal of token associations virtual map interrupted!");
+                Thread.currentThread().interrupt();
+            }
+            while (!tokenAssociations.isEmpty()) {
+                final var tokenRel = tokenAssociations.poll();
+                r.put(tokenRel.getKey(), tokenRel);
+            }
+        } else /* not on disk */ {
+            final var tokenRels = requireNonNull(tokenRelStore.getInMemoryRels());
+            tokenRels.getIndex().forEach((key, value) -> r.put(toLongsPair(toPair(key)), TokenRel.from(value)));
+        }
+
+        return r;
+    }
+
+    @NonNull
+    static Pair<AccountID, TokenID> toPair(@NonNull final EntityNumPair enp) {
+        final var at = enp.asAccountTokenRel();
+        return Pair.of(at.getLeft(), at.getRight());
+    }
+
+    @NonNull
+    static Pair<Long, Long> toLongsPair(@NonNull final Pair<AccountID, TokenID> pat) {
+        return Pair.of(pat.left().getAccountNum(), pat.right().getTokenNum());
+    }
+
+    @NonNull
+    static Comparator<Pair<Long, Long>> getPairOfLongsComparator() {
+        // This two-step dance necessary because of Java inference limitations
+        final Comparator<Pair<Long, Long>> cx = Comparator.comparingLong(Pair::left);
+        return cx.thenComparingLong(Pair::right);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -49,6 +49,7 @@ public final class SignedStateCommand extends AbstractCommand {
 
     @Option(
             names = {"-f", "--file"},
+            required = true,
             arity = "1",
             description = "Input signed state file")
     Path inputFile;

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -22,6 +22,7 @@ import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleSpecialFiles;
 import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
+import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
@@ -254,6 +255,14 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
         final var nftTypes = servicesState.uniqueTokens();
         assertSignedStateComponentExists(nftTypes, "(non-fungible) unique tokens");
         return nftTypes;
+    }
+
+    /** Get all token associations (tokenrels) */
+    @NonNull
+    public TokenRelStorageAdapter getTokenAssociations() {
+        final var tokenRels = servicesState.tokenAssociations();
+        assertSignedStateComponentExists(tokenRels, "token associations (tokenrels)");
+        return tokenRels;
     }
 
     /**


### PR DESCRIPTION
**Description**:

Dumps all token associations in a signed state file as CSV (actually, tab separated), deterministically.

**Related issue(s)**:

Fixes #9694.

**Example**:

`./services-cli.sh signed-state --file=states/2023-10-29T00:01:59Z/151975134/SignedState.swh  dump associations --associations=associations.txt --summary`

```
# ===  4805300 token associations (4805300 the hard way), 1467622 accounts with associations,   32997 token types associated with accounts
#   === token associations per account histogram ===
#         <=1:  1268337
#        <=10:   198265
#       <=100:     1012
#      <=1000:        8
account;token;balance;frozen;kycGranted;automaticAssociation;prev;next
200;2035606;1;T;T;;0;0
201;2035606;1;T;T;;0;0
202;2035606;1;T;T;;0;0
203;2035606;1;T;T;;0;0
204;2035606;1;T;T;;0;0
224;2035606;1;T;T;;0;0
938;127877;935000000;;T;;859814;0
938;624505;4000000000;;T;;1985922;859814
938;859814;373082010;;T;;624505;127877
938;1985922;320000;;T;;3716059;624505
938;3716059;75700000000;;T;;0;1985922
950;107597;1000000000;;T;;107598;0
950;107598;1000000000;;T;;107600;107597
950;107600;1000000000;;T;;107602;107598
950;107602;999997650;;T;;107604;107600
950;107604;1000000000;;T;;107606;107602
950;107606;999997650;;T;;107608;107604
```

and so on and so forth for ~4.8M lines ...

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (manual)
