### PR TITLE
fix: clear expired EventImpls instead of simply discarding

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntake.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntake.java
@@ -168,6 +168,7 @@ public class EventIntake {
         try {
             // an expired event will cause ShadowGraph to throw an exception, so we just to discard it
             if (consensus().isExpired(event)) {
+                event.clear();
                 return;
             }
 


### PR DESCRIPTION
- closes #10198 
