### PR TITLE
fix: 09872: MerkleSynchronizationException: Timed out waiting to supply a new leaf to the hashing iterator buffer

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -495,12 +495,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
                                 VirtualLeafRecord<K, V> leafRecord = dataSource.loadLeafRecord(i);
                                 assert leafRecord != null : "Leaf record should not be null";
                                 try {
-                                    final boolean success =
-                                            rehashIterator.supply(leafRecord, Integer.MAX_VALUE, SECONDS);
-                                    if (!success) {
-                                        throw new MerkleSynchronizationException(
-                                                "Timed out waiting to supply a new leaf to the hashing iterator buffer");
-                                    }
+                                    rehashIterator.supply(leafRecord);
                                 } catch (final MerkleSynchronizationException e) {
                                     throw e;
                                 } catch (final InterruptedException e) {
@@ -1435,11 +1430,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
      */
     public void handleReconnectLeaf(final VirtualLeafRecord<K, V> leafRecord) {
         try {
-            final boolean success = reconnectIterator.supply(leafRecord, MAX_RECONNECT_HASHING_BUFFER_TIMEOUT, SECONDS);
-            if (!success) {
-                throw new MerkleSynchronizationException(
-                        "Timed out waiting to supply a new leaf to the hashing iterator buffer");
-            }
+            reconnectIterator.supply(leafRecord);
         } catch (final MerkleSynchronizationException e) {
             throw e;
         } catch (final InterruptedException e) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIterator.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIterator.java
@@ -30,12 +30,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * This iterator was designed specifically for use with {@link VirtualRootNode} during reconnect on the
  * learner, but in concept could be adapted for more general use. This class enables a publisher/subscriber
- * approach to an iterator. New items are added via {@link #supply(Object, long, TimeUnit)}, while items are
+ * approach to an iterator. New items are added via {@link #supply(Object)}, while items are
  * consumed using {@link #next()}. {@link #hasNext()} will return true until there are no more items to
  * consume and will block if there are no items and {@link #close()} has not been called. Critically,
  * you must call {@link #close()} for the iterator to ever return {@code false} from {@link #hasNext()} or
  * throw {@link NoSuchElementException} from {@link #next()}. If new elements are supplied faster than they
- * are consumed, then {@link #supply(Object, long, TimeUnit)} will block until space becomes available. The
+ * are consumed, then {@link #supply(Object)} will block until space becomes available. The
  * constructor allows you to define what the size of the inner buffer is.
  *
  * @param <T>
@@ -142,17 +142,16 @@ public class ConcurrentBlockingIterator<T> implements Iterator<T> {
      *
      * @param element
      * 		The element to add. Cannot be null.
-     * @return true if submitted, false if the timeout was exceeded.
      * @throws InterruptedException
      * 		If interrupted while waiting
      */
-    public boolean supply(final T element, final long timeout, final TimeUnit timeUnit) throws InterruptedException {
+    public void supply(final T element) throws InterruptedException {
         if (closed.get()) {
             throw new IllegalStateException("Cannot supply elements to a closed ConcurrentBlockingIterator");
         }
 
         Objects.requireNonNull(element);
-        return buffer.offer(element, timeout, timeUnit);
+        buffer.put(element);
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIteratorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIteratorTest.java
@@ -61,7 +61,7 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("hasNext on non-empty, open iterator returns true")
     void hasNextOnFull() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(123, 10, MILLISECONDS);
+        itr.supply(123);
         assertTrue(itr.hasNext(), "Should be true on non-empty iterator");
     }
 
@@ -69,7 +69,7 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("hasNext twice on good element is OK")
     void hasTwice() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(123, 10, MILLISECONDS);
+        itr.supply(123);
         //noinspection ResultOfMethodCallIgnored
         itr.hasNext();
         assertTrue(itr.hasNext(), "Should be true on non-empty iterator");
@@ -79,7 +79,7 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("hasNext on non-empty, closed iterator returns true")
     void hasNextOnFullWhenClosed() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(123, 10, MILLISECONDS);
+        itr.supply(123);
         itr.close();
         assertTrue(itr.hasNext(), "Should be true on non-empty iterator");
     }
@@ -107,7 +107,7 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("next on consumed iterator throws when closed")
     void nextOnConsumedThrowsWhenClosed() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(123, 10, MILLISECONDS);
+        itr.supply(123);
         itr.close();
         itr.next();
         assertThrows(NoSuchElementException.class, itr::next, "Should throw on empty");
@@ -117,7 +117,7 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("next on consumed iterator throws if subsequently closed")
     void nextOnConsumedThrowsWhenFinallyClosed() throws InterruptedException, ExecutionException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(123, 10, MILLISECONDS);
+        itr.supply(123);
         final AtomicBoolean firstNextWasFine = new AtomicBoolean(false);
         final Future<Class<NoSuchElementException>> thrown = thrownByCall(() -> {
             itr.next(); // should be fine
@@ -135,9 +135,9 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("next on iterator with elements returns")
     void nextOnFullOk() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(1, 10, MILLISECONDS);
-        itr.supply(2, 10, MILLISECONDS);
-        itr.supply(3, 10, MILLISECONDS);
+        itr.supply(1);
+        itr.supply(2);
+        itr.supply(3);
         assertTrue(itr.hasNext(), "Should have next");
         assertEquals(1, itr.next(), "First element should be 1");
         assertTrue(itr.hasNext(), "Should have next");
@@ -151,7 +151,7 @@ public class ConcurrentBlockingIteratorTest {
     void iterateAfterClose() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
         for (int i = 0; i < 10; i++) {
-            itr.supply(i, 10, MILLISECONDS);
+            itr.supply(i);
         }
 
         itr.close();
@@ -167,20 +167,12 @@ public class ConcurrentBlockingIteratorTest {
     @DisplayName("cannot add elements after close")
     void cannotAddElementsAfterClosed() throws InterruptedException {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
-        itr.supply(1, 10, MILLISECONDS);
+        itr.supply(1);
         itr.close();
         assertThrows(
                 IllegalStateException.class,
-                () -> itr.supply(2, 10, MILLISECONDS),
+                () -> itr.supply(2),
                 "Should have thrown IllegalStateException");
-    }
-
-    @Test
-    @DisplayName("supply blocks until timeout if buffer is full")
-    void blocksUntilTimeoutIfFull() throws InterruptedException {
-        final var itr = new ConcurrentBlockingIterator<Integer>(1, 1, SECONDS);
-        itr.supply(1, 10, MILLISECONDS);
-        assertFalse(itr.supply(2, 10, MILLISECONDS), "Timeout should have happened");
     }
 
     @Test
@@ -192,7 +184,7 @@ public class ConcurrentBlockingIteratorTest {
         final Future<?> submission = threadPool.submit(() -> {
             for (int i = 0; i < max; i++) {
                 try {
-                    itr.supply(i, 1, SECONDS);
+                    itr.supply(i);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new RuntimeException(e);

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIteratorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIteratorTest.java
@@ -169,10 +169,7 @@ public class ConcurrentBlockingIteratorTest {
         final var itr = new ConcurrentBlockingIterator<Integer>(100, 1, SECONDS);
         itr.supply(1);
         itr.close();
-        assertThrows(
-                IllegalStateException.class,
-                () -> itr.supply(2),
-                "Should have thrown IllegalStateException");
+        assertThrows(IllegalStateException.class, () -> itr.supply(2), "Should have thrown IllegalStateException");
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Do not timeout when adding to an internal queue. If the operation blocks for a very long time it should be considered a performance issue and addresses at the root cause (f.e. flushing).

**Related issue(s)**:

Fixes #9872

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
