### PR TITLE
Contract Store migration from mono's representation to modular's representation

### DIFF
--- a/hedera-node/cli-clients/build.gradle.kts
+++ b/hedera-node/cli-clients/build.gradle.kts
@@ -21,6 +21,11 @@ plugins {
 
 description = "Hedera Services Command-Line Clients"
 
+dependencies {
+    // For NoOpGenesisRecordsBuilder in DumpContractBytescodesSubcommand
+    implementation(project(mapOf("path" to ":app-spi")))
+}
+
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.mockito")

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -20,12 +20,26 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 import static java.util.Comparator.naturalOrder;
 import static java.util.Map.Entry.comparingByKey;
 
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.node.app.service.contract.ContractService;
+import com.hedera.node.app.service.contract.impl.state.ContractSchema;
+import com.hedera.node.app.service.mono.state.migration.ContractStateMigrator;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
-import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
+import com.hedera.node.app.spi.state.StateDefinition;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.node.app.state.merkle.StateMetadata;
+import com.hedera.node.app.state.merkle.memory.InMemoryKey;
+import com.hedera.node.app.state.merkle.memory.InMemoryValue;
+import com.hedera.node.app.state.merkle.memory.InMemoryWritableKVState;
 import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.signedstate.DumpStateCommand.WithMigration;
 import com.hedera.services.cli.signedstate.DumpStateCommand.WithSlots;
+import com.hedera.services.cli.signedstate.DumpStateCommand.WithValidation;
 import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import com.swirlds.merkle.map.MerkleMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -37,20 +51,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
 @SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 public class DumpContractStoresSubcommand {
+
+    static final int ESTIMATED_NUMBER_OF_CONTRACT_SLOTS = 5_000_000;
+
     static void doit(
             @NonNull final SignedStateHolder state,
             @NonNull final Path storePath,
             @NonNull final EmitSummary emitSummary,
             @NonNull final WithSlots withSlots,
+            @NonNull final WithMigration withMigration,
+            @NonNull final WithValidation withValidation,
             @NonNull final Verbosity verbosity) {
-        new DumpContractStoresSubcommand(state, storePath, emitSummary, withSlots, verbosity).doit();
+        new DumpContractStoresSubcommand(
+                        state, storePath, emitSummary, withSlots, withMigration, withValidation, verbosity)
+                .doit();
     }
 
     @NonNull
@@ -66,6 +88,12 @@ public class DumpContractStoresSubcommand {
     final WithSlots withSlots;
 
     @NonNull
+    final WithMigration withMigration;
+
+    @NonNull
+    final WithValidation withValidation;
+
+    @NonNull
     final Verbosity verbosity;
 
     DumpContractStoresSubcommand(
@@ -73,12 +101,22 @@ public class DumpContractStoresSubcommand {
             @NonNull final Path storePath,
             @NonNull final EmitSummary emitSummary,
             @NonNull final WithSlots withSlots,
+            @NonNull final WithMigration withMigration,
+            @NonNull final WithValidation withValidation,
             @NonNull final Verbosity verbosity) {
         this.state = state;
         this.storePath = storePath;
         this.emitSummary = emitSummary;
         this.withSlots = withSlots;
+        this.withMigration = withMigration;
+        this.withValidation = withValidation;
         this.verbosity = verbosity;
+    }
+
+    record ContractKeyLocal(long contractId, UInt256 key) {
+        public static ContractKeyLocal from(@NonNull final ContractKey ckey) {
+            return new ContractKeyLocal(ckey.getContractId(), toUint256FromPackedIntArray(ckey.getKey()));
+        }
     }
 
     @SuppressWarnings(
@@ -87,31 +125,21 @@ public class DumpContractStoresSubcommand {
     // _am in fact_ being properly cautious, thank you Sonar
     void doit() {
 
-        record ContractKeyLocal(long contractId, UInt256 key) {
-            public static ContractKeyLocal from(ContractKey ckey) {
-                return new ContractKeyLocal(ckey.getContractId(), toUint256FromPackedIntArray(ckey.getKey()));
-            }
-        }
-
         // First grab all slot pairs from all contracts from the signed state
-        final var contractKeys = new ConcurrentLinkedQueue<ContractKeyLocal>();
         final var contractState = new ConcurrentHashMap<Long, ConcurrentLinkedQueue<Pair<UInt256, UInt256>>>(5000);
-        final var traversalOk = iterateThroughContractStorage((ckey, iter) -> {
-            final var contractId = ckey.getContractId();
-            final var ckeyLocal = ContractKeyLocal.from(ckey);
 
-            contractKeys.add(ckeyLocal);
+        final Predicate<BiConsumer<ContractKeyLocal, UInt256>> contractStoreIterator = withMigration == WithMigration.NO
+                ? this::iterateThroughContractStorage
+                : this::iterateThroughMigratedContractStorage;
 
-            contractState.computeIfAbsent(contractId, k -> new ConcurrentLinkedQueue<>());
-            contractState.get(contractId).add(Pair.of(ckeyLocal.key(), iter.asUInt256()));
+        final var traversalOk = contractStoreIterator.test((ckey, value) -> {
+            contractState.computeIfAbsent(ckey.contractId(), k -> new ConcurrentLinkedQueue<>());
+            contractState.get(ckey.contractId()).add(Pair.of(ckey.key(), value));
         });
 
         if (traversalOk) {
 
-            final var nDistinctContractIds = contractKeys.stream()
-                    .map(ContractKeyLocal::contractId)
-                    .distinct()
-                    .count();
+            final var nDistinctContractIds = contractState.size();
 
             final var nContractStateValues = contractState.values().stream()
                     .mapToInt(ConcurrentLinkedQueue::size)
@@ -120,7 +148,7 @@ public class DumpContractStoresSubcommand {
             // I can't seriously be intending to cons up the _entire_ store of all contracts as a single string, can I?
             // Well, Toto, this isn't the 1990s anymore ...
 
-            long reportSizeEstimate = (nDistinctContractIds * 20)
+            long reportSizeEstimate = (nDistinctContractIds * 20L)
                     + (nContractStateValues * 2 /*K/V*/ * (32 /*bytes*/ * 2 /*hexits/byte*/ + 3 /*whitespace+slop*/));
             final var sb = new StringBuilder((int) reportSizeEstimate);
 
@@ -141,13 +169,13 @@ public class DumpContractStoresSubcommand {
                     .toList();
 
             if (emitSummary == EmitSummary.YES) {
-                sb.append("%s%n%d contractKeys found, %d distinct; %d contract state entries, totalling %d values %n"
-                        .formatted(
-                                "=".repeat(80),
-                                contractKeys.size(),
-                                nDistinctContractIds,
-                                contractState.size(),
-                                nContractStateValues));
+
+                final var validationSummary = withValidation == WithValidation.NO ? "" : "validated ";
+                final var migrationSummary =
+                        withMigration == WithMigration.NO ? "" : "(with %smigration)".formatted(validationSummary);
+
+                sb.append("%s%n%d contractKeys found, %d total slots %s%n"
+                        .formatted("=".repeat(80), nDistinctContractIds, nContractStateValues, migrationSummary));
                 appendContractStoreSummary(sb, contractStates);
             }
 
@@ -167,18 +195,24 @@ public class DumpContractStoresSubcommand {
      * virtual merkle tree and it does the traversal on multiple threads.  (So the visitor needs to be able to handle
      * multiple concurrent calls.)
      */
-    boolean iterateThroughContractStorage(BiConsumer<ContractKey, IterableContractValue> visitor) {
+    boolean iterateThroughContractStorage(BiConsumer<ContractKeyLocal, UInt256> visitor) {
+
+        System.err.printf("iterateThroughContractStorage: start%n");
+
         final int THREAD_COUNT = 8; // size it for a laptop, why not?
         final var contractStorageVMap = state.getRawContractStorage();
+
+        final var nSlotsSeen = new AtomicLong();
 
         boolean didRunToCompletion = true;
         try {
             contractStorageVMap.extractVirtualMapData(
                     getStaticThreadManager(),
                     entry -> {
-                        final var contractKey = entry.left();
+                        final var contractKey = ContractKeyLocal.from(entry.left());
                         final var iterableContractValue = entry.right();
-                        visitor.accept(contractKey, iterableContractValue);
+                        nSlotsSeen.incrementAndGet();
+                        visitor.accept(contractKey, iterableContractValue.asUInt256());
                     },
                     THREAD_COUNT);
         } catch (final InterruptedException ex) {
@@ -186,7 +220,78 @@ public class DumpContractStoresSubcommand {
             didRunToCompletion = false;
         }
 
+        System.err.printf(
+                "iterateThroughContractStorage: end - %d slots seen, completed? %b%n",
+                nSlotsSeen.get(), didRunToCompletion);
+
         return didRunToCompletion;
+    }
+
+    boolean iterateThroughMigratedContractStorage(BiConsumer<ContractKeyLocal, UInt256> visitor) {
+
+        System.err.printf("iterateThroughMigratedContractStorage: start%n");
+
+        final var contractStorageStore = getMigratedContractStore();
+
+        System.err.printf("iterateThroughMigratedContractStorage: migrated%n");
+
+        final var nSlotsSeen = new AtomicLong();
+
+        if (contractStorageStore == null) return false;
+        contractStorageStore.keys().forEachRemaining(key -> {
+            // (Not sure how many temporary _copies_ of a byte arrays are made here ... best not to ask ...)
+            final var contractKeyLocal = ContractKeyLocal.from(
+                    new ContractKey(key.contractNumber(), key.key().toByteArray()));
+            final var slotValue = contractStorageStore.get(key);
+            assert (slotValue != null);
+            final var value = uint256FromByteArray(slotValue.value().toByteArray());
+            nSlotsSeen.incrementAndGet();
+            visitor.accept(contractKeyLocal, value);
+        });
+
+        System.err.printf("iterateThroughContractStorage: end - %d slots seen, completed? true%n", nSlotsSeen.get());
+
+        return true;
+    }
+
+    /** First migrates the contract store from the mono-service representation to the modular-service representations,
+     *  and then returns all contracts with bytecodes from the migrated contract store, plus the ids of contracts with
+     *  0-length bytecodes.
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    WritableKVState<SlotKey, SlotValue> getMigratedContractStore() {
+
+        // Start the migration with a clean writable KV store.  Use a nice, simple, in memory implementation
+
+        final var contractSchema = new ContractSchema();
+        final var contractSchemas = contractSchema.statesToCreate();
+        final StateDefinition<SlotKey, SlotValue> contractStoreStateDefinition = contractSchemas.stream()
+                .filter(sd -> sd.stateKey().equals(ContractSchema.STORAGE_KEY))
+                .findFirst()
+                .orElseThrow();
+        final var contractStoreSchemaMetadata =
+                new StateMetadata<>(ContractService.NAME, contractSchema, contractStoreStateDefinition);
+        final var contractMerkleMap = new MerkleMap<InMemoryKey<SlotKey>, InMemoryValue<SlotKey, SlotValue>>(
+                ESTIMATED_NUMBER_OF_CONTRACT_SLOTS);
+        final var toStore = new InMemoryWritableKVState<>(contractStoreSchemaMetadata, contractMerkleMap);
+
+        // And now we can grab the fromStore and do the migration
+        final var fromStore = state.getRawContractStorage();
+        final var validationFailures = new ArrayList<String>();
+        try {
+            final var migrationStatus =
+                    ContractStateMigrator.migrateFromContractStoreVirtualMap(fromStore, toStore, validationFailures);
+            assert (migrationStatus == ContractStateMigrator.Status.SUCCESS);
+        } catch (final RuntimeException ex) {
+            System.err.printf("*** Error(s) transforming mono-state to modular state: %n%s", ex);
+            if (!validationFailures.isEmpty()) {
+                validationFailures.forEach(s -> System.err.printf("   %s%n", s));
+            }
+            return null;
+        }
+
+        return toStore;
     }
 
     // Produce a report, one line per contract, summarizing the #slot pairs and the min/max slot#
@@ -273,6 +378,11 @@ public class DumpContractStoresSubcommand {
     static UInt256 toUint256FromPackedIntArray(@NonNull final int[] packed) {
         final var buf = ByteBuffer.allocate(32);
         buf.asIntBuffer().put(packed);
-        return UInt256.fromBytes(Bytes.wrap(buf.array()));
+        return uint256FromByteArray(buf.array());
+    }
+
+    @NonNull
+    static UInt256 uint256FromByteArray(@NonNull final byte[] bytes) {
+        return UInt256.fromBytes(org.apache.tuweni.bytes.Bytes.wrap(bytes));
     }
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -66,6 +66,16 @@ public class DumpStateCommand extends AbstractCommand {
         YES
     }
 
+    enum WithMigration {
+        NO,
+        YES
+    }
+
+    enum WithValidation {
+        NO,
+        YES
+    }
+
     enum OmitContents {
         NO,
         YES
@@ -139,7 +149,16 @@ public class DumpStateCommand extends AbstractCommand {
             @Option(
                             names = {"-k", "--slots"},
                             description = "Emit the slot/value pairs for each contract's store")
-                    final boolean withSlots) {
+                    final boolean withSlots,
+            @Option(
+                            names = {"--migrate"},
+                            description =
+                                    "migrate from mono-service representation to modular-service representation (before dump)")
+                    final boolean withMigration,
+            @Option(
+                            names = {"--validate-migration"},
+                            description = "validate the migrated contract store")
+                    final boolean withValidationOfMigration) {
         Objects.requireNonNull(storePath);
         init();
         System.out.println("=== contract stores ===");
@@ -148,6 +167,8 @@ public class DumpStateCommand extends AbstractCommand {
                 storePath,
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 withSlots ? WithSlots.YES : WithSlots.NO,
+                withMigration ? WithMigration.YES : WithMigration.NO,
+                withValidationOfMigration ? WithValidation.YES : WithValidation.NO,
                 parent.verbosity);
         finish();
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -346,7 +346,12 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
     /** register all applicable classes on classpath before deserializing signed state */
     private void registerConstructables() {
         try {
-            ConstructableRegistry.getInstance().registerConstructables("*");
+            final var registry = ConstructableRegistry.getInstance();
+            registry.reset();
+
+            registry.registerConstructables("com.hedera.node.app.service.mono");
+            registry.registerConstructables("com.hedera.node.app.service.mono.*");
+            registry.registerConstructables("com.swirlds.*");
         } catch (final ConstructableRegistryException ex) {
             throw new UncheckedConstructableRegistryException(ex);
         }

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -8,13 +8,14 @@ module com.hedera.node.services.cli {
     requires transitive com.swirlds.platform.core;
     requires transitive info.picocli;
     requires com.hedera.node.app.hapi.utils;
-    requires com.hedera.node.app.service.evm;
     requires com.hedera.node.app.service.contract.impl;
-    requires com.hedera.node.app.spi.test.fixtures;
+    requires com.hedera.node.app.service.contract;
+    requires com.hedera.node.app.service.evm;
     requires com.hedera.node.app;
     requires com.hedera.node.hapi;
     requires com.google.common;
     requires com.google.protobuf;
+    requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -9,6 +9,9 @@ module com.hedera.node.services.cli {
     requires transitive info.picocli;
     requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.app.service.evm;
+    requires com.hedera.node.app.service.contract.impl;
+    requires com.hedera.node.app.spi.test.fixtures;
+    requires com.hedera.node.app;
     requires com.hedera.node.hapi;
     requires com.google.common;
     requires com.google.protobuf;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app;
 
 import com.hedera.node.app.config.ConfigProviderImpl;
-import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskAccount;
 import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.system.NodeId;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -110,8 +110,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      */
     private static final long DO_NOT_USE_IN_REAL_LIFE_CLASS_ID = 0x0000deadbeef0000L;
 
-    //    private static final long CLASS_ID = 0x2de3ead3caf06392L;
-    private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
+    private static final long CLASS_ID = 0x2de3ead3caf06392L;
     private static final int VERSION_1 = 25;
     private static final int CURRENT_VERSION = VERSION_1;
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -110,7 +110,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      */
     private static final long DO_NOT_USE_IN_REAL_LIFE_CLASS_ID = 0x0000deadbeef0000L;
 
-//    private static final long CLASS_ID = 0x2de3ead3caf06392L;
+    //    private static final long CLASS_ID = 0x2de3ead3caf06392L;
     private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
     private static final int VERSION_1 = 25;
     private static final int CURRENT_VERSION = VERSION_1;
@@ -194,8 +194,10 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
             final SwirldDualState dualState,
             final InitTrigger trigger,
             final SoftwareVersion deserializedVersion) {
-        logger.info("Now we have a mono-service state, e.g. child {} is {}",
-                StateChildIndices.NETWORK_CTX, getChild(StateChildIndices.NETWORK_CTX).getClass().getSimpleName());
+        logger.info(
+                "Now we have a mono-service state, e.g. child {} is {}",
+                StateChildIndices.NETWORK_CTX,
+                getChild(StateChildIndices.NETWORK_CTX).getClass().getSimpleName());
         if (true) {
             throw new AssertionError("Not implemented");
         }

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -54,10 +54,12 @@ module com.hedera.node.app {
     exports com.hedera.node.app.workflows to
             com.hedera.node.app.test.fixtures;
     exports com.hedera.node.app.state.merkle to
+            com.hedera.node.services.cli,
             com.swirlds.common;
     exports com.hedera.node.app.state.merkle.disk to
             com.swirlds.common;
     exports com.hedera.node.app.state.merkle.memory to
+            com.hedera.node.services.cli,
             com.swirlds.common;
     exports com.hedera.node.app.state.merkle.singleton to
             com.swirlds.common;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -116,7 +116,7 @@ public class ServicesState extends PartialNaryMerkleInternal
         implements MerkleInternal, SwirldState, StateChildrenProvider {
     private static final Logger log = LogManager.getLogger(ServicesState.class);
 
-    private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1bL;
+    private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1aL;
     public static final ImmutableHash EMPTY_HASH = new ImmutableHash(new byte[DigestType.SHA_384.digestLength()]);
 
     // Only over-written when Platform deserializes a legacy version of the state

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.state.migration;
+
+import static com.hedera.node.app.service.mono.utils.MiscUtils.withLoggedDuration;
+import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
+import com.hedera.node.app.service.mono.state.virtual.ContractKey;
+import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
+import com.hedera.node.app.service.mono.utils.NonAtomicReference;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.threading.interrupt.InterruptableConsumer;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentHashMap.KeySetView;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Migrate mono service's contract store (contract slots, i.e. per-contract K/V pairs) to modular service's contract store.
+ */
+public class ContractStateMigrator {
+    private static final Logger log = LogManager.getLogger(ContractStateMigrator.class);
+
+    /**
+     * The actual migration routine, called by the thing that migrates all the stores
+     */
+    public static void migrateFromContractStoreVirtualMap(
+            @NonNull final VirtualMapLike<ContractKey, IterableContractValue> fromState,
+            @NonNull WritableKVState<SlotKey, SlotValue> toState) {
+        requireNonNull(fromState);
+        requireNonNull(toState);
+
+        final var validationsFailed = new ArrayList<String>();
+        final var migrator = new ContractStateMigrator(fromState, toState);
+        migrator.doit(validationsFailed);
+        if (!validationsFailed.isEmpty()) {
+            final var formattedFailedValidations =
+                    validationsFailed.stream().collect(Collectors.joining("\n   ***", "   ***", "\n"));
+            log.error("{}: transform validations failed:\n{}", LOG_CAPTION, formattedFailedValidations);
+            throw new BrokenTransformationException(LOG_CAPTION + ": transformation didn't complete successfully");
+        }
+    }
+
+    static final int THREAD_COUNT = 8; // TODO: is there a configuration option good for this?
+    static final int MAXIMUM_SLOTS_IN_FLIGHT = 1_000_000; // This holds both mainnet and testnet (at this time, 2023-11)
+    static final int DISTINCT_CONTRACTS_ESTIMATE = 10_000;
+    static final String LOG_CAPTION = "contract-store mono-to-modular migration";
+
+    static final ContractSlotLocal SENTINEL = new ContractSlotLocal(0L, new int[8], new byte[32], null, null);
+
+    final VirtualMapLike<ContractKey, IterableContractValue> fromState;
+    final WritableKVState<SlotKey, SlotValue> toState;
+
+    final Counters counters = Counters.create();
+
+    ContractStateMigrator(
+            @NonNull final VirtualMapLike<ContractKey, IterableContractValue> fromState,
+            @NonNull WritableKVState<SlotKey, SlotValue> toState) {
+        requireNonNull(fromState);
+        requireNonNull(toState);
+        this.fromState = fromState;
+        this.toState = toState;
+    }
+
+    /**
+     * Do the transform from mono-service's contract store to modular-service's contract store, and do some
+     * post-transforms sanity checking.
+     */
+    void doit(@NonNull final List<String> validationsFailed) {
+
+        final var completedProcesses = new NonAtomicReference<EnumSet<CompletedProcesses>>();
+
+        withLoggedDuration(() -> completedProcesses.set(transformStore()), log, LOG_CAPTION + ": complete transform");
+
+        requireNonNull(completedProcesses.get(), "must have valid completed processes set at this point");
+
+        // All that follows is validation that all processing completed and sanity checks pass
+
+        if (completedProcesses.get().size()
+                != EnumSet.allOf(CompletedProcesses.class).size()) {
+            if (!completedProcesses.get().contains(CompletedProcesses.SOURCING))
+                validationsFailed.add("Sourcing process didn't finish");
+            if (!completedProcesses.get().contains(CompletedProcesses.SINKING))
+                validationsFailed.add("Sinking process didn't finish");
+        }
+
+        final var fromSize = fromState.size();
+        if (fromSize != counters.slotsSourced().get()
+                || fromSize != counters.slotsSunk().get()
+                || fromSize != toState.size()) {
+            validationsFailed.add(
+                    "counters of slots processed don't match: %d source size, %d #slots sourced, %d slots sunk, %d final destination size"
+                            .formatted(
+                                    fromSize,
+                                    counters.slotsSourced().get(),
+                                    counters.slotsSunk().get(),
+                                    toState.size()));
+        }
+
+        final var nContracts = counters.contracts().get().size();
+        if (nContracts != counters.nNullPrevs().get()
+                || nContracts != counters.nNullNexts().get()) {
+            validationsFailed.add(
+                    "distinct contracts doesn't match #null prev links and/or #null next links: %d contract, %d null prevs, %d null nexts"
+                            .formatted(
+                                    nContracts,
+                                    counters.nNullPrevs().get(),
+                                    counters.nNullNexts().get()));
+        }
+    }
+
+    /**
+     * The intermediate representation of a contract slot (K/V pair, plus prev/next linked list references.
+     */
+    @SuppressWarnings("java:S6218") // should overload equals/hashcode  - but will never test for equality or hash this
+    record ContractSlotLocal(long contractId, @NonNull int[] key, @NonNull byte[] value, int[] prev, int[] next) {
+        ContractSlotLocal {
+            requireNonNull(key);
+            requireNonNull(value);
+            validateArgument(key.length == 8, "wrong length key");
+            validateArgument(value.length == 32, "wrong length value");
+            if (prev != null) validateArgument(prev.length == 8, "wrong length prev link");
+            if (next != null) validateArgument(next.length == 8, "wrong length next link");
+        }
+
+        ContractSlotLocal(@NonNull final ContractKey k, @NonNull final IterableContractValue v) {
+            this(k.getContractId(), k.getKey(), v.getValue(), v.getExplicitPrevKey(), v.getExplicitNextKey());
+        }
+    }
+
+    /**
+     * Various counters used to perform final validations on the completed transform.
+     *
+     * The counters used by the sink process need not actually be atomic at this time, as the sink process is single
+     * threaded.  But IMO it is more consistent and thus easier to read to treat _all_ of the counters the same.
+     */
+    record Counters(
+            @NonNull AtomicInteger slotsSourced,
+            @NonNull AtomicInteger slotsSunk,
+            @NonNull AtomicReference<KeySetView<Long, Boolean>> contracts,
+            @NonNull AtomicInteger nNullPrevs,
+            @NonNull AtomicInteger nNullNexts) {
+        @NonNull
+        static Counters create() {
+            return new Counters(
+                    new AtomicInteger(),
+                    new AtomicInteger(),
+                    new AtomicReference<>(ConcurrentHashMap.newKeySet(DISTINCT_CONTRACTS_ESTIMATE)),
+                    new AtomicInteger(),
+                    new AtomicInteger());
+        }
+
+        void sourceOne() {
+            slotsSourced.incrementAndGet();
+        }
+
+        void sinkOne() {
+            slotsSunk.incrementAndGet();
+        }
+
+        void addContract(long cid) {
+            contracts.get().add(cid);
+        }
+
+        void addNullPrev() {
+            nNullPrevs.incrementAndGet();
+        }
+
+        void addNullNext() {
+            nNullNexts.incrementAndGet();
+        }
+    }
+
+    /** Indicates that the source or sink process processed all slots */
+    enum CompletedProcesses {
+        SOURCING,
+        SINKING
+    }
+
+    /**
+     *  Operates the source and sink processes to transform the mono-state ("from") into the modular-state ("to").
+     *  */
+    @NonNull
+    EnumSet<CompletedProcesses> transformStore() {
+
+        final var slotQueue = new ArrayBlockingQueue<ContractSlotLocal>(MAXIMUM_SLOTS_IN_FLIGHT);
+
+        // Sinking and sourcing happen concurrently.  (Though sourcing is multithreaded, sinking is all on one thread.)
+        // Consider: For debugging, don't create (and start) `processSlotQueue` until after sourcing is complete. Just
+        // accumulate everything in the fromStore in the queue before sinking anything.
+
+        CompletableFuture<Void> processSlotQueue =
+                CompletableFuture.runAsync(() -> iterateOverQueuedSlots((slotQueue)));
+
+        final var completedTasks = EnumSet.noneOf(CompletedProcesses.class);
+
+        boolean didCompleteSourcing = iterateOverCurrentData(slotQueue::put);
+        try {
+            slotQueue.put(SENTINEL);
+        } catch (InterruptedException ex) { // TODO: This InterruptedException can be ignored, I think; correct?
+            log.error(LOG_CAPTION + ": interrupt when sourcing slots", ex);
+            didCompleteSourcing = false;
+        }
+        if (didCompleteSourcing) completedTasks.add(CompletedProcesses.SOURCING);
+
+        boolean didCompleteSinking = true;
+        try {
+            processSlotQueue.join();
+        } catch (CompletionException cex) {
+            final var ex = cex.getCause();
+            log.error(LOG_CAPTION + ": interrupt when sinking slots", ex);
+            didCompleteSinking = false;
+        }
+        if (didCompleteSinking) completedTasks.add(CompletedProcesses.SINKING);
+
+        return completedTasks;
+    }
+
+    /**
+     * Pull slots off the queue and add each one immediately to the modular-service state.  This is "sinking" the slots.
+     *
+     * This is single-threaded.  (But does operate concurrently with sourcing.)
+     */
+    @SuppressWarnings("java:S2142") // must rethrow InterruptedException - Sonar doesn't understand wrapping it to throw
+    void iterateOverQueuedSlots(@NonNull final ArrayBlockingQueue<ContractSlotLocal> slotQueue) {
+        requireNonNull(slotQueue);
+
+        // TODO: Consider passing this an InterruptableSupplier, not the queue directly.  See how
+        // `iterateOverCurrentData` takes a InterruptableConsumer.
+
+        while (true) {
+            final ContractSlotLocal slot;
+            try {
+                slot = slotQueue.take();
+            } catch (InterruptedException e) {
+                throw new CompletionException(e);
+            }
+            if (slot == SENTINEL) break;
+
+            final var key = SlotKey.newBuilder()
+                    .contractNumber(slot.contractId())
+                    .key(bytesFromInts(slot.key()))
+                    .build();
+            final var value = SlotValue.newBuilder()
+                    .value(Bytes.wrap(slot.value()))
+                    .previousKey(bytesFromInts(slot.prev()))
+                    .nextKey(bytesFromInts((slot.next())))
+                    .build();
+            toState.put(key, value);
+
+            // Some counts to provide some validation
+            counters.sinkOne();
+            counters.addContract(slot.contractId());
+            if (slot.prev() == null) counters.addNullPrev();
+            if (slot.next() == null) counters.addNullNext();
+        }
+    }
+
+    /**
+     * Iterate over the incoming mono-service state, pushing slots (key + value) into the queue.  This is "sourcing"
+     * the slots.
+     *
+     * This iteration operates with multiple threads simultaneously.
+     */
+    boolean iterateOverCurrentData(@NonNull final InterruptableConsumer<ContractSlotLocal> slotSink) {
+        boolean didRunToCompletion = true;
+        try {
+            fromState.extractVirtualMapData(
+                    getStaticThreadManager(),
+                    entry -> {
+                        final var contractKey = entry.left();
+                        final var iterableContractValue = entry.right();
+                        slotSink.accept(new ContractSlotLocal(contractKey, iterableContractValue));
+
+                        // Some counts to provide some validation
+                        counters.sourceOne();
+                    },
+                    THREAD_COUNT);
+        } catch (final InterruptedException ex) {
+            currentThread().interrupt();
+            didRunToCompletion = false;
+        }
+        return didRunToCompletion;
+    }
+
+    //    @NonNull
+    //    static WritableKVState<SlotKey, SlotValue> getNewContractStore() {
+    //        return new InMemoryWritableKVState<SlotKey, SlotValue>();
+    //    }
+
+    /** Convert int[] to byte[] and then to Bytes. If argument is null then return value is null. */
+    static Bytes bytesFromInts(final int[] ints) {
+        if (ints == null) return null;
+
+        // N.B.: `ByteBuffer.allocate` creates the right `byte[]`.  `asIntBuffer` will share it, so no extra copy
+        // there.  Finally, `Bytes.wrap` will wrap it so no extra copy there either.
+        final ByteBuffer buf = ByteBuffer.allocate(32);
+        buf.asIntBuffer().put(ints);
+        return Bytes.wrap(buf.array());
+    }
+
+    /** Validate an argument by throwing `IllegalArgumentException` if the test fails */
+    static void validateArgument(final boolean b, @NonNull final String msg) {
+        if (!b) throw new IllegalArgumentException(msg);
+    }
+
+    static class BrokenTransformationException extends RuntimeException {
+
+        public BrokenTransformationException(String message) {
+            super(message);
+        }
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -308,9 +308,10 @@ public class ContractStateMigrator {
     void commitToStateNow() {
         toState = stateFlusher.apply(toState);
     }
+
     /**
      * Iterate over the incoming mono-service state, pushing slots (key + value) into the queue.  This is "sourcing"
-     * the slots.7y
+     * the slots.
      *
      * This iteration operates with multiple threads simultaneously.
      */

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -358,11 +358,6 @@ public class ContractStateMigrator {
         return validationsFailed.isEmpty() ? Status.VALIDATION_ERRORS : Status.SUCCESS;
     }
 
-    //    @NonNull
-    //    static WritableKVState<SlotKey, SlotValue> getNewContractStore() {
-    //        return new InMemoryWritableKVState<SlotKey, SlotValue>();
-    //    }
-
     /** Convert int[] to byte[] and then to Bytes. If argument is null or 0-length then return `Bytes.EMPTY`. */
     @NonNull
     static Bytes bytesFromInts(@Nullable final int[] ints) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/internal/ContractMigrationValidationCounters.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/internal/ContractMigrationValidationCounters.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.state.migration.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.service.mono.state.migration.ContractStateMigrator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Various counters used to perform final validations on the completed transform.
+ * <p>
+ * The counters used by the sink process need not actually be atomic at this time, as the sink process is single
+ * threaded.  But IMO it is more consistent and thus easier to read to treat _all_ of the counters the same.
+ */
+@SuppressWarnings("java:S6218") // override equals/hashcode because of arrays: but we never compare these things
+public record ContractMigrationValidationCounters(
+        @NonNull AtomicInteger slotsSourced, // #slots the sourcing process read from the source tree
+        @NonNull AtomicInteger slotsSunk, // #slots the sinking process wrote to the destination tree
+        @NonNull ConcurrentHashMap.KeySetView<Long, Boolean> contracts, // set of seen contract ids
+        @NonNull AtomicInteger nMissingPrevs, // #sunk slots where the "previous" link was missing (start of d.l.- list)
+        @NonNull AtomicInteger nMissingNexts, // #sunk slots where the "next" link was missing (end of d.l.-list)
+        @NonNull byte[] runningXorOfLinks // running xor of all previous and next links of all slots sunk
+        ) {
+
+    static final int EVM_WORD_WIDTH_IN_BYTES = 32;
+    static final int DISTINCT_CONTRACTS_ESTIMATE = 10_000;
+
+    @NonNull
+    public static ContractMigrationValidationCounters create() {
+        return new ContractMigrationValidationCounters(
+                new AtomicInteger(),
+                new AtomicInteger(),
+                ConcurrentHashMap.newKeySet(DISTINCT_CONTRACTS_ESTIMATE),
+                new AtomicInteger(),
+                new AtomicInteger(),
+                new byte[EVM_WORD_WIDTH_IN_BYTES]);
+    }
+
+    public void sourceOne() {
+        slotsSourced.incrementAndGet();
+    }
+
+    public void sinkOne() {
+        slotsSunk.incrementAndGet();
+    }
+
+    public void addContract(long cid) {
+        contracts.add(cid);
+    }
+
+    public void addMissingPrev() {
+        nMissingPrevs.incrementAndGet();
+    }
+
+    public void addMissingNext() {
+        nMissingNexts.incrementAndGet();
+    }
+
+    public void xorAnotherLink(@NonNull final byte[] link) {
+        requireNonNull(link);
+        ContractStateMigrator.validateArgument(link.length == EVM_WORD_WIDTH_IN_BYTES, "link length must be 32 bytes");
+        synchronized (runningXorOfLinks) {
+            for (int i = 0; i < EVM_WORD_WIDTH_IN_BYTES; i++) {
+                runningXorOfLinks[i] ^= link[i];
+            }
+        }
+    }
+
+    public boolean runningXorOfLinksIsZero() {
+        byte r = 0;
+        synchronized (runningXorOfLinks) {
+            for (int i = 0; i < EVM_WORD_WIDTH_IN_BYTES; i++) {
+                r |= runningXorOfLinks[i];
+            }
+        }
+        return r == 0;
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module com.hedera.node.app.service.contract.impl {
     exports com.hedera.node.app.service.contract.impl.handlers;
     exports com.hedera.node.app.service.contract.impl.hevm;
     exports com.hedera.node.app.service.contract.impl.state to
+            com.hedera.node.services.cli,
             com.hedera.node.app.service.contract.impl.test,
             com.hedera.node.app;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -129,7 +129,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
@@ -152,7 +151,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-//@HapiTestSuite
+// @HapiTestSuite
 public class CryptoTransferSuite extends HapiSuite {
     private static final Logger LOG = LogManager.getLogger(CryptoTransferSuite.class);
     private static final String OWNER = "owner";


### PR DESCRIPTION
**Description**:

New class `ContractStateMigrator` will migrate from a mono service's contract store representation to a modular service's contract store (given by a `WritableKVStore`).

Shown correct by enhancing the contract store dumper to (optionally) migrate the contract store before dumping it.  Diff on the two dumps (without migration and with migration) shows only the summary line changes: and that only to include a migration flag.

Has code that commits the migration-in-progress modular store every 10000 items added (to force flush-to-disk).  Tricky thing there is there doesn't appear currently to be any access path from a `WritableKVState` to get to the point where you can `copy()` the underlying `VirtualMap`/`MerkleMap`.  But the _caller_ must have access to the underlying structure.  And so it passes in an operator that does the commit + copy and returns the new store to work with.

**Related issue(s)**:

TBD

**Notes for reviewer**:

An example command line for the dumper:

```
./services-cli.sh signed-state -f states/2023-10-29T03:18:19Z/151988064/SignedState.swh dump contract-stores -k -s -o 2023-10-29T03:18:19Z-151988064.contract-stores.new.txt --migrate --validate-migration
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (incorporated into contract store dumper, as described above, and results match)
