### PR TITLE
Gradle: fix 'hedera-protobufs' git pull

### DIFF
--- a/hedera-node/hapi/build.gradle.kts
+++ b/hedera-node/hapi/build.gradle.kts
@@ -56,6 +56,15 @@ providers
     .result
     .get()
 
+@Suppress("UnstableApiUsage")
+providers
+    .exec {
+        workingDir = hederaProtoDir.asFile
+        commandLine("git", "reset", "--hard", "origin/$hapiProtoBranchOrTag", "-q")
+    }
+    .result
+    .get()
+
 testModuleInfo {
     requires("com.hedera.node.hapi")
     // we depend on the protoc compiled hapi during test as we test our pbj generated code


### PR DESCRIPTION
**Description**:

Fixes an issue introduced in #9651 
If the branch is already checked out, the build wouldn't update it, because we only used`fetch`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
