### PR TITLE
chore: disable Gradle configuration cache and parallelism when releasing to Maven Central

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -589,7 +589,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.svcs-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "releaseEvmMavenCentral --scan -PpublishSigningEnabled=true"
+          arguments: "releaseEvmMavenCentral --scan -PpublishSigningEnabled=true --no-configuration-cache --no-parallel"
 
       - name: Gradle Maven Central Snapshot
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2.8.0
@@ -599,7 +599,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.svcs-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "releaseEvmMavenCentralSnapshot --scan -PpublishSigningEnabled=true"
+          arguments: "releaseEvmMavenCentralSnapshot --scan -PpublishSigningEnabled=true --no-configuration-cache --no-parallel"
 
   sdk-publish:
     name: Publish Platform to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'GCP Registry' }}
@@ -755,7 +755,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.sdk-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "release${{ inputs.sdk-release-profile }} --scan -PpublishSigningEnabled=true"
+          arguments: "release${{ inputs.sdk-release-profile }} --scan -PpublishSigningEnabled=true --no-configuration-cache --no-parallel"
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}


### PR DESCRIPTION
## Description

This pull request changes the following:

- Cherry pick #10065 

### Required Cherry Picks 

- `develop`

### Related Issues

- Related to #9711 