### PR TITLE
Gradle: set moduleNamePrefix for ModuleDirectivesOrderingCheck (com.swirlds... modules)

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.sdk.conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.sdk.conventions.gradle.kts
@@ -22,6 +22,8 @@ plugins {
 
 group = "com.swirlds"
 
+tasks.checkModuleInfo { moduleNamePrefix = "com.swirlds" }
+
 javaModuleDependencies { versionsFromConsistentResolution(":swirlds-platform-core") }
 
 configurations.getByName("mainRuntimeClasspath") {

--- a/platform-sdk/swirlds-common/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-common/src/main/java/module-info.java
@@ -166,11 +166,11 @@ module com.swirlds.common {
     exports com.swirlds.common.startup;
     exports com.swirlds.common.threading.atomic;
 
-    requires transitive com.fasterxml.jackson.core;
-    requires transitive com.fasterxml.jackson.databind;
     requires transitive com.swirlds.base;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.logging;
+    requires transitive com.fasterxml.jackson.core;
+    requires transitive com.fasterxml.jackson.databind;
     requires transitive io.prometheus.simpleclient;
     requires transitive lazysodium.java;
     requires transitive org.apache.logging.log4j;

--- a/platform-sdk/swirlds-logging/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-logging/src/main/java/module-info.java
@@ -6,8 +6,8 @@ module com.swirlds.logging {
     requires transitive com.fasterxml.jackson.annotation;
     requires transitive com.fasterxml.jackson.databind;
     requires transitive org.apache.logging.log4j;
+    requires com.swirlds.base;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.datatype.jsr310;
-    requires com.swirlds.base;
     requires static com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
@@ -129,22 +129,22 @@ module com.swirlds.platform.core {
             com.swirlds.common,
             com.swirlds.config.impl;
 
-    requires transitive com.fasterxml.jackson.annotation;
-    requires transitive com.fasterxml.jackson.databind;
     requires transitive com.swirlds.base;
     requires transitive com.swirlds.cli;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.platform.gui;
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.fasterxml.jackson.databind;
     requires transitive info.picocli;
     requires transitive org.apache.logging.log4j;
-    requires com.fasterxml.jackson.core;
-    requires com.fasterxml.jackson.dataformat.yaml;
     requires com.swirlds.config.extensions;
     requires com.swirlds.fchashmap;
     requires com.swirlds.logging;
     requires com.swirlds.merkledb;
     requires com.swirlds.virtualmap;
+    requires com.fasterxml.jackson.core;
+    requires com.fasterxml.jackson.dataformat.yaml;
     requires java.management;
     requires java.scripting;
     requires jdk.management;

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/module-info.java
@@ -2,16 +2,16 @@ open module com.swirlds.merkle.test {
     exports com.swirlds.merkle.map.test.pta;
     exports com.swirlds.merkle.map.test.lifecycle;
 
-    requires transitive com.fasterxml.jackson.annotation;
-    requires transitive com.fasterxml.jackson.databind;
     requires transitive com.swirlds.common.testing;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.merkle;
-    requires com.fasterxml.jackson.core;
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.fasterxml.jackson.databind;
     requires com.swirlds.base;
     requires com.swirlds.common.test.fixtures;
     requires com.swirlds.fchashmap;
     requires com.swirlds.fcqueue;
+    requires com.fasterxml.jackson.core;
     requires org.apache.logging.log4j.core;
     requires org.apache.logging.log4j;
 }


### PR DESCRIPTION
...so that our own `com.swirlds...` modules come first.

By default, the check automatically determines a "prefix" for the module name and based on that decides if a module is our own module or a 3rd party one. In the case of `com.swirlds...` however, the prefix is only `com.`, because `swirlds-` is already part of the gradle project names.
