### PR TITLE
feat(migration): Migrate contract store (contract's slots) from monservice to modular-service representation

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -20,12 +20,28 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 import static java.util.Comparator.naturalOrder;
 import static java.util.Map.Entry.comparingByKey;
 
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.node.app.service.contract.ContractService;
+import com.hedera.node.app.service.contract.impl.state.ContractSchema;
+import com.hedera.node.app.service.mono.state.migration.ContractStateMigrator;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
-import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
+import com.hedera.node.app.service.mono.utils.NonAtomicReference;
+import com.hedera.node.app.spi.state.StateDefinition;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.node.app.spi.state.WritableKVStateBase;
+import com.hedera.node.app.state.merkle.StateMetadata;
+import com.hedera.node.app.state.merkle.memory.InMemoryKey;
+import com.hedera.node.app.state.merkle.memory.InMemoryValue;
+import com.hedera.node.app.state.merkle.memory.InMemoryWritableKVState;
 import com.hedera.services.cli.signedstate.DumpStateCommand.EmitSummary;
+import com.hedera.services.cli.signedstate.DumpStateCommand.WithMigration;
 import com.hedera.services.cli.signedstate.DumpStateCommand.WithSlots;
+import com.hedera.services.cli.signedstate.DumpStateCommand.WithValidation;
 import com.hedera.services.cli.signedstate.SignedStateCommand.Verbosity;
+import com.swirlds.merkle.map.MerkleMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -37,20 +53,27 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
 @SuppressWarnings("java:S106") // "use of system.out/system.err instead of logger" - not needed/desirable for CLI tool
 public class DumpContractStoresSubcommand {
+
     static void doit(
             @NonNull final SignedStateHolder state,
             @NonNull final Path storePath,
             @NonNull final EmitSummary emitSummary,
             @NonNull final WithSlots withSlots,
+            @NonNull final WithMigration withMigration,
+            @NonNull final WithValidation withValidation,
             @NonNull final Verbosity verbosity) {
-        new DumpContractStoresSubcommand(state, storePath, emitSummary, withSlots, verbosity).doit();
+        new DumpContractStoresSubcommand(
+                        state, storePath, emitSummary, withSlots, withMigration, withValidation, verbosity)
+                .doit();
     }
 
     @NonNull
@@ -66,6 +89,12 @@ public class DumpContractStoresSubcommand {
     final WithSlots withSlots;
 
     @NonNull
+    final WithMigration withMigration;
+
+    @NonNull
+    final WithValidation withValidation;
+
+    @NonNull
     final Verbosity verbosity;
 
     DumpContractStoresSubcommand(
@@ -73,12 +102,22 @@ public class DumpContractStoresSubcommand {
             @NonNull final Path storePath,
             @NonNull final EmitSummary emitSummary,
             @NonNull final WithSlots withSlots,
+            @NonNull final WithMigration withMigration,
+            @NonNull final WithValidation withValidation,
             @NonNull final Verbosity verbosity) {
         this.state = state;
         this.storePath = storePath;
         this.emitSummary = emitSummary;
         this.withSlots = withSlots;
+        this.withMigration = withMigration;
+        this.withValidation = withValidation;
         this.verbosity = verbosity;
+    }
+
+    record ContractKeyLocal(long contractId, UInt256 key) {
+        public static ContractKeyLocal from(@NonNull final ContractKey ckey) {
+            return new ContractKeyLocal(ckey.getContractId(), toUint256FromPackedIntArray(ckey.getKey()));
+        }
     }
 
     @SuppressWarnings(
@@ -87,31 +126,24 @@ public class DumpContractStoresSubcommand {
     // _am in fact_ being properly cautious, thank you Sonar
     void doit() {
 
-        record ContractKeyLocal(long contractId, UInt256 key) {
-            public static ContractKeyLocal from(ContractKey ckey) {
-                return new ContractKeyLocal(ckey.getContractId(), toUint256FromPackedIntArray(ckey.getKey()));
-            }
-        }
-
         // First grab all slot pairs from all contracts from the signed state
-        final var contractKeys = new ConcurrentLinkedQueue<ContractKeyLocal>();
         final var contractState = new ConcurrentHashMap<Long, ConcurrentLinkedQueue<Pair<UInt256, UInt256>>>(5000);
-        final var traversalOk = iterateThroughContractStorage((ckey, iter) -> {
-            final var contractId = ckey.getContractId();
-            final var ckeyLocal = ContractKeyLocal.from(ckey);
 
-            contractKeys.add(ckeyLocal);
+        // We only handle mono-service state, but we can choose to handle it "native" _or_ migrate it to
+        // modular-service's
+        // representation first.
+        final Predicate<BiConsumer<ContractKeyLocal, UInt256>> contractStoreIterator = withMigration == WithMigration.NO
+                ? this::iterateThroughContractStorage
+                : this::iterateThroughMigratedContractStorage;
 
-            contractState.computeIfAbsent(contractId, k -> new ConcurrentLinkedQueue<>());
-            contractState.get(contractId).add(Pair.of(ckeyLocal.key(), iter.asUInt256()));
+        final var traversalOk = contractStoreIterator.test((ckey, value) -> {
+            contractState.computeIfAbsent(ckey.contractId(), k -> new ConcurrentLinkedQueue<>());
+            contractState.get(ckey.contractId()).add(Pair.of(ckey.key(), value));
         });
 
         if (traversalOk) {
 
-            final var nDistinctContractIds = contractKeys.stream()
-                    .map(ContractKeyLocal::contractId)
-                    .distinct()
-                    .count();
+            final var nDistinctContractIds = contractState.size();
 
             final var nContractStateValues = contractState.values().stream()
                     .mapToInt(ConcurrentLinkedQueue::size)
@@ -120,7 +152,7 @@ public class DumpContractStoresSubcommand {
             // I can't seriously be intending to cons up the _entire_ store of all contracts as a single string, can I?
             // Well, Toto, this isn't the 1990s anymore ...
 
-            long reportSizeEstimate = (nDistinctContractIds * 20)
+            long reportSizeEstimate = (nDistinctContractIds * 20L)
                     + (nContractStateValues * 2 /*K/V*/ * (32 /*bytes*/ * 2 /*hexits/byte*/ + 3 /*whitespace+slop*/));
             final var sb = new StringBuilder((int) reportSizeEstimate);
 
@@ -141,13 +173,13 @@ public class DumpContractStoresSubcommand {
                     .toList();
 
             if (emitSummary == EmitSummary.YES) {
-                sb.append("%s%n%d contractKeys found, %d distinct; %d contract state entries, totalling %d values %n"
-                        .formatted(
-                                "=".repeat(80),
-                                contractKeys.size(),
-                                nDistinctContractIds,
-                                contractState.size(),
-                                nContractStateValues));
+
+                final var validationSummary = withValidation == WithValidation.NO ? "" : "validated ";
+                final var migrationSummary =
+                        withMigration == WithMigration.NO ? "" : "(with %smigration)".formatted(validationSummary);
+
+                sb.append("%s%n%d contractKeys found, %d total slots %s%n"
+                        .formatted("=".repeat(80), nDistinctContractIds, nContractStateValues, migrationSummary));
                 appendContractStoreSummary(sb, contractStates);
             }
 
@@ -167,18 +199,22 @@ public class DumpContractStoresSubcommand {
      * virtual merkle tree and it does the traversal on multiple threads.  (So the visitor needs to be able to handle
      * multiple concurrent calls.)
      */
-    boolean iterateThroughContractStorage(BiConsumer<ContractKey, IterableContractValue> visitor) {
+    boolean iterateThroughContractStorage(BiConsumer<ContractKeyLocal, UInt256> visitor) {
+
         final int THREAD_COUNT = 8; // size it for a laptop, why not?
         final var contractStorageVMap = state.getRawContractStorage();
+
+        final var nSlotsSeen = new AtomicLong();
 
         boolean didRunToCompletion = true;
         try {
             contractStorageVMap.extractVirtualMapData(
                     getStaticThreadManager(),
                     entry -> {
-                        final var contractKey = entry.left();
+                        final var contractKey = ContractKeyLocal.from(entry.left());
                         final var iterableContractValue = entry.right();
-                        visitor.accept(contractKey, iterableContractValue);
+                        nSlotsSeen.incrementAndGet();
+                        visitor.accept(contractKey, iterableContractValue.asUInt256());
                     },
                     THREAD_COUNT);
         } catch (final InterruptedException ex) {
@@ -187,6 +223,84 @@ public class DumpContractStoresSubcommand {
         }
 
         return didRunToCompletion;
+    }
+
+    boolean iterateThroughMigratedContractStorage(BiConsumer<ContractKeyLocal, UInt256> visitor) {
+        final var contractStorageStore = getMigratedContractStore();
+
+        final var nSlotsSeen = new AtomicLong();
+
+        if (contractStorageStore == null) return false;
+        contractStorageStore.keys().forEachRemaining(key -> {
+            // (Not sure how many temporary _copies_ of a byte arrays are made here ... best not to ask ...)
+            final var contractKeyLocal = ContractKeyLocal.from(
+                    new ContractKey(key.contractNumber(), key.key().toByteArray()));
+            final var slotValue = contractStorageStore.get(key);
+            assert (slotValue != null);
+            final var value = uint256FromByteArray(slotValue.value().toByteArray());
+            nSlotsSeen.incrementAndGet();
+            visitor.accept(contractKeyLocal, value);
+        });
+
+        return true;
+    }
+
+    /** First migrates the contract store from the mono-service representation to the modular-service representations,
+     *  and then returns all contracts with bytecodes from the migrated contract store, plus the ids of contracts with
+     *  0-length bytecodes.
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    WritableKVState<SlotKey, SlotValue> getMigratedContractStore() {
+
+        final var fromStore = state.getRawContractStorage();
+        final var expectedNumberOfSlots = Math.toIntExact(fromStore.size());
+
+        // Start the migration with a clean, writable KV store.  Using the in-memory store here.
+
+        final var contractSchema = new ContractSchema();
+        final var contractSchemas = contractSchema.statesToCreate();
+        final StateDefinition<SlotKey, SlotValue> contractStoreStateDefinition = contractSchemas.stream()
+                .filter(sd -> sd.stateKey().equals(ContractSchema.STORAGE_KEY))
+                .findFirst()
+                .orElseThrow();
+        final var contractStoreSchemaMetadata =
+                new StateMetadata<>(ContractService.NAME, contractSchema, contractStoreStateDefinition);
+        final var contractMerkleMap =
+                new NonAtomicReference<MerkleMap<InMemoryKey<SlotKey>, InMemoryValue<SlotKey, SlotValue>>>(
+                        new MerkleMap<>(expectedNumberOfSlots));
+        final var toStore = new NonAtomicReference<WritableKVState<SlotKey, SlotValue>>(
+                new InMemoryWritableKVState<>(contractStoreSchemaMetadata, contractMerkleMap.get()));
+
+        final var flushCounter = new AtomicInteger();
+
+        final ContractStateMigrator.StateFlusher stateFlusher = ignored -> {
+            // Commit all the new leafs to the underlying map
+            ((WritableKVStateBase<SlotKey, SlotValue>) (toStore.get())).commit();
+            // Copy the underlying map, which does the flush
+            contractMerkleMap.set(contractMerkleMap.get().copy());
+            // Create a new store to go on with
+            toStore.set(new InMemoryWritableKVState<>(contractStoreSchemaMetadata, contractMerkleMap.get()));
+
+            flushCounter.incrementAndGet();
+
+            return toStore.get();
+        };
+
+        final var validationFailures = new ArrayList<String>();
+        try {
+            final var migrationStatus = ContractStateMigrator.migrateFromContractStorageVirtualMap(
+                    fromStore, toStore.get(), stateFlusher, validationFailures);
+            assert (migrationStatus == ContractStateMigrator.Status.SUCCESS);
+        } catch (final RuntimeException ex) {
+            System.err.printf("*** Error(s) transforming mono-state to modular state: %n%s", ex);
+            if (!validationFailures.isEmpty()) {
+                validationFailures.forEach(s -> System.err.printf("   %s%n", s));
+            }
+            return null;
+        }
+
+        return toStore.get();
     }
 
     // Produce a report, one line per contract, summarizing the #slot pairs and the min/max slot#
@@ -273,6 +387,11 @@ public class DumpContractStoresSubcommand {
     static UInt256 toUint256FromPackedIntArray(@NonNull final int[] packed) {
         final var buf = ByteBuffer.allocate(32);
         buf.asIntBuffer().put(packed);
-        return UInt256.fromBytes(Bytes.wrap(buf.array()));
+        return uint256FromByteArray(buf.array());
+    }
+
+    @NonNull
+    static UInt256 uint256FromByteArray(@NonNull final byte[] bytes) {
+        return UInt256.fromBytes(org.apache.tuweni.bytes.Bytes.wrap(bytes));
     }
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -225,6 +225,7 @@ public class DumpContractStoresSubcommand {
         return didRunToCompletion;
     }
 
+    /** Iterate through a _migrated_ contract store that is in modular-service's representation */
     boolean iterateThroughMigratedContractStorage(BiConsumer<ContractKeyLocal, UInt256> visitor) {
         final var contractStorageStore = getMigratedContractStore();
 

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -66,6 +66,16 @@ public class DumpStateCommand extends AbstractCommand {
         YES
     }
 
+    enum WithMigration {
+        NO,
+        YES
+    }
+
+    enum WithValidation {
+        NO,
+        YES
+    }
+
     enum OmitContents {
         NO,
         YES
@@ -139,7 +149,16 @@ public class DumpStateCommand extends AbstractCommand {
             @Option(
                             names = {"-k", "--slots"},
                             description = "Emit the slot/value pairs for each contract's store")
-                    final boolean withSlots) {
+                    final boolean withSlots,
+            @Option(
+                            names = {"--migrate"},
+                            description =
+                                    "migrate from mono-service representation to modular-service representation (before dump)")
+                    final boolean withMigration,
+            @Option(
+                            names = {"--validate-migration"},
+                            description = "validate the migrated contract store")
+                    final boolean withValidationOfMigration) {
         Objects.requireNonNull(storePath);
         init();
         System.out.println("=== contract stores ===");
@@ -148,6 +167,8 @@ public class DumpStateCommand extends AbstractCommand {
                 storePath,
                 emitSummary ? EmitSummary.YES : EmitSummary.NO,
                 withSlots ? WithSlots.YES : WithSlots.NO,
+                withMigration ? WithMigration.YES : WithMigration.NO,
+                withValidationOfMigration ? WithValidation.YES : WithValidation.NO,
                 parent.verbosity);
         finish();
     }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -346,7 +346,10 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
     /** register all applicable classes on classpath before deserializing signed state */
     private void registerConstructables() {
         try {
-            ConstructableRegistry.getInstance().registerConstructables("*");
+            final var registry = ConstructableRegistry.getInstance();
+            registry.registerConstructables("com.hedera.node.app.service.mono");
+            registry.registerConstructables("com.hedera.node.app.service.mono.*");
+            registry.registerConstructables("com.swirlds.*");
         } catch (final ConstructableRegistryException ex) {
             throw new UncheckedConstructableRegistryException(ex);
         }

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -8,10 +8,15 @@ module com.hedera.node.services.cli {
     requires transitive com.swirlds.platform.core;
     requires transitive info.picocli;
     requires com.hedera.node.app.hapi.utils;
+    requires com.hedera.node.app.service.contract.impl;
+    requires com.hedera.node.app.service.contract;
     requires com.hedera.node.app.service.evm;
+    requires com.hedera.node.app.spi;
+    requires com.hedera.node.app;
     requires com.hedera.node.hapi;
     requires com.google.common;
     requires com.google.protobuf;
+    requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -54,10 +54,12 @@ module com.hedera.node.app {
     exports com.hedera.node.app.workflows to
             com.hedera.node.app.test.fixtures;
     exports com.hedera.node.app.state.merkle to
+            com.hedera.node.services.cli,
             com.swirlds.common;
     exports com.hedera.node.app.state.merkle.disk to
             com.swirlds.common;
     exports com.hedera.node.app.state.merkle.memory to
+            com.hedera.node.services.cli,
             com.swirlds.common;
     exports com.hedera.node.app.state.merkle.singleton to
             com.swirlds.common;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.state.migration;
+
+import static com.hedera.node.app.service.mono.utils.MiscUtils.withLoggedDuration;
+import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
+import com.hedera.node.app.service.mono.state.migration.internal.ContractMigrationValidationCounters;
+import com.hedera.node.app.service.mono.state.virtual.ContractKey;
+import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
+import com.hedera.node.app.service.mono.utils.NonAtomicReference;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.threading.interrupt.InterruptableConsumer;
+import com.swirlds.common.threading.interrupt.InterruptableSupplier;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Migrate mono service's contract storage (contract slots, i.e. per-contract K/V pairs) to modular service's contract
+ * storage.
+ *
+ * Three static methods run the migrator:  Reading the entire contract storage from `fromState` and writing the migrated
+ * (transformed) slots to `toState`.  Caller is responsible for supplying the state to write.  This class will commit
+ * all items added to the `toState`.
+ */
+public class ContractStateMigrator {
+    private static final Logger log = LogManager.getLogger(ContractStateMigrator.class);
+
+    /** Return status from the contract storage migrator.  The migration methods can also return a list of specific
+     * migration validation consistency failures (strings).
+     */
+    public enum Status {
+        SUCCESS,
+        VALIDATION_ERRORS,
+        INCOMPLETE_TRAVERSAL
+    }
+
+    /** Given a `WritableKVState` for the contract storage, makes a copy of it - thus flushing it to disk! - and then
+     * returns the copy for further writing.
+     *
+     * Supplied by the caller because only it knows how to get (or hold) the underlying datastore for a `WritableKVState`.
+     * (There's an example over at `DumpContractStoresSubcommand`.)
+     */
+    public interface StateFlusher extends UnaryOperator<WritableKVState<SlotKey, SlotValue>> {}
+
+    public static Status migrateFromContractStorageVirtualMap(
+            @NonNull final VirtualMapLike<ContractKey, IterableContractValue> fromState,
+            @NonNull final WritableKVState<SlotKey, SlotValue> initialToState,
+            @NonNull final StateFlusher stateFlusher) {
+        return migrateFromContractStorageVirtualMap(
+                fromState, initialToState, stateFlusher, new ArrayList<>(), false, DEFAULT_THREAD_COUNT);
+    }
+
+    @NonNull
+    public static Status migrateFromContractStorageVirtualMap(
+            @NonNull final VirtualMapLike<ContractKey, IterableContractValue> fromState,
+            @NonNull final WritableKVState<SlotKey, SlotValue> initialToState,
+            @NonNull final StateFlusher stateFlusher,
+            @NonNull final List<String> validationFailures) {
+        return migrateFromContractStorageVirtualMap(
+                fromState, initialToState, stateFlusher, validationFailures, true, DEFAULT_THREAD_COUNT);
+    }
+
+    @NonNull
+    public static Status migrateFromContractStorageVirtualMap(
+            @NonNull final VirtualMapLike<ContractKey, IterableContractValue> fromState,
+            @NonNull final WritableKVState<SlotKey, SlotValue> initialToState,
+            @NonNull final StateFlusher stateFlusher,
+            @NonNull final List<String> validationFailures,
+            final boolean doFullValidation,
+            final int threadCount) {
+        requireNonNull(fromState);
+        requireNonNull(initialToState);
+        requireNonNull(stateFlusher);
+        requireNonNull(validationFailures);
+
+        validationFailures.clear();
+
+        final var migrator = new ContractStateMigrator(fromState, initialToState, stateFlusher)
+                .withValidation(doFullValidation)
+                .withThreadCount(threadCount);
+
+        final var status = migrator.doit(validationFailures);
+        if (status != Status.SUCCESS) {
+            final var formattedFailedValidations =
+                    validationFailures.stream().collect(Collectors.joining("\n   ***", "   ***", "\n"));
+            log.error("{}: transform validations failed:\n{}", LOG_CAPTION, formattedFailedValidations);
+            throw new BrokenTransformationException(LOG_CAPTION + ": transformation didn't complete successfully");
+        }
+        return status;
+    }
+
+    /** A reasonable guess as to the number of threads to devote to the source tree traversal.
+     *
+     *  a) Don't wish to use a configuration option because I want to be able to use this class in test code or a CLI
+     *  tool that doesn't necessarily have the services (or platform) configuration system (easily) available.
+     *  b) And though `availableProcessors()` may in fact give different results during the _same_ JVM invocation: IDC.
+     */
+    static final int DEFAULT_THREAD_COUNT = Math.max(1, Runtime.getRuntime().availableProcessors() * 2 / 3);
+
+    /** Slots are read from `fromState` concurrently with their being transformed and put into `toState`, with a queue
+     *  between the source and the sink.  This is the maximum size of that queue.
+     *
+     *  (Current value of 1M holds both mainnet and testnet state as of 2023-11.)
+     */
+    static final int MAXIMUM_SLOTS_IN_FLIGHT = 1_000_000;
+
+    static final int EVM_WORD_WIDTH_IN_BYTES = 32;
+    static final int EVM_WORD_WIDTH_IN_INTS = 8;
+    static final String LOG_CAPTION = "contract-storage mono-to-modular migration";
+
+    /** Need to commit and flush at intervals; should be VirtualMapConfig.preferredFlushQueueSize() but no access here */
+    private static final int COMMIT_STATE_EVERY_N_INSERTS = 10_000;
+
+    /** Timeout to prevent a thread hanging in case of some design flaw - any guess for timeout is good, it's safety only */
+    private static final Duration MIGRATION_QUEUE_POLL_TIMEOUT = Duration.of(100, ChronoUnit.MILLIS);
+
+    final VirtualMapLike<ContractKey, IterableContractValue> fromState;
+    WritableKVState<SlotKey, SlotValue> toState;
+    final StateFlusher stateFlusher;
+
+    boolean doFullValidation;
+    int threadCount;
+    final ContractMigrationValidationCounters counters;
+    int nInsertionsDone = 0;
+
+    ContractStateMigrator(
+            @NonNull final VirtualMapLike<ContractKey, IterableContractValue> fromState,
+            @NonNull final WritableKVState<SlotKey, SlotValue> initialToState,
+            @NonNull final StateFlusher stateFlusher) {
+        requireNonNull(fromState);
+        requireNonNull(initialToState);
+        requireNonNull(stateFlusher);
+
+        this.fromState = fromState;
+        this.toState = initialToState;
+        this.stateFlusher = stateFlusher;
+        this.threadCount = DEFAULT_THREAD_COUNT;
+        this.doFullValidation = true;
+        this.counters = ContractMigrationValidationCounters.create();
+    }
+
+    /** Perform (optional) validation that `toState` contains the same entities as `fromState`.  Not a direct
+     * comparision, but a rough safety check.  (Default: do not do this validation.)
+     */
+    @NonNull
+    ContractStateMigrator withValidation(final boolean doFullValidation) {
+        this.doFullValidation = doFullValidation;
+        return this;
+    }
+
+    @NonNull
+    ContractStateMigrator withThreadCount(final int threadCount) {
+        this.threadCount = threadCount;
+        return this;
+    }
+
+    /**
+     * Do the transform from mono-service's contract storage to modular-service's contract storage, and do some
+     * post-transforms sanity checking.
+     */
+    @NonNull
+    Status doit(@NonNull final List<String> validationsFailed) {
+
+        final var completedProcesses = new NonAtomicReference<EnumSet<CompletedProcesses>>();
+
+        withLoggedDuration(
+                () -> completedProcesses.set(transformStorage(doFullValidation)),
+                log,
+                LOG_CAPTION + ": complete transform");
+
+        requireNonNull(completedProcesses.get(), "must have valid completed processes set at this point");
+
+        return validateTransform(completedProcesses.get(), validationsFailed, doFullValidation);
+    }
+
+    /**
+     * The intermediate representation of a contract slot (K/V pair, plus prev/next linked list references).
+     */
+    @SuppressWarnings("java:S6218") // should overload equals/hashcode  - but will never test for equality or hash this
+    private record ContractSlotLocal(
+            long contractId, @NonNull int[] key, @NonNull byte[] value, @Nullable int[] prev, @Nullable int[] next) {
+
+        public static final ContractSlotLocal SENTINEL = new ContractSlotLocal(
+                0L, new int[EVM_WORD_WIDTH_IN_INTS], new byte[EVM_WORD_WIDTH_IN_BYTES], null, null);
+
+        private ContractSlotLocal {
+            requireNonNull(key);
+            requireNonNull(value);
+            validateArgument(key.length == EVM_WORD_WIDTH_IN_INTS, "wrong length key");
+            validateArgument(value.length == EVM_WORD_WIDTH_IN_BYTES, "wrong length value");
+            if (prev != null) validateArgument(prev.length == EVM_WORD_WIDTH_IN_INTS, "wrong length prev link");
+            if (next != null) validateArgument(next.length == EVM_WORD_WIDTH_IN_INTS, "wrong length next link");
+        }
+
+        public ContractSlotLocal(@NonNull final ContractKey k, @NonNull final IterableContractValue v) {
+            this(k.getContractId(), k.getKey(), v.getValue(), v.getExplicitPrevKey(), v.getExplicitNextKey());
+        }
+    }
+
+    /** Indicates that the source or sink process processed all slots */
+    enum CompletedProcesses {
+        SOURCING,
+        SINKING
+    }
+
+    /**
+     *  Operates the source and sink processes to transform the mono-state ("from") into the modular-state ("to").
+     *  */
+    @NonNull
+    EnumSet<CompletedProcesses> transformStorage(final boolean doFullValidation) {
+
+        final var slotQueue = new ArrayBlockingQueue<ContractSlotLocal>(MAXIMUM_SLOTS_IN_FLIGHT);
+
+        // Sinking and sourcing happen concurrently.  (Though sourcing is multithreaded, sinking is all on one thread.)
+        // Consider: For debugging, don't create (and start) `processSlotQueue` until after sourcing is complete. Just
+        // accumulate everything in the `fromState` in the queue before sinking anything.
+
+        CompletableFuture<Void> processSlotQueue = CompletableFuture.runAsync(() -> iterateOverAllQueuedSlots(
+                () -> slotQueue.poll(MIGRATION_QUEUE_POLL_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                fromState.size(),
+                doFullValidation));
+
+        final var completedTasks = EnumSet.noneOf(CompletedProcesses.class);
+
+        boolean didCompleteSourcing = iterateOverAllCurrentData(slotQueue::put, doFullValidation);
+        if (didCompleteSourcing) completedTasks.add(CompletedProcesses.SOURCING);
+
+        boolean didCompleteSinking = true;
+        try {
+            processSlotQueue.join();
+        } catch (BrokenTransformationException bex) {
+            log.error("%s: interrupt when sinking slots: %s".formatted(LOG_CAPTION, bex.getMessage()), bex.getCause());
+            didCompleteSinking = false;
+        }
+        if (didCompleteSinking) completedTasks.add(CompletedProcesses.SINKING);
+
+        return completedTasks;
+    }
+
+    /**
+     * Pull slots off the queue and add each one immediately to the modular-service state.  This is "sinking" the slots.
+     *
+     * This is single-threaded.  (But does operate concurrently with sourcing.)
+     */
+    @SuppressWarnings("java:S2142") // must rethrow InterruptedException - Sonar doesn't understand wrapping it to throw
+    void iterateOverAllQueuedSlots(
+            @NonNull final InterruptableSupplier<ContractSlotLocal> slotSource,
+            final long expectedSlotCount,
+            final boolean doFullValidation) {
+        requireNonNull(slotSource);
+
+        // Lambda to get the next item off the concurrent queue between source and sink.  Handles end-of-stream
+        // (finding the sentinel element) by returning an empty `Optional`.  Transforms an `InterruptedException`
+        // (which is _not_ a `RuntimeException`) into the more easily handled exception defined in this class.
+        final Supplier<Optional<ContractSlotLocal>> getter = () -> {
+            try {
+                final var slot = slotSource.get();
+                if (slot == ContractSlotLocal.SENTINEL) return Optional.empty();
+                return Optional.of(slot);
+            } catch (final InterruptedException ex) {
+                throw new BrokenTransformationException(
+                        LOG_CAPTION + ": timeout reading contract slots from queue", ex);
+            }
+        };
+
+        // We know precisely how many slots we have to process.  And they're followed, in the queue, by a sentinel
+        // element.  But this loop checks for too _few_ and too _many_ slots in the queue, for safety.  (The check for
+        // too few is by either finding the sentinel too soon or hitting a timeout waiting for an element from the
+        // queue.)
+        for (int i = 0; i < expectedSlotCount; i++) {
+            final var oslot = getter.get();
+            if (oslot.isEmpty()) {
+                final var msg =
+                        "%s: not enough contract slots read from queue (%d expected, %d read), SENTINEL found too soon"
+                                .formatted(LOG_CAPTION, expectedSlotCount, i);
+                throw new BrokenTransformationException(msg);
+            }
+
+            // The transform from the mono-service slot representation to the modular-service slot representation
+            // is here:
+
+            final var slot = oslot.get();
+            final var key = SlotKey.newBuilder()
+                    .contractNumber(slot.contractId())
+                    .key(bytesFromInts(slot.key()))
+                    .build();
+            final var value = SlotValue.newBuilder()
+                    .value(Bytes.wrap(slot.value()))
+                    .previousKey(bytesFromInts(slot.prev()))
+                    .nextKey(bytesFromInts((slot.next())))
+                    .build();
+            toState.put(key, value);
+
+            commitToStateIfNeeded();
+
+            // Some counts to provide some validation
+            if (doFullValidation) {
+                counters.sinkOne();
+                counters.addContract(key.contractNumber());
+                if (value.previousKey() == Bytes.EMPTY) counters.addMissingPrev();
+                else counters.xorAnotherLink(value.previousKey().toByteArray());
+                if (value.nextKey() == Bytes.EMPTY) counters.addMissingNext();
+                else counters.xorAnotherLink(value.nextKey().toByteArray());
+            }
+        }
+
+        commitToStateNow();
+
+        // Read final sentinel value
+        if (getter.get().isPresent()) {
+            final var msg = "%s: too many contract slots read (%d expected), SENTINEL not yet found"
+                    .formatted(LOG_CAPTION, expectedSlotCount);
+            throw new BrokenTransformationException(msg);
+        }
+    }
+
+    /** State needs to be flushed to disk every so many inserts (for performance reasons w.r.t. the underlying
+     * datasource).  `WritableKVState.commit()` doesn't do it.  IN fact, only the _caller_ knows how to do it.
+     */
+    void commitToStateIfNeeded() {
+        if (++nInsertionsDone % COMMIT_STATE_EVERY_N_INSERTS == 0) commitToStateNow();
+    }
+
+    /** Force a flush of the underlying datastore. */
+    void commitToStateNow() {
+        toState = stateFlusher.apply(toState);
+    }
+
+    /**
+     * Iterate over the incoming mono-service state, pushing slots (key + value) into the queue.  This is "sourcing"
+     * the slots.
+     *
+     * This iteration operates with multiple threads simultaneously.
+     */
+    boolean iterateOverAllCurrentData(
+            @NonNull final InterruptableConsumer<ContractSlotLocal> slotSink, final boolean doFullValidation) {
+        boolean didRunToCompletion = true;
+        try {
+            fromState.extractVirtualMapData(
+                    getStaticThreadManager(),
+                    entry -> {
+                        final var contractKey = entry.left();
+                        final var iterableContractValue = entry.right();
+                        slotSink.accept(new ContractSlotLocal(contractKey, iterableContractValue));
+
+                        // Some counts to provide some validation
+                        if (doFullValidation) {
+                            counters.sourceOne();
+                        }
+                    },
+                    this.threadCount);
+            slotSink.accept(ContractSlotLocal.SENTINEL);
+        } catch (final InterruptedException ex) {
+            currentThread().interrupt();
+            didRunToCompletion = false;
+        }
+        return didRunToCompletion;
+    }
+
+    /** If processing did not complete, report that.  Otherwise, perform (optionally) some simple consistency checks. */
+    @NonNull
+    Status validateTransform(
+            @NonNull final EnumSet<CompletedProcesses> completedProcesses,
+            @NonNull final List<String> validationsFailed,
+            final boolean doFullValidation) {
+        requireNonNull(completedProcesses);
+
+        // Validate that both the source and sink finished processing slots
+        if (completedProcesses.size() != EnumSet.allOf(CompletedProcesses.class).size()) {
+            if (!completedProcesses.contains(CompletedProcesses.SOURCING))
+                validationsFailed.add("Sourcing process didn't finish");
+            if (!completedProcesses.contains(CompletedProcesses.SINKING))
+                validationsFailed.add("Sinking process didn't finish");
+            return Status.INCOMPLETE_TRAVERSAL;
+        }
+
+        if (!doFullValidation) return Status.SUCCESS;
+
+        // Make sure everything agrees on the number of slots migrated
+        final var fromSize = fromState.size();
+        if (fromSize != counters.slotsSourced().get()
+                || fromSize != counters.slotsSunk().get()
+                || fromSize != toState.size()) {
+            validationsFailed.add(
+                    "counters of slots processed don't match: %d source size, %d #slots sourced, %d slots sunk, %d final destination size"
+                            .formatted(
+                                    fromSize,
+                                    counters.slotsSourced().get(),
+                                    counters.slotsSunk().get(),
+                                    toState.size()));
+        }
+
+        // These next two checks are for the consistency of the doubly-linked lists linking each contract's slots.  In
+        // these doubly-linked lists the _end_ links are missing (empty) and each link appears _twice_.
+
+        final var nContracts = counters.contracts().size();
+        if (nContracts != counters.nMissingPrevs().get()
+                || nContracts != counters.nMissingNexts().get()) {
+            validationsFailed.add(
+                    "distinct contracts doesn't match #null prev links and/or #null next links: %d contract, %d null prevs, %d null nexts"
+                            .formatted(
+                                    nContracts,
+                                    counters.nMissingPrevs().get(),
+                                    counters.nMissingNexts().get()));
+        }
+
+        if (!counters.runningXorOfLinksIsZero()) {
+            validationsFailed.add("prev/next links (over all contracts) aren't properly paired");
+        }
+
+        return validationsFailed.isEmpty() ? Status.VALIDATION_ERRORS : Status.SUCCESS;
+    }
+
+    /** Convert int[] to byte[] and then to Bytes. If argument is null or 0-length then return `Bytes.EMPTY`. */
+    @NonNull
+    static Bytes bytesFromInts(@Nullable final int[] ints) {
+        if (ints == null) return Bytes.EMPTY;
+        if (ints.length == 0) return Bytes.EMPTY;
+
+        // N.B.: `ByteBuffer.allocate` creates the right `byte[]`.  `asIntBuffer` will share it, so no extra copy
+        // there.  Finally, `Bytes.wrap` will wrap it - and end up owning it once `buf` goes out of scope - so no extra
+        // copy there either.
+        final ByteBuffer buf = ByteBuffer.allocate(32);
+        buf.asIntBuffer().put(ints);
+        return Bytes.wrap(buf.array());
+    }
+
+    /** Validate an argument by throwing `IllegalArgumentException` if the test fails */
+    public static void validateArgument(final boolean b, @NonNull final String msg) {
+        if (!b) throw new IllegalArgumentException(msg);
+    }
+
+    /** Exception to indicate the migration failed. */
+    static class BrokenTransformationException extends CompletionException {
+
+        public BrokenTransformationException(@NonNull final String message) {
+            super(message);
+        }
+
+        public BrokenTransformationException(@NonNull final String message, @NonNull final Throwable t) {
+            super(message, t);
+        }
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/internal/ContractMigrationValidationCounters.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/internal/ContractMigrationValidationCounters.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.state.migration.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.service.mono.state.migration.ContractStateMigrator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Various counters used to perform final validations on the completed transform.
+ * <p>
+ * The counters used by the sink process need not actually be atomic at this time, as the sink process is single
+ * threaded.  But IMO it is more consistent and thus easier to read to treat _all_ of the counters the same.
+ */
+@SuppressWarnings("java:S6218") // override equals/hashcode because of arrays: but we never compare these things
+public record ContractMigrationValidationCounters(
+        @NonNull AtomicInteger slotsSourced, // #slots the sourcing process read from the source tree
+        @NonNull AtomicInteger slotsSunk, // #slots the sinking process wrote to the destination tree
+        @NonNull ConcurrentHashMap.KeySetView<Long, Boolean> contracts, // set of seen contract ids
+        @NonNull AtomicInteger nMissingPrevs, // #sunk slots where the "previous" link was missing (start of d.l.- list)
+        @NonNull AtomicInteger nMissingNexts, // #sunk slots where the "next" link was missing (end of d.l.-list)
+        @NonNull byte[] runningXorOfLinks // running xor of all previous and next links of all slots sunk
+        ) {
+
+    static final int EVM_WORD_WIDTH_IN_BYTES = 32;
+    static final int DISTINCT_CONTRACTS_ESTIMATE = 10_000;
+
+    @NonNull
+    public static ContractMigrationValidationCounters create() {
+        return new ContractMigrationValidationCounters(
+                new AtomicInteger(),
+                new AtomicInteger(),
+                ConcurrentHashMap.newKeySet(DISTINCT_CONTRACTS_ESTIMATE),
+                new AtomicInteger(),
+                new AtomicInteger(),
+                new byte[EVM_WORD_WIDTH_IN_BYTES]);
+    }
+
+    public void sourceOne() {
+        slotsSourced.incrementAndGet();
+    }
+
+    public void sinkOne() {
+        slotsSunk.incrementAndGet();
+    }
+
+    public void addContract(long cid) {
+        contracts.add(cid);
+    }
+
+    public void addMissingPrev() {
+        nMissingPrevs.incrementAndGet();
+    }
+
+    public void addMissingNext() {
+        nMissingNexts.incrementAndGet();
+    }
+
+    public void xorAnotherLink(@NonNull final byte[] link) {
+        requireNonNull(link);
+        ContractStateMigrator.validateArgument(link.length == EVM_WORD_WIDTH_IN_BYTES, "link length must be 32 bytes");
+        synchronized (runningXorOfLinks) {
+            for (int i = 0; i < EVM_WORD_WIDTH_IN_BYTES; i++) {
+                runningXorOfLinks[i] ^= link[i];
+            }
+        }
+    }
+
+    public boolean runningXorOfLinksIsZero() {
+        byte r = 0;
+        synchronized (runningXorOfLinks) {
+            for (int i = 0; i < EVM_WORD_WIDTH_IN_BYTES; i++) {
+                r |= runningXorOfLinks[i];
+            }
+        }
+        return r == 0;
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module com.hedera.node.app.service.contract.impl {
     exports com.hedera.node.app.service.contract.impl.handlers;
     exports com.hedera.node.app.service.contract.impl.hevm;
     exports com.hedera.node.app.service.contract.impl.state to
+            com.hedera.node.services.cli,
             com.hedera.node.app.service.contract.impl.test,
             com.hedera.node.app;
 


### PR DESCRIPTION
**Description**:

New class `ContractStateMigrator` will migrate from a mono service's contract store representation to a modular service's contract store (given by a `WritableKVStore`).

Can optionally perform a validation on the resulting migrated state, ensuring that it is consistent in some ways
* has same number of entries as original state
* all linked lists of slots are still linked

Shown correct by enhancing the contract store dumper to (optionally) migrate the contract store before dumping it. Diff on the two dumps (without migration and with migration) shows only the summary line changes: and that only to include a migration flag (to distinguish them).

Has code that commits the migration-in-progress modular store every 10000 items added (to force flush-to-disk).  Tricky thing there is there doesn't appear currently to be any access path from a `WritableKVState` to get to the point where you can `copy()` the underlying `VirtualMap`/`MerkleMap`.  But the _caller_ must have access to the underlying structure.  And so the caller passes in an operator that does the commit + copy and returns the new store to work with.

An example command line for the dumper:

```
./services-cli.sh signed-state -f states/2023-10-29T03:18:19Z/151988064/SignedState.swh dump contract-stores -k -s \
     --migration --validate-migration \
     -o 2023-10-29T03:18:19Z-151988064.contract-stores.new.txt
```

**Related issue(s)**:

Fixes #10210 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (via dumper, against mainnet states)
