### PR TITLE
fix(ci): snyk workflow should not run on dependabot or forked pull requests

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -214,6 +214,7 @@ jobs:
   snyk-scan:
     name: Snyk Scan
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       custom-job-label: Standard
       enable-unit-tests: false


### PR DESCRIPTION
## Description

This pull request changes the following:

- Ensures the Snyk workflow does not run on dependabot or forked pull requests.

### Related Issues

- Closes #10354 