### PR TITLE
2095 fix redundant unused statements in test code

### DIFF
--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/OwnershipTrackerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/OwnershipTrackerTest.java
@@ -19,7 +19,6 @@ package com.hedera.node.app.service.mono.store.models;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OwnershipTrackerTest {
@@ -28,12 +27,6 @@ class OwnershipTrackerTest {
     private final Id treasury = new Id(1, 2, 3);
     private final Id account = new Id(4, 5, 6);
     private final Id token = new Id(0, 0, 1);
-
-    @BeforeEach
-    void setup() {
-        // setup the getter/setter test
-        subject = new OwnershipTracker();
-    }
 
     @Test
     void add() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/UniqueTokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/UniqueTokenTest.java
@@ -30,14 +30,13 @@ class UniqueTokenTest {
         assertEquals(1, subj.getSerialNumber());
         assertEquals(Id.DEFAULT, subj.getTokenId());
 
-        var metadata = new byte[] {107, 117, 114};
         subj = new UniqueToken(Id.DEFAULT, 1, RichInstant.MISSING_INSTANT, new Id(1, 2, 3), new byte[] {111, 23, 85});
         assertEquals(RichInstant.MISSING_INSTANT, subj.getCreationTime());
         assertEquals(new Id(1, 2, 3), subj.getOwner());
         subj.setSerialNumber(2);
         assertEquals(2, subj.getSerialNumber());
 
-        metadata = new byte[] {1, 2, 3};
+        var metadata = new byte[] {1, 2, 3};
         subj.setMetadata(metadata);
         assertEquals(metadata, subj.getMetadata());
         subj.setTokenId(Id.DEFAULT);


### PR DESCRIPTION
**Description:**
This PR changes the following:

- Remove redundant `setup()` method in `OwnershipTrackerTest` (JUnit 5 auto-instantiation)
- Remove redundant metadata assignment in UniqueTokenTest

**Related issue(s):**
Closes [#2095](https://github.com/hashgraph/hedera-services/issues/2095)