### PR TITLE
fix: ensure failed `CREATE2` action is finalized w/ proper frame

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -141,32 +141,6 @@ tasks.jar {
     }
 }
 
-// Define build directory
-val buildDir = layout.projectDirectory.dir("./build/node")
-
-// Copy everything from hedera-node/data
-val copyNodeData =
-    tasks.register<Sync>("copyNodeData") {
-        dependsOn(copyLib)
-        dependsOn(copyApp)
-        from(layout.projectDirectory.dir("../data/keys")) { into("data/keys") }
-        from(layout.projectDirectory.dir("../data"))
-        into(buildDir)
-        exclude("config", "keys") // Exclude config directory
-        shouldRunAfter(tasks.named("copyApp"))
-        shouldRunAfter(tasks.named("copyLib"))
-    }
-
-//// Copy hedera-node/configuration/dev as hedera-node/hedera-app/build/node/data/config  }
-val copyConfig =
-    tasks.register<Copy>("copyConfig") {
-        from(layout.projectDirectory.dir("../configuration/dev")) { into("data/config") }
-        from(layout.projectDirectory.file("../config.txt"))
-        from(layout.projectDirectory.file("../log4j2.xml"))
-        into(buildDir)
-        shouldRunAfter(tasks.named("copyNodeData"))
-    }
-
 // Copy dependencies into `data/lib`
 val copyLib =
     tasks.register<Sync>("copyLib") {
@@ -186,24 +160,22 @@ val copyApp =
 tasks.assemble {
     dependsOn(copyLib)
     dependsOn(copyApp)
-    dependsOn(copyNodeData)
-    dependsOn(copyConfig)
 }
 
 // Create the "run" task for running a Hedera consensus node
 tasks.register<JavaExec>("run") {
     group = "application"
     dependsOn(tasks.assemble)
-    workingDir = layout.projectDirectory.dir("./build/node").asFile
-    jvmArgs = listOf("-cp", "lib/*")
+    workingDir = layout.projectDirectory.dir("..").asFile
+    jvmArgs = listOf("-cp", "data/lib/*")
     mainClass.set("com.swirlds.platform.Browser")
 }
 
 tasks.register<JavaExec>("modrun") {
     group = "application"
     dependsOn(tasks.assemble)
-    workingDir = layout.projectDirectory.dir("./build/node").asFile
-    jvmArgs = listOf("-cp", "lib/*:apps/*", "-Dhedera.workflows.enabled=true")
+    workingDir = layout.projectDirectory.dir("..").asFile
+    jvmArgs = listOf("-cp", "data/lib/*:data/apps/*", "-Dhedera.workflows.enabled=true")
     mainClass.set("com.hedera.node.app.ServicesMain")
 }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessor.java
@@ -43,7 +43,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
@@ -155,7 +154,5 @@ public class HederaMessageCallProcessor extends HederaEvmMessageCallProcessor {
         final var wrappedHaltReason = Optional.of(haltReason);
         frame.setExceptionalHaltReason(wrappedHaltReason);
         operationTracer.traceAccountCreationResult(frame, wrappedHaltReason);
-        final var result = new Operation.OperationResult(frame.getRemainingGas(), haltReason);
-        operationTracer.tracePostExecution(frame, result);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038.java
@@ -43,7 +43,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
@@ -157,7 +156,5 @@ public class HederaMessageCallProcessorV038 extends HederaEvmMessageCallProcesso
         final var wrappedHaltReason = Optional.of(haltReason);
         frame.setExceptionalHaltReason(wrappedHaltReason);
         operationTracer.traceAccountCreationResult(frame, wrappedHaltReason);
-        final var result = new Operation.OperationResult(frame.getRemainingGas(), haltReason);
-        operationTracer.tracePostExecution(frame, result);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
@@ -46,6 +46,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.code.CodeV0;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.hyperledger.besu.evm.frame.MessageFrame.Type;
@@ -126,6 +127,13 @@ public class HederaTracer implements HederaOperationTracer {
                 allActions.removeAll(invalidActions);
                 invalidActions.clear();
             }
+        }
+    }
+
+    @Override
+    public void traceAccountCreationResult(MessageFrame frame, Optional<ExceptionalHaltReason> haltReason) {
+        if (areActionSidecarsEnabled() && haltReason.isPresent()) {
+            popActionStack(frame).ifPresent(action -> finalizeActionFor(action, frame, frame.getState()));
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorTest.java
@@ -27,7 +27,6 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -374,11 +373,7 @@ class HederaMessageCallProcessorTest {
         verify(frame).setState(EXCEPTIONAL_HALT);
         verify(frame, times(1)).getState();
         verify(hederaTracer).traceAccountCreationResult(frame, Optional.of(INSUFFICIENT_GAS));
-        verify(hederaTracer)
-                .tracePostExecution(
-                        eq(frame),
-                        argThat(result ->
-                                isSameResult(result, new Operation.OperationResult(initialGas, INSUFFICIENT_GAS))));
+        verify(hederaTracer).traceAccountCreationResult(eq(frame), eq(Optional.of(INSUFFICIENT_GAS)));
         verify(transactionalLedger, never()).set(change.accountId(), BALANCE, 1000L);
         verifyNoMoreInteractions(autoCreationLogic);
         verify(hederaTracer, never()).tracePrecompileCall(any(), anyLong(), any());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038Test.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.mono.contracts.execution;
 
 import static com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason.FAILURE_DURING_LAZY_ACCOUNT_CREATE;
-import static com.hedera.node.app.service.mono.contracts.execution.HederaMessageCallProcessorTest.isSameResult;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.BALANCE;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.PRECOMPILE_ERROR;
@@ -29,7 +28,6 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -65,7 +63,6 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.AltBN128AddPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
@@ -412,12 +409,7 @@ class HederaMessageCallProcessorV038Test {
         verify(frame).setState(EXCEPTIONAL_HALT);
         verify(frame, times(1)).getState();
         verify(hederaTracer).traceAccountCreationResult(frame, Optional.of(FAILURE_DURING_LAZY_ACCOUNT_CREATE));
-        verify(hederaTracer)
-                .tracePostExecution(
-                        eq(frame),
-                        argThat(result -> isSameResult(
-                                result,
-                                new Operation.OperationResult(initialGas, FAILURE_DURING_LAZY_ACCOUNT_CREATE))));
+        verify(hederaTracer).traceAccountCreationResult(eq(frame), eq(Optional.of(FAILURE_DURING_LAZY_ACCOUNT_CREATE)));
         verifyNoMoreInteractions(autoCreationLogic);
         verify(hederaTracer, never()).tracePrecompileCall(any(), anyLong(), any());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/ValidContractIdsAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/ValidContractIdsAssertion.java
@@ -16,6 +16,8 @@
 
 package com.hedera.services.bdd.spec.utilops.streams.assertions;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -65,6 +67,9 @@ public class ValidContractIdsAssertion implements RecordStreamAssertion {
             } else if (action.hasRecipientContract()) {
                 assertValid(action.getRecipientContract(), "action#recipientContract", sidecar, this::isValidId);
             }
+
+            final var isMissingResult = !action.hasOutput() && !action.hasError() && !action.hasRevertReason();
+            assertFalse(isMissingResult, "action is missing result (output, error, or revertReason)");
         }
     }
 


### PR DESCRIPTION
**Description**:
 - Closes #10360 
 - Since `tracePostExecution()` is never called upon a `CREATE2` address collision, re-implements `traceAccountCreationResult()` in mono-service `HederaTracer` and updates the `MessageCallProcessors` not to make duplicate calls to `tracePostExecution()`.