### PR TITLE
Fix ContractKeysStillWorkAsExpectedSuite tests 

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCall.java
@@ -61,7 +61,7 @@ public abstract class AbstractHtsCall implements HtsCall {
         return gasOnly(revertResult(standardized(status), gasRequirement));
     }
 
-    private ResponseCodeEnum standardized(@NonNull final ResponseCodeEnum status) {
+    public static ResponseCodeEnum standardized(@NonNull final ResponseCodeEnum status) {
         return requireNonNull(status) == INVALID_SIGNATURE ? INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE : status;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/DispatchForResponseCodeHtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/DispatchForResponseCodeHtsCall.java
@@ -154,7 +154,7 @@ public class DispatchForResponseCodeHtsCall<T extends SingleTransactionRecordBui
                 systemContractOperations().dispatch(syntheticBody, verificationStrategy, senderId, recordBuilderType);
         final var gasRequirement =
                 dispatchGasCalculator.gasRequirement(syntheticBody, gasCalculator, enhancement, senderId);
-        var status = recordBuilder.status();
+        var status = standardized(recordBuilder.status());
         if (status != SUCCESS) {
             status = failureCustomizer.customize(syntheticBody, status, enhancement);
             recordBuilder.status(status);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -72,6 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
@@ -685,6 +686,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         .hasKnownStatus(expectedStatus)));
     }
 
+    @HapiTest
     private HapiSpec canStillTransferByVirtueOfContractIdInEOAThreshold() {
         final var fungibleToken = "token";
         final var managementContract = "DoTokenManagement";


### PR DESCRIPTION
**Description**:
Fix ContractKeysStillWorkAsExpectedSuite tests 

**Related issue(s)**:
Fixes #9993

**Notes for reviewer**:
- Enabled `canStillTransferByVirtueOfContractIdInEOAThreshold` and partial fix for `contractKeysStillHaveSpecificityNoMatterTopLevelSignatures`
- Depends on #9795 

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
