### PR TITLE
Adjust the key gathering context methods to translate exceptions from preHandle

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
@@ -353,7 +353,12 @@ public class HandleContextImpl implements HandleContext, FeeContext {
         dispatcher.dispatchPureChecks(nestedTxn);
         final var nestedContext = new PreHandleContextImpl(
                 readableStoreFactory(), nestedTxn, payerForNested, configuration(), dispatcher);
-        dispatcher.dispatchPreHandle(nestedContext);
+        try {
+            dispatcher.dispatchPreHandle(nestedContext);
+        } catch (final PreCheckException ignored) {
+            // We must ignore/translate the exception here, as this is key gathering, not transaction validation.
+            throw new PreCheckException(ResponseCodeEnum.UNRESOLVABLE_REQUIRED_SIGNERS);
+        }
         return nestedContext;
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
@@ -451,7 +451,12 @@ public class PreHandleContextImpl implements PreHandleContext {
         dispatcher.dispatchPureChecks(nestedTxn);
         final var nestedContext =
                 new PreHandleContextImpl(storeFactory, nestedTxn, payerForNested, configuration, dispatcher);
-        dispatcher.dispatchPreHandle(nestedContext);
+        try {
+            dispatcher.dispatchPreHandle(nestedContext);
+        } catch (final PreCheckException ignored) {
+            // We must ignore/translate the exception here, as this is key gathering, not transaction validation.
+            throw new PreCheckException(ResponseCodeEnum.UNRESOLVABLE_REQUIRED_SIGNERS);
+        }
         return nestedContext;
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.workflows.handle;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.UNRESOLVABLE_REQUIRED_SIGNERS;
 import static com.hedera.node.app.spi.HapiUtils.functionOf;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_EXTERNALIZED_RECORD_CUSTOMIZER;
@@ -573,15 +574,14 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
 
         @Test
         void testAllKeysForTransactionWithFailingPreHandle() throws PreCheckException {
-            // given
             doThrow(new PreCheckException(INSUFFICIENT_ACCOUNT_BALANCE))
                     .when(dispatcher)
                     .dispatchPreHandle(any());
 
-            // when
+            // gathering keys should not throw exceptions except for inability to read a key.
             assertThatThrownBy(() -> context.allKeysForTransaction(defaultTransactionBody(), ERIN.accountID()))
                     .isInstanceOf(PreCheckException.class)
-                    .has(responseCode(INSUFFICIENT_ACCOUNT_BALANCE));
+                    .has(responseCode(UNRESOLVABLE_REQUIRED_SIGNERS));
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.workflows.prehandle;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.UNRESOLVABLE_REQUIRED_SIGNERS;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static com.hedera.node.app.workflows.prehandle.PreHandleContextListUpdatesTest.A_COMPLEX_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -189,10 +190,10 @@ class PreHandleContextImplTest implements Scenarios {
                     .when(dispatcher)
                     .dispatchPreHandle(any());
 
-            // then
+            // gathering keys should not throw exceptions except for inability to read a key.
             assertThatThrownBy(() -> subject.allKeysForTransaction(TransactionBody.DEFAULT, ERIN.accountID()))
                     .isInstanceOf(PreCheckException.class)
-                    .has(responseCode(INSUFFICIENT_ACCOUNT_BALANCE));
+                    .has(responseCode(UNRESOLVABLE_REQUIRED_SIGNERS));
         }
     }
 }


### PR DESCRIPTION
Adjust the key gathering context methods to translate exceptions from preHandle; key gathering should not fail for non-pure checks.
* Modified PreHandleContextImpl to translate exceptions from PreHandle in `allKeysForTransaction`
* Modified HandleContextImpl to translate exceptions from PreHandle in `allKeysForTransaction`
* Modified tests to match

Note: These changes assume that services preHandle methods only fail for situations where keys cannot be gathered.  To be fully correct we will need to modify a few service handlers that do not meet that expectation.
