### PR TITLE
Use Google AutoService for SPI

### DIFF
--- a/platform-sdk/swirlds-config-impl/build.gradle.kts
+++ b/platform-sdk/swirlds-config-impl/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
     id("com.hedera.hashgraph.platform-maven-publish")
 }
 
+mainModuleInfo { annotationProcessor("com.google.auto.service.processor") }
+
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationBuilderFactoryImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationBuilderFactoryImpl.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.config.impl.internal;
 
+import com.google.auto.service.AutoService;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Implentation of the {@link ConfigurationBuilderFactory} interface that will automatically be loaded by Java SPI (see
  * {@link java.util.ServiceLoader}).
  */
+@AutoService(ConfigurationBuilderFactory.class)
 public final class ConfigurationBuilderFactoryImpl implements ConfigurationBuilderFactory {
 
     @NonNull

--- a/platform-sdk/swirlds-config-impl/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.swirlds.config.impl {
     requires com.swirlds.common;
     requires com.swirlds.config.extensions;
     requires static com.github.spotbugs.annotations;
+    requires static com.google.auto.service;
 
     provides ConfigurationBuilderFactory with
             ConfigurationBuilderFactoryImpl;

--- a/platform-sdk/swirlds-config-impl/src/main/resources/META-INF/services/com.swirlds.config.api.spi.ConfigurationBuilderFactory
+++ b/platform-sdk/swirlds-config-impl/src/main/resources/META-INF/services/com.swirlds.config.api.spi.ConfigurationBuilderFactory
@@ -1,1 +1,0 @@
-com.swirlds.config.impl.internal.ConfigurationBuilderFactoryImpl


### PR DESCRIPTION
Fixes #10112

Adds Google AutoService annotation processor to config API.