### PR TITLE
chore(ci): add a new CI workflow to ensure release artifact determinism

### DIFF
--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -31,7 +31,7 @@ defaults:
 permissions:
   id-token: write
   contents: read
-
+Intentionally broken
 jobs:
   check:
     name: Gradle

--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -31,7 +31,7 @@ defaults:
 permissions:
   id-token: write
   contents: read
-Intentionally broken
+
 jobs:
   check:
     name: Gradle

--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -1,4 +1,4 @@
-name: Gradle Determinism
+name: Artifact Determinism
 on:
   workflow_dispatch:
     inputs:
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   check:
-    name: Check
+    name: Gradle
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}

--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -1,3 +1,19 @@
+##
+# Copyright (C) 2023 Hedera Hashgraph, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
 name: Artifact Determinism
 on:
   workflow_dispatch:

--- a/.github/workflows/flow-gradle-determinism.yaml
+++ b/.github/workflows/flow-gradle-determinism.yaml
@@ -40,3 +40,6 @@ jobs:
       ref: ${{ github.event.inputs.ref || '' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
       java-version: ${{ inputs.java-version || '17.0.9' }}
+    secrets:
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}

--- a/.github/workflows/flow-gradle-determinism.yaml
+++ b/.github/workflows/flow-gradle-determinism.yaml
@@ -31,7 +31,7 @@ defaults:
 permissions:
   id-token: write
   contents: read
-Intentionally broken
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/flow-gradle-determinism.yaml
+++ b/.github/workflows/flow-gradle-determinism.yaml
@@ -1,0 +1,42 @@
+name: Gradle Determinism
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag, or commit to checkout:"
+        type: string
+        required: false
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        type: string
+        required: false
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        type: string
+        required: false
+        default: "17.0.9"
+  push:
+    branches:
+      - develop
+      - 'release/**'
+    tags:
+      - 'v*.*.*'
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
+    with:
+      ref: ${{ github.event.inputs.ref || '' }}
+      java-distribution: ${{ inputs.java-distribution || 'temurin' }}
+      java-version: ${{ inputs.java-version || '17.0.9' }}

--- a/.github/workflows/flow-gradle-determinism.yaml
+++ b/.github/workflows/flow-gradle-determinism.yaml
@@ -31,7 +31,7 @@ defaults:
 permissions:
   id-token: write
   contents: read
-
+Intentionally broken
 jobs:
   check:
     name: Check

--- a/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
+++ b/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -o pipefail
+set +e
+
+readonly RELEASE_LIB_PATH="hedera-node/data/lib"
+readonly RELEASE_APPS_PATH="hedera-node/data/apps"
+
+GROUP_ACTIVE="false"
+
+function fail {
+    printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+    if [[ "${GROUP_ACTIVE}" == "true" ]]; then
+      end_group
+    fi
+    exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function start_group {
+  if [[ "${GROUP_ACTIVE}" == "true" ]]; then
+    end_group
+  fi
+
+  GROUP_ACTIVE="true"
+  printf "::group::%s\n" "${1}"
+}
+
+function end_group {
+  GROUP_ACTIVE="false"
+  printf "::endgroup::\n"
+}
+
+function log {
+  local message="${1}"
+  shift
+  # shellcheck disable=SC2059
+  printf "${message}" "${@}"
+}
+
+function log_line {
+  local message="${1}"
+  shift
+  # shellcheck disable=SC2059
+  printf "${message}\n" "${@}"
+}
+
+function start_task {
+  local message="${1}"
+  shift
+  # shellcheck disable=SC2059
+  printf "${message} .....\t" "${@}"
+}
+
+function end_task {
+  printf "%s\n" "${1:-DONE}"
+}
+
+start_group "Configuring Environment"
+  # Access workflow environment variables
+  export GITHUB_WORKSPACE GITHUB_SHA GITHUB_OUTPUT MANIFEST_PATH
+
+  start_task "Initializing Temporary Directory"
+    TEMP_DIR="$(mktemp -d)" || fail "ERROR (Exit Code: ${?})" "${?}"
+    trap 'rm -rf "${TEMP_DIR}"' EXIT
+  end_task "DONE (Path: ${TEMP_DIR})"
+
+  start_task "Resolving the GITHUB_WORKSPACE path"
+    # Ensure GITHUB_WORKSPACE is provided or default to the repository root
+    if [[ -z "${GITHUB_WORKSPACE}" || ! -d "${GITHUB_WORKSPACE}" ]]; then
+      GITHUB_WORKSPACE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../" && pwd)"
+    fi
+  end_task "DONE (Path: ${GITHUB_WORKSPACE})"
+
+  start_task "Resolving the GITHUB_OUTPUT path"
+    # Ensure GITHUB_OUTPUT is provided or default to the repository root
+    if [[ -z "${GITHUB_OUTPUT}" || ! -d "${GITHUB_OUTPUT}" ]]; then
+      GITHUB_OUTPUT="${TEMP_DIR}/workflow-output.txt"
+    fi
+  end_task "DONE (Path: ${GITHUB_OUTPUT})"
+
+  start_task "Resolving the GITHUB_SHA hash"
+    if [[ -z "${GITHUB_SHA}" ]]; then
+      GITHUB_SHA="$(git rev-parse HEAD | tr -d '[:space:]')" || fail "ERROR (Exit Code: ${?})" "${?}"
+    fi
+  end_task "DONE (Commit: ${GITHUB_SHA})"
+
+  start_task "Resolving the MANIFEST_PATH variable"
+    if [[ -z "${MANIFEST_PATH}" ]]; then
+      MANIFEST_PATH="${GITHUB_WORKSPACE}/.manifests/gradle"
+    fi
+  end_task "DONE (Path: ${MANIFEST_PATH})"
+
+  start_task "Ensuring the MANIFEST_PATH location is present"
+    if [[ ! -d "${MANIFEST_PATH}" ]]; then
+      mkdir -p "${MANIFEST_PATH}" || fail "ERROR (Exit Code: ${?})" "${?}"
+    fi
+  end_task
+
+  start_task "Checking for the sha256sum command"
+    if command -v sha256sum >/dev/null 2>&1; then
+      SHA256SUM="$(command -v sha256sum)" || fail "ERROR (Exit Code: ${?})" "${?}"
+    else
+      fail "ERROR (Exit Code: ${?})" "${?}"
+    fi
+  end_task "DONE (Found: ${SHA256SUM})"
+
+  start_task "Checking for prebuilt libraries"
+    ls -al "${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}"/*.jar >/dev/null 2>&1 || fail "ERROR (Exit Code: ${?})" "${?}"
+  end_task "FOUND (Path: ${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}/*.jar)"
+
+  start_task "Checking for prebuilt applications"
+    ls -al "${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}"/*.jar >/dev/null 2>&1 || fail "ERROR (Exit Code: ${?})" "${?}"
+  end_task "FOUND (Path: ${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}/*.jar)"
+end_group
+
+start_group "Generating Library Hashes (${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}/*.jar)"
+  pushd "${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}" >/dev/null 2>&1 || fail "PUSHD ERROR (Exit Code: ${?})" "${?}"
+  ${SHA256SUM} -- *.jar | sort -k 2 | tee -a "${TEMP_DIR}"/libraries.sha256
+  popd >/dev/null 2>&1 || fail "POPD ERROR (Exit Code: ${?})" "${?}"
+end_group
+
+start_group "Generating Application Hashes (${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}/*.jar)"
+  pushd "${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}" >/dev/null 2>&1 || fail "PUSHD ERROR (Exit Code: ${?})" "${?}"
+  ${SHA256SUM} -- *.jar | sort -k 2 | tee -a "${TEMP_DIR}"/applications.sha256
+  popd >/dev/null 2>&1 || fail "POPD ERROR (Exit Code: ${?})" "${?}"
+end_group
+
+start_group "Generating Final Release Manifests"
+
+  start_task "Generating the manifest file"
+  tar -czf "${TEMP_DIR}/manifest.tar.gz" -C "${TEMP_DIR}" libraries.sha256 applications.sha256 >/dev/null 2>&1 || fail "TAR ERROR (Exit Code: ${?})" "${?}"
+  end_task
+
+  start_task "Copying the manifest file"
+  cp "${TEMP_DIR}/manifest.tar.gz" "${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
+  end_task "DONE (Path: ${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz)"
+
+  start_task "Setting Step Outputs"
+    {
+      printf "path=%s\n" "${MANIFEST_PATH}"
+      printf "file=%s\n" "${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz"
+      printf "name=%s\n" "${GITHUB_SHA}.tar.gz"
+    } >> "${GITHUB_OUTPUT}"
+  end_task
+end_group
+

--- a/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
+++ b/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
@@ -126,12 +126,14 @@ end_group
 
 start_group "Generating Final Release Manifests"
 
-  start_task "Generating the manifest file"
+  start_task "Generating the manifest archive"
   tar -czf "${TEMP_DIR}/manifest.tar.gz" -C "${TEMP_DIR}" libraries.sha256 applications.sha256 >/dev/null 2>&1 || fail "TAR ERROR (Exit Code: ${?})" "${?}"
   end_task
 
-  start_task "Copying the manifest file"
+  start_task "Copying the manifest files"
   cp "${TEMP_DIR}/manifest.tar.gz" "${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
+  cp "${TEMP_DIR}/libraries.sha256" "${MANIFEST_PATH}/libraries.sha256" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
+  cp "${TEMP_DIR}/applications.sha256" "${MANIFEST_PATH}/applications.sha256" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
   end_task "DONE (Path: ${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz)"
 
   start_task "Setting Step Outputs"
@@ -139,6 +141,8 @@ start_group "Generating Final Release Manifests"
       printf "path=%s\n" "${MANIFEST_PATH}"
       printf "file=%s\n" "${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz"
       printf "name=%s\n" "${GITHUB_SHA}.tar.gz"
+      printf "applications=%s\n" "${MANIFEST_PATH}/applications.sha256"
+      printf "libraries=%s\n" "${MANIFEST_PATH}/libraries.sha256"
     } >> "${GITHUB_OUTPUT}"
   end_task
 end_group

--- a/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
+++ b/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
@@ -72,7 +72,7 @@ start_group "Configuring Environment"
 
   start_task "Resolving the GITHUB_OUTPUT path"
     # Ensure GITHUB_OUTPUT is provided or default to the repository root
-    if [[ -z "${GITHUB_OUTPUT}" || ! -d "${GITHUB_OUTPUT}" ]]; then
+    if [[ -z "${GITHUB_OUTPUT}" ]]; then
       GITHUB_OUTPUT="${TEMP_DIR}/workflow-output.txt"
     fi
   end_task "DONE (Path: ${GITHUB_OUTPUT})"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -1,3 +1,19 @@
+##
+# Copyright (C) 2023 Hedera Hashgraph, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
 name: "ZXC: Verify Gradle Build Determinism"
 on:
   workflow_call:
@@ -87,11 +103,11 @@ jobs:
           BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/gradle/baselines"
           BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
           BASELINE_EXISTS="false"
-          
+
           if gsutil ls "${BASELINE_FILE}" >/dev/null 2>&1; then
              BASELINE_EXISTS="true"
           fi
-          
+
           echo "exists=${BASELINE_EXISTS}" >> "${GITHUB_OUTPUT}"
           echo "path=${BASELINE_PATH}" >> "${GITHUB_OUTPUT}"
           echo "name=${BASELINE_NAME}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          cache-disabled: true
 
       - name: Authenticate to Google Cloud
         id: google-auth
@@ -104,10 +106,10 @@ jobs:
 
       - name: Upload Baseline
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.path }}"
+        run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.file }}"
 
   verify-artifacts:
-    name: "Verify Artifacts (${{ format('%s[%s]', matrix.os[1], matrix.os[2]) || matrix.os }})"
+    name: "Verify Artifacts (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs:
       - generate-baseline
@@ -137,6 +139,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          cache-disabled: true
 
       - name: Authenticate to Google Cloud
         id: google-auth

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -168,6 +168,10 @@ jobs:
         with:
           cache-disabled: true
 
+      - name: Setup CoreUtils (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install coreutils
+
       - name: Authenticate to Google Cloud
         id: google-auth
         uses: google-github-actions/auth@f105ef0cdb3b102a020be1767fcc8a974898b7c6 # v1.2.0

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -118,8 +118,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - generate-baseline
-    env:
-      PYTHON3_EXECUTABLE: ${{ runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3' }}
     strategy:
       fail-fast: false
       matrix:
@@ -164,11 +162,11 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
         env:
-          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, env.PYTHON3_EXECUTABLE) }}
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3') }}
 
       - name: Download Baseline
         env:
-          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, env.PYTHON3_EXECUTABLE) }}
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3') }}
         run: |
           mkdir -p "${GRADLE_MANIFEST_PATH}"
           cd "${GRADLE_MANIFEST_PATH}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -185,3 +185,26 @@ jobs:
         working-directory: ${{ github.workspace }}/hedera-node/data/apps
         run: sha256sum -c "${GRADLE_MANIFEST_PATH}/applications.sha256"
 
+      - name: Regenerate Manifest
+        id: regen-manifest
+        env:
+          MANIFEST_PATH: ${{ env.GRADLE_MANIFEST_PATH }}/regenerated
+        run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
+
+      - name: Compare Library Manifests
+        run: |
+          if ! diff -u "${GRADLE_MANIFEST_PATH}/libraries.sha256" "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null 2>&1; then
+            echo "::group::Library Manifest Differences"
+            diff -u "${GRADLE_MANIFEST_PATH}/libraries.sha256" "${{ steps.regen-manifest.outputs.libraries }}"
+            echo "::endgroup::"
+            exit 1
+          fi
+
+      - name: Compare Application Manifests
+        run: |
+          if ! diff -u "${GRADLE_MANIFEST_PATH}/applications.sha256" "${{ steps.regen-manifest.outputs.applications }}" >/dev/null 2>&1; then
+            echo "::group::Application Manifest Differences"
+            diff -u "${GRADLE_MANIFEST_PATH}/applications.sha256" "${{ steps.regen-manifest.outputs.applications }}"
+            echo "::endgroup::"
+            exit 1
+          fi

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -162,11 +162,11 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
         env:
-          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.pythonLocation, runner.os == 'Windows' && '\python.exe' || '/python3') }}
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.pythonLocation, runner.os == 'Windows' && '\python.exe' || '/bin/python3') }}
 
       - name: Download Baseline
         env:
-          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.pythonLocation, runner.os == 'Windows' && '\python.exe' || '/python3') }}
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.pythonLocation, runner.os == 'Windows' && '\python.exe' || '/bin/python3') }}
         run: |
           mkdir -p "${GRADLE_MANIFEST_PATH}"
           cd "${GRADLE_MANIFEST_PATH}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -118,6 +118,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - generate-baseline
+    env:
+      PYTHON3_EXECUTABLE: ${{ runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3' }}
     strategy:
       fail-fast: false
       matrix:
@@ -162,11 +164,11 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
         env:
-          CLOUDSDK_PYTHON: "${{ env.Python3_ROOT_DIR }}${{ runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3' }}"
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, env.PYTHON3_EXECUTABLE) }}
 
       - name: Download Baseline
         env:
-          CLOUDSDK_PYTHON: "${{ env.Python3_ROOT_DIR }}${{ runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3' }}"
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, env.PYTHON3_EXECUTABLE) }}
         run: |
           mkdir -p "${GRADLE_MANIFEST_PATH}"
           cd "${GRADLE_MANIFEST_PATH}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -197,24 +197,21 @@ jobs:
         id: gradle-build
         run: ./gradlew assemble --scan --no-build-cache
 
-      - name: Validate Libraries
-        continue-on-error: true
-        working-directory: ${{ github.workspace }}/hedera-node/data/lib
-        run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"
-
-      - name: Validate Applications
-        continue-on-error: true
-        working-directory: ${{ github.workspace }}/hedera-node/data/apps
-        run: sha256sum -c "${GRADLE_MANIFEST_PATH}/applications.sha256"
-
       - name: Regenerate Manifest
         id: regen-manifest
         env:
           MANIFEST_PATH: ${{ env.GRADLE_MANIFEST_PATH }}/regenerated
         run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
 
+      - name: Validate Libraries
+        working-directory: ${{ github.workspace }}/hedera-node/data/lib
+        run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"
+
+      - name: Validate Applications
+        working-directory: ${{ github.workspace }}/hedera-node/data/apps
+        run: sha256sum -c "${GRADLE_MANIFEST_PATH}/applications.sha256"
+
       - name: Compare Library Manifests
-        continue-on-error: true
         run: |
           if ! diff -u "${GRADLE_MANIFEST_PATH}/libraries.sha256" "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null 2>&1; then
             echo "::group::Library Manifest Differences"
@@ -231,3 +228,10 @@ jobs:
             echo "::endgroup::"
             exit 1
           fi
+
+      - name: Publish Manifests
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        if: ${{ steps.regen-manifest.conclusion == 'success' && failure() && !cancelled() }}
+        with:
+          name: Gradle Manifests [${{ join(matrix.os, ', ') }}]
+          path: ${{ env.GRADLE_MANIFEST_PATH }}/**

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -45,6 +45,7 @@ jobs:
     name: Generate Baseline
     runs-on: [self-hosted, Linux, medium, ephemeral]
     outputs:
+      sha: ${{ steps.commit.outputs.sha }}
       path: ${{ steps.baseline.outputs.path }}
       file: ${{ steps.baseline.outputs.file }}
       name: ${{ steps.baseline.outputs.name }}
@@ -75,10 +76,14 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
 
+      - name: Retrieve Commit Hash
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
       - name: Baseline Existence Check
         id: baseline
         run: |
-          BASELINE_NAME="${{ github.sha }}.tar.gz"
+          BASELINE_NAME="${{ steps.commit.outputs.sha }}.tar.gz"
           BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/gradle/baselines"
           BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
           BASELINE_EXISTS="false"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -92,18 +92,18 @@ jobs:
 
       - name: Build Artifacts
         id: gradle-build
-        if: ${{ steps.baseline.outputs.exists == 'false' && !failed() && !cancelled() }}
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: ./gradlew assemble --scan
 
       - name: Generate Manifest
         id: manifest
         env:
           MANIFEST_PATH: ${{ env.GRADLE_MANIFEST_PATH }}
-        if: ${{ steps.baseline.outputs.exists == 'false' && !failed() && !cancelled() }}
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
 
       - name: Upload Baseline
-        if: ${{ steps.baseline.outputs.exists == 'false' && !failed() && !cancelled() }}
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.path }}"
 
   verify-artifacts:

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -194,10 +194,12 @@ jobs:
         run: ./gradlew assemble --scan --no-build-cache
 
       - name: Validate Libraries
+        continue-on-error: true
         working-directory: ${{ github.workspace }}/hedera-node/data/lib
         run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"
 
       - name: Validate Applications
+        continue-on-error: true
         working-directory: ${{ github.workspace }}/hedera-node/data/apps
         run: sha256sum -c "${GRADLE_MANIFEST_PATH}/applications.sha256"
 
@@ -208,6 +210,7 @@ jobs:
         run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
 
       - name: Compare Library Manifests
+        continue-on-error: true
         run: |
           if ! diff -u "${GRADLE_MANIFEST_PATH}/libraries.sha256" "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null 2>&1; then
             echo "::group::Library Manifest Differences"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -1,0 +1,169 @@
+name: "ZXC: Verify Gradle Build Determinism"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag, or commit to checkout:"
+        type: string
+        required: false
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        type: string
+        required: false
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        type: string
+        required: false
+        default: "17.0.9"
+
+    secrets:
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  GRADLE_MANIFEST_PATH: ${{ github.workspace }}/.manifests/gradle
+  GRADLE_MANIFEST_GENERATOR: ${{ github.workspace }}/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+
+jobs:
+  generate-baseline:
+    name: Generate Baseline
+    runs-on: [self-hosted, Linux, medium, ephemeral]
+    outputs:
+      path: ${{ steps.baseline.outputs.path }}
+      file: ${{ steps.baseline.outputs.file }}
+      name: ${{ steps.baseline.outputs.name }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@f105ef0cdb3b102a020be1767fcc8a974898b7c6 # v1.2.0
+        with:
+          workload_identity_provider: "projects/235822363393/locations/global/workloadIdentityPools/hedera-builds-pool/providers/hedera-builds-gh-actions"
+          service_account: "swirlds-automation@hedera-registry.iam.gserviceaccount.com"
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+
+      - name: Baseline Existence Check
+        id: baseline
+        run: |
+          BASELINE_NAME="${{ github.sha }}.tar.gz"
+          BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/gradle/baselines"
+          BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
+          BASELINE_EXISTS="false"
+          
+          if gsutil ls "${BASELINE_FILE}" >/dev/null 2>&1; then
+             BASELINE_EXISTS="true"
+          fi
+          
+          echo "exists=${BASELINE_EXISTS}" >> "${GITHUB_OUTPUT}"
+          echo "path=${BASELINE_PATH}" >> "${GITHUB_OUTPUT}"
+          echo "name=${BASELINE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "file=${BASELINE_FILE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build Artifacts
+        id: gradle-build
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failed() && !cancelled() }}
+        run: ./gradlew assemble --scan
+
+      - name: Generate Manifest
+        id: manifest
+        env:
+          MANIFEST_PATH: ${{ env.GRADLE_MANIFEST_PATH }}
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failed() && !cancelled() }}
+        run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
+
+      - name: Upload Baseline
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failed() && !cancelled() }}
+        run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.path }}"
+
+  verify-artifacts:
+    name: "Verify Artifacts (${{ format('%s[%s]', matrix.os[1], matrix.os[2]) || matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    needs:
+      - generate-baseline
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-20.04
+          - macos-12
+          - macos-11
+          - windows-2022
+          - windows-2019
+          - [self-hosted, Linux, medium, ephemeral]
+          - [self-hosted, Linux, large, ephemeral]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@f105ef0cdb3b102a020be1767fcc8a974898b7c6 # v1.2.0
+        with:
+          workload_identity_provider: "projects/235822363393/locations/global/workloadIdentityPools/hedera-builds-pool/providers/hedera-builds-gh-actions"
+          service_account: "swirlds-automation@hedera-registry.iam.gserviceaccount.com"
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+
+      - name: Download Baseline
+        run: |
+          mkdir -p "${GRADLE_MANIFEST_PATH}"
+          cd "${GRADLE_MANIFEST_PATH}"
+          gsutil cp "${{ needs.generate-baseline.outputs.file }}" .
+          tar -xzf "${{ needs.generate-baseline.outputs.name }}"
+
+      - name: Build Artifacts
+        id: gradle-build
+        run: ./gradlew assemble --scan
+
+      - name: Validate Libraries
+        working-directory: ${{ github.workspace }}/hedera-node/data/libs
+        run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"
+
+      - name: Validate Applications
+        working-directory: ${{ github.workspace }}/hedera-node/data/apps
+        run: sha256sum -c "${GRADLE_MANIFEST_PATH}/applications.sha256"
+

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -178,7 +178,7 @@ jobs:
         run: ./gradlew assemble --scan --no-build-cache
 
       - name: Validate Libraries
-        working-directory: ${{ github.workspace }}/hedera-node/data/libs
+        working-directory: ${{ github.workspace }}/hedera-node/data/lib
         run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"
 
       - name: Validate Applications

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -114,12 +114,12 @@ jobs:
         run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.file }}"
 
   verify-artifacts:
-    name: "Verify Artifacts (${{ matrix.os }})"
+    name: "Verify Artifacts (${{ join(matrix.os, ', ') }})"
     runs-on: ${{ matrix.os }}
     needs:
       - generate-baseline
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04
@@ -162,11 +162,11 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
         env:
-          CLOUDSDK_PYTHON: ${{ env.Python3_ROOT_DIR }}
+          CLOUDSDK_PYTHON: "${{ env.Python3_ROOT_DIR }}${{ runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3' }}"
 
       - name: Download Baseline
         env:
-          CLOUDSDK_PYTHON: ${{ env.Python3_ROOT_DIR }}
+          CLOUDSDK_PYTHON: "${{ env.Python3_ROOT_DIR }}${{ runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3' }}"
         run: |
           mkdir -p "${GRADLE_MANIFEST_PATH}"
           cd "${GRADLE_MANIFEST_PATH}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
-          python-version: '3.12'
+          python-version: 3.9
 
       - name: Setup Java
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
@@ -162,11 +162,11 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
         env:
-          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3') }}
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.pythonLocation, runner.os == 'Windows' && '\python.exe' || '/python3') }}
 
       - name: Download Baseline
         env:
-          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.Python3_ROOT_DIR, runner.os == 'Windows' && '\bin\python3.exe' || '/bin/python3') }}
+          CLOUDSDK_PYTHON: ${{ format('{0}{1}', env.pythonLocation, runner.os == 'Windows' && '\python.exe' || '/python3') }}
         run: |
           mkdir -p "${GRADLE_MANIFEST_PATH}"
           cd "${GRADLE_MANIFEST_PATH}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -131,6 +131,11 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Setup Python
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
+        with:
+          python-version: '3.12'
+
       - name: Setup Java
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
@@ -161,7 +166,7 @@ jobs:
 
       - name: Build Artifacts
         id: gradle-build
-        run: ./gradlew assemble --scan
+        run: ./gradlew assemble --scan --no-build-cache
 
       - name: Validate Libraries
         working-directory: ${{ github.workspace }}/hedera-node/data/libs

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -52,7 +52,7 @@ permissions:
 
 env:
   GRADLE_MANIFEST_PATH: ${{ github.workspace }}/.manifests/gradle
-  GRADLE_MANIFEST_GENERATOR: ${{ github.workspace }}/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
+  GRADLE_MANIFEST_GENERATOR: .github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
   GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
 

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -161,8 +161,12 @@ jobs:
 
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        env:
+          CLOUDSDK_PYTHON: ${{ env.Python3_ROOT_DIR }}
 
       - name: Download Baseline
+        env:
+          CLOUDSDK_PYTHON: ${{ env.Python3_ROOT_DIR }}
         run: |
           mkdir -p "${GRADLE_MANIFEST_PATH}"
           cd "${GRADLE_MANIFEST_PATH}"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds a new CI workflow which runs on `develop` commits and tags to verify all Gradle artifacts are produced deterministically.

**NOTE: This pipeline is expected to fail until we fix the build determinism issues with follow up pull requests.**

### Related Issues

- Closes #10311 