### PR TITLE
fix: Correct payer account on `Issue1744Spec`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1744Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1744Suite.java
@@ -23,6 +23,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
@@ -47,11 +48,14 @@ public class Issue1744Suite extends HapiSuite {
         return List.of(keepsRecordOfPayerIBE());
     }
 
-    //    @HapiTest This will pass after NetworkGetTransactionRecordHandler fee is implemented
+    @HapiTest
     public HapiSpec keepsRecordOfPayerIBE() {
         return defaultHapiSpec("KeepsRecordOfPayerIBE")
                 .given(
-                        cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)).via("referenceTxn"),
+                        cryptoCreate(CIVILIAN_PAYER),
+                        cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L))
+                                .payingWith(CIVILIAN_PAYER)
+                                .via("referenceTxn"),
                         UtilVerbs.withOpContext((spec, ctxLog) -> {
                             HapiGetTxnRecord subOp = getTxnRecord("referenceTxn");
                             allRunFor(spec, subOp);


### PR DESCRIPTION
**Description**:
This PR adds a civilian payer account for the only test in the `Issue1744Spec`. This is needed, because some part of the test depends on the fees payed by the first crypto transfer. However previously it depended on account 0.0.2 to be charged, which can't happen

**Related issue(s)**:

Fixes #8765 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
