### PR TITLE
fix: Override properties for `Issue2098Spec`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
@@ -33,7 +33,6 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -68,7 +67,8 @@ public class Issue2098Spec extends HapiSuite {
                 .then(
                         cryptoTransfer(tinyBarsFromTo(CIVILIAN, FUNDING, 1L))
                                 .payingWith(CIVILIAN)
-                                .hasPrecheckFrom(NOT_SUPPORTED, OK).hasKnownStatus(UNAUTHORIZED),
+                                .hasPrecheckFrom(NOT_SUPPORTED, OK)
+                                .hasKnownStatus(UNAUTHORIZED),
                         fileUpdate(API_PERMISSIONS)
                                 .payingWith(ADDRESS_BOOK_CONTROL)
                                 .overridingProps(Map.of(CRYPTO_TRANSFER, "0-*")),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
@@ -24,7 +24,10 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -55,28 +58,30 @@ public class Issue2098Spec extends HapiSuite {
         });
     }
 
+    @HapiTest
     final HapiSpec txnApiPermissionsChangeImmediately() {
         return defaultHapiSpec("TxnApiPermissionsChangeImmediately")
                 .given(cryptoCreate(CIVILIAN))
                 .when(fileUpdate(API_PERMISSIONS)
                         .payingWith(ADDRESS_BOOK_CONTROL)
-                        .erasingProps(Set.of(CRYPTO_TRANSFER)))
+                        .overridingProps(Map.of(CRYPTO_TRANSFER, "0-1")))
                 .then(
                         cryptoTransfer(tinyBarsFromTo(CIVILIAN, FUNDING, 1L))
                                 .payingWith(CIVILIAN)
-                                .hasPrecheck(NOT_SUPPORTED),
+                                .hasPrecheckFrom(NOT_SUPPORTED, OK).hasKnownStatus(UNAUTHORIZED),
                         fileUpdate(API_PERMISSIONS)
                                 .payingWith(ADDRESS_BOOK_CONTROL)
                                 .overridingProps(Map.of(CRYPTO_TRANSFER, "0-*")),
                         cryptoTransfer(tinyBarsFromTo(CIVILIAN, FUNDING, 1L)).payingWith(CIVILIAN));
     }
 
+    @HapiTest
     final HapiSpec queryApiPermissionsChangeImmediately() {
         return defaultHapiSpec("QueryApiPermissionsChangeImmediately")
                 .given(cryptoCreate(CIVILIAN), createTopic("misc"))
                 .when(fileUpdate(API_PERMISSIONS)
                         .payingWith(ADDRESS_BOOK_CONTROL)
-                        .erasingProps(Set.of(GET_TOPIC_INFO)))
+                        .overridingProps(Map.of(GET_TOPIC_INFO, "0-1")))
                 .then(
                         getTopicInfo("misc").payingWith(CIVILIAN).hasAnswerOnlyPrecheck(NOT_SUPPORTED),
                         fileUpdate(API_PERMISSIONS)
@@ -85,12 +90,13 @@ public class Issue2098Spec extends HapiSuite {
                         getTopicInfo("misc").payingWith(CIVILIAN));
     }
 
+    @HapiTest
     final HapiSpec adminsCanQueryNoMatterPermissions() {
         return defaultHapiSpec("AdminsCanQueryNoMatterPermissions")
                 .given(cryptoCreate(CIVILIAN), createTopic("misc"))
                 .when(fileUpdate(API_PERMISSIONS)
                         .payingWith(ADDRESS_BOOK_CONTROL)
-                        .erasingProps(Set.of(GET_TOPIC_INFO)))
+                        .overridingProps(Map.of(GET_TOPIC_INFO, "0-1")))
                 .then(
                         getTopicInfo("misc").payingWith(CIVILIAN).hasAnswerOnlyPrecheck(NOT_SUPPORTED),
                         getTopicInfo("misc"),
@@ -99,16 +105,18 @@ public class Issue2098Spec extends HapiSuite {
                                 .overridingProps(Map.of(GET_TOPIC_INFO, "0-*")));
     }
 
+    @HapiTest
     final HapiSpec adminsCanTransactNoMatterPermissions() {
         return defaultHapiSpec("AdminsCanTransactNoMatterPermissions")
                 .given(cryptoCreate(CIVILIAN))
                 .when(fileUpdate(API_PERMISSIONS)
                         .payingWith(ADDRESS_BOOK_CONTROL)
-                        .erasingProps(Set.of(CRYPTO_TRANSFER)))
+                        .overridingProps(Map.of(CRYPTO_TRANSFER, "0-1")))
                 .then(
                         cryptoTransfer(tinyBarsFromTo(CIVILIAN, FUNDING, 1L))
                                 .payingWith(CIVILIAN)
-                                .hasPrecheck(NOT_SUPPORTED),
+                                .hasPrecheckFrom(NOT_SUPPORTED, OK)
+                                .hasKnownStatus(UNAUTHORIZED),
                         cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
                         fileUpdate(API_PERMISSIONS)
                                 .payingWith(ADDRESS_BOOK_CONTROL)


### PR DESCRIPTION
**Description**:
This PR changes the tests by instead of erasing the property it sets them to 0-1. Which is essentially the same thing, as far as the testing is concern.

**Related issue(s)**:

Fixes #8769 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
