### PR TITLE
chore: apply limits to the Gradle parallelism to stabilize the Github runner agent

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -63,11 +63,6 @@ on:
         type: string
         required: false
         default: "temurin"
-      gradle-version:
-        description: "Gradle Version:"
-        type: string
-        required: false
-        default: "wrapper"
   push:
     branches:
       - develop
@@ -85,7 +80,6 @@ jobs:
     with:
       java-version: ${{ github.event.inputs.java-version || '17.0.3' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
-      gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
       enable-unit-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-unit-tests == 'true' }}
       enable-sonar-analysis: ${{ github.event_name == 'push' || github.event.inputs.enable-sonar-analysis == 'true' }}
       enable-integration-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-integration-tests == 'true' }}

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -73,11 +73,6 @@ on:
         type: string
         required: false
         default: "17.0.3"
-      gradle-version:
-        description: "Gradle Version:"
-        type: string
-        required: false
-        default: "wrapper"
       node-version:
         description: "NodeJS Version:"
         type: string
@@ -141,8 +136,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
 
       - name: Setup NodeJS
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
@@ -151,32 +144,20 @@ jobs:
 
       - name: Compile
         id: gradle-build
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: assemble --scan
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew assemble --scan --no-daemon
 
       - name: Spotless Check
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         if: ${{ inputs.enable-spotless-check && !cancelled() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: spotlessCheck --scan
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew spotlessCheck --scan --no-daemon
 
       - name: Gradle Dependency Scopes Check
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         if: ${{ inputs.enable-dependency-check && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: checkAllModuleInfo --scan --continue
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew checkAllModuleInfo --scan --continue --no-daemon
 
       - name: Unit Testing
         id: gradle-test
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: check --continue --scan
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew check --continue --scan --no-daemon
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
@@ -188,25 +169,19 @@ jobs:
           junit_files: "**/build/test-results/test/TEST-*.xml"
 
       - name: Setup Docker BuildX
-        if: ${{ (inputs.enable-integration-tests || inputs.enable-e2e-tests) && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        if: ${{ (inputs.enable-integration-tests || inputs.enable-e2e-tests) && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         with:
           version: v0.11.0
 
       - name: Build Docker Image # build the image for hedera-node
         if: ${{ (inputs.enable-integration-tests || inputs.enable-e2e-tests) && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: createDockerImage
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew createDockerImage --scan --no-daemon
 
       - name: Integration Testing
         id: gradle-itest
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         if: ${{ inputs.enable-integration-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: itest --scan
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew itest --scan --no-daemon
 
       - name: Publish Integration Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
@@ -227,14 +202,11 @@ jobs:
 
       - name: HAPI Testing
         id: gradle-hapiTest
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         if: ${{ inputs.enable-hapi-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         env:
           LC_ALL: en.UTF-8
           LANG: en_US.UTF-8
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: hapiTest -Dfile.encoding=UTF-8 --scan
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew hapiTest -Dfile.encoding=UTF-8 --scan --no-daemon
 
       - name: Publish HAPI Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
@@ -255,11 +227,8 @@ jobs:
 
       - name: E2E Testing
         id: gradle-eet
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         if: ${{ inputs.enable-e2e-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: eet --scan
+        run: ionice -c 2 -n 2 nice -n 19 ./gradlew eet --scan --no-daemon
 
       - name: Publish E2E Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
@@ -364,7 +333,7 @@ jobs:
             ) &&
             !cancelled()
           }}
-        run: snyk test --all-sub-projects --severity-threshold=high --json-file-output=snyk-test.json
+        run: ionice -c 2 -n 2 nice -n 19 snyk test --all-sub-projects --severity-threshold=high --json-file-output=snyk-test.json
 
       - name: Snyk Code
         id: snyk-code
@@ -381,7 +350,7 @@ jobs:
             ) &&
             !cancelled()
           }}
-        run: snyk code test --severity-threshold=high --json-file-output=snyk-code.json
+        run: ionice -c 2 -n 2 nice -n 19 snyk code test --severity-threshold=high --json-file-output=snyk-code.json
 
       - name: Publish Snyk Results
         if: >-

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,8 @@ org.gradle.jvmargs=-Xmx6144m
 # Enable Gradle caching
 org.gradle.caching=true
 
+# Enable parallel workers
 org.gradle.parallel=true
+
+# Limit parallel workers
+org.gradle.workers.max=6


### PR DESCRIPTION
## Description

This pull request changes the following:

- Limits the Gradle parallel worker count to 6 workers.
- Applies I/O niceness to the Gradle processes.
- Applies CPU niceness to the Gradle processes.
- Removes the configurable Gradle version from the CI workflows and instead always uses the Gradle wrapper version.

### Related Issues

- Closes #9773 