### PR TITLE
perf: Optimize safeResetThrottles Method

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
@@ -822,8 +822,6 @@ public final class MiscUtils {
             final List<DeterministicThrottle> throttles,
             final DeterministicThrottle.UsageSnapshot[] snapshots,
             final String source) {
-        final var currUsageSnapshots =
-                throttles.stream().map(DeterministicThrottle::usageSnapshot).toList();
         for (int i = 0, n = snapshots.length; i < n; i++) {
             final var savedUsageSnapshot = snapshots[i];
             final var throttle = throttles.get(i);
@@ -837,6 +835,8 @@ public final class MiscUtils {
                         source,
                         (i + 1),
                         e.getMessage());
+                final var currUsageSnapshots  =
+                        throttles.stream().map(DeterministicThrottle::usageSnapshot).toList();
                 resetUnconditionally(throttles, currUsageSnapshots);
                 break;
             }


### PR DESCRIPTION
**Description**:

This pull request introduces a performance optimization in the safeResetThrottles method. By strategically relocating the generation of `currUsageSnapshots` to the catch block, we've achieved about 4% decrease in CPU usage and  similar 4% performance boost in TPS. The change reduces the overhead of snapshot creation, which was previously executed unconditionally at the method's start.

**Related issue(s)**:

Fixes #9793 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
I've extensively tested the impact of this change using the `NftTransferLoadTest` scenario on a `r6a.8xlarge` instance in AWS.
The average results have consistently shown a 4% increase in TPS
Before the change: 3149 TPS
After the change: 3275 TPS 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
