### PR TITLE
fix: Eliminate extra service registration

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/OrderedServiceMigrator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/OrderedServiceMigrator.java
@@ -77,9 +77,7 @@ public class OrderedServiceMigrator {
                 .filter(service -> EntityIdService.NAME.equals(service.service().getServiceName()))
                 .findFirst()
                 .orElseThrow();
-        final var entityIdService = new EntityIdService();
         final var entityIdRegistry = (MerkleSchemaRegistry) entityIdRegistration.registry();
-        entityIdService.registerSchemas(entityIdRegistry, currentVersion);
         entityIdRegistry.migrate(
                 state,
                 previousVersion,


### PR DESCRIPTION
There's an unnecessary round of registration happening for the `EntityIdService` in the `OrderedServiceMigrator`. Since the registration is already invoked in the `Hedera` class (along with all other services), there's no need to do so here. 

Discovered while implementing #10084 