### PR TITLE
chore: simplify Gradle signing setup

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -610,7 +610,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.svcs-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "releaseEvmMavenCentral --scan -PpublishSigningEnabled=true --no-configuration-cache"
+          arguments: "releaseEvmMavenCentral --scan -PpublishSigningEnabled=true"
 
       - name: Gradle Maven Central Snapshot
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
@@ -620,7 +620,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.svcs-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "releaseEvmMavenCentralSnapshot --scan -PpublishSigningEnabled=true --no-configuration-cache"
+          arguments: "releaseEvmMavenCentralSnapshot --scan -PpublishSigningEnabled=true"
 
   sdk-publish:
     name: Publish Platform to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'GCP Registry' }}

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.maven-publish.gradle.kts
@@ -25,54 +25,50 @@ java {
     withSourcesJar()
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components.getByName("java"))
-            versionMapping {
-                usage("java-api") { fromResolutionResult() }
-                usage("java-runtime") { fromResolutionResult() }
+val maven =
+    publishing.publications.create<MavenPublication>("maven") {
+        from(components.getByName("java"))
+        versionMapping {
+            usage("java-api") { fromResolutionResult() }
+            usage("java-runtime") { fromResolutionResult() }
+        }
+
+        pom {
+            packaging = findProperty("maven.project.packaging")?.toString() ?: "jar"
+            name.set(project.name)
+            url.set("https://www.swirlds.com/")
+            inceptionYear.set("2016")
+
+            description.set(provider(project::getDescription))
+
+            organization {
+                name.set("Hedera Hashgraph, LLC")
+                url.set("https://www.hedera.com")
             }
 
-            pom {
-                packaging = findProperty("maven.project.packaging")?.toString() ?: "jar"
-                name.set(project.name)
-                url.set("https://www.swirlds.com/")
-                inceptionYear.set("2016")
-
-                description.set(provider(project::getDescription))
-
-                organization {
-                    name.set("Hedera Hashgraph, LLC")
-                    url.set("https://www.hedera.com")
-                }
-
-                licenses {
-                    license {
-                        name.set("Apache License, Version 2.0")
-                        url.set(
-                            "https://raw.githubusercontent.com/hashgraph/hedera-services/main/LICENSE"
-                        )
-                    }
-                }
-
-                scm {
-                    connection.set("scm:git:git://github.com/hashgraph/hedera-services.git")
-                    developerConnection.set(
-                        "scm:git:ssh://github.com:hashgraph/hedera-services.git"
+            licenses {
+                license {
+                    name.set("Apache License, Version 2.0")
+                    url.set(
+                        "https://raw.githubusercontent.com/hashgraph/hedera-services/main/LICENSE"
                     )
-                    url.set("https://github.com/hashgraph/hedera-services")
                 }
+            }
+
+            scm {
+                connection.set("scm:git:git://github.com/hashgraph/hedera-services.git")
+                developerConnection.set("scm:git:ssh://github.com:hashgraph/hedera-services.git")
+                url.set("https://github.com/hashgraph/hedera-services")
             }
         }
     }
-}
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications.getByName("maven"))
-}
+val publishSigningEnabled =
+    providers.gradleProperty("publishSigningEnabled").getOrElse("false").toBoolean()
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { providers.gradleProperty("publishSigningEnabled").getOrElse("false").toBoolean() }
+if (publishSigningEnabled) {
+    signing {
+        sign(maven)
+        useGpgCmd()
+    }
 }


### PR DESCRIPTION

**Description**:
This allows running maven central publishing with configuration cache enabled, so we do not need to call Gradle in a special way here on CI.

Revert of / follow up to: #10027 



**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
