### PR TITLE
fix: disable Gradle cache cleanup features

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -159,7 +159,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
         with:
-          gradle-home-cache-cleanup: true
           cache-read-only: false
 
       - name: Setup NodeJS


### PR DESCRIPTION
## Description

This pull request changes the following:

- Disable Gradle cache cleanup features.

### Related Issues

- Closes #10202 