### PR TITLE
Consider input bytes when calculating gas cost - mono service fix

### DIFF
--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -179,8 +179,8 @@ public abstract class HederaEvmTxProcessor {
         }
     }
 
-    public void setupFields(final boolean contractCreation) {
-        this.intrinsicGas = gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, contractCreation);
+    public void setupFields(final Bytes payload, final boolean contractCreation) {
+        this.intrinsicGas = gasCalculator.transactionIntrinsicGasCost(payload, contractCreation);
         this.updater = worldState.updater();
         this.coinbase = dynamicProperties.fundingAccountAddress();
     }

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
@@ -152,7 +152,7 @@ class HederaEvmTxProcessorTest {
         givenValidMock(0L);
         given(globalDynamicProperties.fundingAccountAddress()).willReturn(fundingAccount);
 
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY, false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, 33_333L, 1234L, 1L, Bytes.EMPTY, true, mirrorReceiver);
         assertTrue(result.isSuccessful());
@@ -184,7 +184,7 @@ class HederaEvmTxProcessorTest {
 
         given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
         given(globalDynamicProperties.fundingAccountAddress()).willReturn(fundingAccount);
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, 0L, GAS_LIMIT, 1234L, Bytes.EMPTY, false, mirrorReceiver);
         assertTrue(result.isSuccessful());
@@ -200,7 +200,7 @@ class HederaEvmTxProcessorTest {
         given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(intrinsicGasCost);
         given(globalDynamicProperties.fundingAccountAddress()).willReturn(fundingAccount);
 
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, 0L, GAS_LIMIT, 1234L, Bytes.EMPTY, false, mirrorReceiver);
         assertTrue(result.isSuccessful());
@@ -224,7 +224,7 @@ class HederaEvmTxProcessorTest {
         given(stackedUpdater.getOrCreate(any())).willReturn(wrappedRecipientAccount);
         given(updater.updater()).willReturn(stackedUpdater);
 
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, 333_333L, 1234L, 1L, Bytes.EMPTY, true, mirrorReceiver);
         assertEquals(INSUFFICIENT_GAS, result.getHaltReason().get().name());
@@ -252,7 +252,7 @@ class HederaEvmTxProcessorTest {
 
         givenInvalidMock();
 
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, 33_333L, 0L, 1234L, Bytes.EMPTY, true, mirrorReceiver);
         assertEquals(INSUFFICIENT_GAS, result.getHaltReason().get().name());
@@ -265,7 +265,7 @@ class HederaEvmTxProcessorTest {
         final int maxGasLimit = 10_000_000;
         given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(maxGasLimit + 1L);
 
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, 0L, maxGasLimit, 1234L, Bytes.EMPTY, false, mirrorReceiver);
         assertEquals(INSUFFICIENT_GAS, result.getHaltReason().get().name());
@@ -308,7 +308,7 @@ class HederaEvmTxProcessorTest {
         given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(100);
         given(globalDynamicProperties.fundingAccountAddress()).willReturn(fundingAccount);
 
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
         final var result =
                 evmTxProcessor.execute(sender, receiver, GAS_LIMIT, 0L, 1234L, Bytes.EMPTY, true, mirrorReceiver);
 
@@ -348,7 +348,7 @@ class HederaEvmTxProcessorTest {
         given(globalDynamicProperties.fundingAccountAddress()).willReturn(fundingAccount);
 
         // uses default setup
-        evmTxProcessor.setupFields(false);
+        evmTxProcessor.setupFields(Bytes.EMPTY,false);
 
         evmTxProcessor.execute(sender, receiver, 33_333L, 1234L, 1L, Bytes.EMPTY, true, mirrorReceiver);
         assertEquals(EVM_VERSION_0_30, mcpVersion);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
@@ -115,7 +115,7 @@ abstract class EvmTxProcessor extends HederaEvmTxProcessor {
         final Wei gasCost = Wei.of(Math.multiplyExact(gasLimit, gasPrice));
         final Wei upfrontCost = gasCost.add(value);
 
-        super.setupFields(contractCreation);
+        super.setupFields(payload, contractCreation);
 
         final var chargingResult = chargeForGas(
                 gasCost,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -339,7 +340,7 @@ class CreateEvmTxProcessorTest {
             given(updater.getOrCreate(any())).willReturn(evmAccount);
         }
 
-        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(0L);
+        given(gasCalculator.transactionIntrinsicGasCost(any(), eq(true))).willReturn(0L);
 
         given(evmAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
         given(evmAccount.incrementBalance(any())).willReturn(Wei.of(1500L));


### PR DESCRIPTION
**Description**:
Take into consideration the input bytes' size from the evm transaction when calculating the intrinsic gas cost. 

**Related issue(s)**:

Fixes #9988

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
