### PR TITLE
Fix `standardImmutabilitySemanticsHold` in `TokenUpdateSpec`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImpl.java
@@ -19,8 +19,8 @@ package com.hedera.node.app.workflows.handle.validation;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_EXPIRED_AND_PENDING_REMOVAL;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.node.app.service.mono.fees.calculation.FeeCalcUtils.clampedAdd;
@@ -130,7 +130,7 @@ public class ExpiryValidatorImpl implements ExpiryValidator {
         var resolvedExpiry = currentMeta.expiry();
         if (updateMeta.hasExplicitExpiry()) {
             context.attributeValidator().validateExpiry(updateMeta.expiry());
-            validateFalse(updateMeta.expiry() < currentMeta.expiry(), EXPIRATION_REDUCTION_NOT_ALLOWED);
+            validateFalse(updateMeta.expiry() < currentMeta.expiry(), INVALID_EXPIRATION_TIME);
             resolvedExpiry = updateMeta.expiry();
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -177,6 +177,7 @@ public class TokenUpdateSpecs extends HapiSuite {
                                 .hasKnownStatus(TOKEN_IS_IMMUTABLE));
     }
 
+    @HapiTest
     private HapiSpec standardImmutabilitySemanticsHold() {
         long then = Instant.now().getEpochSecond() + 1_234_567L;
         final var immutable = "immutable";


### PR DESCRIPTION
**Description**:

This PR aims to fix the last test in the TokenUpdateSpec, by adding additional validation in the ExpiryValidatorImpl, which is responsible to checking whether the current expiry is smaller number than the new expiry and if it's not, it should throw `INVALID_EXPIRATION_TIME`. This is not valid for Topic, hence the check.

**Related issue(s)**:

Fixes #8939 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
