### PR TITLE
fix: Rotate address books at genesis startup

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
@@ -136,7 +136,9 @@ public class AddressBookInitializer {
 
         final InitializedAddressBooks addressBooks = initialize();
         currentAddressBook = addressBooks.currentAddressBook();
-        if (!useConfigAddressBook) {
+        if (!useConfigAddressBook && !initialState.isGenesisState()) {
+            // validate the new address book against the previous address book when
+            // not forcing the use of config.txt and not starting from genesis
             AddressBookValidator.validateNewAddressBook(stateAddressBook, currentAddressBook);
         }
         previousAddressBook = addressBooks.previousAddressBook();
@@ -193,14 +195,11 @@ public class AddressBookInitializer {
             candidateAddressBook = configAddressBook;
             previousAddressBook = stateAddressBook;
         } else if (initialState.isGenesisState()) {
-            // Starting from Genesis, config and state address book should be the same.
-            if (!Objects.equals(configAddressBook, initialState.getAddressBook())) {
-                throw new IllegalStateException("Config and State Address Books do not match on Genesis Start.");
-            }
+            // Starting from Genesis, adopt config address book and move state address book to previous address book
             logger.info(STARTUP.getMarker(), "Starting from genesis: using the config address book.");
             candidateAddressBook = configAddressBook;
             checkCandidateAddressBookValidity(candidateAddressBook);
-            previousAddressBook = null;
+            previousAddressBook = initialState.getAddressBook();
         } else if (!softwareUpgrade) {
             // Loaded State From Disk, Non-Genesis, No Software Upgrade
             logger.info(STARTUP.getMarker(), "Using the loaded state's address book and weight values.");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -23,7 +23,6 @@ import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_AD
 import static com.swirlds.platform.state.address.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -95,8 +94,9 @@ class AddressBookInitializerTest {
     @DisplayName("Genesis. Config.txt Initializes Address Book.")
     void noStateLoadedFromDisk() throws IOException {
         clearTestDirectory();
+        final AddressBook stateAddressBook = getRandomAddressBook();
         final AddressBook configAddressBook = getRandomAddressBook();
-        final SignedState signedState = getMockSignedState(10, configAddressBook, true);
+        final SignedState signedState = getMockSignedState(10, stateAddressBook, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 new NodeId(0),
                 getMockSoftwareVersion(2),
@@ -110,7 +110,10 @@ class AddressBookInitializerTest {
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the expected address book.");
-        assertNull(initializer.getPreviousAddressBook(), "The previous address book should be null.");
+        assertEquals(
+                stateAddressBook,
+                initializer.getPreviousAddressBook(),
+                "The previous address book must equal the state address book.");
         assertAddressBookFileContent(
                 initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
     }
@@ -119,8 +122,9 @@ class AddressBookInitializerTest {
     @DisplayName("No state loaded from disk. Genesis State set 0 weight.")
     void noStateLoadedFromDiskGenesisStateSetZeroWeight() throws IOException {
         clearTestDirectory();
+        final AddressBook stateAddressBook = getRandomAddressBook();
         final AddressBook configAddressBook = getRandomAddressBook();
-        final SignedState signedState = getMockSignedState(10, configAddressBook, true);
+        final SignedState signedState = getMockSignedState(10, stateAddressBook, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 new NodeId(0),
                 getMockSoftwareVersion(2),
@@ -134,7 +138,10 @@ class AddressBookInitializerTest {
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the config address book.");
-        assertNull(initializer.getPreviousAddressBook(), "The previous address book should be null.");
+        assertEquals(
+                stateAddressBook,
+                initializer.getPreviousAddressBook(),
+                "The previous address book must equal the state address book.");
         assertAddressBookFileContent(
                 initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
     }
@@ -143,8 +150,9 @@ class AddressBookInitializerTest {
     @DisplayName("No state loaded from disk. Genesis State modifies address book entries.")
     void noStateLoadedFromDiskGenesisStateChangedAddressBook() throws IOException {
         clearTestDirectory();
+        final AddressBook stateAddressBook = getRandomAddressBook();
         final AddressBook configAddressBook = getRandomAddressBook();
-        final SignedState signedState = getMockSignedState(7, configAddressBook, true);
+        final SignedState signedState = getMockSignedState(7, stateAddressBook, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 new NodeId(0),
                 getMockSoftwareVersion(2),
@@ -158,7 +166,10 @@ class AddressBookInitializerTest {
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the config address book.");
-        assertNull(initializer.getPreviousAddressBook(), "The previous address book should be null.");
+        assertEquals(
+                stateAddressBook,
+                initializer.getPreviousAddressBook(),
+                "The previous address book must equal the state address book.");
         assertAddressBookFileContent(
                 initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
     }


### PR DESCRIPTION
When starting a node from a state that has been turned into a genesis state, the AddressBookInitializer would complain that the address book in the state did not match the config.txt address book.  The code was written prior to the addition of previous address book in the state.  The new implementation rotates the address books.   The "current" address book in the loaded state becomes the "previous" address book in the new state.  The config.txt address book becomes the "current" address book in the new state. 

Fixes #10448
