### PR TITLE
Catch UncheckedIOException during PCES file copy.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/BestEffortPreconsensusEventFileCopy.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/BestEffortPreconsensusEventFileCopy.java
@@ -24,6 +24,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.system.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -92,7 +93,9 @@ public final class BestEffortPreconsensusEventFileCopy {
                                 platformContext, selfId, temporaryDirectory, minimumGenerationNonAncient));
 
                 return;
-            } catch (final IOException e) {
+            } catch (final IOException | UncheckedIOException e) {
+                // Note: Files.walk() sometimes throws an UncheckedIOException (?!!), so we have to catch both.
+
                 if (triesRemaining > 0) {
                     logger.warn(STATE_TO_DISK.getMarker(), "Unable to copy PCES files. Retrying.");
                 } else {


### PR DESCRIPTION
Related to #10082 
Needs to be cherry picked to 0.44