### PR TITLE
Fix `updateHappyPath` in `TokenUpdateSpec`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsage.java
@@ -104,7 +104,8 @@ public class TokenUpdateResourceUsage extends AbstractTokenResourceUsage impleme
                             token.hasPauseKey() ? Optional.of(fromPbj(token.pauseKey())) : Optional.empty())
                     .givenCurrentName(token.name())
                     .givenCurrentMemo(token.memo())
-                    .givenCurrentSymbol(token.symbol());
+                    .givenCurrentSymbol(token.symbol())
+                    .givenCurrentExpiry(token.expirationSecond());
             if (token.hasAutoRenewAccountId()) {
                 estimate.givenCurrentlyUsingAutoRenewAccount();
             }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -460,6 +460,7 @@ public class TokenUpdateSpecs extends HapiSuite {
                 .then(tokenUpdate("tbu").treasury(INVALID_TREASURY).hasKnownStatus(ACCOUNT_DELETED));
     }
 
+    @HapiTest
     public HapiSpec updateHappyPath() {
         String originalMemo = "First things first";
         String updatedMemo = "Nothing left to do";


### PR DESCRIPTION
**Description**:
This PR fixes `updateHappyPath` in `TokenUpdateSpec` by enriching the fee calculation by adding the expiration date to it, similar to how it's done in the mono code.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
