### PR TITLE
chore: Drop upgrade test support for Ubuntu 18.04

### DIFF
--- a/.github/workflows/node-flow-fsts-daily-interval-01.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-01.yaml
@@ -39,35 +39,14 @@ concurrency:
   group: ${{ github.event.inputs.concurrency-group || format('{0}-{1}-flow-jrs-daily-interval-groups', github.ref_name, github.sha) }}
 
 # Panel Definition & Timings:
-#   "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-Ubuntu1804-4N-2C.json"    ----         90m
 #   "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-Rhel7-4N-2C.json"         ----         90m
 #   "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-Rhel8-4N-2C.json"         ----         90m
 #   "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-CentOS7-4N-2C.json"       ----         90m
 #   "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-4N-2C.json"               ----         90m
 #   "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-Ubuntu2204-4N-2C.json"    ----         90m
-#   TOTAL RUN TIME:             540 minutes, 9 hours
+#   TOTAL RUN TIME:             450 minutes, 7.5 hours
 
 jobs:
-  crypto-update-ubuntu1804-4n-2c:
-    name: Crypto-Update-Ubuntu1804-4N-2C
-    uses: ./.github/workflows/zxc-jrs-regression.yaml
-    with:
-      ref: ${{ github.event.inputs.ref }}
-      branch-name: ${{ github.event.inputs.branch-name }}
-      hedera-tests-enabled: true
-      use-branch-for-slack-channel: true
-      panel-config: "configs/services/suites/daily/GCP-Daily-Services-Crypto-Update-Ubuntu1804-4N-2C.json"
-    secrets:
-      access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
-      jrs-ssh-user-name: ${{ secrets.PLATFORM_JRS_SSH_USER_NAME }}
-      jrs-ssh-key-file: ${{ secrets.PLATFORM_JRS_SSH_KEY_FILE }}
-      gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
-      gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}
-      slack-api-token: ${{ secrets.PLATFORM_SLACK_API_TOKEN }}
-      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-    if: ${{ !cancelled() && always() }}
-
 
   crypto-update-rhel7-4n-2c:
     name: Crypto-Update-Rhel7-4N-2C

--- a/.github/workflows/node-flow-fsts-daily-regression.yaml
+++ b/.github/workflows/node-flow-fsts-daily-regression.yaml
@@ -56,24 +56,24 @@ jobs:
     secrets:
       access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
 
-#  interval-03:
-#    name: Interval 3
-#    uses: ./.github/workflows/platform-zxc-launch-jrs-workflow.yaml
-#    needs:
-#      - interval-02
-#    with:
-#      ref: ${{ github.event.inputs.ref || github.sha }}
-#      branch-name: ${{ github.event.inputs.branch-name || github.ref_name }}
-#      workflow-file: node-flow-fsts-daily-interval-03.yaml
-#      concurrency-group: ${{ github.event.inputs.ref || github.sha }}-node-flow-fsts-daily-group-03
-#    secrets:
-#      access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+  interval-03:
+    name: Interval 3
+    uses: ./.github/workflows/platform-zxc-launch-jrs-workflow.yaml
+    needs:
+      - interval-02
+    with:
+      ref: ${{ github.event.inputs.ref || github.sha }}
+      branch-name: ${{ github.event.inputs.branch-name || github.ref_name }}
+      workflow-file: node-flow-fsts-daily-interval-03.yaml
+      concurrency-group: ${{ github.event.inputs.ref || github.sha }}-node-flow-fsts-daily-group-03
+    secrets:
+      access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
 
   interval-04:
     name: Interval 4
     uses: ./.github/workflows/platform-zxc-launch-jrs-workflow.yaml
     needs:
-      - interval-02
+      - interval-03
     with:
       ref: ${{ github.event.inputs.ref || github.sha }}
       branch-name: ${{ github.event.inputs.branch-name || github.ref_name }}


### PR DESCRIPTION
**Description**:

Also reenable previously failed upgrade tests after NMT fix

**Related issue(s)**:
