### PR TITLE
fix(migration): Migrate contract slots from mono- to modular- in deterministic order

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/BrokenTransformationException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/BrokenTransformationException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.state.migration;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.CompletionException;
+
+/** Exception to indicate the migration failed. */
+class BrokenTransformationException extends CompletionException {
+
+    public BrokenTransformationException(@NonNull final String message) {
+        super(message);
+    }
+
+    public BrokenTransformationException(@NonNull final String message, @NonNull final Throwable t) {
+        super(message, t);
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -215,7 +215,6 @@ public class ContractStateMigrator {
             long contractId, @NonNull int[] key, @NonNull byte[] value, @Nullable int[] prev, @Nullable int[] next)
             implements Comparable<ContractSlotLocal> {
 
-        // (with contractId == -1 (otherwise invalid) the sentinel always sorts _first_)
         public static final ContractSlotLocal SENTINEL = new ContractSlotLocal(
                 -1L, new int[EVM_WORD_WIDTH_IN_INTS], new byte[EVM_WORD_WIDTH_IN_BYTES], null, null);
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -31,23 +31,18 @@ import com.hedera.node.app.service.mono.utils.NonAtomicReference;
 import com.hedera.node.app.spi.state.WritableKVState;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.threading.interrupt.InterruptableConsumer;
-import com.swirlds.common.threading.interrupt.InterruptableSupplier;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.ByteBuffer;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
+import java.nio.IntBuffer;
 import java.util.ArrayList;
-import java.util.EnumSet;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -62,7 +57,8 @@ import org.apache.logging.log4j.Logger;
 public class ContractStateMigrator {
     private static final Logger log = LogManager.getLogger(ContractStateMigrator.class);
 
-    /** Return status from the contract storage migrator.  The migration methods can also return a list of specific
+    /**
+     * Return status from the contract storage migrator.  The migration methods can also return a list of specific
      * migration validation consistency failures (strings).
      */
     public enum Status {
@@ -71,11 +67,12 @@ public class ContractStateMigrator {
         INCOMPLETE_TRAVERSAL
     }
 
-    /** Given a `WritableKVState` for the contract storage, makes a copy of it - thus flushing it to disk! - and then
+    /**
+     * Given a `WritableKVState` for the contract storage, makes a copy of it - thus flushing it to disk! - and then
      * returns the copy for further writing.
-     *
-     * Supplied by the caller because only it knows how to get (or hold) the underlying datastore for a `WritableKVState`.
-     * (There's an example over at `DumpContractStoresSubcommand`.)
+     * <p>
+     * Supplied by the caller because only it knows how to get (or hold) the underlying datastore for a
+     * `WritableKVState`. (There's an example over at `DumpContractStoresSubcommand`.)
      */
     public interface StateFlusher extends UnaryOperator<WritableKVState<SlotKey, SlotValue>> {}
 
@@ -114,6 +111,7 @@ public class ContractStateMigrator {
 
         final var migrator = new ContractStateMigrator(fromState, initialToState, stateFlusher)
                 .withValidation(doFullValidation)
+                .withValidationFailureMessages(validationFailures)
                 .withThreadCount(threadCount);
 
         final var status = migrator.doit(validationFailures);
@@ -126,20 +124,14 @@ public class ContractStateMigrator {
         return status;
     }
 
-    /** A reasonable guess as to the number of threads to devote to the source tree traversal.
-     *
-     *  a) Don't wish to use a configuration option because I want to be able to use this class in test code or a CLI
-     *  tool that doesn't necessarily have the services (or platform) configuration system (easily) available.
-     *  b) And though `availableProcessors()` may in fact give different results during the _same_ JVM invocation: IDC.
+    /**
+     * A reasonable guess as to the number of threads to devote to the source tree traversal.
+     * <p>
+     * a) Don't wish to use a configuration option because I want to be able to use this class in test code or a CLI
+     * tool that doesn't necessarily have the services (or platform) configuration system (easily) available. b) And
+     * though `availableProcessors()` may in fact give different results during the _same_ JVM invocation: IDC.
      */
     static final int DEFAULT_THREAD_COUNT = Math.max(1, Runtime.getRuntime().availableProcessors() * 2 / 3);
-
-    /** Slots are read from `fromState` concurrently with their being transformed and put into `toState`, with a queue
-     *  between the source and the sink.  This is the maximum size of that queue.
-     *
-     *  (Current value of 1M holds both mainnet and testnet state as of 2023-11.)
-     */
-    static final int MAXIMUM_SLOTS_IN_FLIGHT = 1_000_000;
 
     static final int EVM_WORD_WIDTH_IN_BYTES = 32;
     static final int EVM_WORD_WIDTH_IN_INTS = 8;
@@ -148,14 +140,13 @@ public class ContractStateMigrator {
     /** Need to commit and flush at intervals; should be VirtualMapConfig.preferredFlushQueueSize() but no access here */
     private static final int COMMIT_STATE_EVERY_N_INSERTS = 10_000;
 
-    /** Timeout to prevent a thread hanging in case of some design flaw - any guess for timeout is good, it's safety only */
-    private static final Duration MIGRATION_QUEUE_POLL_TIMEOUT = Duration.of(100, ChronoUnit.MILLIS);
-
     final VirtualMapLike<ContractKey, IterableContractValue> fromState;
     WritableKVState<SlotKey, SlotValue> toState;
     final StateFlusher stateFlusher;
 
     boolean doFullValidation;
+
+    List<String> validationFailures;
     int threadCount;
     final ContractMigrationValidationCounters counters;
     int nInsertionsDone = 0;
@@ -173,15 +164,24 @@ public class ContractStateMigrator {
         this.stateFlusher = stateFlusher;
         this.threadCount = DEFAULT_THREAD_COUNT;
         this.doFullValidation = true;
+        this.validationFailures = new ArrayList<>();
         this.counters = ContractMigrationValidationCounters.create();
     }
 
-    /** Perform (optional) validation that `toState` contains the same entities as `fromState`.  Not a direct
+    /**
+     * Perform (optional) validation that `toState` contains the same entities as `fromState`.  Not a direct
      * comparision, but a rough safety check.  (Default: do not do this validation.)
      */
     @NonNull
     ContractStateMigrator withValidation(final boolean doFullValidation) {
         this.doFullValidation = doFullValidation;
+        return this;
+    }
+
+    @NonNull
+    ContractStateMigrator withValidationFailureMessages(@NonNull final List<String> validationFailures) {
+        requireNonNull(validationFailures);
+        this.validationFailures = validationFailures;
         return this;
     }
 
@@ -198,27 +198,26 @@ public class ContractStateMigrator {
     @NonNull
     Status doit(@NonNull final List<String> validationsFailed) {
 
-        final var completedProcesses = new NonAtomicReference<EnumSet<CompletedProcesses>>();
+        final var sourcingCompleted = new NonAtomicReference<SourcingCompleted>();
 
         withLoggedDuration(
-                () -> completedProcesses.set(transformStorage(doFullValidation)),
+                () -> sourcingCompleted.set(transformStorage(doFullValidation)),
                 log,
                 LOG_CAPTION + ": complete transform");
 
-        requireNonNull(completedProcesses.get(), "must have valid completed processes set at this point");
-
-        return validateTransform(completedProcesses.get(), validationsFailed, doFullValidation);
+        return validateTransform(validationsFailed, sourcingCompleted.get(), doFullValidation);
     }
 
     /**
      * The intermediate representation of a contract slot (K/V pair, plus prev/next linked list references).
      */
-    @SuppressWarnings("java:S6218") // should overload equals/hashcode  - but will never test for equality or hash this
     private record ContractSlotLocal(
-            long contractId, @NonNull int[] key, @NonNull byte[] value, @Nullable int[] prev, @Nullable int[] next) {
+            long contractId, @NonNull int[] key, @NonNull byte[] value, @Nullable int[] prev, @Nullable int[] next)
+            implements Comparable<ContractSlotLocal> {
 
+        // (with contractId == -1 (otherwise invalid) the sentinel always sorts _first_)
         public static final ContractSlotLocal SENTINEL = new ContractSlotLocal(
-                0L, new int[EVM_WORD_WIDTH_IN_INTS], new byte[EVM_WORD_WIDTH_IN_BYTES], null, null);
+                -1L, new int[EVM_WORD_WIDTH_IN_INTS], new byte[EVM_WORD_WIDTH_IN_BYTES], null, null);
 
         private ContractSlotLocal {
             requireNonNull(key);
@@ -232,91 +231,108 @@ public class ContractStateMigrator {
         public ContractSlotLocal(@NonNull final ContractKey k, @NonNull final IterableContractValue v) {
             this(k.getContractId(), k.getKey(), v.getValue(), v.getExplicitPrevKey(), v.getExplicitNextKey());
         }
-    }
 
-    /** Indicates that the source or sink process processed all slots */
-    enum CompletedProcesses {
-        SOURCING,
-        SINKING
-    }
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ContractSlotLocal that = (ContractSlotLocal) o;
 
-    /**
-     *  Operates the source and sink processes to transform the mono-state ("from") into the modular-state ("to").
-     *  */
-    @NonNull
-    EnumSet<CompletedProcesses> transformStorage(final boolean doFullValidation) {
-
-        final var slotQueue = new ArrayBlockingQueue<ContractSlotLocal>(MAXIMUM_SLOTS_IN_FLIGHT);
-
-        // Sinking and sourcing happen concurrently.  (Though sourcing is multithreaded, sinking is all on one thread.)
-        // Consider: For debugging, don't create (and start) `processSlotQueue` until after sourcing is complete. Just
-        // accumulate everything in the `fromState` in the queue before sinking anything.
-
-        CompletableFuture<Void> processSlotQueue = CompletableFuture.runAsync(() -> iterateOverAllQueuedSlots(
-                () -> slotQueue.poll(MIGRATION_QUEUE_POLL_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
-                fromState.size(),
-                doFullValidation));
-
-        final var completedTasks = EnumSet.noneOf(CompletedProcesses.class);
-
-        boolean didCompleteSourcing = iterateOverAllCurrentData(slotQueue::put, doFullValidation);
-        if (didCompleteSourcing) completedTasks.add(CompletedProcesses.SOURCING);
-
-        boolean didCompleteSinking = true;
-        try {
-            processSlotQueue.join();
-        } catch (BrokenTransformationException bex) {
-            log.error("%s: interrupt when sinking slots: %s".formatted(LOG_CAPTION, bex.getMessage()), bex.getCause());
-            didCompleteSinking = false;
+            return this.contractId == that.contractId && Arrays.equals(this.key, that.key);
         }
-        if (didCompleteSinking) completedTasks.add(CompletedProcesses.SINKING);
 
-        return completedTasks;
+        @Override
+        public int hashCode() {
+            int result = Long.hashCode(this.contractId);
+            result = 31 * result + Arrays.hashCode(this.key);
+            return result;
+        }
+
+        static final Comparator<ContractSlotLocal> comparator = Comparator.comparingLong(ContractSlotLocal::contractId)
+                .thenComparing(ContractSlotLocal::key, Comparator.comparing(IntBuffer::wrap));
+
+        @Override
+        public int compareTo(@NonNull final ContractSlotLocal that) {
+            return comparator.compare(this, that);
+        }
+
+        @Override
+        public String toString() {
+            return "ContractKeyLocal{id:%d,key:%s,value:%s,prev:%s,next:%s}"
+                    .formatted(
+                            contractId,
+                            Arrays.toString(key),
+                            Arrays.toString(value),
+                            Arrays.toString(prev),
+                            Arrays.toString(next));
+        }
+    }
+
+    enum SourcingCompleted {
+        NO,
+        YES
     }
 
     /**
-     * Pull slots off the queue and add each one immediately to the modular-service state.  This is "sinking" the slots.
+     * Operates the source and sink processes to transform the mono-state ("from") into the modular-state ("to").
+     */
+    @SuppressWarnings(
+            "java:S5411") // Avoid using boxed "Boolean" types directly - suggested rewrite is far worse to read
+    SourcingCompleted transformStorage(final boolean doFullValidation) {
+
+        // Nodes must be added to the merkle tree in _deterministic_ order.  Because this migrator writes nodes over
+        // _multiple_ commit batches it is responsible for ordering _all_ contract slots written to `toState`.  Thus
+        // _all_ nodes are sourced from the `fromState` (in non-deterministic order) and only after _all_ have been
+        // read are they processed:  first sorted, then transformed.
+
+        final var slotQueue = new ConcurrentLinkedDeque<ContractSlotLocal>();
+
+        // Multipart test here, during and after the traversal of `fromState`, to ensure that all `fromState` slots got
+        // handled and put in the queue
+        final boolean didCompleteSourcing = addMsgIfFailed(
+                        iterateOverAllCurrentData(slotQueue::add, doFullValidation),
+                        "traversal of `fromState` interrupted")
+                && addMsgIfFailed(
+                        slotQueue.size() == fromState.size() + 1,
+                        "did not source expected number of slots (expected %d+1 slots, found %d)"
+                                .formatted(fromState.size(), slotQueue.size()))
+                && addMsgIfFailed(
+                        slotQueue.getLast() == ContractSlotLocal.SENTINEL,
+                        "slot source did not end with expected sentinel");
+
+        if (!didCompleteSourcing) return SourcingCompleted.NO;
+
+        // Achieve the deterministic ordering of all slots
+        final var slotArray = slotQueue.toArray(new ContractSlotLocal[0]);
+        Arrays.parallelSort(slotArray, Comparator.naturalOrder());
+
+        // Prepare to strip out the sentinel
+        final var slotsToProcess = Arrays.stream(slotArray).filter(e -> e != ContractSlotLocal.SENTINEL);
+
+        // Now process all slots
+        iterateOverAllQueuedSlots(slotsToProcess, doFullValidation);
+
+        return SourcingCompleted.YES;
+    }
+
+    boolean addMsgIfFailed(final boolean condition, @NonNull final String messageOnFailure) {
+        if (!condition) validationFailures.add(messageOnFailure);
+        return condition;
+    }
+
+    /**
+     * Pull slots off the stream and add each one immediately to the modular-service state.  This is "sinking" the slots.
      *
-     * This is single-threaded.  (But does operate concurrently with sourcing.)
+     * (Caller checked to make sure that the source did run to completion and stripped away the sentinel.)
      */
     @SuppressWarnings("java:S2142") // must rethrow InterruptedException - Sonar doesn't understand wrapping it to throw
     void iterateOverAllQueuedSlots(
-            @NonNull final InterruptableSupplier<ContractSlotLocal> slotSource,
-            final long expectedSlotCount,
-            final boolean doFullValidation) {
+            @NonNull final Stream<ContractSlotLocal> slotSource, final boolean doFullValidation) {
         requireNonNull(slotSource);
 
-        // Lambda to get the next item off the concurrent queue between source and sink.  Handles end-of-stream
-        // (finding the sentinel element) by returning an empty `Optional`.  Transforms an `InterruptedException`
-        // (which is _not_ a `RuntimeException`) into the more easily handled exception defined in this class.
-        final Supplier<Optional<ContractSlotLocal>> getter = () -> {
-            try {
-                final var slot = slotSource.get();
-                if (slot == ContractSlotLocal.SENTINEL) return Optional.empty();
-                return Optional.of(slot);
-            } catch (final InterruptedException ex) {
-                throw new BrokenTransformationException(
-                        LOG_CAPTION + ": timeout reading contract slots from queue", ex);
-            }
-        };
-
-        // We know precisely how many slots we have to process.  And they're followed, in the queue, by a sentinel
-        // element.  But this loop checks for too _few_ and too _many_ slots in the queue, for safety.  (The check for
-        // too few is by either finding the sentinel too soon or hitting a timeout waiting for an element from the
-        // queue.)
-        for (int i = 0; i < expectedSlotCount; i++) {
-            final var oslot = getter.get();
-            if (oslot.isEmpty()) {
-                final var msg =
-                        "%s: not enough contract slots read from queue (%d expected, %d read), SENTINEL found too soon"
-                                .formatted(LOG_CAPTION, expectedSlotCount, i);
-                throw new BrokenTransformationException(msg);
-            }
-
+        slotSource.forEachOrdered(slot -> {
             // The transform from the mono-service slot representation to the modular-service slot representation
             // is here:
-
-            final var slot = oslot.get();
             final var key = SlotKey.newBuilder()
                     .contractNumber(slot.contractId())
                     .key(bytesFromInts(slot.key()))
@@ -339,16 +355,9 @@ public class ContractStateMigrator {
                 if (value.nextKey() == Bytes.EMPTY) counters.addMissingNext();
                 else counters.xorAnotherLink(value.nextKey().toByteArray());
             }
-        }
+        });
 
         commitToStateNow();
-
-        // Read final sentinel value
-        if (getter.get().isPresent()) {
-            final var msg = "%s: too many contract slots read (%d expected), SENTINEL not yet found"
-                    .formatted(LOG_CAPTION, expectedSlotCount);
-            throw new BrokenTransformationException(msg);
-        }
     }
 
     /** State needs to be flushed to disk every so many inserts (for performance reasons w.r.t. the underlying
@@ -397,17 +406,12 @@ public class ContractStateMigrator {
     /** If processing did not complete, report that.  Otherwise, perform (optionally) some simple consistency checks. */
     @NonNull
     Status validateTransform(
-            @NonNull final EnumSet<CompletedProcesses> completedProcesses,
-            @NonNull final List<String> validationsFailed,
+            @NonNull final List<String> validationFailures,
+            @NonNull final SourcingCompleted sourcingCompleted,
             final boolean doFullValidation) {
-        requireNonNull(completedProcesses);
 
         // Validate that both the source and sink finished processing slots
-        if (completedProcesses.size() != EnumSet.allOf(CompletedProcesses.class).size()) {
-            if (!completedProcesses.contains(CompletedProcesses.SOURCING))
-                validationsFailed.add("Sourcing process didn't finish");
-            if (!completedProcesses.contains(CompletedProcesses.SINKING))
-                validationsFailed.add("Sinking process didn't finish");
+        if (sourcingCompleted == SourcingCompleted.NO) {
             return Status.INCOMPLETE_TRAVERSAL;
         }
 
@@ -418,7 +422,7 @@ public class ContractStateMigrator {
         if (fromSize != counters.slotsSourced().get()
                 || fromSize != counters.slotsSunk().get()
                 || fromSize != toState.size()) {
-            validationsFailed.add(
+            validationFailures.add(
                     "counters of slots processed don't match: %d source size, %d #slots sourced, %d slots sunk, %d final destination size"
                             .formatted(
                                     fromSize,
@@ -433,7 +437,7 @@ public class ContractStateMigrator {
         final var nContracts = counters.contracts().size();
         if (nContracts != counters.nMissingPrevs().get()
                 || nContracts != counters.nMissingNexts().get()) {
-            validationsFailed.add(
+            validationFailures.add(
                     "distinct contracts doesn't match #null prev links and/or #null next links: %d contract, %d null prevs, %d null nexts"
                             .formatted(
                                     nContracts,
@@ -442,10 +446,10 @@ public class ContractStateMigrator {
         }
 
         if (!counters.runningXorOfLinksIsZero()) {
-            validationsFailed.add("prev/next links (over all contracts) aren't properly paired");
+            validationFailures.add("prev/next links (over all contracts) aren't properly paired");
         }
 
-        return validationsFailed.isEmpty() ? Status.VALIDATION_ERRORS : Status.SUCCESS;
+        return validationFailures.isEmpty() ? Status.VALIDATION_ERRORS : Status.SUCCESS;
     }
 
     /** Convert int[] to byte[] and then to Bytes. If argument is null or 0-length then return `Bytes.EMPTY`. */
@@ -465,17 +469,5 @@ public class ContractStateMigrator {
     /** Validate an argument by throwing `IllegalArgumentException` if the test fails */
     public static void validateArgument(final boolean b, @NonNull final String msg) {
         if (!b) throw new IllegalArgumentException(msg);
-    }
-
-    /** Exception to indicate the migration failed. */
-    static class BrokenTransformationException extends CompletionException {
-
-        public BrokenTransformationException(@NonNull final String message) {
-            super(message);
-        }
-
-        public BrokenTransformationException(@NonNull final String message, @NonNull final Throwable t) {
-            super(message, t);
-        }
     }
 }


### PR DESCRIPTION
**Description**:

Nodes added to the merkle tree _must be added in deterministic order_.

Especially for the migrators, which add so many nodes they cross _commit_ boundaries.

Remove the concurrent sinking of contract slots; replace with accumulating all `fromState` slots into a concurrent queue, then placing them in an array, and then sorting them.

**Related issue(s)**:

Fixes #10293

**Checklist**

- [x] Documented (code comments)
- [x] Tested (via incorporation into contract store dumper)
