### PR TITLE
fix: disassociate deleted nft does not commit a transfer list

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -83,13 +83,15 @@ public class RecordFinalizerBase {
      *
      * @param writableTokenRelStore the {@link WritableTokenRelationStore} to get the token relation balances from
      * @param tokenStore the {@link ReadableTokenStore} to get the token from
+     * @param nftChanges the map of nft changes from previous step
      * @return a {@link Map} of {@link EntityIDPair} to {@link Long} representing the token relation balances for all
      * modified token relations
      */
     @NonNull
     protected Map<EntityIDPair, Long> fungibleChangesFrom(
             @NonNull final WritableTokenRelationStore writableTokenRelStore,
-            @NonNull final ReadableTokenStore tokenStore) {
+            @NonNull final ReadableTokenStore tokenStore,
+            final Map<TokenID, List<NftTransfer>> nftChanges) {
         final var fungibleChanges = new HashMap<EntityIDPair, Long>();
         for (final EntityIDPair modifiedRel : writableTokenRelStore.modifiedTokens()) {
             final var relAcctId = modifiedRel.accountIdOrThrow();

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -83,15 +83,13 @@ public class RecordFinalizerBase {
      *
      * @param writableTokenRelStore the {@link WritableTokenRelationStore} to get the token relation balances from
      * @param tokenStore the {@link ReadableTokenStore} to get the token from
-     * @param nftChanges the map of nft changes from previous step
      * @return a {@link Map} of {@link EntityIDPair} to {@link Long} representing the token relation balances for all
      * modified token relations
      */
     @NonNull
     protected Map<EntityIDPair, Long> fungibleChangesFrom(
             @NonNull final WritableTokenRelationStore writableTokenRelStore,
-            @NonNull final ReadableTokenStore tokenStore,
-            final Map<TokenID, List<NftTransfer>> nftChanges) {
+            @NonNull final ReadableTokenStore tokenStore) {
         final var fungibleChanges = new HashMap<EntityIDPair, Long>();
         for (final EntityIDPair modifiedRel : writableTokenRelStore.modifiedTokens()) {
             final var relAcctId = modifiedRel.accountIdOrThrow();
@@ -121,6 +119,45 @@ public class RecordFinalizerBase {
         }
 
         return fungibleChanges;
+    }
+
+    /**
+     * Gets all non-fungible tokenRelation balances for all modified token relations from the given {@link WritableTokenRelationStore}.
+     *
+     * @param writableTokenRelStore the {@link WritableTokenRelationStore} to get the token relation balances from
+     * @param tokenStore the {@link ReadableTokenStore} to get the token from
+     */
+    protected void nonFungibleChangesFrom(
+            @NonNull final WritableTokenRelationStore writableTokenRelStore,
+            @NonNull final ReadableTokenStore tokenStore,
+            Map<EntityIDPair, Long> tokenChanges) {
+        for (final EntityIDPair modifiedRel : writableTokenRelStore.modifiedTokens()) {
+            final var relAcctId = modifiedRel.accountId();
+            final var relTokenId = modifiedRel.tokenId();
+            final var token = tokenStore.get(relTokenId);
+
+            // Add this to fungible token transfer list only if this token is a fungible token
+            if (!token.tokenType().equals(TokenType.NON_FUNGIBLE_UNIQUE)) {
+                continue;
+            }
+            final var modifiedTokenRel = writableTokenRelStore.get(relAcctId, relTokenId);
+            final var persistedTokenRel = writableTokenRelStore.getOriginalValue(relAcctId, relTokenId);
+
+            // It's possible the modified token rel was created in this transaction. If so, use a persisted balance of 0
+            // for the token rel that didn't exist
+            final var persistedBalance = persistedTokenRel != null ? persistedTokenRel.balance() : 0;
+            // It is possible that the account is dissociated with the token in this transaction. If so, use a
+            // balance of 0 for the token rel that didn't exist
+            final var modifiedTokenRelBalance = modifiedTokenRel != null ? modifiedTokenRel.balance() : 0;
+            // Never allow a fungible token's balance to be negative
+            validateTrue(modifiedTokenRelBalance >= 0, FAIL_INVALID);
+
+            // If the token rel's balance has changed, add it to the list of changes
+            final var netFungibleChange = modifiedTokenRelBalance - persistedBalance;
+            if (netFungibleChange != 0) {
+                tokenChanges.put(modifiedRel, netFungibleChange);
+            }
+        }
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
@@ -70,7 +70,7 @@ public class FinalizeChildRecordHandler extends RecordFinalizerBase implements C
         final ArrayList<TokenTransferList> tokenTransferLists;
 
         // ---------- fungible token transfers -------------------------
-        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore, null);
+        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore);
         final var fungibleTokenTransferLists = asTokenTransferListFrom(fungibleChanges);
         tokenTransferLists = new ArrayList<>(fungibleTokenTransferLists);
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
@@ -70,7 +70,7 @@ public class FinalizeChildRecordHandler extends RecordFinalizerBase implements C
         final ArrayList<TokenTransferList> tokenTransferLists;
 
         // ---------- fungible token transfers -------------------------
-        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore);
+        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore, null);
         final var fungibleTokenTransferLists = asTokenTransferListFrom(fungibleChanges);
         tokenTransferLists = new ArrayList<>(fungibleTokenTransferLists);
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
@@ -20,6 +20,7 @@ import static com.hedera.node.app.service.token.impl.comparator.TokenComparators
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.asAccountAmounts;
 
 import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.RecordFinalizerBase;
@@ -70,7 +71,7 @@ public class FinalizeChildRecordHandler extends RecordFinalizerBase implements C
         final ArrayList<TokenTransferList> tokenTransferLists;
 
         // ---------- fungible token transfers -------------------------
-        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore);
+        final var fungibleChanges = tokenChangesFrom(writableTokenRelStore, tokenStore, TokenType.FUNGIBLE_COMMON);
         final var fungibleTokenTransferLists = asTokenTransferListFrom(fungibleChanges);
         tokenTransferLists = new ArrayList<>(fungibleTokenTransferLists);
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
@@ -85,8 +85,12 @@ public class FinalizeParentRecordHandler extends RecordFinalizerBase implements 
 
         // Hbar changes from transaction including staking rewards
         final var hbarChanges = hbarChangesFrom(writableAccountStore);
+        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore);
         final var nftChanges = nftChangesFrom(writableNftStore, tokenStore);
-        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore, nftChanges);
+
+        if (nftChanges.isEmpty()) {
+            nonFungibleChangesFrom(writableTokenRelStore, tokenStore, fungibleChanges);
+        }
 
         if (context.hasChildRecords()) {
             // All the above changes maps are mutable

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
@@ -85,8 +85,9 @@ public class FinalizeParentRecordHandler extends RecordFinalizerBase implements 
 
         // Hbar changes from transaction including staking rewards
         final var hbarChanges = hbarChangesFrom(writableAccountStore);
-        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore);
         final var nftChanges = nftChangesFrom(writableNftStore, tokenStore);
+        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore, nftChanges);
+
         if (context.hasChildRecords()) {
             // All the above changes maps are mutable
             deductChangesFromChildRecords(context, fungibleChanges, nftChanges, hbarChanges);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
@@ -26,6 +26,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NftID;
 import com.hedera.hapi.node.base.NftTransfer;
 import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -85,19 +86,21 @@ public class FinalizeParentRecordHandler extends RecordFinalizerBase implements 
 
         // Hbar changes from transaction including staking rewards
         final var hbarChanges = hbarChangesFrom(writableAccountStore);
-        final var fungibleChanges = fungibleChangesFrom(writableTokenRelStore, tokenStore);
+        final var tokenChanges = tokenChangesFrom(writableTokenRelStore, tokenStore, TokenType.FUNGIBLE_COMMON);
         final var nftChanges = nftChangesFrom(writableNftStore, tokenStore);
 
         if (nftChanges.isEmpty()) {
-            nonFungibleChangesFrom(writableTokenRelStore, tokenStore, fungibleChanges);
+            final var nonFungibleTokenChanges =
+                    tokenChangesFrom(writableTokenRelStore, tokenStore, TokenType.NON_FUNGIBLE_UNIQUE);
+            nonFungibleTokenChanges.forEach(tokenChanges::putIfAbsent);
         }
 
         if (context.hasChildRecords()) {
             // All the above changes maps are mutable
-            deductChangesFromChildRecords(context, fungibleChanges, nftChanges, hbarChanges);
+            deductChangesFromChildRecords(context, tokenChanges, nftChanges, hbarChanges);
             // In the current system a parent transaction that has child transactions cannot
             // *itself* cause any net fungible or NFT transfers; fail fast if that happens
-            validateTrue(fungibleChanges.isEmpty(), FAIL_INVALID);
+            validateTrue(tokenChanges.isEmpty(), FAIL_INVALID);
             validateTrue(nftChanges.isEmpty(), FAIL_INVALID);
         }
         if (!hbarChanges.isEmpty()) {
@@ -106,9 +109,9 @@ public class FinalizeParentRecordHandler extends RecordFinalizerBase implements 
                     .accountAmounts(asAccountAmounts(hbarChanges))
                     .build());
         }
-        final var hasTokenTransferLists = !fungibleChanges.isEmpty() || !nftChanges.isEmpty();
+        final var hasTokenTransferLists = !tokenChanges.isEmpty() || !nftChanges.isEmpty();
         if (hasTokenTransferLists) {
-            final var tokenTransferLists = asTokenTransferListFrom(fungibleChanges);
+            final var tokenTransferLists = asTokenTransferListFrom(tokenChanges);
             final var nftTokenTransferLists = asTokenTransferListFromNftChanges(nftChanges);
             tokenTransferLists.addAll(nftTokenTransferLists);
             tokenTransferLists.sort(TOKEN_TRANSFER_LIST_COMPARATOR);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
@@ -111,6 +111,8 @@ public class TokenDeleteHandler implements TransactionHandler {
         requireNonNull(feeContext);
         final var op = feeContext.body();
 
-        return feeContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> new TokenDeleteResourceUsage(txnEstimateFactory).usageGiven(fromPbj(op), sigValueObj, null));
+        return feeContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> new TokenDeleteResourceUsage(
+                        txnEstimateFactory)
+                .usageGiven(fromPbj(op), sigValueObj, null));
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
@@ -111,8 +111,6 @@ public class TokenDeleteHandler implements TransactionHandler {
         requireNonNull(feeContext);
         final var op = feeContext.body();
 
-        return feeContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> {
-            return new TokenDeleteResourceUsage(txnEstimateFactory).usageGiven(fromPbj(op), sigValueObj, null);
-        });
+        return feeContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> new TokenDeleteResourceUsage(txnEstimateFactory).usageGiven(fromPbj(op), sigValueObj, null));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -82,7 +82,6 @@ public class TokenAssociationSpecs extends HapiSuite {
     public static final String VANILLA_TOKEN = "TokenD";
     public static final String MULTI_KEY = "multiKey";
     public static final String TBD_TOKEN = "ToBeDeleted";
-    public static final String TOKENS = " tokens";
     public static final String CREATION = "creation";
     public static final String SIMPLE = "simple";
     public static final String FREEZE_KEY = "freezeKey";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -51,26 +51,19 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.FreezeNotApplicable;
-import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.Frozen;
 import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.Unfrozen;
 import static com.hederahashgraph.api.proto.java.TokenKycStatus.Granted;
 import static com.hederahashgraph.api.proto.java.TokenKycStatus.KycNotApplicable;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.assertions.BaseErroringAssertsProvider;
-import com.hedera.services.bdd.spec.assertions.ErroringAsserts;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiSuite;
-import com.hederahashgraph.api.proto.java.AccountAmount;
-import com.hederahashgraph.api.proto.java.TokenTransferList;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
@@ -110,7 +103,6 @@ public class TokenAssociationSpecs extends HapiSuite {
                 dissociateHasExpectedSemantics(),
                 associatedContractsMustHaveAdminKeys(),
                 expiredAndDeletedTokensStillAppearInContractInfo(),
-                dissociationFromExpiredTokensAsExpected(),
                 accountInfoQueriesAsExpected(),
                 handlesUseOfDefaultTokenId(),
                 contractInfoQueriesAsExpected(),


### PR DESCRIPTION
**Description**:
This PR move `dissociationFromExpiredTokensAsExpected()` test to `TokenUnhappyAccountsSuite` as it's using expiry logic, which is not implemented.
Fixes dissaciation of deleted tokens and especially nfts, by checking for changes in the token reletions to add them in the transfers list while finalizing the record.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
