### PR TITLE
Update to use `0.43.0` tag for protobufs

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -142,7 +142,7 @@ fun includeAllProjects(containingFolder: String) {
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
 val hapiProtoVersion = "0.43.0"
-val hapiProtoBranchOrTag = "0.43.0"
+val hapiProtoBranchOrTag = "v0.43.0"
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -141,8 +141,8 @@ fun includeAllProjects(containingFolder: String) {
 
 // The HAPI API version to use for Protobuf sources. This can be a tag or branch
 // name from the hedera-protobufs GIT repo.
-val hapiProtoVersion = "0.43.0-rc-SNAPSHOT"
-val hapiProtoBranchOrTag = "add-pbj-types-for-state"
+val hapiProtoVersion = "0.43.0"
+val hapiProtoBranchOrTag = "0.43.0"
 
 gitRepositories {
     checkoutsDirectory.set(File(rootDir, "hedera-node/hapi"))


### PR DESCRIPTION
Update to use `0.43.0` tag for protobufs