### PR TITLE
ci: change cron job to every 16 hours

### DIFF
--- a/.github/workflows/flow-node-performance-tests.yaml
+++ b/.github/workflows/flow-node-performance-tests.yaml
@@ -17,7 +17,7 @@
 name: "Node: Performance Tests"
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 */16 * * *'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
**Description**:

12 hours is  too tight for current workflow