### PR TITLE
Update .gitignore to exclude generated files located in */data/* dire…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1050,6 +1050,9 @@ hedera-node/cli-clients/testFile
 hedera-node/hedera-mono-service/src/test/resources/balance*/**
 hedera-node/hedera-mono-service/temp/**
 hedera-node/hedera-mono-service/swirlds-sst-tmp/**
+hedera-node/data/
+hedera-node/settingsUsed.txt
+hedera-node/hedera-node/data/
 
 # Test Files (Poorly Behaved Tests)
 *.json.gz


### PR DESCRIPTION
**Description**:

When executing gradle modrun, a lot of new files are generated that shouldn't be commited here

This PR changes the following:
* Update .gitignore to exclude generated files located in */data/* directories

**Related issue(s)**:
Closes #4313 