### PR TITLE
chore: Enable HapiTest debug via environment variable

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -25,6 +25,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hedera.services.bdd.suites.TargetNetworkType;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
@@ -34,6 +35,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -178,9 +182,12 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
                 return context;
             }
 
+            // Allow for a simple switch to enable in-process Alice node for debugging
+            final String debugEnv = System.getenv("HAPI_DEBUG_NODE");
+            final boolean useInProcessAlice = Boolean.parseBoolean(debugEnv);
             // For now, switching to non-in process servers, because in process doesn't work for the
             // restart and reconnect testing.
-            env = new HapiTestEnv("HAPI Tests", true, false);
+            env = new HapiTestEnv("HAPI Tests", true, useInProcessAlice);
             context.setEnv(env);
 
             final var tmpDir = Path.of("data");
@@ -310,6 +317,7 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
      */
     private static final class MethodTestDescriptor extends AbstractTestDescriptor
             implements Node<HapiTestEngineExecutionContext> {
+        private final Logger classLogger = LogManager.getLogger(getClass());
 
         /** The method under test */
         private final Method testMethod;
@@ -360,28 +368,38 @@ public class HapiTestEngine extends HierarchicalTestEngine<HapiTestEngineExecuti
             } else if (disabledAnnotation.isPresent()) {
                 final var msg = disabledAnnotation.get().value();
                 return SkipResult.skip(msg == null || msg.isBlank() ? "Disabled" : msg);
+            } else if (testMethod.getParameterCount() != 0) {
+                final String message =
+                        "%s requires %d parameters.".formatted(testMethod.getName(), testMethod.getParameterCount());
+                return SkipResult.skip(message);
             }
-
             return SkipResult.doNotSkip();
         }
 
         @Override
         public HapiTestEngineExecutionContext execute(
-                HapiTestEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
+                HapiTestEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor)
+                throws NoSuchMethodException, InvocationTargetException, InstantiationException,
+                        IllegalAccessException {
             // First, create an instance of the HapiSuite class (the class that owns this method).
             final var parent = (ClassTestDescriptor) getParent().get();
             final var suite =
                     (HapiSuite) parent.testClass.getDeclaredConstructor().newInstance();
             // Second, call the method to get the HapiSpec
             testMethod.setAccessible(true);
-            final var spec = (HapiSpec) testMethod.invoke(suite);
-            spec.setTargetNetworkType(TargetNetworkType.HAPI_TEST_NETWORK);
-            final var env = context.getEnv();
-            // Third, call `runSuite` with just the one HapiSpec.
-            final var result = suite.runSpecSync(spec, env.getNodes());
-            // Fourth, report the result. YAY!!
-            if (result == HapiSuite.FinalOutcome.SUITE_FAILED) {
-                throw new AssertionError();
+            if (testMethod.getParameterCount() == 0) {
+                final var spec = (HapiSpec) testMethod.invoke(suite);
+                spec.setTargetNetworkType(TargetNetworkType.HAPI_TEST_NETWORK);
+                final var env = context.getEnv();
+                // Third, call `runSuite` with just the one HapiSpec.
+                final var result = suite.runSpecSync(spec, env.getNodes());
+                // Fourth, report the result. YAY!!
+                if (result == HapiSuite.FinalOutcome.SUITE_FAILED) {
+                    throw new AssertionError();
+                }
+            } else {
+                final String message = "Not running spec {}.  Method requires {} parameters.";
+                classLogger.log(Level.INFO, message, testMethod.getName(), testMethod.getParameterCount());
             }
             return context;
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
@@ -67,14 +67,15 @@ public class HapiTestEnv {
                 nodeHosts.add("127.0.0.1:" + (FIRST_GRPC_PORT + (nodeId * 2)) + ":" + account);
             }
             sb.append("\nnextNodeId, ").append(numNodes).append("\n");
-            final var configText = sb.toString();
+            final String configText = sb.toString();
 
             for (int nodeId = 0; nodeId < numNodes; nodeId++) {
-                final var workingDir =
+                final Path workingDir =
                         Path.of("./build/hapi-test/node" + nodeId).normalize();
                 setupWorkingDirectory(workingDir, configText);
-                final var nodeName = NODE_NAMES[nodeId];
-                final var acct = AccountID.newBuilder().accountNum(3L + nodeId).build();
+                final String nodeName = NODE_NAMES[nodeId];
+                final AccountID acct =
+                        AccountID.newBuilder().accountNum(3L + nodeId).build();
                 if (useInProcessAlice && nodeId == 0) {
                     nodes.add(new InProcessHapiTestNode(nodeName, nodeId, acct, workingDir, FIRST_GRPC_PORT));
                 } else {
@@ -90,18 +91,13 @@ public class HapiTestEnv {
     /**
      * Starts all nodes in the environment.
      */
-    public void start() {
+    public void start() throws TimeoutException {
         started = true;
         for (final var node : nodes) {
             node.start();
         }
-
         for (final var node : nodes) {
-            try {
-                node.waitForActive(CAPTIVE_NODE_STARTUP_TIME_LIMIT);
-            } catch (TimeoutException e) {
-                throw new RuntimeException(e);
-            }
+            node.waitForActive(CAPTIVE_NODE_STARTUP_TIME_LIMIT);
         }
     }
 


### PR DESCRIPTION
* Added the environment variable `HAPI_DEBUG_NODE`.  When set to "true" this enables an in-process node for debugging HapiTest specs.
* Fixed a bug in the `HapiTestEngine` that caused failures if a method with non-empty parameter list was annotated with `@HapiTest`; now it skips that test and logs a note.
* Minor fix to exception handling in `HapiTestEnv`.
