### PR TITLE
fix: use `RecordBuilder` variants of result construction in transfer HtsCalls

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -1084,7 +1084,7 @@ public class SingleTransactionRecordBuilderImpl
      *
      * @return the in-progress {@link TransactionBody}
      */
-    public TransactionBody inProgressBody() {
+    private TransactionBody inProgressBody() {
         try {
             final var signedTransaction = SignedTransaction.PROTOBUF.parseStrict(
                     transaction.signedTransactionBytes().toReadableSequentialData());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -381,20 +381,10 @@ public class SingleTransactionRecordBuilderImpl
     @NonNull
     public SingleTransactionRecordBuilderImpl syncBodyIdFromRecordId() {
         final var newTransactionID = transactionID;
-        try {
-            final var signedTransaction = SignedTransaction.PROTOBUF.parseStrict(
-                    transaction.signedTransactionBytes().toReadableSequentialData());
-            final var existingTransactionBody =
-                    TransactionBody.PROTOBUF.parse(signedTransaction.bodyBytes().toReadableSequentialData());
-            final var body = existingTransactionBody
-                    .copyBuilder()
-                    .transactionID(newTransactionID)
-                    .build();
-            this.transaction = SingleTransactionRecordBuilder.transactionWith(body);
-            return this;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        final var body =
+                inProgressBody().copyBuilder().transactionID(newTransactionID).build();
+        this.transaction = SingleTransactionRecordBuilder.transactionWith(body);
+        return this;
     }
 
     /**
@@ -1087,5 +1077,20 @@ public class SingleTransactionRecordBuilderImpl
      */
     public ContractFunctionResult contractFunctionResult() {
         return contractFunctionResult;
+    }
+
+    /**
+     * Returns the in-progress {@link TransactionBody}.
+     *
+     * @return the in-progress {@link TransactionBody}
+     */
+    public TransactionBody inProgressBody() {
+        try {
+            final var signedTransaction = SignedTransaction.PROTOBUF.parseStrict(
+                    transaction.signedTransactionBytes().toReadableSequentialData());
+            return TransactionBody.PROTOBUF.parse(signedTransaction.bodyBytes().toReadableSequentialData());
+        } catch (Exception e) {
+            throw new IllegalStateException("Record being built for unparseable transaction", e);
+        }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
@@ -37,6 +37,25 @@ import java.util.concurrent.Future;
  * Metadata collected when transactions are handled as part of "pre-handle". This is then made available to the
  * handle workflow.
  *
+ * <p>Several fields are pure functions of the input transaction. These are,
+ * <ul>
+ *     <li>{@link #payer}</li>
+ *     <li>{@link #txInfo}</li>
+ * </ul>
+ *
+ * <p>But the remaining fields depend on both the input transaction and the state of the world
+ * in which the transaction is being handled; both state and configuration. These are,
+ * <ul>
+ *     <li>{@link #payerKey}</li>
+ *     <li>{@link #status}</li>
+ *     <li>{@link #responseCode}</li>
+ *     <li>{@link #requiredKeys}</li>
+ *     <li>{@link #optionalKeys}</li>
+ *     <li>{@link #hollowAccounts}</li>
+ *     <li>{@link #verificationResults}</li>
+ *     <li>{@link #configVersion}</li>
+ * </ul>
+ *
  * @param payer payer for the transaction, which could be from the transaction body, or could be a node account.
  *              The payer **may be null** only in the event of a catastrophic unknown exception. That is, if the
  *              status is {@link Status#UNKNOWN_FAILURE}, then the payer will be null. If the status is

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
@@ -37,25 +37,6 @@ import java.util.concurrent.Future;
  * Metadata collected when transactions are handled as part of "pre-handle". This is then made available to the
  * handle workflow.
  *
- * <p>Several fields are pure functions of the input transaction. These are,
- * <ul>
- *     <li>{@link #payer}</li>
- *     <li>{@link #txInfo}</li>
- * </ul>
- *
- * <p>But the remaining fields depend on both the input transaction and the state of the world
- * in which the transaction is being handled; both state and configuration. These are,
- * <ul>
- *     <li>{@link #payerKey}</li>
- *     <li>{@link #status}</li>
- *     <li>{@link #responseCode}</li>
- *     <li>{@link #requiredKeys}</li>
- *     <li>{@link #optionalKeys}</li>
- *     <li>{@link #hollowAccounts}</li>
- *     <li>{@link #verificationResults}</li>
- *     <li>{@link #configVersion}</li>
- * </ul>
- *
  * @param payer payer for the transaction, which could be from the transaction body, or could be a node account.
  *              The payer **may be null** only in the event of a catastrophic unknown exception. That is, if the
  *              status is {@link Status#UNKNOWN_FAILURE}, then the payer will be null. If the status is

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
-import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
 import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -80,7 +79,7 @@ public record FullResult(
         requireNonNull(recordBuilder);
         return new FullResult(
                 PrecompiledContract.PrecompileContractResult.revert(
-                        ReturnTypes.tuweniEncodedRc(recordBuilder.status())),
+                        Bytes.wrap(recordBuilder.status().protoName().getBytes())),
                 gasRequirement,
                 recordBuilder);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
@@ -105,7 +105,7 @@ public record FullResult(
                 null);
     }
 
-    public static FullResult completionResult(
+    public static FullResult successResult(
             @NonNull final ByteBuffer encoded,
             final long gasRequirement,
             @NonNull final ContractCallRecordBuilder recordBuilder) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCall.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts;
 
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.completionResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.haltResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.revertResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.successResult;
@@ -75,7 +74,7 @@ public abstract class AbstractHtsCall implements HtsCall {
             @NonNull final ByteBuffer output) {
         requireNonNull(output);
         requireNonNull(recordBuilder);
-        return gasOnly(completionResult(output, gasRequirement, recordBuilder), recordBuilder.status(), isViewCall);
+        return gasOnly(successResult(output, gasRequirement, recordBuilder), recordBuilder.status(), isViewCall);
     }
 
     protected PricedResult reversionWith(@NonNull final ResponseCodeEnum status, final long gasRequirement) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferEventLoggingUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferEventLoggingUtils.java
@@ -58,8 +58,8 @@ public class TransferEventLoggingUtils {
         requireNonNull(frame);
         requireNonNull(adjusts);
         requireNonNull(accountStore);
-        AccountID senderId = null;
-        AccountID receiverId = null;
+        var senderId = AccountID.DEFAULT;
+        var receiverId = AccountID.DEFAULT;
         long amount = 0L;
         for (final var adjust : adjusts) {
             amount = Math.abs(adjust.amount());
@@ -69,7 +69,7 @@ public class TransferEventLoggingUtils {
                 senderId = adjust.accountIDOrThrow();
             }
         }
-        frame.addLog(builderFor(tokenId, requireNonNull(senderId), requireNonNull(receiverId), accountStore)
+        frame.addLog(builderFor(tokenId, senderId, receiverId, accountStore)
                 .forDataItem(amount)
                 .build());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
@@ -597,6 +597,10 @@ public class TestHelpers {
         assertEquals(expected.getGasCost(), actual.getGasCost());
     }
 
+    public static org.apache.tuweni.bytes.Bytes readableRevertReason(@NonNull final ResponseCodeEnum status) {
+        return org.apache.tuweni.bytes.Bytes.wrap(status.protoName().getBytes());
+    }
+
     public static void assertSamePrecompileResult(final FullResult expected, final FullResult actual) {
         assertEquals(expected.gasRequirement(), actual.gasRequirement());
         final var expectedResult = expected.result();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
@@ -26,6 +26,7 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.A_NEW_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.asBytesResult;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.readableRevertReason;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -184,7 +185,7 @@ class ClassicTransfersCallTest extends HtsCallTestBase {
         final var result = subject.execute(frame).fullResult().result();
 
         assertEquals(MessageFrame.State.REVERT, result.getState());
-        assertEquals(tuweniEncodedRc(INVALID_RECEIVING_NODE_ACCOUNT), result.getOutput());
+        assertEquals(readableRevertReason(INVALID_RECEIVING_NODE_ACCOUNT), result.getOutput());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
@@ -39,9 +39,9 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersCall;
+import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ class Erc20TransfersCallTest extends HtsCallTestBase {
     private VerificationStrategy verificationStrategy;
 
     @Mock
-    private CryptoTransferRecordBuilder recordBuilder;
+    private ContractCallRecordBuilder recordBuilder;
 
     @Mock
     private SystemContractGasCalculator systemContractGasCalculator;
@@ -93,7 +93,7 @@ class Erc20TransfersCallTest extends HtsCallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(CryptoTransferRecordBuilder.class)))
+                        eq(ContractCallRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
 
@@ -112,7 +112,7 @@ class Erc20TransfersCallTest extends HtsCallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(CryptoTransferRecordBuilder.class)))
+                        eq(ContractCallRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
 
@@ -131,7 +131,7 @@ class Erc20TransfersCallTest extends HtsCallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(CryptoTransferRecordBuilder.class)))
+                        eq(ContractCallRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(INSUFFICIENT_ACCOUNT_BALANCE);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
@@ -35,10 +35,10 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc721TransferFromCall;
+import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ class Erc721TransferFromCallTest extends HtsCallTestBase {
     private VerificationStrategy verificationStrategy;
 
     @Mock
-    private CryptoTransferRecordBuilder recordBuilder;
+    private ContractCallRecordBuilder recordBuilder;
 
     private Erc721TransferFromCall subject;
 
@@ -71,7 +71,7 @@ class Erc721TransferFromCallTest extends HtsCallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(CryptoTransferRecordBuilder.class)))
+                        eq(ContractCallRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         given(addressIdConverter.convert(FROM_ADDRESS)).willReturn(SENDER_ID);
@@ -96,7 +96,7 @@ class Erc721TransferFromCallTest extends HtsCallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(CryptoTransferRecordBuilder.class)))
+                        eq(ContractCallRecordBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -115,6 +115,10 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return submitTime;
     }
 
+    public Optional<EnumSet<ResponseCodeEnum>> getPermissibleStatuses() {
+        return permissibleStatuses;
+    }
+
     public ResponseCodeEnum getExpectedStatus() {
         return expectedStatus.orElse(SUCCESS);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
@@ -144,6 +144,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         this.txnName = contractCall.getTxnName();
         this.gas = contractCall.getGas();
         this.expectedStatus = Optional.of(contractCall.getExpectedStatus());
+        this.permissibleStatuses = contractCall.getPermissibleStatuses();
         this.payer = contractCall.getPayer();
         this.expectedPrecheck = Optional.of(contractCall.getExpectedPrecheck());
         this.fiddler = contractCall.getFiddler();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/NetworkTypeFilterOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/NetworkTypeFilterOp.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops;
+
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.suites.TargetNetworkType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/**
+ * A {@link UtilOp} that runs a {@link HapiSpecOperation} if the {@link HapiSpec} is configured to run on a
+ * {@link TargetNetworkType} that is contained in the {@link Set} of {@link TargetNetworkType} provided to the
+ * constructor.
+ */
+public class NetworkTypeFilterOp extends UtilOp {
+    private final Set<TargetNetworkType> allowedNetworkTypes;
+    private final HapiSpecOperation[] ops;
+
+    public NetworkTypeFilterOp(
+            @NonNull final Set<TargetNetworkType> allowedNetworkTypes, @NonNull final HapiSpecOperation[] ops) {
+        this.allowedNetworkTypes = requireNonNull(allowedNetworkTypes);
+        this.ops = requireNonNull(ops);
+    }
+
+    @Override
+    protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
+        requireNonNull(spec);
+        if (allowedNetworkTypes.contains(spec.targetNetworkType())) {
+            allRunFor(spec, ops);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "NetworkTypeFilterOp{targets=" + allowedNetworkTypes + "}";
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -51,6 +51,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.FEE_SCHEDULE;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.TargetNetworkType.HAPI_TEST_NETWORK;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.traceability.TraceabilitySuite.SIDECARS_PROP;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
@@ -167,6 +168,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -237,6 +239,14 @@ public class UtilVerbs {
     public static <T> RecordSystemProperty<T> recordSystemProperty(
             String property, Function<String, T> converter, Consumer<T> historian) {
         return new RecordSystemProperty<>(property, converter, historian);
+    }
+
+    public static NetworkTypeFilterOp ifHapiTest(@NonNull final HapiSpecOperation... ops) {
+        return new NetworkTypeFilterOp(EnumSet.of(HAPI_TEST_NETWORK), ops);
+    }
+
+    public static NetworkTypeFilterOp ifNotHapiTest(@NonNull final HapiSpecOperation... ops) {
+        return new NetworkTypeFilterOp(EnumSet.complementOf(EnumSet.of(HAPI_TEST_NETWORK)), ops);
     }
 
     public static SourcedOp sourcing(Supplier<HapiSpecOperation> source) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
@@ -44,6 +44,8 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.ifHapiTest;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.ifNotHapiTest;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
@@ -158,6 +160,7 @@ public class LazyCreateThroughPrecompileSuite extends HapiSuite {
                 autoCreationFailsWithMirrorAddress());
     }
 
+    @HapiTest
     HapiSpec resourceLimitExceededRevertsAllRecords() {
         final var n = 4; // preceding child record limit is 3
         final var nft = "nft";
@@ -196,16 +199,27 @@ public class LazyCreateThroughPrecompileSuite extends HapiSuite {
                         .via(creationAttempt)
                         .gas(GAS_TO_OFFER)
                         .alsoSigningWithFullPrefix(CIVILIAN)
-                        .hasKnownStatus(MAX_CHILD_RECORDS_EXCEEDED)))
+                        .hasKnownStatusFrom(MAX_CHILD_RECORDS_EXCEEDED, CONTRACT_REVERT_EXECUTED)))
                 .then(
-                        emptyChildRecordsCheck(creationAttempt, MAX_CHILD_RECORDS_EXCEEDED),
-                        inParallel(IntStream.range(0, n)
-                                .mapToObj(i -> sourcing(() -> getLiteralAliasAccountInfo(hex(Bytes.fromHexString(
-                                                        nonMirrorAddrWith(civilianId.get() + 3_050_000 + n)
-                                                                .toString())
-                                                .toArray()))
-                                        .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID)))
-                                .toArray(HapiSpecOperation[]::new)));
+                        // mono-service did not do an "orderly shutdown" of the EVM transaction when it hit
+                        // a resource limit exception like MAX_CHILD_RECORDS_EXCEEDED, instead throwing an
+                        // exception to the top-level HAPI transaction and eradicating traceability exports
+                        // in the process; we don't want to replicate that behavior in mod-service, hence
+                        // the ifHapiTest() / ifNotHapiTest() split below
+                        ifHapiTest(childRecordsCheck(
+                                creationAttempt,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(MAX_CHILD_RECORDS_EXCEEDED))),
+                        ifNotHapiTest(
+                                emptyChildRecordsCheck(creationAttempt, MAX_CHILD_RECORDS_EXCEEDED),
+                                inParallel(IntStream.range(0, n)
+                                        .mapToObj(i -> sourcing(() -> getLiteralAliasAccountInfo(
+                                                        hex(Bytes.fromHexString(nonMirrorAddrWith(
+                                                                                civilianId.get() + 3_050_000 + n)
+                                                                        .toString())
+                                                                .toArray()))
+                                                .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID)))
+                                        .toArray(HapiSpecOperation[]::new))));
     }
 
     @HapiTest
@@ -318,7 +332,8 @@ public class LazyCreateThroughPrecompileSuite extends HapiSuite {
     }
 
     // Expected INSUFFICIENT_GAS but was REVERTED_SUCCESS
-    private HapiSpec erc20TransferFromLazyCreate() {
+    @HapiTest
+    public HapiSpec erc20TransferFromLazyCreate() {
         return defaultHapiSpec("erc20TransferFromLazyCreate")
                 .given(
                         newKeyNamed(MULTI_KEY),


### PR DESCRIPTION
**Description**:
 - Closes #10424 by returning the `RecordBuilder` from an ERC transfer dispatch to the `MessageCallProcessor` so it can be updated with a status of `INSUFFICIENT_GAS`.
 - Closes #10431 by adding `ifHapiTest()` and `ifNotHapiTest()` spec operations to target the different behavior mod-service will exhibit in the edge case that insufficient child records are available to handle a contract operation.
    * Instead of throwing an exception to the top-level HAPI transaction, mod-service preserves a "clean shutdown" of the EVM transaction w/ traceability information.
 - _Misc_: 
    * Extracts an `inProgressBody()` method in `SingleTransactionRecordBuilderImpl` to improve readability and possible reuse.
    * Deletes the unused `execute()` overload in `Erc721TransferFromCall`.