### PR TITLE
chore: execute the build workflow before running other workflows to improve cache utilization

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -42,9 +42,24 @@ jobs:
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
+  dependency-check:
+    name: Dependency (Module Info)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
+    with:
+      custom-job-label: "Check"
+      enable-dependency-check: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
   spotless:
     name: Spotless
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: "Check"
       enable-unit-tests: false
@@ -60,6 +75,8 @@ jobs:
   unit-tests:
     name: Unit Tests
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: true
@@ -75,6 +92,8 @@ jobs:
   eet-tests:
     name: E2E Tests
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -91,6 +110,8 @@ jobs:
   integration-tests:
     name: Integration Tests
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -107,6 +128,8 @@ jobs:
   hapi-tests-misc:
     name: HAPI Tests (Misc)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -124,6 +147,8 @@ jobs:
   hapi-tests-crypto:
     name: HAPI Tests (Crypto)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -141,6 +166,8 @@ jobs:
   hapi-tests-token:
     name: HAPI Tests (Token)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -158,6 +185,8 @@ jobs:
   hapi-tests-smart-contract:
     name: HAPI Tests (Smart Contract)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -175,6 +204,8 @@ jobs:
   hapi-tests-time-consuming:
     name: HAPI Tests (Time Consuming)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     with:
       custom-job-label: Standard
       enable-unit-tests: false
@@ -192,6 +223,8 @@ jobs:
   abbreviated-panel:
     name: JRS Panel
     uses: ./.github/workflows/zxc-jrs-regression.yaml
+    needs:
+      - build
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       custom-job-name: "Platform SDK"
@@ -214,6 +247,8 @@ jobs:
   snyk-scan:
     name: Snyk Scan
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - build
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       custom-job-label: Standard
@@ -231,6 +266,8 @@ jobs:
   artifact-determinism:
     name: Artifact Determinism
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
+    needs: 
+      - build
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       ref: ${{ github.event.inputs.ref || '' }}

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -266,7 +266,7 @@ jobs:
   artifact-determinism:
     name: Artifact Determinism
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
-    needs: 
+    needs:
       - build
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -72,7 +72,7 @@ on:
         description: "Dependency Scope Check Enabled"
         type: boolean
         required: false
-        default: true
+        default: false
       enable-snyk-scan:
         description: "Snyk Scan Enabled"
         type: boolean


### PR DESCRIPTION
## Description

This pull request changes the following:

- Changes the default value for the `enable-dependency-check` input to be disabled.
- Adds a discrete `dependency-check` job to make the reason for failure clear.
- Ensures the `Code / Compiles` job is run prior to all other PR check jobs.

### Related Issues 

- Closes #10192 