### PR TITLE
feat: Set recipient to null as appropriate during contract tracing

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
@@ -174,7 +174,7 @@ public class HederaTracer implements HederaOperationTracer {
                 && messageFrame.getWorldUpdater().getAccount(contractAddress) == null) {
             action.setTargetedAddress(contractAddress.toArray());
         } else {
-            final var recipient = getEntityIdOrNullByAddressAndMessageFrame(contractAddress, messageFrame);
+            final var recipient = getEntityIdOrNullByAddressAndMessageFrame(contractAddress, messageFrame, action);
             if (CodeV0.EMPTY_CODE.equals(messageFrame.getCode())) {
                 // code can be empty when calling precompiles too, but we handle
                 // that in tracePrecompileCall, after precompile execution is completed
@@ -206,7 +206,7 @@ public class HederaTracer implements HederaOperationTracer {
                         // or set it to null if it's noop for non existing account
                         Address recipientAddress = Address.wrap(Bytes.of(action.getInvalidSolidityAddress()));
                         final var recipientAsHederaId =
-                                getEntityIdOrNullByAddressAndMessageFrame(recipientAddress, frame);
+                                getEntityIdOrNullByAddressAndMessageFrame(recipientAddress, frame, action);
                         action.setTargetedAddress(null);
                         action.setRecipientAccount(recipientAsHederaId);
                     }
@@ -366,10 +366,12 @@ public class HederaTracer implements HederaOperationTracer {
         return null != subject ? processor.compose(getter).apply(subject) : "null";
     }
 
-    private EntityId getEntityIdOrNullByAddressAndMessageFrame(Address address, MessageFrame frame) {
+    private EntityId getEntityIdOrNullByAddressAndMessageFrame(
+            Address address, MessageFrame frame, SolidityAction action) {
         try {
             return EntityId.fromAddress(asMirrorAddress(address, frame));
         } catch (IllegalArgumentException e) {
+            action.setTargetedAddress(address.toArray());
             return null;
         }
     }


### PR DESCRIPTION
**Description**:
If the recipient address cannot be converted into an Entity Id then set its value to null.  We search for the recipient address in both the ledger and in the alias map prior to setting the value to null.

**Related issue(s)**:

Fixes #10346 
