### PR TITLE
fix: clear "side-effect fields" after switch a child record from SUCCESS to REVERTED_SUCCESS

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
@@ -32,6 +32,7 @@ import com.hedera.node.app.state.SingleTransactionRecord;
 import com.hedera.node.app.workflows.handle.HandleContextImpl;
 import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl.ReversingBehavior;
 import com.hedera.node.config.data.ConsensusConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -376,7 +377,31 @@ public final class RecordListBuilder {
                 followingChildRemoved = true;
             } else {
                 if (child.reversingBehavior() == ReversingBehavior.REVERSIBLE && SUCCESSES.contains(child.status())) {
+                    // clear "side effect" fields
+                    child.accountID(null);
+                    child.contractID(null);
+                    child.fileID(null);
+                    child.tokenID(null);
+                    child.scheduleID(null);
+                    child.scheduledTransactionID(null);
+                    child.serialNumbers().clear();
+                    child.topicRunningHash(Bytes.EMPTY);
+                    child.newTotalSupply(-1L);
+                    child.topicRunningHashVersion(0L);
+                    child.topicSequenceNumber(0L);
                     child.tokenTransferLists().clear();
+                    child.automaticTokenAssociations().clear();
+                    if (child.transferList().hasAccountAmounts()) {
+                        child.transferList().accountAmounts().clear();
+                    }
+                    child.paidStakingRewards().clear();
+                    child.contractCreateResult(null);
+                    child.scheduleRef(null);
+                    child.assessedCustomFees().clear();
+                    child.alias(Bytes.EMPTY);
+                    child.ethereumHash(Bytes.EMPTY);
+                    child.evmAddress(Bytes.EMPTY);
+
                     child.status(ResponseCodeEnum.REVERTED_SUCCESS);
                 }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
@@ -32,7 +32,6 @@ import com.hedera.node.app.state.SingleTransactionRecord;
 import com.hedera.node.app.workflows.handle.HandleContextImpl;
 import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl.ReversingBehavior;
 import com.hedera.node.config.data.ConsensusConfig;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -377,31 +376,7 @@ public final class RecordListBuilder {
                 followingChildRemoved = true;
             } else {
                 if (child.reversingBehavior() == ReversingBehavior.REVERSIBLE && SUCCESSES.contains(child.status())) {
-                    // clear "side effect" fields
-                    child.accountID(null);
-                    child.contractID(null);
-                    child.fileID(null);
-                    child.tokenID(null);
-                    child.scheduleID(null);
-                    child.scheduledTransactionID(null);
-                    child.serialNumbers().clear();
-                    child.topicRunningHash(Bytes.EMPTY);
-                    child.newTotalSupply(-1L);
-                    child.topicRunningHashVersion(0L);
-                    child.topicSequenceNumber(0L);
-                    child.tokenTransferLists().clear();
-                    child.automaticTokenAssociations().clear();
-                    if (child.transferList().hasAccountAmounts()) {
-                        child.transferList().accountAmounts().clear();
-                    }
-                    child.paidStakingRewards().clear();
-                    child.contractCreateResult(null);
-                    child.scheduleRef(null);
-                    child.assessedCustomFees().clear();
-                    child.alias(Bytes.EMPTY);
-                    child.ethereumHash(Bytes.EMPTY);
-                    child.evmAddress(Bytes.EMPTY);
-
+                    child.nullOutSideEffectFields();
                     child.status(ResponseCodeEnum.REVERTED_SUCCESS);
                 }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -483,6 +483,17 @@ public class SingleTransactionRecordBuilderImpl
     }
 
     /**
+     * Gets the transferList.
+     *
+     * @return transferList
+     */
+    @Override
+    @NonNull
+    public TransferList transferList() {
+        return transferList;
+    }
+
+    /**
      * Sets the transferList.
      *
      * @param transferList the transferList
@@ -494,12 +505,6 @@ public class SingleTransactionRecordBuilderImpl
         requireNonNull(transferList, "transferList must not be null");
         this.transferList = transferList;
         return this;
-    }
-
-    @Override
-    @NonNull
-    public TransferList transferList() {
-        return transferList;
     }
 
     /**
@@ -550,6 +555,16 @@ public class SingleTransactionRecordBuilderImpl
     }
 
     /**
+     * Gets the assessedCustomFees.
+     *
+     * @return assessedCustomFees
+     */
+    @NonNull
+    public List<AssessedCustomFee> assessedCustomFees() {
+        return this.assessedCustomFees;
+    }
+
+    /**
      * Sets the assessedCustomFees.
      *
      * @param assessedCustomFees the assessedCustomFees
@@ -575,6 +590,16 @@ public class SingleTransactionRecordBuilderImpl
         requireNonNull(assessedCustomFee, "assessedCustomFee must not be null");
         assessedCustomFees.add(assessedCustomFee);
         return this;
+    }
+
+    /**
+     * Gets the automaticTokenAssociations.
+     *
+     * @return automaticTokenAssociations
+     */
+    @NonNull
+    public List<TokenAssociation> automaticTokenAssociations() {
+        return this.automaticTokenAssociations;
     }
 
     /**
@@ -629,6 +654,16 @@ public class SingleTransactionRecordBuilderImpl
         requireNonNull(ethereumHash, "ethereumHash must not be null");
         transactionRecordBuilder.ethereumHash(ethereumHash);
         return this;
+    }
+
+    /**
+     * Gets the paidStakingRewards.
+     *
+     * @return paidStakingRewards
+     */
+    @NonNull
+    public final List<AccountAmount> paidStakingRewards() {
+        return this.paidStakingRewards;
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -320,6 +320,7 @@ public class SingleTransactionRecordBuilderImpl
         paidStakingRewards.clear();
         assessedCustomFees.clear();
 
+        newTotalSupply = 0L;
         contractFunctionResult = null;
 
         transactionReceiptBuilder.accountID((AccountID) null);
@@ -329,7 +330,7 @@ public class SingleTransactionRecordBuilderImpl
         transactionReceiptBuilder.scheduleID((ScheduleID) null);
         transactionReceiptBuilder.scheduledTransactionID((TransactionID) null);
         transactionReceiptBuilder.topicRunningHash(Bytes.EMPTY);
-        transactionReceiptBuilder.newTotalSupply(-1L);
+        transactionReceiptBuilder.newTotalSupply(0L);
         transactionReceiptBuilder.topicRunningHashVersion(0L);
         transactionReceiptBuilder.topicSequenceNumber(0L);
         transactionRecordBuilder.contractCreateResult((ContractFunctionResult) null);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -310,6 +310,35 @@ public class SingleTransactionRecordBuilderImpl
         return new SingleTransactionRecord(transaction, transactionRecord, transactionSidecarRecords);
     }
 
+    public void nullOutSideEffectFields() {
+        serialNumbers.clear();
+        tokenTransferLists.clear();
+        automaticTokenAssociations.clear();
+        if (transferList.hasAccountAmounts()) {
+            transferList.accountAmounts().clear();
+        }
+        paidStakingRewards.clear();
+        assessedCustomFees.clear();
+
+        contractFunctionResult = null;
+
+        transactionReceiptBuilder.accountID((AccountID) null);
+        transactionReceiptBuilder.contractID((ContractID) null);
+        transactionReceiptBuilder.fileID((FileID) null);
+        transactionReceiptBuilder.tokenID((TokenID) null);
+        transactionReceiptBuilder.scheduleID((ScheduleID) null);
+        transactionReceiptBuilder.scheduledTransactionID((TransactionID) null);
+        transactionReceiptBuilder.topicRunningHash(Bytes.EMPTY);
+        transactionReceiptBuilder.newTotalSupply(-1L);
+        transactionReceiptBuilder.topicRunningHashVersion(0L);
+        transactionReceiptBuilder.topicSequenceNumber(0L);
+        transactionRecordBuilder.contractCreateResult((ContractFunctionResult) null);
+        transactionRecordBuilder.scheduleRef((ScheduleID) null);
+        transactionRecordBuilder.alias(Bytes.EMPTY);
+        transactionRecordBuilder.ethereumHash(Bytes.EMPTY);
+        transactionRecordBuilder.evmAddress(Bytes.EMPTY);
+    }
+
     public ReversingBehavior reversingBehavior() {
         return reversingBehavior;
     }
@@ -555,16 +584,6 @@ public class SingleTransactionRecordBuilderImpl
     }
 
     /**
-     * Gets the assessedCustomFees.
-     *
-     * @return assessedCustomFees
-     */
-    @NonNull
-    public List<AssessedCustomFee> assessedCustomFees() {
-        return this.assessedCustomFees;
-    }
-
-    /**
      * Sets the assessedCustomFees.
      *
      * @param assessedCustomFees the assessedCustomFees
@@ -590,16 +609,6 @@ public class SingleTransactionRecordBuilderImpl
         requireNonNull(assessedCustomFee, "assessedCustomFee must not be null");
         assessedCustomFees.add(assessedCustomFee);
         return this;
-    }
-
-    /**
-     * Gets the automaticTokenAssociations.
-     *
-     * @return automaticTokenAssociations
-     */
-    @NonNull
-    public List<TokenAssociation> automaticTokenAssociations() {
-        return this.automaticTokenAssociations;
     }
 
     /**
@@ -654,16 +663,6 @@ public class SingleTransactionRecordBuilderImpl
         requireNonNull(ethereumHash, "ethereumHash must not be null");
         transactionRecordBuilder.ethereumHash(ethereumHash);
         return this;
-    }
-
-    /**
-     * Gets the paidStakingRewards.
-     *
-     * @return paidStakingRewards
-     */
-    @NonNull
-    public final List<AccountAmount> paidStakingRewards() {
-        return this.paidStakingRewards;
     }
 
     /**


### PR DESCRIPTION
**Description**:
Clear "side-effect fields" after switch a child record from `SUCCESS` to `REVERTED_SUCCESS`.

**Related issue(s)**:
Fixes #10308

**Notes for reviewer**:
At first, I followed this strategy to remove side-effect fields:
- Find specs with system contract call with `REVERTED_SUCCESS`
- Fuzzy match them mod vs mono (individual specs)
- Clear side-effect fields based on results of fuzzy matching

What did I check:
- `ContractMintHTSSuite.rollbackOnFailedMintAfterFungibleTransfer()` — side-effect fields removed in prev PR
- `ContractDeleteSuite.cannotUseMoreThanChildContractLimit()` — checked records and didn’t find any side-effect fields under `REVERTED_SUCCESS`
- `LazyCreateThroughPrecompileSuite.erc20TransferLazyCreate()`  — checked and removed `automatic_token_associations` under `REVERTED_SUCCESS`
- `LazyCreateThroughPrecompileSuite.erc721TransferFromLazyCreate()` — checked records and didn’t find any side-effect fields under `REVERTED_SUCCESS`
- `LazyCreateThroughPrecompileSuite.erc20TransferFromLazyCreate()` is still WIP and I can’t check it
- `Create2OperationSuite.canUseAliasesInPrecompilesAndContractKeys()` is still WIP and I can’t check it

Other side-effect fields were mentioned in the issue (ones I that didnt encounter while did relevant spec fuzzy matching, like: transferList, created ids in the transactionReceipt, etc.) I added anyway from from mono `TxnReceipt#Builder.revert()` and `ExpirableTxnRecord#Builder.nullOutSideEffectFields()`.

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
