### PR TITLE
chore: Add platform-base as code owners to two platform modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,8 +59,8 @@
 /platform-sdk/swirlds-platform-core/            @hashgraph/platform-hashgraph
 /platform-sdk/swirlds-sign-tool/                @hashgraph/platform-hashgraph
 /platform-sdk/swirlds-unit-tests/common/        @hashgraph/platform-hashgraph @hashgraph/platform-base
-/platform-sdk/swirlds-unit-tests/core/          @hashgraph/platform-hashgraph
-/platform-sdk/swirlds-unit-tests/structures/    @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/swirlds-unit-tests/core/          @hashgraph/platform-hashgraph @hashgraph/platform-base
+/platform-sdk/swirlds-unit-tests/structures/    @hashgraph/platform-data @hashgraph/platform-architects  @hashgraph/platform-base
 /platform-sdk/swirlds-virtualmap/               @hashgraph/platform-data @hashgraph/platform-architects
 /platform-sdk/**/module-info.java               @hashgraph/platform-hashgraph @hashgraph/platform-base @hashgraph/release-engineering @hashgraph/release-engineering-managers
 


### PR DESCRIPTION
**Description**:
Adds the `platform-base` team as code owners to two modules that are going away so they can prevent new code from being added.

**Related issue(s)**:

Fixes #10323

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
