### PR TITLE
Gradle: Version Upgrades - SnakeYAML and Jackson / Module Name fixes

### DIFF
--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     )
     implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
-    implementation("org.gradlex:extra-java-module-info:1.5")
+    implementation("org.gradlex:extra-java-module-info:1.6")
     implementation("org.gradlex:java-ecosystem-capabilities:1.3.1")
     implementation("org.gradlex:java-module-dependencies:1.4.1")
     implementation("org.owasp:dependency-check-gradle:8.4.2")

--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 dependencies {
     implementation("com.adarshr:gradle-test-logger-plugin:4.0.0")
-    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.25.0")
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.26.0")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.22.0")
     implementation("com.github.johnrengelman:shadow:8.1.1")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-module-dependencies.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-module-dependencies.gradle.kts
@@ -54,6 +54,8 @@ javaModuleDependencies {
     )
 
     // Testing only
+    moduleNameToGA.put("com.google.protobuf.util", "com.google.protobuf:protobuf-java-util")
+    moduleNameToGA.put("org.hamcrest", "org.hamcrest:hamcrest")
     moduleNameToGA.put("org.mockito.junit.jupiter", "org.mockito:mockito-junit-jupiter")
     moduleNameToGA.put("org.objenesis", "org.objenesis:objenesis")
 }

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -216,7 +216,7 @@ extraJavaModuleInfo {
         exportAllPackages()
         // no dependencies
     }
-    module("org.hyperledger.besu.internal:algorithms", "org.hyperledger.besu.internal.algorithms") {
+    module("org.hyperledger.besu.internal:algorithms", "org.hyperledger.besu.internal.crypto") {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
@@ -224,15 +224,15 @@ extraJavaModuleInfo {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
-    module("org.hyperledger.besu:arithmetic", "org.hyperledger.besu.arithmetic") {
+    module("org.hyperledger.besu:arithmetic", "org.hyperledger.besu.nativelib.arithmetic") {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
-    module("org.hyperledger.besu:blake2bf", "org.hyperledger.besu.blake2bf") {
+    module("org.hyperledger.besu:blake2bf", "org.hyperledger.besu.nativelib.blake2bf") {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
-    module("org.hyperledger.besu:bls12-381", "org.hyperledger.besu.bls12.for381") {
+    module("org.hyperledger.besu:bls12-381", "org.hyperledger.besu.nativelib.bls12_381") {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
@@ -248,11 +248,11 @@ extraJavaModuleInfo {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
-    module("org.hyperledger.besu:secp256k1", "org.hyperledger.besu.secp256k1") {
+    module("org.hyperledger.besu:secp256k1", "org.hyperledger.besu.nativelib.secp256k1") {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
-    module("org.hyperledger.besu:secp256r1", "org.hyperledger.besu.secp256r1") {
+    module("org.hyperledger.besu:secp256r1", "org.hyperledger.besu.nativelib.secp256r1") {
         exportAllPackages()
         requireAllDefinedDependencies()
     }
@@ -328,14 +328,12 @@ extraJavaModuleInfo {
     )
     automaticModule("com.google.errorprone:javac-shaded", "com.google.errorprone.javac.shaded")
     automaticModule("com.google.googlejavaformat:google-java-format", "com.google.googlejavaformat")
-    automaticModule("com.squareup:javapoet", "com.squareup.javapoet")
     automaticModule("net.ltgt.gradle.incap:incap", "net.ltgt.gradle.incap")
     automaticModule("org.jetbrains.kotlinx:kotlinx-metadata-jvm", "kotlinx.metadata.jvm")
 
     // Testing only
     automaticModule("com.google.jimfs:jimfs", "com.google.jimfs")
     automaticModule("org.awaitility:awaitility", "awaitility")
-    automaticModule("org.hamcrest:hamcrest", "org.hamcrest")
     automaticModule("org.hamcrest:hamcrest-core", "org.hamcrest.core")
     automaticModule("org.mockito:mockito-inline", "org.mockito.inline")
     automaticModule("uk.org.webcompere:system-stubs-core", "uk.org.webcompere.systemstubs.core")
@@ -343,7 +341,6 @@ extraJavaModuleInfo {
         "uk.org.webcompere:system-stubs-jupiter",
         "uk.org.webcompere.systemstubs.jupiter"
     )
-    automaticModule("com.google.protobuf:protobuf-java-util", "com.google.protobuf.util")
 
     // JMH only
     automaticModule("net.sf.jopt-simple:jopt-simple", "jopt.simple")

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -212,10 +212,6 @@ extraJavaModuleInfo {
         exportAllPackages()
         // no dependencies
     }
-    module("org.yaml:snakeyaml", "org.yaml.snakeyaml") {
-        exportAllPackages()
-        // no dependencies
-    }
     module("org.hyperledger.besu.internal:algorithms", "org.hyperledger.besu.internal.crypto") {
         exportAllPackages()
         requireAllDefinedDependencies()

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -91,7 +91,7 @@ moduleInfo {
     version("org.hamcrest", "2.2")
     version("org.hyperledger.besu.datatypes", besuVersion)
     version("org.hyperledger.besu.evm", besuVersion)
-    version("org.hyperledger.besu.secp256k1", besuNativeVersion)
+    version("org.hyperledger.besu.nativelib.secp256k1", besuNativeVersion)
     version("org.json", "20231013")
     version("org.junit.jupiter.api", "5.9.1")
     version("org.junit.platform.engine", "1.9.1")

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -25,7 +25,7 @@ val daggerVersion = "2.42"
 val eclipseCollectionsVersion = "10.4.0"
 val grpcVersion = "1.54.1"
 val helidonVersion = "3.2.1"
-val jacksonVersion = "2.13.5"
+val jacksonVersion = "2.16.0"
 val log4jVersion = "2.21.1"
 val mockitoVersion = "4.11.0"
 val nettyVersion = "4.1.87.Final"
@@ -102,7 +102,7 @@ moduleInfo {
     version("org.opentest4j", "1.2.0")
     version("org.testcontainers", testContainersVersion)
     version("org.testcontainers.junit.jupiter", testContainersVersion)
-    version("org.yaml.snakeyaml", "1.33")
+    version("org.yaml.snakeyaml", "2.2")
     version("tuweni.bytes", tuweniVersion)
     version("tuweni.units", tuweniVersion)
     version("uk.org.webcompere.systemstubs.core", systemStubsVersion)

--- a/hedera-node/hapi-utils/src/main/java/module-info.java
+++ b/hedera-node/hapi-utils/src/main/java/module-info.java
@@ -32,7 +32,7 @@ module com.hedera.node.app.hapi.utils {
     requires org.apache.logging.log4j;
     requires org.bouncycastle.pkix;
     requires org.bouncycastle.provider;
-    requires org.hyperledger.besu.secp256k1;
+    requires org.hyperledger.besu.nativelib.secp256k1;
     requires static com.github.spotbugs.annotations;
     requires static java.compiler; // javax.annotation.processing.Generated
 }

--- a/hedera-node/hedera-evm/src/main/java/module-info.java
+++ b/hedera-node/hedera-evm/src/main/java/module-info.java
@@ -11,7 +11,7 @@ module com.hedera.node.app.service.evm {
     requires transitive org.apache.commons.lang3;
     requires transitive org.hyperledger.besu.datatypes;
     requires transitive org.hyperledger.besu.evm;
-    requires transitive org.hyperledger.besu.secp256k1;
+    requires transitive org.hyperledger.besu.nativelib.secp256k1;
     requires transitive tuweni.bytes;
     requires transitive tuweni.units;
     requires com.google.common;

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -280,7 +280,7 @@ module com.hedera.node.app.service.mono {
     requires org.apache.commons.io;
     requires org.bouncycastle.provider;
     requires org.eclipse.collections.impl;
-    requires org.hyperledger.besu.secp256k1;
+    requires org.hyperledger.besu.nativelib.secp256k1;
     requires static com.github.spotbugs.annotations;
     requires static java.compiler; // javax.annotation.processing.Generated
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/EntityManager.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/EntityManager.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -102,7 +103,7 @@ public class EntityManager {
             parentEntitiesDir += File.separator;
         }
 
-        var yamlIn = new Yaml(new Constructor(Entity.class));
+        var yamlIn = new Yaml(new Constructor(Entity.class, new LoaderOptions()));
         List<Entity> candEntities = new ArrayList<>();
         for (String subDir : ALL_SUBDIRS) {
             String entitiesDir = parentEntitiesDir + subDir;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SkipNullRepresenter.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SkipNullRepresenter.java
@@ -16,12 +16,18 @@
 
 package com.hedera.services.bdd.spec.persistence;
 
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
 public class SkipNullRepresenter extends Representer {
+
+    public SkipNullRepresenter() {
+        super(new DumperOptions());
+    }
+
     @Override
     protected NodeTuple representJavaBeanProperty(
             Object javaBean, Property property, Object propertyValue, Tag customTag) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
@@ -182,6 +182,8 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.Property;
@@ -1800,7 +1802,7 @@ public class ValidationScenarios extends HapiSuite {
     }
 
     private static void readConfig() {
-        var yamlIn = new Yaml(new Constructor(ValidationConfig.class));
+        var yamlIn = new Yaml(new Constructor(ValidationConfig.class, new LoaderOptions()));
         try {
             System.out.println("Config loc: " + params.getConfigLoc());
             validationConfig = yamlIn.load(Files.newInputStream(Paths.get(params.getConfigLoc())));
@@ -1923,6 +1925,10 @@ public class ValidationScenarios extends HapiSuite {
     }
 
     private static class SkipNullRepresenter extends Representer {
+
+        public SkipNullRepresenter() {
+            super(new DumperOptions());
+        }
 
         @Override
         protected NodeTuple representJavaBeanProperty(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/PostUpgradeValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/PostUpgradeValidation.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import picocli.CommandLine;
@@ -91,7 +92,7 @@ public class PostUpgradeValidation implements Callable<Integer> {
     }
 
     private void loadConfig() {
-        var yamlIn = new Yaml(new Constructor(TopLevelConfig.class));
+        var yamlIn = new Yaml(new Constructor(TopLevelConfig.class, new LoaderOptions()));
         try {
             config = yamlIn.load(Files.newInputStream(Paths.get(CONFIG_LOC)));
         } catch (IOException e) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -35,6 +35,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import picocli.CommandLine;
@@ -57,7 +58,7 @@ public class ConfigManager {
 
     static ConfigManager from(Yahcli yahcli) throws IOException {
         var yamlLoc = yahcli.getConfigLoc();
-        var yamlIn = new Yaml(new Constructor(GlobalConfig.class));
+        var yamlIn = new Yaml(new Constructor(GlobalConfig.class, new LoaderOptions()));
         try (InputStream fin = Files.newInputStream(Paths.get(yamlLoc))) {
             GlobalConfig globalConfig = yamlIn.load(fin);
             return new ConfigManager(yahcli, globalConfig);

--- a/hedera-node/test-clients/src/main/java/module-info.java
+++ b/hedera-node/test-clients/src/main/java/module-info.java
@@ -36,7 +36,7 @@ module com.hedera.node.test.clients {
     requires org.bouncycastle.provider;
     requires org.hyperledger.besu.datatypes;
     requires org.hyperledger.besu.evm;
-    requires org.hyperledger.besu.internal.algorithms;
+    requires org.hyperledger.besu.internal.crypto;
     requires org.json;
     requires org.opentest4j;
     requires tuweni.units;

--- a/platform-sdk/swirlds-common/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-common/src/main/java/module-info.java
@@ -182,6 +182,6 @@ module com.swirlds.common {
     requires jdk.management;
     requires org.apache.logging.log4j.core;
     requires org.bouncycastle.provider;
-    requires org.hyperledger.besu.secp256k1;
+    requires org.hyperledger.besu.nativelib.secp256k1;
     requires static com.github.spotbugs.annotations;
 }


### PR DESCRIPTION
**Description**:

- Fix module names that are already defined via `Automatic-Module-Name` so we do not change them during patching
- Update SnakeYAML to 2.x (and Jackson using it) to remove the need to patch it 

There are some production code changes in this PR because the API of constructors in SnakeYAML 2.x has changed.