### PR TITLE
9839 Prevented possible NPE caused by a race condition

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -489,6 +489,9 @@ public class DataFileCollection<D> implements Snapshotable {
             return null;
         }
         final ByteBuffer dataItemBytes = file.readDataItemBytes(dataLocation);
+        if (dataItemBytes == null) {
+            return null;
+        }
         return dataItemSerializer.deserialize(dataItemBytes, file.getMetadata().getSerializationVersion());
     }
 


### PR DESCRIPTION
**Description**:

This change prevents possible NPE described in #9839 Instead, the method returns null and other methods pass that null to the point where it's retried on (see `DataFileCollection#retryReadUsingIndex`)


**Related issue(s)**:

Fixes #9839 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
