### PR TITLE
chore: publish release artifacts to the public CDN

### DIFF
--- a/.github/workflows/node-flow-deploy-adhoc-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-adhoc-artifact.yaml
@@ -60,6 +60,7 @@ jobs:
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}
+      cdn-bucket-name: ${{ secrets.CDN_ARTIFACT_BUCKET_NAME }}
       svcs-ossrh-username: ${{ secrets.SVCS_OSSRH_USERNAME }}
       svcs-ossrh-password: ${{ secrets.SVCS_OSSRH_PASSWORD }}
       svcs-gpg-key-contents: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -74,6 +74,7 @@ jobs:
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}
+      cdn-bucket-name: ${{ secrets.CDN_ARTIFACT_BUCKET_NAME }}
       svcs-ossrh-username: ${{ secrets.SVCS_OSSRH_USERNAME }}
       svcs-ossrh-password: ${{ secrets.SVCS_OSSRH_PASSWORD }}
       svcs-gpg-key-contents: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
@@ -96,6 +97,7 @@ jobs:
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}
+      cdn-bucket-name: ${{ secrets.CDN_ARTIFACT_BUCKET_NAME }}
       svcs-ossrh-username: ${{ secrets.SVCS_OSSRH_USERNAME }}
       svcs-ossrh-password: ${{ secrets.SVCS_OSSRH_PASSWORD }}
       svcs-gpg-key-contents: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -71,6 +71,8 @@ on:
         required: true
       bucket-name:
         required: true
+      cdn-bucket-name:
+        required: true
       svcs-ossrh-username:
         required: true
       svcs-ossrh-password:
@@ -115,6 +117,8 @@ jobs:
       commit-id: ${{ steps.parameters.outputs.commit-id }}
       commit-id-short: ${{ steps.parameters.outputs.commit-id-short }}
       version: ${{ steps.effective-version.outputs.number }}
+      version-prefix: ${{ steps.effective-version.outputs.prefix }}
+      prerelease: ${{ steps.effective-version.outputs.prerelease }}
     steps:
       - name: Install Semantic Version Tools
         run: |
@@ -188,7 +192,16 @@ jobs:
         id: effective-version
         run: |
           EFF_VERSION="$(./gradlew showVersion --quiet | tr -d '[:space:]')"
+          PRERELEASE_SUFFIX="$(semver get prerel "${EFF_VERSION}")"
+          PRERELEASE="false"
+          [[ -n "${PRERELEASE_SUFFIX}" ]] && PRERELEASE="true"
+          
+          MAJOR_VERSION="$(semver get major "${EFF_VERSION}")"
+          MINOR_VERSION="$(semver get minor "${EFF_VERSION}")"
+          
           echo "number=${EFF_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "prefix=${MAJOR_VERSION}.${MINOR_VERSION" >>"${GITHUB_OUTPUT}"
+          echo "prerelease=${PRERELEASE}" >>"${GITHUB_OUTPUT}"
 
       - name: Cache Build Version
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
@@ -345,6 +358,14 @@ jobs:
         with:
           path: ${{ steps.artifact-release.outputs.folder }}
           destination: ${{ secrets.bucket-name }}
+          parent: false
+
+      - name: Upload Artifacts (CDN Bucket)
+        uses: google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c # v1.0.3
+        if: ${{ inputs.dry-run-enabled != true && needs.validate.outputs.prerelease != 'true' && !cancelled() && !failure() }}
+        with:
+          path: ${{ steps.artifact-release.outputs.folder }}
+          destination: ${{ secrets.cdn-bucket-name }}/node/software/v${{ needs.validate.outputs.version-prefix }}/
           parent: false
 
       - name: Notify Jenkins of Release (Integration)

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -195,10 +195,10 @@ jobs:
           PRERELEASE_SUFFIX="$(semver get prerel "${EFF_VERSION}")"
           PRERELEASE="false"
           [[ -n "${PRERELEASE_SUFFIX}" ]] && PRERELEASE="true"
-          
+
           MAJOR_VERSION="$(semver get major "${EFF_VERSION}")"
           MINOR_VERSION="$(semver get minor "${EFF_VERSION}")"
-          
+
           echo "number=${EFF_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prefix=${MAJOR_VERSION}.${MINOR_VERSION" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${PRERELEASE}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for publishing the release artifacts to the public CDN

### Required Cherry Picks

- `release/0.44`

### Related Issues

- Closes #9691 