### PR TITLE
fix: Match monoservice "hidden default payer" behavior

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
@@ -158,7 +158,8 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
             realPreContext = new PreHandleContextImpl(
                     mockStoreFactory, next.originalCreateTransaction(), testConfig, mockDispatcher);
             Set<Key> keysObtained = testHandler.allKeysForTransaction(next, realPreContext);
-            assertThat(keysObtained).isNotEmpty().hasSize(1).containsExactly(schedulerKey);
+            // Should have no keys, because the mock dispatcher returns no keys
+            assertThat(keysObtained).isEmpty();
         }
         // One check with a complex set of key returns, to ensure we process required and optional correctly.
         final TransactionKeys testKeys =
@@ -171,7 +172,7 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
         BDDMockito.doReturn(testKeys).when(spiedContext).allKeysForTransaction(any(), any());
         final Set<Key> keysObtained = testHandler.allKeysForTransaction(scheduleInState, spiedContext);
         assertThat(keysObtained).isNotEmpty();
-        assertThat(keysObtained).containsExactly(otherKey, optionKey, payerKey, schedulerKey, adminKey);
+        assertThat(keysObtained).containsExactly(otherKey, optionKey, payerKey, adminKey);
     }
 
     @Test
@@ -195,7 +196,10 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
             // we *mock* verificationFor side effects, which is what fills in/clears the sets,
             // so results should all be the same, despite empty signatories and mocked HandleContext.
             // We do so based on verifier calls, so it still exercises the code to be tested, however.
-            assertThat(keysRequired).isNotEmpty().hasSize(2).containsExactly(optionKey, schedulerKey);
+            // @todo('9447') add the schedulerKey back in.
+            // Note, however, we exclude the schedulerKey because it paid for the original create, so it
+            //    is "deemed valid" and not included.
+            assertThat(keysRequired).isNotEmpty().hasSize(1).containsExactly(optionKey);
             assertThat(keysObtained).isNotEmpty().hasSize(2).containsExactly(payerKey, adminKey);
         }
     }

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandlerTest.java
@@ -176,7 +176,6 @@ class ScheduleSignHandlerTest extends ScheduleHandlerTestBase {
         final Set<Key> combinedSet = new LinkedHashSet<>(5);
         combinedSet.addAll(expectedKeys.requiredNonPayerKeys());
         combinedSet.addAll(expectedKeys.optionalNonPayerKeys());
-        combinedSet.add(expectedKeys.payerKey());
         verifySignatorySet(original, combinedSet);
     }
 
@@ -200,8 +199,8 @@ class ScheduleSignHandlerTest extends ScheduleHandlerTestBase {
         given(mockContext.body()).willReturn(signTransaction);
         given(mockContext.allKeysForTransaction(Mockito.any(), Mockito.any())).willReturn(testChildKeys);
         // for signature verification to be in-between, the "Answer" needs to be "valid" for only some required keys
-        // We leave out admin key and scheduler key from the "valid" keys for that reason.
-        final Set<Key> acceptedKeys = Set.of(payerKey, optionKey, otherKey);
+        // We leave out "other" key from the "valid" keys for that reason.
+        final Set<Key> acceptedKeys = Set.of(payerKey, optionKey);
         final TestTransactionKeys accepted = new TestTransactionKeys(payerKey, acceptedKeys, Collections.emptySet());
         // This is how you get side-effects replicated, by having the "Answer" called in place of the real method.
         given(mockContext.verificationFor(BDDMockito.any(Key.class), BDDMockito.any(VerificationAssistant.class)))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -1681,7 +1681,7 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         }));
     }
 
-    // @todo('9974') Need to work out why this generates INVALID_SIGNATURE
+    @HapiTest
     private HapiSpec executionWithCustomPayerWorksWithLastSigBeingCustomPayer() {
         long noBalance = 0L;
         long transferAmount = 1;


### PR DESCRIPTION
Modified the key validation to only add primitive keys to remaining keys if a non-validated key is not the original create payer key (i.e. "Default Payer").
 * This ensures the original create payer, which had to sign the original create transaction, counts as having signed.
 * This also allows us to not *store* the keys for that payer, if those primitive keys are not otherwise required.

Fixes: #10364