### PR TITLE
Add base team to module-info and swirlds-logging modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@
 /platform-sdk/swirlds-fchashmap/                @hashgraph/platform-data @hashgraph/platform-architects
 /platform-sdk/swirlds-fcqueue/                  @hashgraph/platform-data @hashgraph/platform-architects
 /platform-sdk/swirlds-jasperdb/                 @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/swirlds-logging/                  @hashgraph/platform-hashgraph
+/platform-sdk/swirlds-logging/                  @hashgraph/platform-hashgraph @hashgraph/platform-base
 /platform-sdk/swirlds-merkle/                   @hashgraph/platform-data @hashgraph/platform-architects
 /platform-sdk/swirlds-platform-core/            @hashgraph/platform-hashgraph
 /platform-sdk/swirlds-sign-tool/                @hashgraph/platform-hashgraph
@@ -62,7 +62,7 @@
 /platform-sdk/swirlds-unit-tests/core/          @hashgraph/platform-hashgraph
 /platform-sdk/swirlds-unit-tests/structures/    @hashgraph/platform-data @hashgraph/platform-architects
 /platform-sdk/swirlds-virtualmap/               @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/**/module-info.java               @hashgraph/platform-hashgraph @hashgraph/release-engineering @hashgraph/release-engineering-managers
+/platform-sdk/**/module-info.java               @hashgraph/platform-hashgraph @hashgraph/platform-base @hashgraph/release-engineering @hashgraph/release-engineering-managers
 
 #########################
 #####  Core Files  ######


### PR DESCRIPTION
**Description**:
Add the platform-base team to the code owners for `/platform-sdk/swirlds-logging/` and `/platform-sdk/**/module-info.java`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
