### PR TITLE
Fix develop while adding responseCode as the additional required parameter

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractRevertibleTokenViewCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractRevertibleTokenViewCall.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.revertResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemContract.HTS_PRECOMPILE_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCall.PricedResult.gasOnly;
@@ -64,7 +65,8 @@ public abstract class AbstractRevertibleTokenViewCall extends AbstractHtsCall {
                 .systemOperations()
                 .externalizeResult(
                         contractFunctionResultSuccessFor(gasRequirement, output, contractID),
-                        SystemContractUtils.ResultStatus.IS_SUCCESS);
+                        SystemContractUtils.ResultStatus.IS_SUCCESS,
+                        SUCCESS);
 
         return result;
     }


### PR DESCRIPTION
**Description**:
Fix `develop` after merging [PR1](https://github.com/hashgraph/hedera-services/pull/9737) and [PR2](https://github.com/hashgraph/hedera-services/pull/9625) because of the related changes in those two PRs

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
