### PR TITLE
TokenAndTypeCheckFix (#9672)

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
@@ -62,9 +62,6 @@ public class IsTokenCall extends AbstractNonRevertibleTokenViewCall {
     private @NonNull FullResult fullResultsFor(
             @NonNull final ResponseCodeEnum status, final long gasRequirement, final boolean isToken) {
         // @Future remove to revert #9065 after modularization is completed
-        if (isStaticCall && status != SUCCESS) {
-            return revertResult(status, gasRequirement);
-        }
         return successResult(IS_TOKEN.getOutputs().encodeElements(status.protoOrdinal(), isToken), gasRequirement);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
@@ -56,7 +56,7 @@ public class IsTokenCall extends AbstractNonRevertibleTokenViewCall {
     @Override
     protected @NonNull FullResult viewCallResultWith(
             @NonNull final ResponseCodeEnum status, final long gasRequirement) {
-        return fullResultsFor(status, gasRequirement, false);
+        return fullResultsFor(SUCCESS, gasRequirement, false);
     }
 
     private @NonNull FullResult fullResultsFor(

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.istoken;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.revertResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.successResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.istoken.IsTokenTranslator.IS_TOKEN;
 import static java.util.Objects.requireNonNull;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeCall.java
@@ -79,7 +79,6 @@ public class TokenTypeCall extends AbstractNonRevertibleTokenViewCall {
         return successResult(TOKEN_TYPE.getOutputs().encodeElements(status.protoOrdinal(), tokenType), gasRequirement);
     }
 
-
     @Override
     public @NonNull PricedResult execute() {
         PricedResult result;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeCall.java
@@ -16,12 +16,19 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokentype;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.revertResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult.successResult;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemContract.HTS_PRECOMPILE_ADDRESS;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCall.PricedResult.gasOnly;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokentype.TokenTypeTranslator.TOKEN_TYPE;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asEvmContractId;
+import static com.hedera.node.app.service.contract.impl.utils.SystemContractUtils.contractFunctionResultFailedFor;
+import static com.hedera.node.app.service.contract.impl.utils.SystemContractUtils.contractFunctionResultSuccessFor;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
@@ -29,8 +36,11 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSyst
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract.FullResult;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AbstractNonRevertibleTokenViewCall;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
+import com.hedera.node.app.service.contract.impl.utils.SystemContractUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
 
 public class TokenTypeCall extends AbstractNonRevertibleTokenViewCall {
     private final boolean isStaticCall;
@@ -67,5 +77,38 @@ public class TokenTypeCall extends AbstractNonRevertibleTokenViewCall {
             return revertResult(status, gasRequirement);
         }
         return successResult(TOKEN_TYPE.getOutputs().encodeElements(status.protoOrdinal(), tokenType), gasRequirement);
+    }
+
+
+    @Override
+    public @NonNull PricedResult execute() {
+        PricedResult result;
+        long gasRequirement;
+        Bytes output;
+
+        ContractID contractID = asEvmContractId(Address.fromHexString(HTS_PRECOMPILE_ADDRESS));
+        if (token == null) {
+            result = gasOnly(viewCallResultWith(INVALID_TOKEN_ID, gasCalculator.viewGasRequirement()));
+
+            gasRequirement = result.fullResult().gasRequirement();
+            enhancement
+                    .systemOperations()
+                    .externalizeResult(
+                            contractFunctionResultFailedFor(gasRequirement, INVALID_TOKEN_ID.toString(), contractID),
+                            SystemContractUtils.ResultStatus.IS_ERROR,
+                            INVALID_TOKEN_ID);
+        } else {
+            result = gasOnly(resultOfViewingToken(token));
+
+            gasRequirement = result.fullResult().gasRequirement();
+            output = result.fullResult().result().getOutput();
+            enhancement
+                    .systemOperations()
+                    .externalizeResult(
+                            contractFunctionResultSuccessFor(gasRequirement, output, contractID),
+                            SystemContractUtils.ResultStatus.IS_SUCCESS,
+                            SUCCESS);
+        }
+        return result;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenCallTest.java
@@ -16,10 +16,8 @@
 
 package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.istoken;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.revertOutputFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.iskyc.IsKycTranslator;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenCallTest.java
@@ -58,18 +58,8 @@ class IsTokenCallTest extends HtsCallTestBase {
         assertEquals(
                 Bytes.wrap(IsKycTranslator.IS_KYC
                         .getOutputs()
-                        .encodeElements(INVALID_TOKEN_ID.protoOrdinal(), false)
+                        .encodeElements(SUCCESS.protoOrdinal(), false)
                         .array()),
                 result.getOutput());
-    }
-
-    @Test
-    void returnsIsTokenForMissingTokenStaticCall() {
-        final var subject = new IsTokenCall(gasCalculator, mockEnhancement(), true, null);
-
-        final var result = subject.execute().fullResult().result();
-
-        assertEquals(MessageFrame.State.REVERT, result.getState());
-        assertEquals(revertOutputFor(INVALID_TOKEN_ID), result.getOutput());
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenAndTypeCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenAndTypeCheckSuite.java
@@ -122,6 +122,7 @@ public class TokenAndTypeCheckSuite extends HapiSuite {
                 .then();
     }
 
+    @HapiTest
     private HapiSpec checkTokenAndTypeNegativeCases() {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final var notAnAddress = new byte[20];


### PR DESCRIPTION
**Description**:
Purpose of the PR is fixing the TokenAndTypeCheckSuite. Problems with the checkTokenAndTypeNegativeCases were the following:

In case of a call with invalid token ID to the IsTokenCall class, the status of the result was INVALID_TOKEN_ID, which doesn't match the mono output (success in all cases and false on the isToken field).
In case of a call with invalid token ID to the TokenTypeCall class, the status of the result was REVERTED_SUCCESS, which is a status which overrides the correct one after it is returned, so I had to override the execute function.

**Related issue(s)**:

Fixes #9427 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
