### PR TITLE
Revert PBJ version back `0.7.6`

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -55,7 +55,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.7")
+    version("com.hedera.pbj.runtime", "0.7.6")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)


### PR DESCRIPTION
**Description**:
Revert PBJ version back `0.7.6` to fix failing HAPI tests