### PR TITLE
fix: Add check for empty inline initcode for contract creation

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -25,6 +25,7 @@ import static com.hedera.node.app.service.mono.state.EntityCreator.NO_CUSTOM_FEE
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.contractIdFromEvmAddress;
 import static com.hederahashgraph.api.proto.java.ContractCreateTransactionBody.InitcodeSourceCase.INITCODE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_BYTECODE_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
@@ -349,6 +350,7 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
 
     Bytes prepareCodeWithConstructorArguments(final ContractCreateTransactionBody op) {
         if (op.getInitcodeSourceCase() == INITCODE) {
+            validateFalse(op.getInitcode().isEmpty(), CONTRACT_BYTECODE_EMPTY);
             return Bytes.wrap(ByteStringUtils.unwrapUnsafelyIfPossible(op.getInitcode()));
         } else {
             final var bytecodeSrc = op.getFileID();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
@@ -22,6 +22,7 @@ import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty
 import static com.hedera.node.app.service.mono.sigs.utils.ImmutableKeyUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.create1ContractAddress;
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ContractCreateTransactionBody.InitcodeSourceCase.INITCODE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
@@ -1257,6 +1258,17 @@ class ContractCreateTransitionLogicTest {
                 InvalidTransactionException.class, () -> subject.prepareCodeWithConstructorArguments(transactionBody));
         // then:
         assertEquals("ERROR_DECODING_BYTESTRING", exception.getMessage());
+    }
+
+    @Test
+    void throwsErrorOnEmptyInitcode() {
+        given(transactionBody.getInitcodeSourceCase()).willReturn(INITCODE);
+        given(transactionBody.getInitcode()).willReturn(ByteString.EMPTY);
+        // when:
+        Exception exception = assertThrows(
+                InvalidTransactionException.class, () -> subject.prepareCodeWithConstructorArguments(transactionBody));
+        // then:
+        assertEquals("CONTRACT_BYTECODE_EMPTY", exception.getMessage());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.contract.impl.infra;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_BYTECODE_EMPTY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_DELETED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
@@ -295,6 +296,7 @@ public class HevmTransactionFactory {
 
     private Bytes initcodeFor(@NonNull final ContractCreateTransactionBody body) {
         if (body.hasInitcode()) {
+            validateTrue(body.initcode().length() > 0, CONTRACT_BYTECODE_EMPTY);
             return body.initcode();
         } else {
             final var initcode = fileStore.getFileLeaf(body.fileIDOrElse(FileID.DEFAULT));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.contract.impl.test.infra;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BAD_ENCODING;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_BYTECODE_EMPTY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
@@ -360,6 +361,17 @@ class HevmTransactionFactoryTest {
         assertCreateFailsWith(CONTRACT_FILE_EMPTY, b -> b.memo(SOME_MEMO)
                 .adminKey(AN_ED25519_KEY)
                 .fileID(INITCODE_FILE_ID)
+                .autoRenewAccountId(NON_SYSTEM_ACCOUNT_ID)
+                .gas(DEFAULT_CONTRACTS_CONFIG.maxGasPerSec())
+                .proxyAccountID(AccountID.DEFAULT)
+                .autoRenewPeriod(SOME_DURATION));
+    }
+
+    @Test
+    void fromHapiCreationValidatesInlineInitcodeNotEmpty() {
+        assertCreateFailsWith(CONTRACT_BYTECODE_EMPTY, b -> b.memo(SOME_MEMO)
+                .adminKey(AN_ED25519_KEY)
+                .initcode(Bytes.EMPTY)
                 .autoRenewAccountId(NON_SYSTEM_ACCOUNT_ID)
                 .gas(DEFAULT_CONTRACTS_CONFIG.maxGasPerSec())
                 .proxyAccountID(AccountID.DEFAULT)


### PR DESCRIPTION
**Description**:
Cherry pick #10449 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
