### PR TITLE
Ensure all non-daemon threads are shutdown even if `exec()` throws 

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -370,7 +370,14 @@ public class HapiSpec implements Runnable {
                     Stream.of(given, when, then).flatMap(Arrays::stream).toList());
         }
 
-        exec(ops);
+        try {
+            exec(ops);
+        } catch (Throwable t) {
+            log.error("Uncaught exception in HapiSpec::exec", t);
+            status = FAILED;
+            failure = new Failure(t, "Unhandled exception executing '" + name + "' - " + t.getMessage());
+            tearDown();
+        }
 
         if (hapiSetup.costSnapshotMode() == TAKE) {
             takeCostSnapshot();


### PR DESCRIPTION
**Description**:
 - It is possible that recent "hanging" runs of `recordStreamValidation()` are due to an intermittent failure in a validator that itself runs `HapiSpec`'s (e.g. the `TokenReconciliationValidator`) throwing an exception instead of returning a failed assertion from `HapiSpecOperation.exec()`.
 - This would prevent the finalizer `ExecutorService` from being shut down, and lead to the test hanging forever.