### PR TITLE
Rationalize treatment of auto-create `MAX_CHILD_RECORDS_EXCEEDED`

### DIFF
--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockRecordsHistorian.java
@@ -99,6 +99,11 @@ public class MockRecordsHistorian implements RecordsHistorian {
     }
 
     @Override
+    public boolean canTrackPrecedingChildRecords(int n) {
+        return false;
+    }
+
+    @Override
     public void trackPrecedingChildRecord(
             final int sourceId, final Builder syntheticBody, final ExpirableTxnRecord.Builder recordSoFar) {
         // No-op

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsHistorian.java
@@ -148,6 +148,14 @@ public interface RecordsHistorian {
             int sourceId, TransactionBody.Builder syntheticBody, ExpirableTxnRecord.Builder recordSoFar);
 
     /**
+     * Returns whether the active transaction has the capacity to track the given number of preceding children.
+     *
+     * @param n the number of preceding children to track
+     * @return whether the active transaction has the capacity to track the given number of preceding children
+     */
+    boolean canTrackPrecedingChildRecords(int n);
+
+    /**
      * Reverts all records created by the given source.
      *
      * @param sourceId the id of the source whose records should be reverted

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
@@ -216,6 +216,11 @@ public class TxnAwareRecordsHistorian implements RecordsHistorian {
     }
 
     @Override
+    public boolean canTrackPrecedingChildRecords(final int n) {
+        return consensusTimeTracker.isAllowablePrecedingOffset(precedingChildRecords.size() + (long) n);
+    }
+
+    @Override
     public void trackPrecedingChildRecord(
             final int sourceId,
             final TransactionBody.Builder syntheticTxn,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/LedgerBalanceChangesTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -433,6 +434,7 @@ class LedgerBalanceChangesTest {
         given(validator.expiryStatusGiven(anyLong(), anyBoolean(), anyBoolean()))
                 .willReturn(OK);
         given(aliasManager.lookupIdBy(aliasA.toByteString())).willReturn(EntityNum.MISSING_NUM);
+        given(historian.canTrackPrecedingChildRecords(anyInt())).willReturn(true);
 
         subject.begin();
         assertDoesNotThrow(() -> subject.doZeroSum(changes));
@@ -488,6 +490,7 @@ class LedgerBalanceChangesTest {
         given(txnCtx.isSelfSubmitted()).willReturn(true);
         given(autoCreationLogic.create(any(), eq(accountsLedger), any())).willReturn(Pair.of(INVALID_ACCOUNT_ID, 100L));
         given(aliasManager.lookupIdBy(aliasA.toByteString())).willReturn(EntityNum.MISSING_NUM);
+        given(historian.canTrackPrecedingChildRecords(anyInt())).willReturn(true);
 
         subject.begin();
         assertFailsWith(() -> subject.doZeroSum(changes), INVALID_ACCOUNT_ID);
@@ -532,6 +535,7 @@ class LedgerBalanceChangesTest {
         given(txnCtx.activePayer()).willReturn(payer);
         given(autoCreationLogic.create(any(), eq(accountsLedger), any())).willReturn(Pair.of(INVALID_ACCOUNT_ID, 100L));
         given(aliasManager.lookupIdBy(aliasA.toByteString())).willReturn(EntityNum.MISSING_NUM);
+        given(historian.canTrackPrecedingChildRecords(anyInt())).willReturn(true);
 
         subject.begin();
         assertFailsWith(() -> subject.doZeroSum(changes), INVALID_ACCOUNT_ID);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
@@ -34,10 +34,29 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 
 public class TransferListAsserts extends BaseErroringAssertsProvider<TransferList> {
+    // non-standard initialization
+    @SuppressWarnings("java:S3599")
+    public static TransferListAsserts noCreditAboveNumber(ToLongFunction<HapiSpec> provider) {
+        return new TransferListAsserts() {
+            {
+                registerProvider((spec, o) -> {
+                    TransferList actual = (TransferList) o;
+                    long maxAllowed = provider.applyAsLong(spec);
+                    Assertions.assertTrue(
+                            actual.getAccountAmountsList().stream()
+                                    .filter(aa -> aa.getAmount() > 0)
+                                    .allMatch(aa -> aa.getAccountID().getAccountNum() <= maxAllowed),
+                            "Transfers include a credit above account 0.0." + maxAllowed);
+                });
+            }
+        };
+    }
+
     public static TransferListAsserts exactParticipants(Function<HapiSpec, List<AccountID>> provider) {
         return new ExactParticipantsAssert(provider);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -607,15 +607,25 @@ public class UtilVerbs {
             final String parentTxnId,
             final ResponseCodeEnum parentalStatus,
             final TransactionRecordAsserts... childRecordAsserts) {
+        return childRecordsCheck(parentTxnId, parentalStatus, parentRecordAsserts -> {}, childRecordAsserts);
+    }
+
+    public static HapiSpecOperation childRecordsCheck(
+            final String parentTxnId,
+            final ResponseCodeEnum parentalStatus,
+            final Consumer<TransactionRecordAsserts> parentRecordAssertsSpec,
+            final TransactionRecordAsserts... childRecordAsserts) {
         return withOpContext((spec, opLog) -> {
             final var lookup = getTxnRecord(parentTxnId);
             allRunFor(spec, lookup);
             final var parentId = lookup.getResponseRecord().getTransactionID();
+            final var parentRecordAsserts = recordWith().status(parentalStatus).txnId(parentId);
+            parentRecordAssertsSpec.accept(parentRecordAsserts);
             allRunFor(
                     spec,
                     getTxnRecord(parentTxnId)
                             .andAllChildRecords()
-                            .hasPriority(recordWith().status(parentalStatus).txnId(parentId))
+                            .hasPriority(parentRecordAsserts)
                             .hasChildRecords(parentId, childRecordAsserts)
                             .logged());
         });

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -685,6 +685,7 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
         final var ecdsaKey2 = "ecdsaKey2";
         final var recipientKey = "recipient";
         final var recipientKey2 = "recipient2";
+        final var receiverId = new AtomicLong();
         return defaultHapiSpec("txnWith2CompletionsAndAnother2PrecedingChildRecords")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -19,7 +19,6 @@ package com.hedera.services.bdd.suites.crypto;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.noCreditAboveNumber;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -19,8 +19,10 @@ package com.hedera.services.bdd.suites.crypto;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.noCreditAboveNumber;
 import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
@@ -50,13 +52,11 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVER
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REVERTED_SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountInfo;
@@ -71,12 +71,13 @@ import com.hederahashgraph.api.proto.java.TransferList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@HapiTestSuite
+// @HapiTestSuite
 public class HollowAccountFinalizationSuite extends HapiSuite {
     private static final Logger LOG = LogManager.getLogger(HollowAccountFinalizationSuite.class);
     private static final String ANOTHER_SECP_256K1_SOURCE_KEY = "anotherSecp256k1Alias";
@@ -691,7 +692,9 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                         newKeyNamed(recipientKey).shape(SECP_256K1_SHAPE),
                         newKeyNamed(recipientKey2).shape(SECP_256K1_SHAPE),
                         cryptoCreate(LAZY_CREATE_SPONSOR).balance(INITIAL_BALANCE * ONE_HBAR),
-                        cryptoCreate(CRYPTO_TRANSFER_RECEIVER).balance(INITIAL_BALANCE * ONE_HBAR))
+                        cryptoCreate(CRYPTO_TRANSFER_RECEIVER)
+                                .balance(INITIAL_BALANCE * ONE_HBAR)
+                                .exposingCreatedIdTo(id -> receiverId.set(id.getAccountNum())))
                 .when(withOpContext((spec, opLog) -> {
                     final var op1 = sendToEvmAddressFromECDSAKey(spec, SECP_256K1_SOURCE_KEY, TRANSFER_TXN);
                     final var op2 = sendToEvmAddressFromECDSAKey(spec, ecdsaKey2, "randomTxn");
@@ -722,10 +725,13 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                     final var childRecordCheck = childRecordsCheck(
                             TRANSFER_TXN_2,
                             MAX_CHILD_RECORDS_EXCEEDED,
+                            // Ensure there are no credits to auto-created accounts
+                            parentAsserts -> parentAsserts.transfers(noCreditAboveNumber(ignore -> spec.registry()
+                                    .getAccountID(SECP_256K1_SOURCE_KEY)
+                                    .getAccountNum())),
                             recordWith().status(SUCCESS),
-                            recordWith().status(SUCCESS),
-                            recordWith().status(REVERTED_SUCCESS));
-                    //                    // assert that the payer has been finalized
+                            recordWith().status(SUCCESS));
+                    // assert that the payer has been finalized
                     final var ecdsaKey = spec.registry().getKey(SECP_256K1_SOURCE_KEY);
                     final var payerEvmAddress = ByteString.copyFrom(recoverAddressFromPubKey(
                             ecdsaKey.getECDSASecp256K1().toByteArray()));


### PR DESCRIPTION
**Description**:
 - Cherry-pick mono-service changes from #9904 