### PR TITLE
9764: ReconnectNodeRemover.getRecordsToDelete() loops forever

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/StoppableThreadImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/StoppableThreadImpl.java
@@ -575,11 +575,11 @@ public class StoppableThreadImpl<T extends InterruptableRunnable> implements Typ
      */
     private void interruptClose() throws InterruptedException {
         join(joinWaitMs);
-
         if (isAlive()) {
             interrupt();
             joinInternal();
         }
+        doFinalCycleWork();
     }
 
     /**

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySet.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySet.java
@@ -84,7 +84,7 @@ public class HalfDiskVirtualKeySet<K extends VirtualKey> implements VirtualKeySe
         bloomFilter = new BloomFilter<>(bloomFilterHashCount, new SelfSerializableBloomHasher<>(), bloomFilterSize);
 
         try {
-            tempDir = TemporaryFileBuilder.buildTemporaryDirectory(STORE_PREFIX + "-keyset");
+            tempDir = TemporaryFileBuilder.buildTemporaryDirectory(STORE_PREFIX).resolve("data");
             flushedData = new HalfDiskHashMap<>(
                     halfDiskHashMapSize,
                     keySerializer,

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySet.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySet.java
@@ -20,12 +20,12 @@ import static com.swirlds.merkledb.files.DataFileCommon.deleteDirectoryAndConten
 
 import com.swirlds.common.bloom.BloomFilter;
 import com.swirlds.common.bloom.hasher.SelfSerializableBloomHasher;
+import com.swirlds.common.io.utility.TemporaryFileBuilder;
 import com.swirlds.merkledb.serialize.KeySerializer;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.datasource.VirtualKeySet;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
@@ -84,7 +84,7 @@ public class HalfDiskVirtualKeySet<K extends VirtualKey> implements VirtualKeySe
         bloomFilter = new BloomFilter<>(bloomFilterHashCount, new SelfSerializableBloomHasher<>(), bloomFilterSize);
 
         try {
-            tempDir = Files.createTempDirectory(STORE_PREFIX).resolve("data");
+            tempDir = TemporaryFileBuilder.buildTemporaryDirectory(STORE_PREFIX + "-keyset");
             flushedData = new HalfDiskHashMap<>(
                     halfDiskHashMapSize,
                     keySerializer,

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/threading/QueueThreadTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/threading/QueueThreadTests.java
@@ -559,7 +559,8 @@ class QueueThreadTests {
                 .setStopBehavior(Stoppable.StopBehavior.INTERRUPTABLE)
                 .setHandler((final Integer next) -> {
                     count.set(next);
-                    if (enableLongSleep.get()) {
+                    // Disable long sleep for subsequent calls
+                    if (enableLongSleep.getAndSet(false)) {
                         longSleepStarted.countDown();
                         SECONDS.sleep(999999999);
                     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
@@ -235,7 +235,7 @@ public class ReconnectNodeRemover<K extends VirtualKey, V extends VirtualValue> 
         }
 
         if (handledPath.get() < requiredPath) {
-            throw new RuntimeException("VirtualMap reconnect node removal is closed");
+            throw new RuntimeException("VirtualMap reconnect node removal couldn't process all paths");
         }
 
         workQueue.pause();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
@@ -235,7 +235,7 @@ public class ReconnectNodeRemover<K extends VirtualKey, V extends VirtualValue> 
         }
 
         if (handledPath.get() < requiredPath) {
-            throw new RuntimeException("VirtualMap reconnect node removal is closed on reconnect abort");
+            throw new RuntimeException("VirtualMap reconnect node removal is closed");
         }
 
         workQueue.pause();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
@@ -119,6 +119,8 @@ public class ReconnectNodeRemover<K extends VirtualKey, V extends VirtualValue> 
 
     private final AtomicBoolean exceptionEncountered = new AtomicBoolean(false);
 
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
     /**
      * Create an object responsible for removing virtual map nodes during a reconnect.
      *
@@ -224,12 +226,16 @@ public class ReconnectNodeRemover<K extends VirtualKey, V extends VirtualValue> 
      * 		are populated, all other data is uninitialized.
      */
     public Stream<VirtualLeafRecord<K, V>> getRecordsToDelete(final long requiredPath) {
-        while (handledPath.get() < requiredPath && !exceptionEncountered.get()) {
+        while (handledPath.get() < requiredPath && !exceptionEncountered.get() && !closed.get()) {
             tryToSleep(Duration.ofMillis(1));
         }
 
         if (exceptionEncountered.get()) {
             throw new RuntimeException("VirtualMap reconnect node removal thread has crashed");
+        }
+
+        if (handledPath.get() < requiredPath) {
+            throw new RuntimeException("VirtualMap reconnect node removal is closed on reconnect abort");
         }
 
         workQueue.pause();
@@ -369,6 +375,7 @@ public class ReconnectNodeRemover<K extends VirtualKey, V extends VirtualValue> 
      * Stop the work thread.
      */
     public void close() {
+        closed.set(true);
         workQueue.stop();
     }
 }


### PR DESCRIPTION

Fixes: https://github.com/hashgraph/hedera-services/issues/9764
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
