### PR TITLE
Detect delegated sender authorization in `CustomMessageCallProcessor` 

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -17,8 +17,8 @@
 package com.hedera.node.app.service.contract.impl.exec.processors;
 
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_FEE_SUBMITTED;
+import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.acquiredSenderAuthorizationViaDelegateCall;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.alreadyHalted;
-import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.isDelegateCall;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.transfersValue;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.PRECOMPILE_ERROR;
@@ -210,7 +210,7 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
                     frame.getSenderAddress(),
                     frame.getRecipientAddress(),
                     frame.getValue().toLong(),
-                    isDelegateCall(frame));
+                    acquiredSenderAuthorizationViaDelegateCall(frame));
             maybeReasonToHalt.ifPresent(reason -> doHalt(frame, reason, operationTracer));
         }
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
+import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
 import com.hedera.node.app.service.contract.impl.infra.StorageAccessTracker;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
@@ -77,6 +78,46 @@ public class FrameUtils {
     public static @NonNull SystemContractGasCalculator systemContractGasCalculatorOf(
             @NonNull final MessageFrame frame) {
         return initialFrameOf(frame).getContextVariable(SYSTEM_CONTRACT_GAS_GAS_CALCULATOR_VARIABLE);
+    }
+
+    /**
+     * Returns true if the given frame achieved its sender authorization via a delegate call.
+     *
+     * <p>That is, returns true if the frame's <i>parent</i> was executing code via a
+     * {@code DELEGATECALL} (or chain of {@code DELEGATECALL}'s); and the delegated code
+     * contained a {@code CALL}, {@code CALLCODE}, or {@code DELEGATECALL} instruction. In
+     * this case, the frame's sender is the recipient of the parent frame; the same as if the
+     * parent frame directly initiated a call. But our {@link com.hedera.hapi.node.base.Key}
+     * types are designed to enforce stricter permissions here, even though the sender address
+     * is the same.
+     *
+     * <p>In particular, if a contract {@code 0xabcd} initiates a call directly, then it
+     * can "activate" the signature of any {@link com.hedera.hapi.node.base.Key.KeyOneOfType#CONTRACT_ID}
+     * or {@link com.hedera.hapi.node.base.Key.KeyOneOfType#DELEGATABLE_CONTRACT_ID} key needed
+     * to authorize the call. But if its delegated code initiates a call, then it should activate
+     * <b>only</b> signatures of keys of type {@link com.hedera.hapi.node.base.Key.KeyOneOfType#DELEGATABLE_CONTRACT_ID}.
+     *
+     * <p>We thus use this helper in the {@link CustomMessageCallProcessor} to detect when an
+     * initiated call is being initiated by delegated code; and enforce the stricter permissions.
+     *
+     * @param frame the frame to check
+     * @return true if the frame achieved its sender authorization via a delegate call
+     */
+    public static boolean acquiredSenderAuthorizationViaDelegateCall(@NonNull final MessageFrame frame) {
+        final var iter = frame.getMessageFrameStack().iterator();
+        // Always skip the current frame
+        final var executingFrame = iter.next();
+        if (frame != executingFrame) {
+            // This should be impossible
+            throw new IllegalArgumentException(
+                    "Only the executing frame should be tested for delegate sender authorization");
+        }
+        if (!iter.hasNext()) {
+            // The current frame is the initial frame, and thus not initiated from delegated code
+            return false;
+        }
+        final var parent = iter.next();
+        return isDelegateCall(parent);
     }
 
     public static boolean isDelegateCall(@NonNull final MessageFrame frame) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -302,11 +302,6 @@ public class TokenServiceApiImpl implements TokenServiceApi {
         requireNonNull(payerId);
 
         final var payerAccount = lookupAccount("Payer", payerId);
-        logger.info(
-                "Charging network fee of {} tinybars to {} ({} balance)",
-                amount,
-                payerId,
-                payerAccount.tinybarBalance());
         final var amountToCharge = Math.min(amount, payerAccount.tinybarBalance());
         chargePayer(payerAccount, amountToCharge);
         // We may be charging for preceding child record fees, which are additive to the base fee
@@ -393,11 +388,6 @@ public class TokenServiceApiImpl implements TokenServiceApi {
                 .copyBuilder()
                 .tinybarBalance(currentBalance - amount)
                 .build());
-        logger.info(
-                "Payer {} balance changing from {} to {}",
-                payerAccount.accountIdOrThrow(),
-                currentBalance,
-                currentBalance - amount);
     }
 
     /**
@@ -553,24 +543,20 @@ public class TokenServiceApiImpl implements TokenServiceApi {
         // We may have a rounding error, so we will first remove the node and staking rewards from the total, and then
         // whatever is left over goes to the funding account.
         long balance = amount;
-        logger.info("Distributing {} to funding accounts", balance);
 
         // We only pay node and staking rewards if the feature is enabled
         if (stakingConfig.isEnabled()) {
             final long nodeReward = (stakingConfig.feesNodeRewardPercentage() * amount) / 100;
             balance -= nodeReward;
-            logger.info("Distributing {} to node reward account {}", nodeReward, nodeRewardAccountID);
             payNodeRewardAccount(nodeReward);
 
             final long stakingReward = (stakingConfig.feesStakingRewardPercentage() * amount) / 100;
             balance -= stakingReward;
-            logger.info("Distributing {} to staking reward account {}", stakingReward, stakingRewardAccountID);
             payStakingRewardAccount(stakingReward);
         }
 
         // Whatever is left over goes to the funding account
         final var fundingAccount = lookupAccount("Funding", fundingAccountID);
-        logger.info("Distributing {} to funding account {}", balance, fundingAccountID);
         accountStore.put(fundingAccount
                 .copyBuilder()
                 .tinybarBalance(fundingAccount.tinybarBalance() + balance)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -415,6 +415,7 @@ public class ContractCreateSuite extends HapiSuite {
                 .then(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT).balance(1L).hasKnownStatus(CONTRACT_REVERT_EXECUTED));
     }
 
+    @HapiTest
     private HapiSpec delegateContractIdRequiredForTransferInDelegateCall() {
         final var justSendContract = "JustSend";
         final var sendInternalAndDelegateContract = "SendInternalAndDelegate";


### PR DESCRIPTION
**Description**:
 - Closes #8717 
 - On `develop`, the `CustomMessageCallProcessor` incorrectly checks whether the **executing** frame is a `delegatecall` to decide when to activate only `delegatable_contract_id` keys in a `receiverSigRequired` key structure.
     * But this just limits a contract's ability to use `DELEGATECALL` to transfer value to an account it controls, which does not make sense.
     * Instead we want to limit when a contract can use _delegated code_ to transfer value to an account that it controls.
 - This PR fixes the mistake by adding a `FrameUtils.acquiredSenderAuthorizationViaDelegateCall()` method that instead tests if the executing frame acquired its `sender` authorization via `delegatecall` (i.e. whether its parent receiver address was running delegated code when it initiated the call represented by the executing frame).