### PR TITLE
Fix previewnet deployment workflow to use correct Jenkins pipeline name for validation

### DIFF
--- a/.github/workflows/node-zxc-deploy-preview.yaml
+++ b/.github/workflows/node-zxc-deploy-preview.yaml
@@ -135,7 +135,7 @@ jobs:
           PRE_JSON_REQUEST: ${{ toJSON(github.event) }}
         run: echo "request=$(jq --compact-output '.ref = "v${{ inputs.new-version }}"' <<<"${PRE_JSON_REQUEST}")" >>"${GITHUB_OUTPUT}"
 
-      - name: Notify Jenkins of Release (previewnet)
+      - name: Notify Jenkins of Release (Preview Network)
         id: jenkins-preview
         uses: fjogeleit/http-request-action@eab8015483ccea148feff7b1c65f320805ddc2bf # v1.14.1
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
@@ -150,7 +150,7 @@ jobs:
           jq '.' <<<"${JSON_RESPONSE}"
           printf "### Jenkins Response Payload\n\`\`\`json\n%s\n\`\`\`\n" "$(jq '.' <<<"${JSON_RESPONSE}")" >>"${GITHUB_STEP_SUMMARY}"
 
-      - name: Check for Jenkins Failures (previewnet)
+      - name: Check for Jenkins Failures (Preview Network)
         env:
           JSON_RESPONSE: ${{ steps.jenkins-preview.outputs.response }}
         run: |

--- a/.github/workflows/node-zxc-deploy-preview.yaml
+++ b/.github/workflows/node-zxc-deploy-preview.yaml
@@ -135,7 +135,7 @@ jobs:
           PRE_JSON_REQUEST: ${{ toJSON(github.event) }}
         run: echo "request=$(jq --compact-output '.ref = "v${{ inputs.new-version }}"' <<<"${PRE_JSON_REQUEST}")" >>"${GITHUB_OUTPUT}"
 
-      - name: Notify Jenkins of Release (Preview)
+      - name: Notify Jenkins of Release (previewnet)
         id: jenkins-preview
         uses: fjogeleit/http-request-action@eab8015483ccea148feff7b1c65f320805ddc2bf # v1.14.1
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
@@ -150,13 +150,13 @@ jobs:
           jq '.' <<<"${JSON_RESPONSE}"
           printf "### Jenkins Response Payload\n\`\`\`json\n%s\n\`\`\`\n" "$(jq '.' <<<"${JSON_RESPONSE}")" >>"${GITHUB_STEP_SUMMARY}"
 
-      - name: Check for Jenkins Failures (Preview)
+      - name: Check for Jenkins Failures (previewnet)
         env:
           JSON_RESPONSE: ${{ steps.jenkins-preview.outputs.response }}
         run: |
-          PREVIEW_TRIGGERED="$(jq '.jobs."build-preview-testnet".triggered' <<<"${JSON_RESPONSE}")"
+          PREVIEW_TRIGGERED="$(jq '.jobs."build-previewnet".triggered' <<<"${JSON_RESPONSE}")"
 
           if [[ "${PREVIEW_TRIGGERED}" != true ]]; then
-            echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-preview-testnet' job via the Jenkins 'preview' pipeline!"
+            echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-previewnet' pipeline in Jenkins!"
             exit 1
           fi


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the Jenkins job name used by the validator from `build-preview-testnet` to `build-previewnet`.
- Clarifies the name of the github action step. 

```[tasklist]
## tasks
- [x] Change code in GHA
- [x] See if `secret.jenkins-preview-url` needs to be updated
```

### Related Issues

- Closes #10069 