### PR TITLE
fix: windows runner failure when verifying the artifact determinism

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -227,3 +227,15 @@ jobs:
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       snyk-token: ${{ secrets.SNYK_TOKEN }}
+
+  artifact-determinism:
+    name: Artifact Determinism
+    uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    with:
+      ref: ${{ github.event.inputs.ref || '' }}
+      java-distribution: temurin
+      java-version: 17.0.9
+    secrets:
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}

--- a/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
+++ b/.github/workflows/support/scripts/generate-gradle-artifact-baseline.sh
@@ -114,13 +114,13 @@ end_group
 
 start_group "Generating Library Hashes (${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}/*.jar)"
   pushd "${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}" >/dev/null 2>&1 || fail "PUSHD ERROR (Exit Code: ${?})" "${?}"
-  ${SHA256SUM} -- *.jar | sort -k 2 | tee -a "${TEMP_DIR}"/libraries.sha256
+  ${SHA256SUM} -b -- *.jar | sort -k 2 | tee -a "${TEMP_DIR}"/libraries.sha256
   popd >/dev/null 2>&1 || fail "POPD ERROR (Exit Code: ${?})" "${?}"
 end_group
 
 start_group "Generating Application Hashes (${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}/*.jar)"
   pushd "${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}" >/dev/null 2>&1 || fail "PUSHD ERROR (Exit Code: ${?})" "${?}"
-  ${SHA256SUM} -- *.jar | sort -k 2 | tee -a "${TEMP_DIR}"/applications.sha256
+  ${SHA256SUM} -b -- *.jar | sort -k 2 | tee -a "${TEMP_DIR}"/applications.sha256
   popd >/dev/null 2>&1 || fail "POPD ERROR (Exit Code: ${?})" "${?}"
 end_group
 

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -211,8 +211,8 @@ jobs:
       - name: Fix Windows Manifests
         if: ${{ runner.os == 'Windows' && steps.regen-manifest.conclusion == 'success' && !cancelled() && !failure() }}
         run: |
-          cat "${{ steps.regen-manifest.outputs.libraries }}" | tr '*' ' ' > >(tee "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null)
-          cat "${{ steps.regen-manifest.outputs.applications }}" | tr '*' ' ' > >(tee "${{ steps.regen-manifest.outputs.applications }}" >/dev/null)
+          cat "${{ steps.regen-manifest.outputs.libraries }}" | tr '*' ' ' | tee "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null
+          cat "${{ steps.regen-manifest.outputs.applications }}" | tr '*' ' ' | tee "${{ steps.regen-manifest.outputs.applications }}" >/dev/null
 
       - name: Validate Libraries
         working-directory: ${{ github.workspace }}/hedera-node/data/lib

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -208,12 +208,6 @@ jobs:
           MANIFEST_PATH: ${{ env.GRADLE_MANIFEST_PATH }}/regenerated
         run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
 
-      - name: Fix Windows Manifests
-        if: ${{ runner.os == 'Windows' && steps.regen-manifest.conclusion == 'success' && !cancelled() && !failure() }}
-        run: |
-          cat "${{ steps.regen-manifest.outputs.libraries }}" | tr '*' ' ' | tee "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null
-          cat "${{ steps.regen-manifest.outputs.applications }}" | tr '*' ' ' | tee "${{ steps.regen-manifest.outputs.applications }}" >/dev/null
-
       - name: Validate Libraries
         working-directory: ${{ github.workspace }}/hedera-node/data/lib
         run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -208,6 +208,12 @@ jobs:
           MANIFEST_PATH: ${{ env.GRADLE_MANIFEST_PATH }}/regenerated
         run: ${{ env.GRADLE_MANIFEST_GENERATOR }}
 
+      - name: Fix Windows Manifests
+        if: ${{ runner.os == 'Windows' && steps.regen-manifest.conclusion == 'success' && !cancelled() && !failure() }}
+        run: |
+          cat "${{ steps.regen-manifest.outputs.libraries }}" | tr '*' ' ' > >(tee "${{ steps.regen-manifest.outputs.libraries }}" >/dev/null)
+          cat "${{ steps.regen-manifest.outputs.applications }}" | tr '*' ' ' > >(tee "${{ steps.regen-manifest.outputs.applications }}" >/dev/null)
+
       - name: Validate Libraries
         working-directory: ${{ github.workspace }}/hedera-node/data/lib
         run: sha256sum -c "${GRADLE_MANIFEST_PATH}/libraries.sha256"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Fixes an issue with the windows runners generating `sha256sum` output containing a leading asterisk `*` mark. 
- Adds the determinism test as a pull request check.

### Related Issues

- Closes #10454 