### PR TITLE
chore: Remove `concurrentEthSpecs()`

### DIFF
--- a/hedera-node/test-clients/src/itest/java/AllIntegrationTests.java
+++ b/hedera-node/test-clients/src/itest/java/AllIntegrationTests.java
@@ -65,8 +65,7 @@ class AllIntegrationTests extends DockerIntegrationTestBase {
     @Order(2)
     @TestFactory
     List<DynamicTest> concurrentSpecs() {
-        return List.of(
-                concurrentSpecsFrom(ConcurrentSuites.all()), concurrentEthSpecsFrom(ConcurrentSuites.ethereumSuites()));
+        return List.of(concurrentSpecsFrom(ConcurrentSuites.all()));
     }
 
     @Tag("integration")


### PR DESCRIPTION
**Description**:
- Disables `concurrentEthSpecs()` per https://github.com/hashgraph/hedera-services/issues/10516 but does not close it (RCA pending).