### PR TITLE
fix(HapiTest): fixing null pointer exception in hapi in process test node shutdown.

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/InProcessHapiTestNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/InProcessHapiTestNode.java
@@ -28,7 +28,6 @@ import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.system.NodeId;
 import com.swirlds.common.system.Platform;
 import com.swirlds.config.api.ConfigurationBuilder;
-import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.PlatformBuilder;
 import com.swirlds.platform.util.BootstrapUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -214,7 +213,6 @@ public class InProcessHapiTestNode implements HapiTestNode {
             threadsToStop.forEach(Thread::interrupt);
             threadsToStop.forEach(Thread::stop);
 
-            MerkleDb.setDefaultPath(null);
             ConstructableRegistry.getInstance().reset();
         }
     }

--- a/hedera-node/test-clients/src/main/java/module-info.java
+++ b/hedera-node/test-clients/src/main/java/module-info.java
@@ -27,7 +27,6 @@ module com.hedera.node.test.clients {
     requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
     requires com.swirlds.config.api;
-    requires com.swirlds.merkledb;
     requires com.swirlds.platform.core;
     requires com.swirlds.test.framework;
     requires grpc.netty;


### PR DESCRIPTION
The in process hapi test node tried to set a null value in shutdown for a method that no longer accepts null.  This caused a crash after each HapiTest.  The fix is to simply not call the method with null.

Fixes #10157