### PR TITLE
Remove the check in `FileAppendHandler`  to see contents of the file are empty

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileAppendHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileAppendHandler.java
@@ -77,9 +77,6 @@ public class FileAppendHandler implements TransactionHandler {
         if (transactionBody.fileID() == null) {
             throw new PreCheckException(INVALID_FILE_ID);
         }
-        if (transactionBody.contents() == null || transactionBody.contents().length() == 0) {
-            throw new PreCheckException(FILE_CONTENT_EMPTY);
-        }
     }
 
     /**


### PR DESCRIPTION
Remove the check in `FileAppendHandler`  to see contents of the file are empty to fix a failing HAPI test. This check is not being done in `mono-service`