### PR TITLE
fix: finalize actions from stack for ALL failed creation attempts

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/EvmActionTracer.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/EvmActionTracer.java
@@ -109,10 +109,10 @@ public class EvmActionTracer implements ActionSidecarContentTracer {
             @NonNull final MessageFrame frame, @NonNull final Optional<ExceptionalHaltReason> haltReason) {
         requireNonNull(frame);
         requireNonNull(haltReason);
-        // It is important NOT to finalize the last action on the stack unless the creation
-        // failed, as otherwise the action could accidentally be finalized twice depending
-        // on the value returned from this tracer's isExtendedTracing()---c.f. the call in
-        // ContractCreationProcessor given both the deposit fee passing validation rules.
+        // It is important NOT to finalize the last action on the stack unless a halt reason
+        // is present, as otherwise the same action could be finalized twice depending on the
+        // value returned from this tracer's isExtendedTracing()---c.f. the call in Besu's
+        // ContractCreationProcessor given both the deposit fee and passing validation rules.
         // It is equally important that we DO finalize the last action here when a halt
         // reason is present, since that means creation failed before executing the frame's
         // code, and tracePostExecution() will never be called; so this is our only chance

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/EvmActionTracer.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/EvmActionTracer.java
@@ -16,8 +16,6 @@
 
 package com.hedera.node.app.service.contract.impl.exec;
 
-import static com.hedera.node.app.service.contract.impl.exec.utils.ActionStack.Source.POPPED_FROM_STACK;
-import static com.hedera.node.app.service.contract.impl.exec.utils.ActionStack.Source.READ_FROM_LIST_END;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.hasActionSidecarsEnabled;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.hasActionValidationEnabled;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.hasValidatedActionSidecarsEnabled;
@@ -87,7 +85,7 @@ public class EvmActionTracer implements ActionSidecarContentTracer {
         if (state == CODE_SUSPENDED) {
             actionStack.pushActionOfIntermediate(frame);
         } else if (state != CODE_EXECUTING) {
-            actionStack.finalizeLastAction(POPPED_FROM_STACK, frame, stackValidationChoice(frame));
+            actionStack.finalizeLastAction(frame, stackValidationChoice(frame));
         }
     }
 
@@ -111,8 +109,16 @@ public class EvmActionTracer implements ActionSidecarContentTracer {
             @NonNull final MessageFrame frame, @NonNull final Optional<ExceptionalHaltReason> haltReason) {
         requireNonNull(frame);
         requireNonNull(haltReason);
-        if (hasActionSidecarsEnabled(frame)) {
-            actionStack.finalizeLastAction(READ_FROM_LIST_END, frame, stackValidationChoice(frame));
+        // It is important NOT to finalize the last action on the stack unless the creation
+        // failed, as otherwise the action could accidentally be finalized twice depending
+        // on the value returned from this tracer's isExtendedTracing()---c.f. the call in
+        // ContractCreationProcessor given both the deposit fee passing validation rules.
+        // It is equally important that we DO finalize the last action here when a halt
+        // reason is present, since that means creation failed before executing the frame's
+        // code, and tracePostExecution() will never be called; so this is our only chance
+        // to keep the action stack in sync with the message frame stack.
+        if (hasActionSidecarsEnabled(frame) && haltReason.isPresent()) {
+            actionStack.finalizeLastAction(frame, stackValidationChoice(frame));
         }
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/processors/CustomContractCreationProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/processors/CustomContractCreationProcessorTest.java
@@ -123,7 +123,7 @@ class CustomContractCreationProcessorTest {
 
         verify(frame).setExceptionalHaltReason(maybeReasonToHalt);
         verify(frame).setState(MessageFrame.State.EXCEPTIONAL_HALT);
-        verify(tracer, never()).traceAccountCreationResult(frame, maybeReasonToHalt);
+        verify(tracer).traceAccountCreationResult(frame, maybeReasonToHalt);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/ActionStackTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/ActionStackTest.java
@@ -23,8 +23,6 @@ import static com.hedera.hapi.streams.ContractActionType.CREATE;
 import static com.hedera.hapi.streams.ContractActionType.PRECOMPILE;
 import static com.hedera.hapi.streams.ContractActionType.SYSTEM;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
-import static com.hedera.node.app.service.contract.impl.exec.utils.ActionStack.Source.POPPED_FROM_STACK;
-import static com.hedera.node.app.service.contract.impl.exec.utils.ActionStack.Source.READ_FROM_LIST_END;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_EOA_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALL_ACTION;
@@ -198,7 +196,7 @@ class ActionStackTest {
         actionsStack.push(wrappedAction);
         given(parentFrame.getType()).willReturn(CONTRACT_CREATION);
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -281,14 +279,12 @@ class ActionStackTest {
         final var wrappedAction = new ActionWrapper(CALL_ACTION);
         allActions.add(wrappedAction);
 
-        assertDoesNotThrow(
-                () -> subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF));
+        assertDoesNotThrow(() -> subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF));
     }
 
     @Test
     void worksAroundEmptyList() {
-        assertDoesNotThrow(
-                () -> subject.finalizeLastAction(READ_FROM_LIST_END, parentFrame, ActionStack.Validation.OFF));
+        assertDoesNotThrow(() -> subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF));
     }
 
     @Test
@@ -300,7 +296,7 @@ class ActionStackTest {
         given(parentFrame.getType()).willReturn(MessageFrame.Type.MESSAGE_CALL);
         given(parentFrame.getExceptionalHaltReason()).willReturn(Optional.of(ILLEGAL_STATE_CHANGE));
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -320,7 +316,7 @@ class ActionStackTest {
         given(parentFrame.getExceptionalHaltReason()).willReturn(Optional.of(INVALID_SOLIDITY_ADDRESS));
         given(helper.createSynthActionForMissingAddressIn(parentFrame)).willReturn(MISSING_ADDRESS_CALL_ACTION);
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(2, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -340,7 +336,7 @@ class ActionStackTest {
         given(parentFrame.getType()).willReturn(CONTRACT_CREATION);
         given(parentFrame.getExceptionalHaltReason()).willReturn(Optional.of(INVALID_SOLIDITY_ADDRESS));
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -349,18 +345,14 @@ class ActionStackTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"NOT_STARTED,true", "CODE_EXECUTING,false", "CODE_SUSPENDED,true"})
-    void finalizationDoesNothingButMaybePopStackForUnexpectedStates(
-            @NonNull final MessageFrame.State state, final boolean actionIsOnStack) {
+    @CsvSource({"NOT_STARTED", "CODE_EXECUTING", "CODE_SUSPENDED"})
+    void finalizationDoesNothingButMaybePopStackForUnexpectedStates(@NonNull final MessageFrame.State state) {
         given(parentFrame.getState()).willReturn(state);
         final var wrappedAction = new ActionWrapper(CALL_ACTION);
         allActions.add(wrappedAction);
-        if (actionIsOnStack) {
-            actionsStack.push(wrappedAction);
-        }
+        actionsStack.push(wrappedAction);
 
-        final var source = actionIsOnStack ? POPPED_FROM_STACK : READ_FROM_LIST_END;
-        subject.finalizeLastAction(source, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -396,7 +388,7 @@ class ActionStackTest {
         allActions.add(wrappedAction);
         actionsStack.push(wrappedAction);
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -426,7 +418,7 @@ class ActionStackTest {
         allActions.add(wrappedAction);
         actionsStack.push(wrappedAction);
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));
@@ -447,7 +439,7 @@ class ActionStackTest {
         allActions.add(wrappedAction);
         actionsStack.push(wrappedAction);
 
-        subject.finalizeLastAction(POPPED_FROM_STACK, parentFrame, ActionStack.Validation.OFF);
+        subject.finalizeLastAction(parentFrame, ActionStack.Validation.OFF);
 
         assertEquals(1, allActions.size());
         assertEquals(wrappedAction, allActions.get(0));


### PR DESCRIPTION
**Description**:
- Closes #8533 
- Fix incorrect behavior which, upon a creation failing in a `AbstractMessageProcessor.start()` implementation, would leave the pending action for the originating `CALL`/`CREATE` _still on the tracer's action stack_.
    * This removes the need for the `Source` enum's `POPPED_FROM_STACK`/`READ_FROM_LIST_END` distinction.
- Ensure a failed creation is traced even in the case of a failed value transfer to the new contract address.
    * This removes the need for the `HaltShouldTraceAccountCreation `'s enum's `YES`/`NO` distinction.