### PR TITLE
feat(Schedule-Modularization): Fix and enable three ScheduleExecutionSpecs tests

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -99,7 +99,6 @@ abstract class AbstractScheduleHandler {
         final Key payerKey = getKeyForAccount(context, payer);
         if (payerKey != null) scheduledRequiredKeys.add(payerKey);
         final Set<Key> currentSignatories = setOfKeys(scheduleInState.signatories());
-        scheduledRequiredKeys.removeAll(currentSignatories);
         final Set<Key> remainingRequiredKeys =
                 filterRemainingRequiredKeys(context, scheduledRequiredKeys, currentSignatories);
         // Mono doesn't store extra signatures, so for now we mustn't either.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -78,7 +78,7 @@ abstract class AbstractScheduleHandler {
     protected ScheduleKeysResult allKeysForTransaction(
             @NonNull final Schedule scheduleInState, @NonNull final HandleContext context) throws HandleException {
         final AccountID originalPayer =
-                        scheduleInState.originalCreateTransaction().transactionID().accountID();
+                scheduleInState.originalCreateTransaction().transactionID().accountID();
         // note, payerAccount should never be null, but we're playing it safe here.
         final AccountID payer = scheduleInState.payerAccountIdOrElse(originalPayer);
         final TransactionBody scheduledAsOrdinary = HandlerUtility.childAsOrdinary(scheduleInState);

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
@@ -170,9 +170,7 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
         // given...return fails because it calls the real method before it can be replaced.
         BDDMockito.doReturn(testKeys).when(spiedContext).allKeysForTransaction(any(), any());
         final Set<Key> keysObtained = testHandler.allKeysForTransaction(scheduleInState, spiedContext);
-        assertThat(keysObtained)
-                .isNotEmpty()
-                .containsExactly(otherKey, optionKey, payerKey, schedulerKey, adminKey);
+        assertThat(keysObtained).isNotEmpty().containsExactly(otherKey, optionKey, payerKey, schedulerKey, adminKey);
     }
 
     @Test

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
@@ -170,8 +170,9 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
         // given...return fails because it calls the real method before it can be replaced.
         BDDMockito.doReturn(testKeys).when(spiedContext).allKeysForTransaction(any(), any());
         final Set<Key> keysObtained = testHandler.allKeysForTransaction(scheduleInState, spiedContext);
-        assertThat(keysObtained).isNotEmpty();
-        assertThat(keysObtained).containsExactly(otherKey, optionKey, payerKey, schedulerKey, adminKey);
+        assertThat(keysObtained)
+                .isNotEmpty()
+                .containsExactly(otherKey, optionKey, payerKey, schedulerKey, adminKey);
     }
 
     @Test
@@ -195,7 +196,7 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
             // we *mock* verificationFor side effects, which is what fills in/clears the sets,
             // so results should all be the same, despite empty signatories and mocked HandleContext.
             // We do so based on verifier calls, so it still exercises the code to be tested, however.
-            assertThat(keysRequired).isNotEmpty().hasSize(2).containsExactly(optionKey, schedulerKey);
+            assertThat(keysRequired).isNotEmpty().hasSize(1).containsExactly(optionKey);
             assertThat(keysObtained).isNotEmpty().hasSize(2).containsExactly(payerKey, adminKey);
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -175,9 +175,9 @@ public class ScheduleExecutionSpecs extends HapiSuite {
     private static final String SCHEDULE_CREATE_FEE = "scheduleCreateFee";
     private static final String ACCOUNT = "civilian";
     private static final String TOKENS_NFTS_MAX_BATCH_SIZE_MINT = "tokens.nfts.maxBatchSizeMint";
-    private static final String defaultMaxBatchSizeMint =
+    private static final String DEFAULT_MAX_BATCH_SIZE_MINT =
             HapiSpecSetup.getDefaultNodeProps().get(TOKENS_NFTS_MAX_BATCH_SIZE_MINT);
-    private static final String defaultWhitelist =
+    private static final String DEFAULT_WHITELIST =
             HapiSpecSetup.getDefaultNodeProps().get(SCHEDULING_WHITELIST);
 
     /**
@@ -268,7 +268,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                 .when()
                 .then(fileUpdate(APP_PROPERTIES)
                         .payingWith(ADDRESS_BOOK_CONTROL)
-                        .overridingProps(Map.of(SCHEDULING_WHITELIST, defaultWhitelist)));
+                        .overridingProps(Map.of(SCHEDULING_WHITELIST, DEFAULT_WHITELIST)));
     }
 
     private HapiSpec suiteSetup() {
@@ -612,7 +612,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                                 .scheduled()
                                 .hasPriority(recordWith().status(BATCH_SIZE_LIMIT_EXCEEDED)),
                         getTokenInfo(A_TOKEN).hasTotalSupply(0),
-                        overriding(TOKENS_NFTS_MAX_BATCH_SIZE_MINT, defaultMaxBatchSizeMint));
+                        overriding(TOKENS_NFTS_MAX_BATCH_SIZE_MINT, DEFAULT_MAX_BATCH_SIZE_MINT));
     }
 
     // This should not be run for modular service due to key gathering behavior differences.
@@ -1681,7 +1681,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         }));
     }
 
-    // @todo('9974') Need to work out why this generates INVALID_SIGNATURE
+    @HapiTest
     private HapiSpec executionWithCustomPayerWorksWithLastSigBeingCustomPayer() {
         long noBalance = 0L;
         long transferAmount = 1;
@@ -2213,7 +2213,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         .hasKnownStatus(SUCCESS))
                 .then(
                         freezeAbort().payingWith(GENESIS),
-                        overriding(SCHEDULING_WHITELIST, defaultWhitelist),
+                        overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),
                         withOpContext((spec, opLog) -> {
                             var triggeredTx = getTxnRecord(successTxn).scheduled();
@@ -2256,7 +2256,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                                     // there are no throttles for freeze and we deeply check with
                                     // long term enabled
                                     .hasPrecheck(BUSY),
-                            overriding(SCHEDULING_WHITELIST, defaultWhitelist));
+                            overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST));
         }
         return defaultHapiSpec("ScheduledFreezeWithUnauthorizedPayerFails")
                 .given(
@@ -2284,7 +2284,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         .hasKnownStatus(SUCCESS))
                 .then(
                         freezeAbort().payingWith(GENESIS),
-                        overriding(SCHEDULING_WHITELIST, defaultWhitelist),
+                        overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),
                         withOpContext((spec, opLog) -> {
                             var triggeredTx = getTxnRecord(successTxn).scheduled();
@@ -2297,7 +2297,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         }));
     }
 
-    // @todo('9973') Need to work out why this does not actually execute
+    @HapiTest
     private HapiSpec scheduledPermissionedFileUpdateWorksAsExpected() {
         return defaultHapiSpec("ScheduledPermissionedFileUpdateWorksAsExpected")
                 .given(
@@ -2316,7 +2316,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         .via(signTxn)
                         .hasKnownStatus(SUCCESS))
                 .then(
-                        overriding(SCHEDULING_WHITELIST, defaultWhitelist),
+                        overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),
                         withOpContext((spec, opLog) -> {
                             var triggeredTx = getTxnRecord(successTxn).scheduled();
@@ -2350,7 +2350,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         .via(signTxn)
                         .hasKnownStatus(SUCCESS))
                 .then(
-                        overriding(SCHEDULING_WHITELIST, defaultWhitelist),
+                        overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),
                         withOpContext((spec, opLog) -> {
                             var triggeredTx = getTxnRecord(successTxn).scheduled();
@@ -2363,7 +2363,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         }));
     }
 
-    // @todo('9973') Work out permissioned file update issues
+    @HapiTest
     private HapiSpec scheduledSystemDeleteWorksAsExpected() {
 
         return defaultHapiSpec("ScheduledSystemDeleteWorksAsExpected")
@@ -2382,7 +2382,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         .via(signTxn)
                         .hasKnownStatus(SUCCESS))
                 .then(
-                        overriding(SCHEDULING_WHITELIST, defaultWhitelist),
+                        overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),
                         getFileInfo("misc").nodePayment(1_234L).hasAnswerOnlyPrecheck(INVALID_FILE_ID),
                         withOpContext((spec, opLog) -> {
@@ -2419,7 +2419,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                                     // with
                                     // long term enabled
                                     .hasPrecheck(BUSY),
-                            overriding(SCHEDULING_WHITELIST, defaultWhitelist));
+                            overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST));
         }
 
         return defaultHapiSpec("ScheduledSystemDeleteUnauthorizedPayerFails")
@@ -2440,7 +2440,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         .via(signTxn)
                         .hasKnownStatus(SUCCESS))
                 .then(
-                        overriding(SCHEDULING_WHITELIST, defaultWhitelist),
+                        overriding(SCHEDULING_WHITELIST, DEFAULT_WHITELIST),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),
                         getFileInfo("misc").nodePayment(1_234L),
                         withOpContext((spec, opLog) -> {
@@ -2535,7 +2535,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                                         minCongestionPeriod,
                                         HapiSpecSetup.getDefaultNodeProps().get(minCongestionPeriod),
                                         SCHEDULING_WHITELIST,
-                                        defaultWhitelist)),
+                                        DEFAULT_WHITELIST)),
                         cryptoTransfer(HapiCryptoTransfer.tinyBarsFromTo(GENESIS, FUNDING, 1))
                                 .payingWith(GENESIS),
                         getScheduleInfo(A_SCHEDULE).isExecuted(),


### PR DESCRIPTION
Fix and enable three tests in ScheduleExecutionSpecs

**Related issue(s)**:
Fixes #9974
Partially fixes #9973
