### PR TITLE
fix: Fix regression tests failed due to HapiGetAccountInfo

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractInfo.java
@@ -23,6 +23,7 @@ import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.assertExpectedRels;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.assertNoUnexpectedRels;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asContractId;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -149,7 +150,8 @@ public class HapiGetContractInfo extends HapiQueryOp<HapiGetContractInfo> {
                 || expectations.isPresent()
                 || registryEntry.isPresent()) {
             final var detailsLookup = QueryVerbs.getAccountDetails(
-                    "0.0." + actualInfo.getContractID().getContractNum());
+                            "0.0." + actualInfo.getContractID().getContractNum())
+                    .payingWith(GENESIS);
             CustomSpecAssert.allRunFor(spec, detailsLookup);
             final var response = detailsLookup.getResponse();
             var actualTokenRels =

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -19,6 +19,7 @@ package com.hedera.services.bdd.spec.queries.crypto;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTokenId;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -233,7 +234,8 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
         // we are using getAccountDetails query to get token balances.
         if (!expectedTokenBalances.isEmpty() || !tokenBalanceObservers.isEmpty()) {
             final var detailsLookup = QueryVerbs.getAccountDetails(
-                    "0.0." + balanceResponse.getAccountID().getAccountNum());
+                            "0.0." + balanceResponse.getAccountID().getAccountNum())
+                    .payingWith(GENESIS);
             CustomSpecAssert.allRunFor(spec, detailsLookup);
             final var response = detailsLookup.getResponse();
             Map<TokenID, Pair<Long, Integer>> actualTokenBalances =

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -19,6 +19,7 @@ package com.hedera.services.bdd.spec.queries.crypto;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.rethrowSummaryError;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -239,7 +240,8 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
                 || expectations.isPresent()
                 || registryEntry.isPresent()) {
             final var detailsLookup = QueryVerbs.getAccountDetails(
-                    "0.0." + actualInfo.getAccountID().getAccountNum());
+                            "0.0." + actualInfo.getAccountID().getAccountNum())
+                    .payingWith(GENESIS);
             CustomSpecAssert.allRunFor(spec, detailsLookup);
             final var response = detailsLookup.getResponse();
             var actualTokenRels =

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -178,13 +178,14 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest {
                                             continue;
                                         }
                                         var op = getAccountBalance(HapiPropertySource.asAccountString(acctID))
+                                                .payingWith(GENESIS)
                                                 .hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
                                                 .persists(true)
                                                 .noLogging();
                                         ops.add(op);
                                         lastGoodAcct = acctName;
                                     }
-                                    ops.add(getAccountInfo(lastGoodAcct).fee(ONE_HBAR));
+                                    ops.add(getAccountInfo(lastGoodAcct).payingWith(GENESIS).fee(ONE_HBAR));
                                     allRunFor(spec, ops);
                                     acctProcessed += batchSize;
                                 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -185,7 +185,9 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest {
                                         ops.add(op);
                                         lastGoodAcct = acctName;
                                     }
-                                    ops.add(getAccountInfo(lastGoodAcct).payingWith(GENESIS).fee(ONE_HBAR));
+                                    ops.add(getAccountInfo(lastGoodAcct)
+                                            .payingWith(GENESIS)
+                                            .fee(ONE_HBAR));
                                     allRunFor(spec, ops);
                                     acctProcessed += batchSize;
                                 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/MixedSmartContractOpsLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/MixedSmartContractOpsLoadTest.java
@@ -121,9 +121,9 @@ public class MixedSmartContractOpsLoadTest extends LoadTest {
                         contractCreate(PAYABLE_CONTRACT).adminKey(THRESHOLD),
 
                         /* get contract info on all contracts created */
-                        getContractInfo(LOOKUP_CONTRACT).hasExpectedInfo().logged(),
-                        getContractInfo(PAYABLE_CONTRACT).hasExpectedInfo().logged(),
-                        getContractInfo(UPDATABLE_CONTRACT).hasExpectedInfo().logged())
+                        getContractInfo(LOOKUP_CONTRACT).payingWith(GENESIS).hasExpectedInfo().logged(),
+                        getContractInfo(PAYABLE_CONTRACT).payingWith(GENESIS).hasExpectedInfo().logged(),
+                        getContractInfo(UPDATABLE_CONTRACT).payingWith(GENESIS).hasExpectedInfo().logged())
                 .then(defaultLoadTest(mixedOpsBurst, settings));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/MixedSmartContractOpsLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/MixedSmartContractOpsLoadTest.java
@@ -121,9 +121,18 @@ public class MixedSmartContractOpsLoadTest extends LoadTest {
                         contractCreate(PAYABLE_CONTRACT).adminKey(THRESHOLD),
 
                         /* get contract info on all contracts created */
-                        getContractInfo(LOOKUP_CONTRACT).payingWith(GENESIS).hasExpectedInfo().logged(),
-                        getContractInfo(PAYABLE_CONTRACT).payingWith(GENESIS).hasExpectedInfo().logged(),
-                        getContractInfo(UPDATABLE_CONTRACT).payingWith(GENESIS).hasExpectedInfo().logged())
+                        getContractInfo(LOOKUP_CONTRACT)
+                                .payingWith(GENESIS)
+                                .hasExpectedInfo()
+                                .logged(),
+                        getContractInfo(PAYABLE_CONTRACT)
+                                .payingWith(GENESIS)
+                                .hasExpectedInfo()
+                                .logged(),
+                        getContractInfo(UPDATABLE_CONTRACT)
+                                .payingWith(GENESIS)
+                                .hasExpectedInfo()
+                                .logged())
                 .then(defaultLoadTest(mixedOpsBurst, settings));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithStakedAccounts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithStakedAccounts.java
@@ -129,7 +129,7 @@ public class CryptoTransferLoadTestWithStakedAccounts extends LoadTest {
                         }))
                 .then(
                         defaultLoadTest(transferBurst, settings),
-                        getAccountBalance("sender").logged());
+                        getAccountBalance("sender").payingWith(GENESIS).logged());
     }
 
     @Override


### PR DESCRIPTION
Fixes all places `getAccountDetails` is used to pay with GENESIS

Fixes #10253 
Fixes #10255 