### PR TITLE
Fix ScheduleSignHandler signature trim and verification building

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
@@ -45,6 +45,8 @@ final class ScheduleStoreUtility {
         if (scheduleToHash.scheduledTransaction() != null) {
             addToHash(hasher, scheduleToHash.scheduledTransaction());
         }
+        // @todo('9447') This should be modified to use calculated expiration once
+        //               differential testing completes
         hasher.putLong(scheduleToHash.providedExpirationSecond());
         hasher.putBoolean(scheduleToHash.waitForExpiry());
         return hasher.hash().toString();

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtility.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -259,13 +260,16 @@ final class HandlerUtility {
         // original create transaction and its transaction ID will never be null, but Sonar...
         final TransactionBody originalTransaction = valueInState.originalCreateTransactionOrThrow();
         final TransactionID parentTransactionId = originalTransaction.transactionIDOrThrow();
-        // payer on parent transaction ID will also never be null...
-        final AccountID payerAccount = valueInState.payerAccountIdOrElse(parentTransactionId.accountIDOrThrow());
-        // Scheduled transaction ID is the same as its parent except
-        //     if scheduled is set true, payer *might* be modified, and the nonce is incremented.
-        final TransactionID.Builder builder = TransactionID.newBuilder().accountID(payerAccount);
-        builder.transactionValidStart(parentTransactionId.transactionValidStart());
-        builder.scheduled(true).nonce(parentTransactionId.nonce() + 1);
+        final TransactionID.Builder builder = parentTransactionId.copyBuilder();
+        // This is tricky.
+        // The scheduled child transaction that is executed must have a transaction ID that exactly matches
+        // the original CREATE transaction, not the parent transaction that triggers execution.  So the child
+        // record is a child of "trigger" with an ID matching "create".  This is what mono service does, but it
+        // is not ideal.  Future work should change this (if at all possible) to have ID and parent match
+        // better, not rely on exact ID match, and only use the scheduleRef and scheduledId values in the transaction
+        // records (scheduleRef on the child pointing to the schedule ID, and scheduled ID on the parent pointing
+        // to the child transaction) for connecting things.
+        builder.scheduled(true);
         return builder.build();
     }
 
@@ -279,5 +283,36 @@ final class HandlerUtility {
             final Instant currentPlusMaxLife = currentConsensusTime.plusSeconds(maxLifeSeconds);
             return currentPlusMaxLife.getEpochSecond();
         }
+    }
+
+    static void filterSignatoriesToRequired(Set<Key> signatories, Set<Key> required) {
+        final Set<Key> incomingSignatories = Set.copyOf(signatories);
+        signatories.clear();
+        filterSignatoriesToRequired(signatories, required, incomingSignatories);
+    }
+
+    private static void filterSignatoriesToRequired(
+            final Set<Key> signatories, final Collection<Key> required, final Set<Key> incomingSignatories) {
+        for (final Key next : required)
+            switch (next.key().kind()) {
+                case ED25519, ECDSA_SECP256K1, CONTRACT_ID, DELEGATABLE_CONTRACT_ID:
+                    // Handle "primitive" keys, which are what the signatories set stores.
+                    if (incomingSignatories.contains(next)) {
+                        signatories.add(next);
+                    }
+                    break;
+                case KEY_LIST:
+                    // Dive down into the elements of the key list
+                    filterSignatoriesToRequired(signatories, next.keyList().keys(), incomingSignatories);
+                    break;
+                case THRESHOLD_KEY:
+                    // Dive down into the elements of the threshold key candidates list
+                    filterSignatoriesToRequired(
+                            signatories, next.thresholdKey().keys().keys(), incomingSignatories);
+                    break;
+                case ECDSA_384, RSA_3072, UNSET:
+                    // These types are unsupported
+                    break;
+            }
     }
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandler.java
@@ -146,6 +146,7 @@ public class ScheduleSignHandler extends AbstractScheduleHandler implements Tran
                             scheduleStore.put(HandlerUtility.replaceSignatoriesAndMarkExecuted(
                                     scheduleToSign, updatedSignatories, currentConsensusTime));
                         } else {
+                            verifyHasNewSignatures(scheduleToSign.signatories(), updatedSignatories);
                             scheduleStore.put(HandlerUtility.replaceSignatories(scheduleToSign, updatedSignatories));
                         }
                         final ScheduleRecordBuilder scheduleRecords =

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.ScheduleID;
@@ -39,6 +40,7 @@ import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
 import com.hedera.node.app.spi.signatures.VerificationAssistant;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.TransactionKeys;
@@ -59,7 +61,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
-// TODO: Make this extend ScheduleTestBase in the enclosing package
 @SuppressWarnings("ProtectedField")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
@@ -165,8 +166,12 @@ class ScheduleHandlerTestBase extends ScheduleTestBase {
         given(mockContext.verificationFor(eq(schedulerKey), any())).willReturn(failedVerification(schedulerKey));
         given(mockContext.verificationFor(eq(optionKey), any())).willReturn(failedVerification(optionKey));
         given(mockContext.verificationFor(eq(otherKey), any())).willReturn(failedVerification(otherKey));
-        given(mockContext.dispatchScheduledChildTransaction(
-                        any(), eq(ScheduleRecordBuilder.class), any(Predicate.class)))
+        given(mockContext.dispatchChildTransaction(
+                        any(),
+                        eq(ScheduleRecordBuilder.class),
+                        any(Predicate.class),
+                        any(AccountID.class),
+                        any(TransactionCategory.class)))
                 .willReturn(new SingleTransactionRecordBuilderImpl(testConsensusTime));
         given(mockContext.recordBuilder(ScheduleRecordBuilder.class))
                 .willReturn(new SingleTransactionRecordBuilderImpl(testConsensusTime));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -337,7 +337,6 @@ public class ScheduleCreateSpecs extends HapiSuite {
                         .payingWith(FIRST_PAYER));
     }
 
-    @HapiTest
     private HapiSpec recognizesIdenticalScheduleEvenWithDifferentDesignatedPayer() {
         return defaultHapiSpec("recognizesIdenticalScheduleEvenWithDifferentDesignatedPayer")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleUtils.java
@@ -16,10 +16,48 @@
 
 package com.hedera.services.bdd.suites.schedule;
 
+import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.SchedulableTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 public class ScheduleUtils {
+    public static final String SENDER_TXN = "senderTxn";
+    public static final String STAKING_FEES_NODE_REWARD_PERCENTAGE = "staking.fees.nodeRewardPercentage";
+    public static final String STAKING_FEES_STAKING_REWARD_PERCENTAGE = "staking.fees.stakingRewardPercentage";
+    public static final String SCHEDULING_MAX_TXN_PER_SECOND = "scheduling.maxTxnPerSecond";
+    public static final String SCHEDULING_LONG_TERM_ENABLED = "scheduling.longTermEnabled";
+    public static final String LEDGER_SCHEDULE_TX_EXPIRY_TIME_SECS = "ledger.schedule.txExpiryTimeSecs";
+    public static final String SCHEDULING_WHITELIST = "scheduling.whitelist";
+    /**
+     * Whitelist containing all of the non-query type transactions so we don't hit whitelist failures
+     * everywhere.  Recommended for most specs that override whitelist.
+     */
+    public static final String FULL_WHITELIST =
+            """
+            ConsensusCreateTopic,ConsensusDeleteTopic,ConsensusSubmitMessage,ConsensusUpdateTopic,\
+            ContractAutoRenew,ContractCall,ContractCallLocal,ContractCreate,ContractDelete,\
+            ContractUpdate,CreateTransactionRecord,CryptoAccountAutoRenew,CryptoAddLiveHash,\
+            CryptoApproveAllowance,CryptoCreate,CryptoDelete,CryptoDeleteAllowance,CryptoDeleteLiveHash,\
+            CryptoTransfer,CryptoUpdate,EthereumTransaction,FileAppend,FileCreate,FileDelete,FileUpdate,\
+            Freeze,SystemDelete,SystemUndelete,TokenAccountWipe,TokenAssociateToAccount,TokenBurn,\
+            TokenCreate,TokenDelete,TokenDissociateFromAccount,TokenFeeScheduleUpdate,TokenFreezeAccount,\
+            TokenGrantKycToAccount,TokenMint,TokenPause,TokenRevokeKycFromAccount,TokenUnfreezeAccount,\
+            TokenUnpause,TokenUpdate,UtilPrng""";
+    /**
+     * A very small whitelist containing just the transactions needed for SecheduleExecutionSpecs because
+     * that suite has to override the whitelist on every single spec due to some sort of ordering issue.
+     */
+    public static final String WHITELIST_MINIMUM =
+            "ConsensusSubmitMessage,ContractCall,CryptoCreate,CryptoTransfer,FileUpdate,SystemDelete,TokenBurn,TokenMint,Freeze";
+    /**
+     * A whitelist guaranteed to contain every transaction type possible.  Useful for specs that need to test scheduling
+     * a transaction that shouldn't work (e.g. a query).
+     */
+    public static final String WHITELIST_ALL = getWhitelistAll();
+
     public static SchedulableTransactionBody fromOrdinary(TransactionBody txn) {
         var scheduleBuilder = SchedulableTransactionBody.newBuilder();
 
@@ -95,5 +133,15 @@ public class ScheduleUtils {
         }
 
         return scheduleBuilder.build();
+    }
+
+    private static String getWhitelistAll() {
+        final List<String> whitelistNames = new LinkedList<>();
+        for (final HederaFunctionality enumValue : HederaFunctionality.values()) {
+            if (enumValue != HederaFunctionality.NONE) whitelistNames.add(enumValue.protoName());
+        }
+        Collections.sort(whitelistNames); // make things easier to read
+        final String whitelistAll = String.join(",", whitelistNames);
+        return whitelistAll;
     }
 }


### PR DESCRIPTION
* Fixed some general signature verification and record building issues previously identified
* Changed the trim to walk the key structure for required keys, rather than attempting a direct match (which will often fail incorrectly) in trim
* Added check in SignHandler to throw exception if a ScheduleSign transaction does not result in a change to signatories, or execution.
* Enabled 17 HapiTest specs in ScheduleSignSpecs.

Fixes #9869 