### PR TITLE
chore: enable support for the Gradle build cache node

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -98,3 +98,5 @@ jobs:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}
       snyk-token: ${{ secrets.SNYK_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -39,6 +39,8 @@ jobs:
       enable-spotless-check: false
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
   spotless:
     name: Spotless
@@ -53,6 +55,8 @@ jobs:
       enable-spotless-check: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
   unit-tests:
     name: Unit Tests
@@ -66,6 +70,8 @@ jobs:
       enable-sonar-analysis: false
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   eet-tests:
@@ -81,6 +87,8 @@ jobs:
       enable-network-log-capture: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   integration-tests:
@@ -96,6 +104,8 @@ jobs:
       enable-network-log-capture: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   hapi-tests:
@@ -111,6 +121,8 @@ jobs:
       enable-network-log-capture: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   abbreviated-panel:
@@ -125,6 +137,8 @@ jobs:
       use-branch-for-slack-channel: false
     secrets:
       access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       jrs-ssh-user-name: ${{ secrets.PLATFORM_JRS_SSH_USER_NAME }}
       jrs-ssh-key-file: ${{ secrets.PLATFORM_JRS_SSH_KEY_FILE }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
@@ -144,4 +158,6 @@ jobs:
       enable-snyk-scan: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -142,7 +142,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         with:
-          cache-disabled: true
           gradle-version: ${{ inputs.gradle-version }}
 
       - name: Setup NodeJS

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -93,6 +93,12 @@ on:
       access-token:
         description: "The Github access token used to checkout the repository, submodules, and make GitHub API calls."
         required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
       sonar-token:
         description: "The SonarCloud access token used by the SonarQube agent to report an analysis."
         required: false
@@ -110,6 +116,10 @@ permissions:
   statuses: write
   checks: write
   contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
 
 jobs:
   compile:
@@ -132,7 +142,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         with:
-          build-root-directory: hedera-node
+          cache-disabled: true
           gradle-version: ${{ inputs.gradle-version }}
 
       - name: Setup NodeJS

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -128,6 +128,12 @@ on:
       access-token:
         description: "The Github access token used to checkout the repository, submodules, and make GitHub API calls."
         required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
       jrs-ssh-user-name:
         description: ""
         required: true
@@ -148,6 +154,8 @@ on:
 env:
   MAVEN_OPTS: -Xmx16g -XX:ActiveProcessorCount=16
   JAVA_OPTS: -Xmx28g -XX:ActiveProcessorCount=16
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
 
 defaults:
   run:

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -233,7 +233,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         with:
-          build-root-directory: platform-sdk
           gradle-version: ${{ inputs.gradle-version }}
           gradle-home-cache-strict-match: false
           gradle-home-cache-includes: |

--- a/build-logic/settings-plugins/build.gradle.kts
+++ b/build-logic/settings-plugins/build.gradle.kts
@@ -17,6 +17,6 @@
 plugins { `kotlin-dsl` }
 
 dependencies {
-    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.14.1")
+    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.15.1")
     implementation("me.champeau.gradle.includegit:plugin:0.1.6")
 }

--- a/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
+++ b/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
@@ -37,6 +37,31 @@ gradleEnterprise {
     }
 }
 
+val isCiServer = System.getenv().containsKey("CI")
+val gradleCacheUsername: String? = System.getenv("GRADLE_CACHE_USERNAME")
+val gradleCachePassword: String? = System.getenv("GRADLE_CACHE_PASSWORD")
+val gradleCacheAuthorized = (gradleCacheUsername?.isNotEmpty() ?: false) && (gradleCachePassword?.isNotEmpty() ?: false)
+
+buildCache {
+    remote<HttpBuildCache> {
+        url = uri("https://cache.gradle.hedera.svcs.eng.swirldslabs.io/cache/")
+        isPush = isCiServer && gradleCacheAuthorized
+
+        isUseExpectContinue = true
+        isEnabled = !gradle.startParameter.isOffline
+
+        if (isCiServer && gradleCacheAuthorized) {
+            credentials {
+                username = gradleCacheUsername
+                password = gradleCachePassword
+            }
+        }
+    }
+    local{
+        isEnabled = gradle.startParameter.isOffline
+    }
+}
+
 // Allow projects inside a build to be addressed by dependency coordinates notation.
 // https://docs.gradle.org/current/userguide/composite_builds.html#included_build_declaring_substitutions
 // Some functionality of the 'java-module-dependencies' plugin relies on this.

--- a/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
+++ b/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
@@ -40,7 +40,8 @@ gradleEnterprise {
 val isCiServer = System.getenv().containsKey("CI")
 val gradleCacheUsername: String? = System.getenv("GRADLE_CACHE_USERNAME")
 val gradleCachePassword: String? = System.getenv("GRADLE_CACHE_PASSWORD")
-val gradleCacheAuthorized = (gradleCacheUsername?.isNotEmpty() ?: false) && (gradleCachePassword?.isNotEmpty() ?: false)
+val gradleCacheAuthorized =
+    (gradleCacheUsername?.isNotEmpty() ?: false) && (gradleCachePassword?.isNotEmpty() ?: false)
 
 buildCache {
     remote<HttpBuildCache> {
@@ -56,9 +57,6 @@ buildCache {
                 password = gradleCachePassword
             }
         }
-    }
-    local{
-        isEnabled = gradle.startParameter.isOffline
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description

This pull request changes the following:

- Enables Gradle Build Cache Node support
   - Updates CI pipelines to support remote build cache writes.
   - Update Gradle configuration to support reading/writing cache from the remote.

### Related Issues

- Closes #9758  