### PR TITLE
Provide more X test for burnToken key verification

### DIFF
--- a/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
@@ -78,11 +78,13 @@ import org.jetbrains.annotations.NotNull;
  * <ol>
  *     <li>Burns {@code ERC20_TOKEN} via BURN_TOKEN_V1 operation</li>
  *     <li>Burns {@code ERC20_TOKEN} via BURN_TOKEN_V2 operation</li>
+ *     <li>Burns {@code ERC20_TOKEN} without supplyKey via BURN_TOKEN_V1 operation. This should fail with TOKEN_HAS_NO_SUPPLY_KEY</li>
+ *     <li>Burns {@code ERC20_TOKEN} token which is not associated to account via BURN_TOKEN_V1 operation. This should fail with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT</li>
+ *     <li>Burns {@code ERC20_TOKEN} token when totalSupply < amountToBurn via BURN_TOKEN_V1 operation. This should fail with INVALID_TOKEN_BURN_AMOUNT</li>
+ *     <li>Burns {@code ERC20_TOKEN} token with invalid id via BURN_TOKEN_V1 operation. This should fail with INVALID_TOKEN_ID</li>
+ *     <li>Burns {@code ERC20_TOKEN} with invalid supplyKey via BURN_TOKEN_V1 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
  *     <li>Burns {@code ERC721_TOKEN} via BURN_TOKEN_V1 operation</li>
  *     <li>Burns {@code ERC721_TOKEN} via BURN_TOKEN_V2 operation</li>
- *     <li>Burns {@code ERC20_TOKEN} without supplyKey via BURN_TOKEN_V1 operation. This should fail with TOKEN_HAS_NO_SUPPLY_KEY</li>
- *     <li>Burns {@code ERC20_TOKEN} with invalid supplyKey via BURN_TOKEN_V1 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
- *     <li>Burns {@code ERC20_TOKEN} for invalid token address via BURN_TOKEN_V1 operation. This should fail with INVALID_TOKEN_ID</li>
  *     <li>Burns {@code ERC721_TOKEN} with invalid supplyKey via BURN_TOKEN_V1 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
  * </ol>
  */

--- a/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
@@ -79,13 +79,19 @@ import org.jetbrains.annotations.NotNull;
  *     <li>Burns {@code ERC20_TOKEN} via BURN_TOKEN_V1 operation</li>
  *     <li>Burns {@code ERC20_TOKEN} via BURN_TOKEN_V2 operation</li>
  *     <li>Burns {@code ERC20_TOKEN} without supplyKey via BURN_TOKEN_V1 operation. This should fail with TOKEN_HAS_NO_SUPPLY_KEY</li>
+ *     <li>Burns {@code ERC20_TOKEN} without supplyKey via BURN_TOKEN_V2 operation. This should fail with TOKEN_HAS_NO_SUPPLY_KEY</li>
  *     <li>Burns {@code ERC20_TOKEN} token which is not associated to account via BURN_TOKEN_V1 operation. This should fail with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT</li>
+ *     <li>Burns {@code ERC20_TOKEN} token which is not associated to account via BURN_TOKEN_V2 operation. This should fail with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT</li>
  *     <li>Burns {@code ERC20_TOKEN} token when totalSupply < amountToBurn via BURN_TOKEN_V1 operation. This should fail with INVALID_TOKEN_BURN_AMOUNT</li>
+ *     <li>Burns {@code ERC20_TOKEN} token when totalSupply < amountToBurn via BURN_TOKEN_V2 operation. This should fail with INVALID_TOKEN_BURN_AMOUNT</li>
  *     <li>Burns {@code ERC20_TOKEN} token with invalid id via BURN_TOKEN_V1 operation. This should fail with INVALID_TOKEN_ID</li>
+ *     <li>Burns {@code ERC20_TOKEN} token with invalid id via BURN_TOKEN_V2 operation. This should fail with INVALID_TOKEN_ID</li>
  *     <li>Burns {@code ERC20_TOKEN} with invalid supplyKey via BURN_TOKEN_V1 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
+ *     <li>Burns {@code ERC20_TOKEN} with invalid supplyKey via BURN_TOKEN_V2 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
  *     <li>Burns {@code ERC721_TOKEN} via BURN_TOKEN_V1 operation</li>
  *     <li>Burns {@code ERC721_TOKEN} via BURN_TOKEN_V2 operation</li>
  *     <li>Burns {@code ERC721_TOKEN} with invalid supplyKey via BURN_TOKEN_V1 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
+ *     <li>Burns {@code ERC721_TOKEN} with invalid supplyKey via BURN_TOKEN_V2 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
  * </ol>
  */
 public class BurnsXTest extends AbstractContractXTest {
@@ -95,7 +101,7 @@ public class BurnsXTest extends AbstractContractXTest {
 
     @Override
     protected void doScenarioOperations() {
-        // should successfully burn fungible token with V1
+        // should successfully burn fungible token via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -108,7 +114,7 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should successfully burn fungible token with V2
+        // should successfully burn fungible token via V2
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
@@ -121,7 +127,7 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should fail when token has no supplyKey
+        // should fail when token has no supplyKey via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -134,7 +140,20 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should fail when token is not associated to account
+        // should fail when token has no supplyKey via V2
+        runHtsCallAndExpectOnSuccess(
+                SENDER_BESU_ADDRESS,
+                Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                        .encodeCallWithArgs(A_TOKEN_ADDRESS, TOKENS_TO_BURN, new long[] {})
+                        .array()),
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                                .getOutputs()
+                                .encodeElements((long) TOKEN_HAS_NO_SUPPLY_KEY.protoOrdinal(), 0L)
+                                .array()),
+                        output));
+
+        // should fail when token is not associated to account via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -147,7 +166,20 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should fail on totalSupply < amountToBurn
+        // should fail when token is not associated to account via V2
+        runHtsCallAndExpectOnSuccess(
+                SENDER_BESU_ADDRESS,
+                Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                        .encodeCallWithArgs(B_TOKEN_ADDRESS, TOKENS_TO_BURN, new long[] {})
+                        .array()),
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                                .getOutputs()
+                                .encodeElements((long) TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.protoOrdinal(), 0L)
+                                .array()),
+                        output));
+
+        // should fail on totalSupply < amountToBurn via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -160,7 +192,20 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should fail on invalid token id
+        // should fail on totalSupply < amountToBurn via V2
+        runHtsCallAndExpectOnSuccess(
+                SENDER_BESU_ADDRESS,
+                Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                        .encodeCallWithArgs(ERC20_TOKEN_ADDRESS, TOKEN_BALANCE + 1, new long[] {})
+                        .array()),
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                                .getOutputs()
+                                .encodeElements((long) INVALID_TOKEN_BURN_AMOUNT.protoOrdinal(), 0L)
+                                .array()),
+                        output));
+
+        // should fail on invalid token id via V2
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -173,7 +218,20 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should fail when token has wrong supplyKey
+        // should fail on invalid token id via V2
+        runHtsCallAndExpectOnSuccess(
+                SENDER_BESU_ADDRESS,
+                Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                        .encodeCallWithArgs(INVALID_TOKEN_ADDRESS, TOKEN_BALANCE + 1, new long[] {})
+                        .array()),
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                                .getOutputs()
+                                .encodeElements((long) INVALID_TOKEN_ID.protoOrdinal(), 0L)
+                                .array()),
+                        output));
+
+        // should fail when token has wrong supplyKey via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -186,7 +244,20 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should successfully burn NFT with V1
+        // should fail when token has wrong supplyKey via V2
+        runHtsCallAndExpectOnSuccess(
+                SENDER_BESU_ADDRESS,
+                Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                        .encodeCallWithArgs(C_TOKEN_ADDRESS, TOKENS_TO_BURN, new long[] {})
+                        .array()),
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                                .getOutputs()
+                                .encodeElements((long) INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE.protoOrdinal(), 0L)
+                                .array()),
+                        output));
+
+        // should successfully burn NFT via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -200,7 +271,7 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should successfully burn NFT with V2
+        // should successfully burn NFT via V2
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
@@ -213,7 +284,7 @@ public class BurnsXTest extends AbstractContractXTest {
                                 .array()),
                         output));
 
-        // should fail when NFT has wrong supplyKey
+        // should fail when NFT has wrong supplyKey via V1
         runHtsCallAndExpectOnSuccess(
                 SENDER_BESU_ADDRESS,
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
@@ -222,6 +293,19 @@ public class BurnsXTest extends AbstractContractXTest {
                         .array()),
                 output -> assertEquals(
                         Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE.protoOrdinal(), 0L)
+                                .array()),
+                        output));
+
+        // should fail when NFT has wrong supplyKey via V2
+        runHtsCallAndExpectOnSuccess(
+                SENDER_BESU_ADDRESS,
+                Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                        .encodeCallWithArgs(D_TOKEN_ADDRESS, 0L, new long[] {SN_1234.serialNumber()})
+                        .array()),
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
                                 .getOutputs()
                                 .encodeElements((long) INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE.protoOrdinal(), 0L)
                                 .array()),

--- a/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
@@ -18,6 +18,7 @@ package contract;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static contract.AssociationsXTestConstants.A_TOKEN_ADDRESS;
@@ -44,7 +45,6 @@ import static contract.XTestConstants.SN_1234_METADATA;
 import static contract.XTestConstants.SN_2345;
 import static contract.XTestConstants.addErc20Relation;
 import static contract.XTestConstants.addErc721Relation;
-import static contract.XTestConstants.assertSuccess;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -58,7 +58,6 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.burn.BurnTranslator;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import java.math.BigInteger;
@@ -81,7 +80,12 @@ public class BurnsXTest extends AbstractContractXTest {
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
                         .encodeCallWithArgs(ERC20_TOKEN_ADDRESS, BigInteger.valueOf(TOKENS_TO_BURN), new long[] {})
                         .array()),
-                assertSuccess());
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) SUCCESS.protoOrdinal(), TOKEN_BALANCE - TOKENS_TO_BURN)
+                                .array()),
+                        output));
 
         // should successfully burn fungible token with V2
         runHtsCallAndExpectOnSuccess(
@@ -89,7 +93,12 @@ public class BurnsXTest extends AbstractContractXTest {
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
                         .encodeCallWithArgs(ERC20_TOKEN_ADDRESS, TOKENS_TO_BURN, new long[] {})
                         .array()),
-                assertSuccess());
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
+                                .getOutputs()
+                                .encodeElements((long) SUCCESS.protoOrdinal(), TOKEN_BALANCE - 2L)
+                                .array()),
+                        output));
 
         // should fail when token has no supplyKey
         runHtsCallAndExpectOnSuccess(
@@ -98,8 +107,10 @@ public class BurnsXTest extends AbstractContractXTest {
                         .encodeCallWithArgs(A_TOKEN_ADDRESS, BigInteger.valueOf(TOKENS_TO_BURN), new long[] {})
                         .array()),
                 output -> assertEquals(
-                        Bytes.wrap(
-                                ReturnTypes.encodedRc(TOKEN_HAS_NO_SUPPLY_KEY).array()),
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) TOKEN_HAS_NO_SUPPLY_KEY.protoOrdinal(), 0L)
+                                .array()),
                         output));
 
         // should fail when token is not associated to account
@@ -109,7 +120,9 @@ public class BurnsXTest extends AbstractContractXTest {
                         .encodeCallWithArgs(B_TOKEN_ADDRESS, BigInteger.valueOf(TOKENS_TO_BURN), new long[] {})
                         .array()),
                 output -> assertEquals(
-                        Bytes.wrap(ReturnTypes.encodedRc(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.protoOrdinal(), 0L)
                                 .array()),
                         output));
 
@@ -120,8 +133,10 @@ public class BurnsXTest extends AbstractContractXTest {
                         .encodeCallWithArgs(ERC20_TOKEN_ADDRESS, BigInteger.valueOf(TOKEN_BALANCE + 1), new long[] {})
                         .array()),
                 output -> assertEquals(
-                        Bytes.wrap(
-                                ReturnTypes.encodedRc(INVALID_TOKEN_BURN_AMOUNT).array()),
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) INVALID_TOKEN_BURN_AMOUNT.protoOrdinal(), 0L)
+                                .array()),
                         output));
 
         // should fail on invalid token id
@@ -131,7 +146,11 @@ public class BurnsXTest extends AbstractContractXTest {
                         .encodeCallWithArgs(INVALID_TOKEN_ADDRESS, BigInteger.valueOf(TOKEN_BALANCE + 1), new long[] {})
                         .array()),
                 output -> assertEquals(
-                        Bytes.wrap(ReturnTypes.encodedRc(INVALID_TOKEN_ID).array()), output));
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) INVALID_TOKEN_ID.protoOrdinal(), 0L)
+                                .array()),
+                        output));
 
         // should successfully burn NFT with V1
         runHtsCallAndExpectOnSuccess(
@@ -140,7 +159,12 @@ public class BurnsXTest extends AbstractContractXTest {
                         .encodeCallWithArgs(
                                 ERC721_TOKEN_ADDRESS, BigInteger.valueOf(0L), new long[] {SN_1234.serialNumber()})
                         .array()),
-                assertSuccess());
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) SUCCESS.protoOrdinal(), TOKEN_BALANCE - TOKENS_TO_BURN)
+                                .array()),
+                        output));
 
         // should successfully burn NFT with V2
         runHtsCallAndExpectOnSuccess(
@@ -148,7 +172,12 @@ public class BurnsXTest extends AbstractContractXTest {
                 Bytes.wrap(BurnTranslator.BURN_TOKEN_V2
                         .encodeCallWithArgs(ERC721_TOKEN_ADDRESS, 0L, new long[] {SN_2345.serialNumber()})
                         .array()),
-                assertSuccess());
+                output -> assertEquals(
+                        Bytes.wrap(BurnTranslator.BURN_TOKEN_V1
+                                .getOutputs()
+                                .encodeElements((long) SUCCESS.protoOrdinal(), TOKEN_BALANCE - 2)
+                                .array()),
+                        output));
     }
 
     @Override

--- a/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
@@ -71,6 +71,18 @@ import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Exercises burnToken on a fungible and non-fungible token via the following steps relative to an {@code OWNER} account:
+ * <ol>
+ *     <li>Burns {@code ERC20_TOKEN} via BURN_TOKEN_V1 operation</li>
+ *     <li>Burns {@code ERC20_TOKEN} via BURN_TOKEN_V2 operation</li>
+ *     <li>Burns {@code ERC721_TOKEN} via BURN_TOKEN_V1 operation</li>
+ *     <li>Burns {@code ERC721_TOKEN} via BURN_TOKEN_V2 operation</li>
+ *     <li>Burns {@code ERC20_TOKEN} without supplyKey via BURN_TOKEN_V1 operation. This should fail with TOKEN_HAS_NO_SUPPLY_KEY</li>
+ *     <li>Burns {@code ERC20_TOKEN} with invalid supplyKey via BURN_TOKEN_V1 operation. This should fail with INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE</li>
+ *     <li>Burns {@code ERC20_TOKEN} for invalid token address via BURN_TOKEN_V1 operation. This should fail with INVALID_TOKEN_ID</li>
+ * </ol>
+ */
 public class BurnsXTest extends AbstractContractXTest {
 
     private static final long TOKEN_BALANCE = 9L;


### PR DESCRIPTION
**Description**:

* Fixed X test to pass with two return parameters
* Added X test with invalid supplyKey 
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #10040 

