### PR TITLE
fix: canUseAliasesInPrecompilesAndContractKeys suite test

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyUtils.java
@@ -107,15 +107,9 @@ public class KeyUtils {
             return ((Bytes) key.value()).length() == 0;
         } else if (pbjKey.hasEcdsaSecp256k1()) {
             return ((Bytes) key.value()).length() == 0;
-        } else if (pbjKey.hasDelegatableContractId()) {
-            return !((ContractID) key.value()).hasContractNum()
-                    || (((ContractID) key.value()).hasContractNum() && ((ContractID) key.value()).contractNum() == 0);
-        } else if (pbjKey.hasContractID()) {
-            if (((ContractID) key.value()).hasContractNum()) {
-                return ((ContractID) key.value()).contractNum() == 0;
-            } else {
-                return ((Bytes) ((ContractID) key.value()).contract().value()).length() == 0;
-            }
+        } else if (pbjKey.hasDelegatableContractId() || pbjKey.hasContractID()) {
+            return ((ContractID) key.value()).contractNumOrElse(0L) == 0
+                    && ((ContractID) key.value()).evmAddressOrElse(Bytes.EMPTY).length() == 0L;
         }
         // ECDSA_384 and RSA_3072 are not supported yet
         return true;
@@ -156,14 +150,9 @@ public class KeyUtils {
             final var ecKey = ((Bytes) key.value());
             return ecKey.length() == ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH
                     && (ecKey.getByte(0) == EVEN_PARITY || ecKey.getByte(0) == ODD_PARITY);
-        } else if (pbjKey.hasDelegatableContractId()) {
-            return ((ContractID) key.value()).contractNum().intValue() > 0;
-        } else if (pbjKey.hasContractID()) {
-            if (((ContractID) key.value()).hasContractNum()) {
-                return ((ContractID) key.value()).contractNum().intValue() > 0;
-            } else {
-                return ((Bytes) ((ContractID) key.value()).contract().value()).length() == EVM_ADDRESS_BYTE_LENGTH;
-            }
+        } else if (pbjKey.hasDelegatableContractId() || pbjKey.hasContractID()) {
+            return ((ContractID) key.value()).contractNumOrElse(0L) > 0
+                    || ((ContractID) key.value()).evmAddressOrElse(Bytes.EMPTY).length() == EVM_ADDRESS_BYTE_LENGTH;
         }
         // ECDSA_384 and RSA_3072 are not supported yet
         return true;

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyUtils.java
@@ -34,6 +34,7 @@ public class KeyUtils {
 
     public static final Key IMMUTABILITY_SENTINEL_KEY =
             Key.newBuilder().keyList(KeyList.DEFAULT).build();
+    public static final int EVM_ADDRESS_BYTE_LENGTH = 20;
     public static final int ED25519_BYTE_LENGTH = 32;
     private static final byte ODD_PARITY = (byte) 0x03;
     private static final byte EVEN_PARITY = (byte) 0x02;
@@ -110,8 +111,11 @@ public class KeyUtils {
             return !((ContractID) key.value()).hasContractNum()
                     || (((ContractID) key.value()).hasContractNum() && ((ContractID) key.value()).contractNum() == 0);
         } else if (pbjKey.hasContractID()) {
-            return !((ContractID) key.value()).hasContractNum()
-                    || (((ContractID) key.value()).hasContractNum() && ((ContractID) key.value()).contractNum() == 0);
+            if (((ContractID) key.value()).hasContractNum()) {
+                return ((ContractID) key.value()).contractNum() == 0;
+            } else {
+                return ((Bytes) ((ContractID) key.value()).contract().value()).length() == 0;
+            }
         }
         // ECDSA_384 and RSA_3072 are not supported yet
         return true;
@@ -155,7 +159,11 @@ public class KeyUtils {
         } else if (pbjKey.hasDelegatableContractId()) {
             return ((ContractID) key.value()).contractNum().intValue() > 0;
         } else if (pbjKey.hasContractID()) {
-            return ((ContractID) key.value()).contractNum().intValue() > 0;
+            if (((ContractID) key.value()).hasContractNum()) {
+                return ((ContractID) key.value()).contractNum().intValue() > 0;
+            } else {
+                return ((Bytes) ((ContractID) key.value()).contract().value()).length() == EVM_ADDRESS_BYTE_LENGTH;
+            }
         }
         // ECDSA_384 and RSA_3072 are not supported yet
         return true;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -837,6 +837,7 @@ public class Create2OperationSuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5669")
+    @HapiTest
     private HapiSpec canUseAliasesInPrecompilesAndContractKeys() {
         final var creation2 = CREATE_2_TXN;
         final var contract = "Create2PrecompileUser";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -837,7 +837,6 @@ public class Create2OperationSuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5669")
-    @HapiTest
     private HapiSpec canUseAliasesInPrecompilesAndContractKeys() {
         final var creation2 = CREATE_2_TXN;
         final var contract = "Create2PrecompileUser";


### PR DESCRIPTION
**Description**:
Fixes canUseAliasesInPrecompilesAndContractKeys 

**Related issue(s)**:

Fixes #10251

