### PR TITLE
9944 Fix record cache handling to remediate "RECORD_NOT_FOUND" responses.

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -39,11 +39,14 @@ import javax.inject.Singleton;
 public final class DeduplicationCacheImpl implements DeduplicationCache {
     /**
      * The {@link TransactionID}s that this node has already submitted to the platform, sorted by transaction start
-     * time, such that earlier start times come first. We guard this data structure within a synchronized block.
+     * time, such that earlier start times come first. An ID with scheduled set is different from the same ID
+     * without scheduled set (and, in fact, an ID with scheduled set will always match the ID of the ScheduleCreate
+     * transaction that created the schedule, except scheduled is set).
      */
     private final Set<TransactionID> submittedTxns = new ConcurrentSkipListSet<>(
             (t1, t2) -> Comparator.comparing(TransactionID::transactionValidStartOrThrow, TIMESTAMP_COMPARATOR)
                     .thenComparing(TransactionID::accountID, ACCOUNT_ID_COMPARATOR)
+                    .thenComparing(TransactionID::scheduled)
                     .compare(t1, t2));
 
     /** Used for looking up the max transaction duration window. */

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -197,7 +197,6 @@ public class RecordCacheImpl implements HederaRecordCache {
         if (history == null) {
             return DuplicateCheckResult.NO_DUPLICATE;
         }
-
         return history.nodeIds().contains(nodeId) ? DuplicateCheckResult.SAME_NODE : DuplicateCheckResult.OTHER_NODE;
     }
 
@@ -239,9 +238,10 @@ public class RecordCacheImpl implements HederaRecordCache {
         history.nodeIds().add(nodeId);
 
         // Either we add this tx to the main records list if it is a user/preceding transaction, or to the child
-        // transactions list of its parent
-        final var listToAddTo = isChildTx ? history.childRecords() : history.records();
-        listToAddTo.add(transactionRecord);
+        // transactions list of its parent.  Note that scheduled transactions are always child transactions, but
+        // never produce child *records*, the scheduled transaction record is treated as a user transaction record.
+        final var listToAddTo = (isChildTx && !txId.scheduled()) ? history.childRecords() : history.records();
+         listToAddTo.add(transactionRecord);
 
         // Add to the payer-to-transaction index
         final var transactionIDs = payerToTransactionIndex.computeIfAbsent(payerAccountId, ignored -> new HashSet<>());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -258,7 +258,7 @@ public class HandleWorkflow {
             @NonNull final ConsensusTransaction platformTxn) {
         // Get the consensus timestamp. FUTURE We want this to exactly match the consensus timestamp from the hashgraph,
         // but for compatibility with the current implementation, we adjust it as follows.
-        final Instant consensusNow = platformTxn.getConsensusTimestamp().minusNanos(1000 + 3L);
+        final Instant consensusNow = platformTxn.getConsensusTimestamp().minusNanos(1000 - 3L);
 
         // handle user transaction
         handleUserTransaction(consensusNow, state, dualState, platformEvent, creator, platformTxn);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
@@ -23,6 +23,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
 import com.hedera.node.app.state.SingleTransactionRecord;
@@ -376,25 +377,24 @@ public final class RecordListBuilder {
         // a nonce of N, where N is the number of preceding transactions.
         int count = precedingTxnRecordBuilders == null ? 0 : precedingTxnRecordBuilders.size();
         for (int i = count - 1; i >= 0; i--) {
-            final var recordBuilder = precedingTxnRecordBuilders.get(i);
+            final SingleTransactionRecordBuilderImpl recordBuilder = precedingTxnRecordBuilders.get(i);
             records.add(recordBuilder
                     .transactionID(idBuilder.nonce(i + 1).build())
                     .syncBodyIdFromRecordId()
                     .build());
         }
-
         records.add(userTxnRecord);
 
         int nextNonce = count + 1; // Initialize to be 1 more than the number of preceding items
         count = childRecordBuilders == null ? 0 : childRecordBuilders.size();
         for (int i = 0; i < count; i++) {
-            final var recordBuilder = childRecordBuilders.get(i);
-            records.add(recordBuilder
-                    .transactionID(idBuilder.nonce(nextNonce++).build())
-                    .syncBodyIdFromRecordId()
-                    .build());
+            final SingleTransactionRecordBuilderImpl recordBuilder = childRecordBuilders.get(i);
+            // Only create a new transaction ID for child records is one is not provided
+            if (recordBuilder.transactionID() == null || TransactionID.DEFAULT.equals(recordBuilder.transactionID())) {
+                recordBuilder.transactionID(idBuilder.nonce(nextNonce++).build());
+            }
+            records.add(recordBuilder.build());
         }
-
         return new Result(userTxnRecord, unmodifiableList(records));
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -103,7 +103,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class HandleWorkflowTest extends AppTestBase {
 
     private static final Instant CONSENSUS_NOW = Instant.parse("2000-01-01T00:00:00Z");
-    private static final Instant TX_CONSENSUS_NOW = CONSENSUS_NOW.minusNanos(1000 + 3);
+    private static final Instant TX_CONSENSUS_NOW = CONSENSUS_NOW.minusNanos(1000 - 3);
 
     private static final long CONFIG_VERSION = 11L;
 


### PR DESCRIPTION
 * Fixed an arithmetic bug in HandleWorkflow where we added instead of subtracting an offset
 * Adjusted RecordCacheImpl to treat scheduled transactions as top-level istead of children of the sign or create.
 * Adjusted RecordListBuilter to only create a synthetic transactionID if none is provided.
 * Modified the DeduplicationCacheImpl to consider the `scheduled` flag when finding duplicate transaction ID values

Fixes #9944 