### PR TITLE
fix: remove incompatible ip printing in linux

### DIFF
--- a/platform-sdk/platform-apps/demos/HashgraphDemo/src/main/java/com/swirlds/demo/hashgraph/HashgraphDemoMain.java
+++ b/platform-sdk/platform-apps/demos/HashgraphDemo/src/main/java/com/swirlds/demo/hashgraph/HashgraphDemoMain.java
@@ -42,8 +42,6 @@ import com.swirlds.platform.Browser;
 import com.swirlds.platform.ParameterProvider;
 import com.swirlds.platform.gui.GuiPlatformAccessor;
 import com.swirlds.platform.gui.SwirldsGui;
-import com.swirlds.platform.network.ExternalIpAddress;
-import com.swirlds.platform.network.IpAddressStatus;
 import com.swirlds.platform.network.Network;
 import com.swirlds.platform.state.address.AddressBookNetworkUtils;
 import java.awt.Checkbox;
@@ -248,14 +246,6 @@ public class HashgraphDemoMain implements SwirldMain {
             print(g, "%5.3f sec, receive to consensus", recCons);
             final Address address = platform.getAddressBook().getAddress(platform.getSelfId());
             print(g, "Internal: " + Network.getInternalIPAddress() + " : " + address.getPortInternal(), 0);
-
-            final ExternalIpAddress ipAddress = Network.getExternalIpAddress();
-            String externalIpAddress = ipAddress.toString();
-            if (ipAddress.getStatus() == IpAddressStatus.IP_FOUND) {
-                externalIpAddress += " : " + address.getPortExternal();
-            }
-
-            print(g, "External: " + externalIpAddress, 0);
 
             final int height1 = (row - 1) * textLineHeight; // text area at the top
             final int height2 = getHeight() - height1; // the main display, below the text


### PR DESCRIPTION
**Description**:
This pr removes the ip printing for the ui. When executed in a linux environment it was introducing an invalid character in the string interpreted as a format character that ended up in the following exception after:
```
java.util.UnknownFormatConversionException: Conversion = 'w'
        at java.base/java.util.Formatter$FormatSpecifier.conversion(Formatter.java:2855) ~[?:?]
        at java.base/java.util.Formatter$FormatSpecifier.<init>(Formatter.java:2891) ~[?:?]
        at java.base/java.util.Formatter.parse(Formatter.java:2747) ~[?:?]
        at java.base/java.util.Formatter.format(Formatter.java:2671) ~[?:?]
        at java.base/java.util.Formatter.format(Formatter.java:2625) ~[?:?]
        at java.base/java.lang.String.format(String.java:4145) ~[?:?]
        at com.swirlds.demo.hashgraph.HashgraphDemoMain$Picture.print(HashgraphDemoMain.java:221) ~[?:?]
        at com.swirlds.demo.hashgraph.HashgraphDemoMain$Picture.paintComponent(HashgraphDemoMain.java:258) ~[?:?]
``` 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
