### PR TITLE
chore(ci): change the trigger on the PR Formatting workflow

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -16,7 +16,7 @@
 
 name: "PR Formatting"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -21,6 +21,8 @@ on:
       - opened
       - reopened
       - edited
+      - ready_for_review
+      - review_requested
       - synchronize
 
 defaults:

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -32,10 +32,6 @@ defaults:
 permissions:
   statuses: write
 
-concurrency:
-  group: pr-formatting-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   title-check:
     name: Title Check


### PR DESCRIPTION
## Description

This pull request changes the following:

- Changes the `on: pull_request` trigger to a `on: pull_request_target` trigger in order for the `flow-pull-request-formatting.yaml` workflow to function correctly with forks.

### Required Cherry Picks 

- `release/0.45`

### Related Issues

- Closes #10193 