### PR TITLE
JMH benchmarks moved to test module to platform-core

### DIFF
--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -17,10 +17,22 @@
 plugins {
     id("com.hedera.hashgraph.sdk.conventions")
     id("com.hedera.hashgraph.platform-maven-publish")
+    id("com.hedera.hashgraph.benchmark-conventions")
     id("java-test-fixtures")
 }
 
 mainModuleInfo { runtimeOnly("com.swirlds.config.impl") }
+
+jmhModuleInfo {
+    requires("com.swirlds.base")
+    requires("com.swirlds.common")
+    requires("com.swirlds.config.api")
+    requires("com.swirlds.platform.core")
+    requires("com.swirlds.platform.test")
+    requires("com.swirlds.common.test.fixtures")
+    requires("com.swirlds.platform.core.test.fixtures")
+    requires("jmh.core")
+}
 
 testModuleInfo {
     requires("com.swirlds.base.test.fixtures")

--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.swirlds.platform.benchmark.consensus;
+package com.swirlds.platform.core.jmh;
 
 import com.swirlds.base.utility.Pair;
 import com.swirlds.common.config.ConsensusConfig;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/build.gradle.kts
@@ -19,16 +19,6 @@ plugins {
     id("com.hedera.hashgraph.benchmark-conventions")
 }
 
-jmhModuleInfo {
-    requires("com.swirlds.base")
-    requires("com.swirlds.common")
-    requires("com.swirlds.config.api")
-    requires("com.swirlds.platform.core")
-    requires("com.swirlds.common.test.fixtures")
-    requires("com.swirlds.platform.core.test.fixtures")
-    requires("jmh.core")
-}
-
 testModuleInfo {
     requires("com.swirlds.common.testing")
     requires("com.swirlds.merkle")


### PR DESCRIPTION
Part of [#6640](https://github.com/hashgraph/hedera-services/issues/6640)