### PR TITLE
fix: Consider input bytes when calculating gas cost (#10379)

### DIFF
--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.node.app.service.evm.contracts.execution.traceability.HederaEvmOperationTracer;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmMutableWorldState;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmWorldUpdater;
@@ -48,7 +49,7 @@ public abstract class HederaEvmTxProcessor {
     protected BlockMetaSource blockMetaSource;
     protected HederaEvmMutableWorldState worldState;
 
-    protected final GasCalculator gasCalculator;
+    protected GasCalculator gasCalculator;
     // FEATURE WORK to be covered by #3949
     protected final PricesAndFeesProvider livePricesSource;
     protected final Map<String, Provider<MessageCallProcessor>> mcps;
@@ -179,8 +180,8 @@ public abstract class HederaEvmTxProcessor {
         }
     }
 
-    public void setupFields(final boolean contractCreation) {
-        this.intrinsicGas = gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, contractCreation);
+    public void setupFields(final Bytes payload, final boolean contractCreation) {
+        this.intrinsicGas = gasCalculator.transactionIntrinsicGasCost(payload, contractCreation);
         this.updater = worldState.updater();
         this.coinbase = dynamicProperties.fundingAccountAddress();
     }
@@ -222,5 +223,10 @@ public abstract class HederaEvmTxProcessor {
             case MESSAGE_CALL -> messageCallProcessor;
             case CONTRACT_CREATION -> contractCreationProcessor;
         };
+    }
+
+    @VisibleForTesting
+    public void setGasCalculator(GasCalculator gasCalculator) {
+        this.gasCalculator = gasCalculator;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
@@ -115,7 +115,7 @@ abstract class EvmTxProcessor extends HederaEvmTxProcessor {
         final Wei gasCost = Wei.of(Math.multiplyExact(gasLimit, gasPrice));
         final Wei upfrontCost = gasCost.add(value);
 
-        super.setupFields(contractCreation);
+        super.setupFields(payload, contractCreation);
 
         final var chargingResult = chargeForGas(
                 gasCost,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -339,7 +340,7 @@ class CreateEvmTxProcessorTest {
             given(updater.getOrCreate(any())).willReturn(evmAccount);
         }
 
-        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(0L);
+        given(gasCalculator.transactionIntrinsicGasCost(any(), eq(true))).willReturn(0L);
 
         given(evmAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
         given(evmAccount.incrementBalance(any())).willReturn(Wei.of(1500L));

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCharging.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCharging.java
@@ -32,7 +32,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
@@ -114,7 +113,8 @@ public class CustomGasCharging {
         if (context.isNoopGasContext()) {
             return ZERO_CHARGES;
         }
-        final var intrinsicGas = gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, transaction.isCreate());
+        final var intrinsicGas =
+                gasCalculator.transactionIntrinsicGasCost(transaction.evmPayload(), transaction.isCreate());
         validateTrue(transaction.gasLimit() >= intrinsicGas, INSUFFICIENT_GAS);
         if (transaction.isEthereumTransaction()) {
             final var allowanceUsed =

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
@@ -30,6 +30,8 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.wellKno
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.wellKnownRelayedHapiCallWithGasLimit;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.wellKnownRelayedHapiCallWithUserGasPriceAndMaxAllowance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -43,7 +45,6 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
@@ -365,7 +366,6 @@ class CustomGasChargingTest {
     }
 
     private void givenWellKnownIntrinsicGasCost(boolean isCreation) {
-        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, isCreation))
-                .willReturn(TestHelpers.INTRINSIC_GAS);
+        given(gasCalculator.transactionIntrinsicGasCost(any(), eq(isCreation))).willReturn(TestHelpers.INTRINSIC_GAS);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -731,9 +731,11 @@ public class ContractCallSuite extends HapiSuite {
                                 .getContractAccountID())))),
                         uploadInitCode(addressBook, jurisdictions),
                         contractCreate(addressBook)
+                                .gas(1_000_000L)
                                 .exposingNumTo(num -> addressBookMirror.set(asHexedSolidityAddress(0, 0, num)))
                                 .payingWith(DEFAULT_CONTRACT_SENDER),
                         contractCreate(jurisdictions)
+                                .gas(1_000_000L)
                                 .exposingNumTo(num -> jurisdictionMirror.set(asHexedSolidityAddress(0, 0, num)))
                                 .withExplicitParams(() -> EXPLICIT_JURISDICTION_CONS_PARAMS)
                                 .payingWith(DEFAULT_CONTRACT_SENDER),
@@ -742,6 +744,7 @@ public class ContractCallSuite extends HapiSuite {
                                 minters,
                                 bookInterpolated(literalInitcodeFor(minters).toByteArray(), addressBookMirror.get()))),
                         contractCreate(minters)
+                                .gas(2_000_000L)
                                 .withExplicitParams(
                                         () -> String.format(EXPLICIT_MINTER_CONS_PARAMS_TPL, jurisdictionMirror.get()))
                                 .payingWith(DEFAULT_CONTRACT_SENDER))
@@ -1395,7 +1398,7 @@ public class ContractCallSuite extends HapiSuite {
     private HapiSpec multipleSelfDestructsAreSafe() {
         final var contract = "Fuse";
         return defaultHapiSpec("MultipleSelfDestructsAreSafe", NONDETERMINISTIC_TRANSACTION_FEES)
-                .given(uploadInitCode(contract), contractCreate(contract).gas(300_000))
+                .given(uploadInitCode(contract), contractCreate(contract).gas(600_000))
                 .when(contractCall(contract, "light").via("lightTxn").scrambleTxnBody(tx -> tx))
                 .then(getTxnRecord("lightTxn").logged());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallV1SecurityModelSuite.java
@@ -374,7 +374,8 @@ public class ContractCallV1SecurityModelSuite extends HapiSuite {
                                         BigInteger.valueOf(10000L),
                                         BigInteger.valueOf(1000000000000000L),
                                         BigInteger.valueOf(2500000000L))
-                                .bytecode(initcode)),
+                                .bytecode(initcode)
+                                .gas(500_000L)),
                         tokenCreate(sauce)
                                 .supplyType(TokenSupplyType.FINITE)
                                 .initialSupply(300_000_000)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -276,7 +276,7 @@ public class ContractCreateSuite extends HapiSuite {
         return defaultHapiSpec("ChildCreationsHaveExpectedKeysWithOmittedAdminKey")
                 .given(
                         uploadInitCode(contract),
-                        contractCreate(contract).omitAdminKey().gas(300_000).via(txn),
+                        contractCreate(contract).omitAdminKey().gas(600_000).via(txn),
                         withOpContext((spec, opLog) -> {
                             final var op = getTxnRecord(txn);
                             allRunFor(spec, op);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -753,7 +753,7 @@ public class Create2OperationSuite extends HapiSuite {
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
                         uploadInitCode(contract),
-                        contractCreate(contract).payingWith(GENESIS),
+                        contractCreate(contract).payingWith(GENESIS).gas(500_000L),
                         contractCallLocal(contract, "computeChildAddress", salt)
                                 .exposingTypedResultsTo(results -> childAddress.set((Address) results[0])),
                         sourcing(() -> ethereumCryptoTransferToAddress(childAddress.get(), ONE_HBAR)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
@@ -86,7 +86,10 @@ public class ERC1155ContractInteractions extends HapiSuite {
                         uploadInitCode(CONTRACT))
                 .when()
                 .then(
-                        contractCreate(CONTRACT).via("contractCreate").payingWith(ACCOUNT2),
+                        contractCreate(CONTRACT)
+                                .gas(500_000L)
+                                .via("contractCreate")
+                                .payingWith(ACCOUNT2),
                         getTxnRecord("contractCreate").logged(),
                         getAccountBalance(ACCOUNT2).logged(),
                         getAccountInfo(ACCOUNT1).savingSnapshot(ACCOUNT1 + "Info"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
@@ -76,6 +76,7 @@ public class ERC721ContractInteractions extends HapiSuite {
                         contractCreate(CONTRACT)
                                 .payingWith(DEFAULT_CONTRACT_SENDER)
                                 .hasKnownStatus(SUCCESS)
+                                .gas(500_000L)
                                 .via(CREATE_TX))
                 .then(
                         QueryVerbs.getAccountInfo(DEFAULT_CONTRACT_SENDER).savingSnapshot(DEFAULT_CONTRACT_SENDER),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -316,7 +316,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                             .getTransactionRecord(INVALID_SINGLE_ABI_CALL_TXN)
                             .getContractCallResult()
                             .getGasUsed();
-                    assertEquals(99011, gasUsed);
+                    assertEquals(99014, gasUsed);
                 }));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -232,7 +232,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                 cryptoCreate(B_WELL_KNOWN_RECEIVER)
                         .exposingCreatedIdTo(id -> bReceiverAddr.set(idAsHeadlongAddress(id))),
                 uploadInitCode(WELL_KNOWN_TREASURY_CONTRACT),
-                contractCreate(WELL_KNOWN_TREASURY_CONTRACT),
+                contractCreate(WELL_KNOWN_TREASURY_CONTRACT).gas(500_000L),
                 tokenCreate(WELL_KNOWN_FUNGIBLE_TOKEN)
                         .exposingAddressTo(fungibleTokenMirrorAddr::set)
                         .tokenType(TokenType.FUNGIBLE_COMMON)
@@ -359,7 +359,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         // Create an immutable contract with a method
                         // transferViaThresholdContractKey()
                         // that tries to transfer token units from a spender to a receiver
-                        contractCreate(managementContract).omitAdminKey(),
+                        contractCreate(managementContract).gas(500_000L).omitAdminKey(),
                         // Setup a 1/2 threshold key with this contract's ID as the first key
                         newKeyNamed(controlledSpenderKey)
                                 .shape(threshKeyShape.signedWith(sigs(managementContract, ON))),
@@ -407,9 +407,9 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                 .given(
                         uploadInitCode(managementContract, PAY_RECEIVABLE_CONTRACT),
                         newKeyNamed(tmpAdminKey),
-                        contractCreate(managementContract).adminKey(tmpAdminKey),
+                        contractCreate(managementContract).gas(500_000L).adminKey(tmpAdminKey),
                         // Just create some other contract to be the real admin key
-                        contractCreate(PAY_RECEIVABLE_CONTRACT),
+                        contractCreate(PAY_RECEIVABLE_CONTRACT).gas(500_000L),
                         newKeyNamed(otherContractAsKey).shape(CONTRACT.signedWith(PAY_RECEIVABLE_CONTRACT)),
                         cryptoCreate(associatedAccount).keyShape(SECP256K1_ON).exposingEvmAddressTo(accountAddr::set),
                         tokenCreate(fungibleToken)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -184,7 +184,7 @@ public class ContractMintHTSSuite extends HapiSuite {
                                                                     .withStatus(SUCCESS)
                                                                     .withTotalSupply(1L)
                                                                     .withSerialNumbers(1L))
-                                                            .gas(3_837_920L)
+                                                            .gas(3_836_587L)
                                                             .amount(0L)
                                                             .functionParameters(functionParameters()
                                                                     .forFunction(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileV1SecurityModelSuite.java
@@ -411,7 +411,9 @@ public class LazyCreateThroughPrecompileV1SecurityModelSuite extends HapiSuite {
                         cryptoTransfer(moving(500, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SENDER)),
                         cryptoTransfer(moving(500, FUNGIBLE_TOKEN_2).between(TOKEN_TREASURY, SENDER)),
                         uploadInitCode(NESTED_LAZY_PRECOMPILE_CONTRACT),
-                        contractCreate(NESTED_LAZY_PRECOMPILE_CONTRACT).maxAutomaticTokenAssociations(1),
+                        contractCreate(NESTED_LAZY_PRECOMPILE_CONTRACT)
+                                .gas(500_000L)
+                                .maxAutomaticTokenAssociations(1),
                         getContractInfo(NESTED_LAZY_PRECOMPILE_CONTRACT)
                                 .has(ContractInfoAsserts.contractWith().maxAutoAssociations(1))
                                 .logged())
@@ -757,7 +759,7 @@ public class LazyCreateThroughPrecompileV1SecurityModelSuite extends HapiSuite {
                                 .exposingCreatedIdTo(id -> tokenAddr.set(
                                         HapiPropertySource.asHexedSolidityAddress(HapiPropertySource.asToken(id)))),
                         uploadInitCode(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
-                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
+                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT).gas(500_000L),
                         tokenAssociate(OWNER, List.of(FUNGIBLE_TOKEN)),
                         cryptoTransfer(moving(5, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)))
                 .when(withOpContext((spec, opLog) -> {
@@ -820,7 +822,7 @@ public class LazyCreateThroughPrecompileV1SecurityModelSuite extends HapiSuite {
                                 .exposingCreatedIdTo(id -> tokenAddr.set(
                                         HapiPropertySource.asHexedSolidityAddress(HapiPropertySource.asToken(id)))),
                         uploadInitCode(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
-                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
+                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT).gas(500_000L),
                         tokenAssociate(OWNER, List.of(FUNGIBLE_TOKEN)),
                         cryptoTransfer(moving(5, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)))
                 .when(withOpContext((spec, opLog) -> {
@@ -883,7 +885,7 @@ public class LazyCreateThroughPrecompileV1SecurityModelSuite extends HapiSuite {
                                 .adminKey(MULTI_KEY)
                                 .supplyKey(MULTI_KEY),
                         uploadInitCode(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
-                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
+                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT).gas(500_000L),
                         tokenAssociate(OWNER, NON_FUNGIBLE_TOKEN),
                         tokenAssociate(SPENDER, NON_FUNGIBLE_TOKEN),
                         tokenAssociate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT, NON_FUNGIBLE_TOKEN),
@@ -946,7 +948,7 @@ public class LazyCreateThroughPrecompileV1SecurityModelSuite extends HapiSuite {
                                 .adminKey(MULTI_KEY)
                                 .supplyKey(MULTI_KEY),
                         uploadInitCode(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
-                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
+                        contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT).gas(500_000L),
                         tokenAssociate(OWNER, NON_FUNGIBLE_TOKEN),
                         tokenAssociate(SPENDER, NON_FUNGIBLE_TOKEN),
                         tokenAssociate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT, NON_FUNGIBLE_TOKEN),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
@@ -209,7 +209,7 @@ public class PrngPrecompileSuite extends HapiSuite {
                                     .getTransactionRecord(failedCall)
                                     .getContractCallResult()
                                     .getGasUsed();
-                            assertEquals(394209, gasUsed);
+                            assertEquals(394210, gasUsed);
                         }));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/LogsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/LogsSuite.java
@@ -78,7 +78,7 @@ public class LogsSuite extends HapiSuite {
                         .hasPriority(recordWith()
                                 .contractCallResult(resultWith()
                                         .logs(inOrder(logWith().noTopics().longValue(15)))
-                                        .gasUsed(22_285))));
+                                        .gasUsed(22_489))));
     }
 
     @HapiTest
@@ -95,7 +95,7 @@ public class LogsSuite extends HapiSuite {
                                                 .noData()
                                                 .withTopicsInOrder(List.of(
                                                         eventSignatureOf("Log1(uint256)"), parsedToByteString(15)))))
-                                        .gasUsed(22_583))));
+                                        .gasUsed(22_787))));
     }
 
     @HapiTest
@@ -114,7 +114,7 @@ public class LogsSuite extends HapiSuite {
                                                         eventSignatureOf("Log2(uint256,uint256)"),
                                                         parsedToByteString(1),
                                                         parsedToByteString(2)))))
-                                        .gasUsed(23_112))));
+                                        .gasUsed(23_456))));
     }
 
     @HapiTest
@@ -134,7 +134,7 @@ public class LogsSuite extends HapiSuite {
                                                         parsedToByteString(1),
                                                         parsedToByteString(2),
                                                         parsedToByteString(3)))))
-                                        .gasUsed(23_638))));
+                                        .gasUsed(24_122))));
     }
 
     @HapiTest
@@ -160,6 +160,6 @@ public class LogsSuite extends HapiSuite {
                                                         parsedToByteString(1),
                                                         parsedToByteString(2),
                                                         parsedToByteString(3)))))
-                                        .gasUsed(24_294))));
+                                        .gasUsed(24_918))));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -234,6 +234,7 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.valueOf(55), BigInteger.TWO, BigInteger.TWO)
+                                .gas(500_000L)
                                 .via(FIRST_CREATE_TXN),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
@@ -259,7 +260,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -299,7 +300,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -339,7 +340,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -398,7 +399,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(33979)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -418,7 +419,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963018)
+                                                        .setGas(962655)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -432,7 +433,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960236)
+                                                        .setGas(959873)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -445,7 +446,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(952309)
+                                                        .setGas(951947)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -458,7 +459,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(949543)
+                                                        .setGas(949181)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -472,7 +473,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(946053)
+                                                        .setGas(945691)
                                                         .setGasUsed(5778)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -490,7 +491,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(928026)
+                                                        .setGas(927670)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -503,7 +504,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(939987)
+                                                        .setGas(939625)
                                                         .setGasUsed(1501)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -522,7 +523,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(924301)
+                                                        .setGas(923945)
                                                         .setGasUsed(423)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -536,7 +537,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(938149)
+                                                        .setGas(937787)
                                                         .setGasUsed(3345)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -554,7 +555,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(922684)
+                                                        .setGas(922327)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -567,7 +568,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(934470)
+                                                        .setGas(934107)
                                                         .setGasUsed(4235)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -586,7 +587,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(918936)
+                                                        .setGas(918579)
                                                         .setGasUsed(3224)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -628,7 +629,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48260)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(8792)
@@ -668,7 +669,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -708,7 +709,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -765,7 +766,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(70255)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -785,7 +786,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963083)
+                                                        .setGas(962721)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -799,7 +800,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960302)
+                                                        .setGas(959939)
                                                         .setGasUsed(22424)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -812,7 +813,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(937875)
+                                                        .setGas(937512)
                                                         .setGasUsed(5811)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -830,7 +831,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(919912)
+                                                        .setGas(919554)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -843,7 +844,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(931783)
+                                                        .setGas(931421)
                                                         .setGasUsed(4235)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -862,7 +863,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(916248)
+                                                        .setGas(915892)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -876,7 +877,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(927248)
+                                                        .setGas(926886)
                                                         .setGasUsed(5819)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -894,7 +895,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(909474)
+                                                        .setGas(909118)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -907,7 +908,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(921145)
+                                                        .setGas(920783)
                                                         .setGasUsed(21353)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -926,7 +927,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(905801)
+                                                        .setGas(905444)
                                                         .setGasUsed(20323)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -940,7 +941,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(899766)
+                                                        .setGas(899403)
                                                         .setGasUsed(3387)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -958,7 +959,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(884859)
+                                                        .setGas(884502)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -971,7 +972,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(896045)
+                                                        .setGas(895682)
                                                         .setGasUsed(1476)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -990,7 +991,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(881071)
+                                                        .setGas(880714)
                                                         .setGasUsed(424)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1007,7 +1008,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.valueOf(55), BigInteger.TWO, BigInteger.TWO)
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -1032,7 +1034,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -1072,7 +1074,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -1112,7 +1114,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -1170,7 +1172,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(57011)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1190,7 +1192,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963059)
+                                                        .setGas(962697)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1204,7 +1206,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960277)
+                                                        .setGas(959915)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1219,7 +1221,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(954683)
+                                                        .setGas(954321)
                                                         .setGasUsed(5810)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1237,7 +1239,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(936458)
+                                                        .setGas(936102)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1250,7 +1252,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(948592)
+                                                        .setGas(948230)
                                                         .setGasUsed(4209)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1269,7 +1271,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(932820)
+                                                        .setGas(932463)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1283,7 +1285,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(941399)
+                                                        .setGas(941036)
                                                         .setGasUsed(3278)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1301,7 +1303,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(925906)
+                                                        .setGas(925548)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1314,7 +1316,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(937474)
+                                                        .setGas(937112)
                                                         .setGasUsed(21401)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1333,7 +1335,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(921827)
+                                                        .setGas(921471)
                                                         .setGasUsed(20323)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1347,7 +1349,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(915805)
+                                                        .setGas(915443)
                                                         .setGasUsed(3345)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1365,7 +1367,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(900689)
+                                                        .setGas(900333)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1378,7 +1380,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(911814)
+                                                        .setGas(911452)
                                                         .setGasUsed(4235)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1397,7 +1399,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(896634)
+                                                        .setGas(896278)
                                                         .setGasUsed(3224)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1414,7 +1416,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.TWO, BigInteger.valueOf(3), BigInteger.valueOf(4))
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -1439,7 +1442,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -1478,7 +1481,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48260)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(8792)
@@ -1517,7 +1520,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48260)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(8792)
@@ -1563,7 +1566,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(23913)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1583,7 +1586,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963038)
+                                                        .setGas(962676)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1597,7 +1600,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960256)
+                                                        .setGas(959894)
                                                         .setGasUsed(3223)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1610,7 +1613,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(956871)
+                                                        .setGas(956509)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1624,7 +1627,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(954049)
+                                                        .setGas(953687)
                                                         .setGasUsed(3224)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1637,7 +1640,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(950522)
+                                                        .setGas(950160)
                                                         .setGasUsed(5810)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1655,7 +1658,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(932362)
+                                                        .setGas(932006)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1668,7 +1671,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(944118)
+                                                        .setGas(943755)
                                                         .setGasUsed(3953)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1687,7 +1690,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(925954)
+                                                        .setGas(925596)
                                                         .setGasUsed(423)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1704,7 +1707,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.valueOf(55), BigInteger.TWO, BigInteger.TWO)
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -1729,7 +1733,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -1744,7 +1748,8 @@ public class TraceabilitySuite extends HapiSuite {
                                 BigInteger.TWO),
                         contractCustomCreate(
                                         TRACEABILITY, SECOND, BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12))
-                                .via(SECOND_CREATE_TXN),
+                                .via(SECOND_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 SECOND_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY + SECOND)
@@ -1769,7 +1774,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -1784,7 +1789,8 @@ public class TraceabilitySuite extends HapiSuite {
                                 BigInteger.valueOf(12)),
                         contractCustomCreate(
                                         TRACEABILITY, THIRD, BigInteger.valueOf(4), BigInteger.ONE, BigInteger.ZERO)
-                                .via(THIRD_CREATE_TXN),
+                                .via(THIRD_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 THIRD_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY + THIRD)
@@ -1809,7 +1815,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298236)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(48592)
@@ -1865,7 +1871,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(27376)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1885,7 +1891,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963081)
+                                                        .setGas(962719)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1899,7 +1905,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960300)
+                                                        .setGas(959937)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -1914,7 +1920,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(952373)
+                                                        .setGas(952011)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1927,7 +1933,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(949607)
+                                                        .setGas(949245)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1941,7 +1947,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(946117)
+                                                        .setGas(945755)
                                                         .setGasUsed(5777)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1959,7 +1965,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_STATICCALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(928090)
+                                                        .setGas(927734)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -1972,7 +1978,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(940069)
+                                                        .setGas(939707)
                                                         .setGasUsed(3320)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -1990,7 +1996,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_STATICCALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(924598)
+                                                        .setGas(924242)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -2006,7 +2012,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.TWO, BigInteger.valueOf(3), BigInteger.valueOf(4))
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -2031,7 +2038,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -2071,7 +2078,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -2110,7 +2117,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -2164,7 +2171,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(29910)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -2184,7 +2191,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963082)
+                                                        .setGas(962720)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2198,7 +2205,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960301)
+                                                        .setGas(959938)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -2211,7 +2218,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(954706)
+                                                        .setGas(954344)
                                                         .setGasUsed(5810)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2229,7 +2236,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(936481)
+                                                        .setGas(936124)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -2242,7 +2249,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(948616)
+                                                        .setGas(948254)
                                                         .setGasUsed(4209)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2261,7 +2268,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(932843)
+                                                        .setGas(932487)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -2275,7 +2282,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(943883)
+                                                        .setGas(943521)
                                                         .setGasUsed(5777)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2293,7 +2300,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_STATICCALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(925891)
+                                                        .setGas(925534)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -2306,7 +2313,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(937591)
+                                                        .setGas(937229)
                                                         .setGasUsed(3320)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2324,7 +2331,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_STATICCALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + SECOND))
-                                                        .setGas(922159)
+                                                        .setGas(921803)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -2365,7 +2372,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(115992)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY_CALLCODE))
                                                 .setGasUsed(67632)
@@ -2409,7 +2416,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(116016)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY_CALLCODE + SECOND))
                                                 .setGasUsed(27832)
@@ -2453,7 +2460,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(116004)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY_CALLCODE + THIRD))
                                                 .setGasUsed(47732)
@@ -2511,7 +2518,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(51483)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
@@ -2531,7 +2538,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(963159)
+                                                        .setGas(962797)
                                                         .setGasUsed(2500)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2546,7 +2553,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
                                                         .setCallDepth(1)
-                                                        .setGas(960259)
+                                                        .setGas(959897)
                                                         .setGasUsed(5249)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
@@ -2561,7 +2568,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(952294)
+                                                        .setGas(951931)
                                                         .setGasUsed(2368)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -2575,7 +2582,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(949526)
+                                                        .setGas(949163)
                                                         .setGasUsed(3215)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -2589,7 +2596,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(945992)
+                                                        .setGas(945630)
                                                         .setGasUsed(6069)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -2607,7 +2614,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(spec.registry()
                                                                 .getContractId(TRACEABILITY_CALLCODE + SECOND))
-                                                        .setGas(927718)
+                                                        .setGas(927361)
                                                         .setGasUsed(2500)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -2622,7 +2629,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(939626)
+                                                        .setGas(939264)
                                                         .setGasUsed(21544)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -2641,7 +2648,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(spec.registry()
                                                                 .getContractId(TRACEABILITY_CALLCODE + SECOND))
-                                                        .setGas(923822)
+                                                        .setGas(923465)
                                                         .setGasUsed(20381)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -2658,7 +2665,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(918049)
+                                                        .setGas(917687)
                                                         .setGasUsed(3393)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -2676,7 +2683,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(spec.registry()
                                                                 .getContractId(TRACEABILITY_CALLCODE + SECOND))
-                                                        .setGas(902867)
+                                                        .setGas(902511)
                                                         .setGasUsed(2522)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -2691,7 +2698,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(914320)
+                                                        .setGas(913958)
                                                         .setGasUsed(1270)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -2710,7 +2717,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(spec.registry()
                                                                 .getContractId(TRACEABILITY_CALLCODE + SECOND))
-                                                        .setGas(899149)
+                                                        .setGas(898793)
                                                         .setGasUsed(349)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -2755,7 +2762,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(115992)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY_CALLCODE))
                                                 .setGasUsed(67632)
@@ -2799,7 +2806,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(116016)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY_CALLCODE + SECOND))
                                                 .setGasUsed(27832)
@@ -2843,7 +2850,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(116004)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY_CALLCODE + THIRD))
                                                 .setGasUsed(47732)
@@ -2891,7 +2898,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(29301)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
@@ -2911,7 +2918,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(962924)
+                                                        .setGas(962562)
                                                         .setGasUsed(2500)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2926,7 +2933,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
                                                         .setCallDepth(1)
-                                                        .setGas(960024)
+                                                        .setGas(959662)
                                                         .setGasUsed(3281)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
@@ -2941,7 +2948,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(956466)
+                                                        .setGas(956103)
                                                         .setGasUsed(2522)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2956,7 +2963,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
                                                         .setCallDepth(1)
-                                                        .setGas(953547)
+                                                        .setGas(953185)
                                                         .setGasUsed(3149)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
@@ -2971,7 +2978,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(950079)
+                                                        .setGas(949717)
                                                         .setGasUsed(5783)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -2989,7 +2996,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(931893)
+                                                        .setGas(931536)
                                                         .setGasUsed(2368)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -3004,7 +3011,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(943995)
+                                                        .setGas(943633)
                                                         .setGasUsed(4290)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3023,7 +3030,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(928209)
+                                                        .setGas(927853)
                                                         .setGasUsed(3215)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -3040,7 +3047,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY_CALLCODE))
-                                                        .setGas(938961)
+                                                        .setGas(938599)
                                                         .setGasUsed(4144)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(spec.registry()
@@ -3061,7 +3068,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALLCODE)
                                                         .setCallingContract(spec.registry()
                                                                 .getContractId(TRACEABILITY_CALLCODE + SECOND))
-                                                        .setGas(920706)
+                                                        .setGas(920350)
                                                         .setGasUsed(481)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(spec.registry()
@@ -3081,7 +3088,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.valueOf(55), BigInteger.TWO, BigInteger.TWO)
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -3106,7 +3114,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -3146,7 +3154,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -3185,7 +3193,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -3239,7 +3247,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(50335)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -3259,7 +3267,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963040)
+                                                        .setGas(962678)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3273,7 +3281,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960258)
+                                                        .setGas(959896)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -3288,7 +3296,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(952332)
+                                                        .setGas(951970)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3301,7 +3309,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(949566)
+                                                        .setGas(949204)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3315,7 +3323,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(943624)
+                                                        .setGas(943262)
                                                         .setGasUsed(29899)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3329,7 +3337,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(928493)
+                                                        .setGas(928136)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3342,7 +3350,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(925711)
+                                                        .setGas(925354)
                                                         .setGasUsed(20323)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3356,7 +3364,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(905493)
+                                                        .setGas(905136)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3369,7 +3377,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(902659)
+                                                        .setGas(902302)
                                                         .setGasUsed(3224)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3386,7 +3394,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.TWO, BigInteger.valueOf(3), BigInteger.valueOf(4))
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -3411,7 +3420,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -3451,7 +3460,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -3490,7 +3499,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -3545,7 +3554,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(52541)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -3565,7 +3574,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963038)
+                                                        .setGas(962676)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3579,7 +3588,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960256)
+                                                        .setGas(959894)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -3592,7 +3601,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(954662)
+                                                        .setGas(954300)
                                                         .setGasUsed(5811)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3610,7 +3619,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(936436)
+                                                        .setGas(936080)
                                                         .setGasUsed(2315)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3623,7 +3632,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(948571)
+                                                        .setGas(948209)
                                                         .setGasUsed(4235)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3642,7 +3651,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(932774)
+                                                        .setGas(932417)
                                                         .setGasUsed(3180)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3656,7 +3665,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(941591)
+                                                        .setGas(941228)
                                                         .setGasUsed(29898)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3670,7 +3679,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(926492)
+                                                        .setGas(926135)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3683,7 +3692,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(923710)
+                                                        .setGas(923353)
                                                         .setGasUsed(20323)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3697,7 +3706,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(903492)
+                                                        .setGas(903135)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3710,7 +3719,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
-                                                        .setGas(900658)
+                                                        .setGas(900301)
                                                         .setGasUsed(3224)
                                                         .setCallDepth(2)
                                                         .setRecipientContract(
@@ -3727,7 +3736,8 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         uploadInitCode(TRACEABILITY),
                         contractCreate(TRACEABILITY, BigInteger.TWO, BigInteger.valueOf(3), BigInteger.valueOf(4))
-                                .via(FIRST_CREATE_TXN),
+                                .via(FIRST_CREATE_TXN)
+                                .gas(500_000L),
                         expectContractStateChangesSidecarFor(
                                 FIRST_CREATE_TXN,
                                 List.of(StateChange.stateChangeFor(TRACEABILITY)
@@ -3752,7 +3762,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(298224)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY))
                                                 .setGasUsed(68492)
@@ -3792,7 +3802,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + SECOND))
                                                 .setGasUsed(28692)
@@ -3831,7 +3841,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(48248)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(TRACEABILITY + THIRD))
                                                 .setGasUsed(28692)
@@ -3884,7 +3894,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallType(CALL)
                                                         .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                         .setCallOperationType(CallOperationType.OP_CALL)
-                                                        .setGas(979000)
+                                                        .setGas(978632)
                                                         .setGasUsed(44077)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -3904,7 +3914,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(963038)
+                                                        .setGas(962676)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3918,7 +3928,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(960256)
+                                                        .setGas(959894)
                                                         .setGasUsed(5324)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
@@ -3931,7 +3941,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_DELEGATECALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(952341)
+                                                        .setGas(951979)
                                                         .setGasUsed(237)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3946,7 +3956,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(949404)
+                                                        .setGas(949041)
                                                         .setGasUsed(2347)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3960,7 +3970,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
                                                         .setCallDepth(1)
-                                                        .setGas(946606)
+                                                        .setGas(946244)
                                                         .setGasUsed(20323)
                                                         .setRecipientContract(
                                                                 spec.registry().getContractId(TRACEABILITY + THIRD))
@@ -3973,7 +3983,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(926387)
+                                                        .setGas(926025)
                                                         .setGasUsed(2391)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -3986,7 +3996,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                         .setCallOperationType(CallOperationType.OP_CALL)
                                                         .setCallingContract(
                                                                 spec.registry().getContractId(TRACEABILITY))
-                                                        .setGas(923534)
+                                                        .setGas(923172)
                                                         .setGasUsed(3224)
                                                         .setCallDepth(1)
                                                         .setRecipientContract(
@@ -4021,7 +4031,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             spec.registry().getAccountID(GENESIS))
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(contract))
-                                                    .setGas(197000)
+                                                    .setGas(184672)
                                                     .setGasUsed(214)
                                                     .setOutput(EMPTY)
                                                     .build())));
@@ -4063,7 +4073,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                     .setCallingAccount(accountIDAtomicReference.get())
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(PAY_RECEIVABLE_CONTRACT))
-                                                    .setGas(947000)
+                                                    .setGas(937984)
                                                     .setGasUsed(135)
                                                     .setOutput(EMPTY)
                                                     .build())));
@@ -4102,7 +4112,7 @@ public class TraceabilitySuite extends HapiSuite {
                                             .setCallType(CREATE)
                                             .setCallOperationType(CallOperationType.OP_CREATE)
                                             .setCallingAccount(accountIDAtomicReference.get())
-                                            .setGas(947000)
+                                            .setGas(937984)
                                             .setRecipientContract(
                                                     spec.registry().getContractId(PAY_RECEIVABLE_CONTRACT))
                                             .setGasUsed(135)
@@ -4142,7 +4152,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(153184)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(contract))
                                                 .setGasUsed(613)
@@ -4213,7 +4223,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             .setCallType(CALL)
                                                             .setCallOperationType(CallOperationType.OP_CALL)
                                                             .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                            .setGas(3979000)
+                                                            .setGas(3965516)
                                                             .setValue(tcValue)
                                                             .setRecipientContract(
                                                                     spec.registry()
@@ -4233,7 +4243,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             .setCallingContract(
                                                                     spec.registry()
                                                                             .getContractId(contract))
-                                                            .setGas(3883883)
+                                                            .setGas(3870609)
                                                             .setRecipientContract(childId)
                                                             .setGasUsed(44936)
                                                             .setValue(tcValue)
@@ -4278,7 +4288,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             spec.registry().getAccountID(GENESIS))
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(PRECOMPILE_CALLER))
-                                                    .setGas(197000)
+                                                    .setGas(125628)
                                                     .setGasUsed(942)
                                                     .setOutput(EMPTY)
                                                     .build())));
@@ -4303,7 +4313,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                     .setCallOperationType(CallOperationType.OP_CALL)
                                                     .setCallingAccount(
                                                             spec.registry().getAccountID(GENESIS))
-                                                    .setGas(79000)
+                                                    .setGas(78304)
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(PRECOMPILE_CALLER))
                                                     .setGasUsed(5330)
@@ -4322,7 +4332,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                     .setCallOperationType(CallOperationType.OP_STATICCALL)
                                                     .setCallingContract(
                                                             spec.registry().getContractId(PRECOMPILE_CALLER))
-                                                    .setGas(76587)
+                                                    .setGas(75902)
                                                     // SHA 256 precompile address is
                                                     // 0x02
                                                     .setRecipientContract(ContractID.newBuilder()
@@ -4338,7 +4348,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                     .setCallOperationType(CallOperationType.OP_CALL)
                                                     .setCallingContract(
                                                             spec.registry().getContractId(PRECOMPILE_CALLER))
-                                                    .setGas(73240)
+                                                    .setGas(72555)
                                                     // HTS precompile address is
                                                     // 0x167
                                                     .setRecipientContract(ContractID.newBuilder()
@@ -4374,7 +4384,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(185276)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(REVERTING_CONTRACT))
                                                 .setGasUsed(345)
@@ -4397,7 +4407,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CALL)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                 .setCallOperationType(CallOperationType.OP_CALL)
-                                                .setGas(979000)
+                                                .setGas(978796)
                                                 .setGasUsed(32583)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(REVERTING_CONTRACT))
@@ -4410,7 +4420,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingContract(
                                                         spec.registry().getContractId(REVERTING_CONTRACT))
-                                                .setGas(931868)
+                                                .setGas(931667)
                                                 .setCallDepth(1)
                                                 .setGasUsed(201)
                                                 .setRevertReason(EMPTY)
@@ -4433,7 +4443,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(185276)
                                                 .setGasUsed(201)
                                                 .setRevertReason(EMPTY)
                                                 .build())))),
@@ -4488,7 +4498,7 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(uploadInitCode(REVERTING_CONTRACT))
                 .when(contractCreate(REVERTING_CONTRACT, BigInteger.valueOf(6))
                         .via(FIRST_CREATE_TXN)
-                        .gas(53050)
+                        .gas(64774)
                         .hasKnownStatus(INSUFFICIENT_GAS))
                 .then(
                         withOpContext((spec, opLog) -> allRunFor(
@@ -4522,7 +4532,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CREATE)
                                                 .setCallOperationType(CallOperationType.OP_CREATE)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                .setGas(197000)
+                                                .setGas(185276)
                                                 .setRecipientContract(
                                                         spec.registry().getContractId(REVERTING_CONTRACT))
                                                 .setGasUsed(345)
@@ -4545,8 +4555,8 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setCallType(CALL)
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                 .setCallOperationType(CallOperationType.OP_CALL)
-                                                .setGas(979000)
-                                                .setGasUsed(963811)
+                                                .setGas(978936)
+                                                .setGasUsed(963748)
                                                 .setOutput(EMPTY)
                                                 /*
                                                    For EVM v0.34 use this code block instead:
@@ -4563,12 +4573,12 @@ public class TraceabilitySuite extends HapiSuite {
                                                         spec.registry().getContractId(REVERTING_CONTRACT))
                                                 .setCallOperationType(CallOperationType.OP_CALL)
                                                 .setCallDepth(1)
-                                                .setGas(960639)
+                                                .setGas(960576)
                                                 .setInput(ByteStringUtils.wrapUnsafely(
                                                         Function.parse("boo" + "(uint256)")
                                                                 .encodeCallWithArgs(BigInteger.valueOf(234))
                                                                 .array()))
-                                                .setGasUsed(960639)
+                                                .setGasUsed(960576)
                                                 .setError(ByteString.copyFromUtf8(PRECOMPILE_ERROR.name()))
                                                 /*
                                                    For EVM v0.34 use this code block instead:
@@ -4606,7 +4616,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             spec.registry().getAccountID(GENESIS))
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(EMPTY_CONSTRUCTOR_CONTRACT))
-                                                    .setGas(197000)
+                                                    .setGas(195600)
                                                     .setGasUsed(66)
                                                     .setOutput(EMPTY)
                                                     .build())));
@@ -4638,7 +4648,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             spec.registry().getAccountID(GENESIS))
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(contract))
-                                                    .setGas(197000)
+                                                    .setGas(184672)
                                                     .setGasUsed(214)
                                                     .setOutput(EMPTY)
                                                     .build())));
@@ -4664,7 +4674,7 @@ public class TraceabilitySuite extends HapiSuite {
                 .given(
                         overriding(SIDECARS_PROP, "CONTRACT_ACTION"),
                         uploadInitCode(APPROVE_BY_DELEGATE),
-                        contractCreate(APPROVE_BY_DELEGATE).via(contractCreateTxn),
+                        contractCreate(APPROVE_BY_DELEGATE).gas(500_000).via(contractCreateTxn),
                         withOpContext((spec, opLog) -> {
                             final HapiGetTxnRecord txnRecord = getTxnRecord(contractCreateTxn);
                             allRunFor(
@@ -4679,7 +4689,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             spec.registry().getAccountID(GENESIS))
                                                     .setRecipientContract(
                                                             spec.registry().getContractId(APPROVE_BY_DELEGATE))
-                                                    .setGas(197000)
+                                                    .setGas(433856)
                                                     .setGasUsed(214)
                                                     .setOutput(EMPTY)
                                                     .build())));
@@ -4744,8 +4754,8 @@ public class TraceabilitySuite extends HapiSuite {
                                                                             spec.registry()
                                                                                     .getAccountID(somebodyElse))),
                                                             serialNumberId))
-                                                    .setGas(979000)
-                                                    .setGasUsed(948950)
+                                                    .setGas(978120)
+                                                    .setGasUsed(948098)
                                                     .setRevertReason(ByteString.EMPTY)
                                                     .build(),
                                             ContractAction.newBuilder()
@@ -4759,8 +4769,8 @@ public class TraceabilitySuite extends HapiSuite {
                                                                             .getTokenID(tokenInQuestion)
                                                                             .getTokenNum())
                                                             .build())
-                                                    .setGas(959347)
-                                                    .setGasUsed(944446)
+                                                    .setGas(958481)
+                                                    .setGasUsed(943594)
                                                     .setInput(ByteStringUtils.wrapUnsafely(Function.parse(
                                                                     "approve(address,uint256)")
                                                             .encodeCallWithArgs(
@@ -4786,8 +4796,8 @@ public class TraceabilitySuite extends HapiSuite {
                                                     .setRecipientContract(ContractID.newBuilder()
                                                             .setContractNum(359L)
                                                             .build())
-                                                    .setGas(941693)
-                                                    .setGasUsed(941693)
+                                                    .setGas(940841)
+                                                    .setGasUsed(940841)
                                                     .setInput(ByteStringUtils.wrapUnsafely(ArrayUtils.addAll(
                                                             ArrayUtils.addAll(
                                                                     Arrays.copyOfRange(
@@ -5041,7 +5051,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             .setCallType(CALL)
                                                             .setCallOperationType(CallOperationType.OP_CALL)
                                                             .setCallingAccount(TxnUtils.asId(GENESIS, spec))
-                                                            .setGas(3979000)
+                                                            .setGas(3965516)
                                                             .setValue(tcValue)
                                                             .setRecipientContract(
                                                                     spec.registry()
@@ -5061,7 +5071,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                             .setCallingContract(
                                                                     spec.registry()
                                                                             .getContractId(create2Factory))
-                                                            .setGas(3883883)
+                                                            .setGas(3870609)
                                                             // recipient should be the
                                                             // original hollow account id as
                                                             // a contract

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -373,7 +373,7 @@ public class FileUpdateSuite extends HapiSuite {
                 .when(contractCall(CONTRACT, CREATE_TXN).gas(1_000_000L))
                 .then(contractCallLocal(CONTRACT, INDIRECT_GET_ABI)
                         .gas(300_000L)
-                        .has(resultWith().gasUsed(26_451)));
+                        .has(resultWith().gasUsed(26_515)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -513,7 +513,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         cryptoTransfer(moving(500, VANILLA_TOKEN).between(TOKEN_TREASURY, ACCOUNT)),
                         cryptoTransfer(movingUnique(KNOWABLE_TOKEN, 1, 2, 3, 4).between(TOKEN_TREASURY, ACCOUNT)),
                         uploadInitCode(contract),
-                        contractCreate(contract))
+                        contractCreate(contract).gas(500_000L))
                 .when(
                         // Do transfers by calling contract from EOA, and should be failing with
                         // CONTRACT_REVERT_EXECUTED
@@ -657,7 +657,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         cryptoTransfer(moving(500, VANILLA_TOKEN).between(TOKEN_TREASURY, ACCOUNT)),
                         cryptoTransfer(movingUnique(KNOWABLE_TOKEN, 1, 2, 3, 4).between(TOKEN_TREASURY, ACCOUNT)),
                         uploadInitCode(contract),
-                        contractCreate(contract))
+                        contractCreate(contract).gas(500_000L))
                 .when(
                         // Do transfers by calling contract from EOA
                         withOpContext((spec, opLog) -> {
@@ -793,7 +793,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         tokenAssociate(RECEIVER, VANILLA_TOKEN),
                         cryptoTransfer(moving(500, VANILLA_TOKEN).between(TOKEN_TREASURY, ACCOUNT)),
                         uploadInitCode(contract),
-                        contractCreate(contract))
+                        contractCreate(contract).gas(500_000L))
                 .when(withOpContext((spec, opLog) -> {
                     final var receiver1 =
                             asHeadlongAddress(asAddress(spec.registry().getAccountID(RECEIVER)));
@@ -1591,7 +1591,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 .given(
                         overriding(CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT1, "100"),
                         uploadInitCode(contract),
-                        contractCreate(contract))
+                        contractCreate(contract).gas(500_000L))
                 .when(
                         contractCall(contract, "holdTemporary", BigInteger.valueOf(10))
                                 .via("tempHoldTx"),
@@ -1617,7 +1617,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                     .getContractCallResult()
                                     .getGasUsed();
 
-                            Assertions.assertTrue(gasUsedForTemporaryHoldTx < 23535L);
+                            Assertions.assertTrue(gasUsedForTemporaryHoldTx < 23739L);
                             Assertions.assertTrue(gasUsedForPermanentHoldTx > 20000L);
                         }),
                         UtilVerbs.resetToDefault(CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT1));
@@ -2172,7 +2172,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         overriding(CONTRACTS_NONCES_EXTERNALIZATION_ENABLED, "true"),
                         cryptoCreate(PAYER).balance(10 * ONE_HUNDRED_HBARS),
                         uploadInitCode(contract),
-                        contractCreate(contract).via(contractCreateTxn))
+                        contractCreate(contract).via(contractCreateTxn).gas(500_000L))
                 .when()
                 .then(withOpContext((spec, opLog) -> {
                     final var opContractTxnRecord = getTxnRecord(contractCreateTxn);
@@ -2230,7 +2230,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         overriding(CONTRACTS_NONCES_EXTERNALIZATION_ENABLED, "true"),
                         cryptoCreate(payer).balance(10 * ONE_HUNDRED_HBARS),
                         uploadInitCode(contract),
-                        contractCreate(contract).via(contractCreateTx))
+                        contractCreate(contract).via(contractCreateTx).gas(500_000L))
                 .when(withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(contract, deployParentContractFn)
@@ -2320,7 +2320,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         overriding(CONTRACTS_NONCES_EXTERNALIZATION_ENABLED, "false"),
                         cryptoCreate(payer).balance(10 * ONE_HUNDRED_HBARS),
                         uploadInitCode(contract),
-                        contractCreate(contract).logged().via("txn"),
+                        contractCreate(contract).logged().gas(500_000L).via("txn"),
                         withOpContext((spec, opLog) -> {
                             HapiGetTxnRecord op = getTxnRecord("txn")
                                     .logged()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/IdFuzzingProviderFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/IdFuzzingProviderFactory.java
@@ -204,7 +204,7 @@ public class IdFuzzingProviderFactory {
                     .exposingCreatedIdTo(id ->
                             tokenAddr.set(HapiPropertySource.asHexedSolidityAddress(HapiPropertySource.asToken(id)))),
             uploadInitCode(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
-            contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT),
+            contractCreate(TRANSFER_TO_ALIAS_PRECOMPILE_CONTRACT).gas(500_000L),
             tokenAssociate(OWNER, List.of(FUNGIBLE_TOKEN)),
             cryptoTransfer(moving(INITIAL_SUPPLY, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER))
         };

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -212,7 +212,7 @@ public class TokenAssociationSpecs extends HapiSuite {
                         newKeyNamed("admin"),
                         cryptoCreate(treasury),
                         uploadInitCode(contract),
-                        contractCreate(contract).gas(300_000).via(CREATION),
+                        contractCreate(contract).gas(600_000).via(CREATION),
                         withOpContext((spec, opLog) -> {
                             var subOp = getTxnRecord(CREATION);
                             allRunFor(spec, subOp);
@@ -480,7 +480,7 @@ public class TokenAssociationSpecs extends HapiSuite {
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(TOKEN_TREASURY).balance(0L).maxAutomaticTokenAssociations(542),
                         uploadInitCode(contract),
-                        contractCreate(contract).gas(300_000),
+                        contractCreate(contract).gas(600_000),
                         tokenCreate(uniqToken)
                                 .tokenType(NON_FUNGIBLE_UNIQUE)
                                 .initialSupply(0)


### PR DESCRIPTION
**Description**:
Cherry-pick https://github.com/hashgraph/hedera-services/pull/10379 to `release/0.45`.

Context:
Take into consideration the input bytes' size from the evm transaction when calculating the intrinsic gas cost.


**Related issue(s)**:

Fixes #9988

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
