### PR TITLE
chore: ensure the pull request check workflow properly handles forks

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -192,6 +192,7 @@ jobs:
   abbreviated-panel:
     name: JRS Panel
     uses: ./.github/workflows/zxc-jrs-regression.yaml
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       custom-job-name: "Platform SDK"
       panel-config: "configs/suites/GCP-PRCheck-Abbrev-4N.json"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Ensures the JRS job of the PR Checks workflow does not execute when the PR is created from a forked repository or by dependabot.

### Required Cherry Picks

- `release/0.45`

### Related Issues

- Closes #10229 