### PR TITLE
chore: enable passing `ContractCallSuite` specs

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -225,25 +225,26 @@ public class EndOfStakingPeriodUpdater {
         final long reservedStakingRewards = stakingRewardsStore.pendingRewards();
         final long unreservedStakingRewardBalance = rewardAccountBalance - reservedStakingRewards;
         final var syntheticNodeStakeUpdateTxn = newNodeStakeUpdateBuilder(
-                        lastInstantOfPreviousPeriodFor(consensusTime),
-                        finalNodeStakes,
-                        stakingConfig,
-                        totalStakedRewardStart,
-                        perHbarRate,
-                        reservedStakingRewards,
-                        unreservedStakingRewardBalance,
-                        stakingConfig.rewardBalanceThreshold(),
-                        stakingConfig.maxStakeRewarded())
-                .memo("End of staking period calculation record");
+                lastInstantOfPreviousPeriodFor(consensusTime),
+                finalNodeStakes,
+                stakingConfig,
+                totalStakedRewardStart,
+                perHbarRate,
+                reservedStakingRewards,
+                unreservedStakingRewardBalance,
+                stakingConfig.rewardBalanceThreshold(),
+                stakingConfig.maxStakeRewarded());
         log.info("Exporting:\n{}", finalNodeStakes);
         // We don't want to fail adding the preceding child record for the node stake update that happens every
         // midnight. So, we add the preceding child record builder as unchecked, that doesn't fail with
         // MAX_CHILD_RECORDS_EXCEEDED
         final var nodeStakeUpdateBuilder =
                 context.addUncheckedPrecedingChildRecordBuilder(NodeStakeUpdateRecordBuilder.class);
-        nodeStakeUpdateBuilder.transaction(Transaction.newBuilder()
-                .body(syntheticNodeStakeUpdateTxn.build())
-                .build());
+        nodeStakeUpdateBuilder
+                .transaction(Transaction.newBuilder()
+                        .body(syntheticNodeStakeUpdateTxn.build())
+                        .build())
+                .memo("End of staking period calculation record");
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeNodeStakeUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeNodeStakeUpdateRecordBuilder.java
@@ -24,12 +24,20 @@ public class FakeNodeStakeUpdateRecordBuilder {
 
     public NodeStakeUpdateRecordBuilder create() {
         return new NodeStakeUpdateRecordBuilder() {
+            private String memo;
             private Transaction txn;
 
             @NotNull
             @Override
             public NodeStakeUpdateRecordBuilder transaction(@NotNull final Transaction txn) {
                 this.txn = txn;
+                return this;
+            }
+
+            @NotNull
+            @Override
+            public NodeStakeUpdateRecordBuilder memo(@NotNull String memo) {
+                this.memo = memo;
                 return this;
             }
         };

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateRecordBuilder.java
@@ -31,4 +31,13 @@ public interface NodeStakeUpdateRecordBuilder {
      */
     @NonNull
     NodeStakeUpdateRecordBuilder transaction(@NonNull final Transaction transaction);
+
+    /**
+     * Sets the record's memo.
+     *
+     * @param memo the memo
+     * @return the builder
+     */
+    @NonNull
+    NodeStakeUpdateRecordBuilder memo(@NonNull final String memo);
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamAccess.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamAccess.java
@@ -40,6 +40,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A singleton that provides near real-time access to the record stream files for all concurrently
@@ -47,6 +49,8 @@ import org.apache.commons.io.monitor.FileAlterationObserver;
  */
 public enum RecordStreamAccess {
     RECORD_STREAM_ACCESS;
+
+    private static final Logger LOGGER = LogManager.getLogger(RecordStreamAccess.class);
 
     private static final int MONITOR_INTERVAL_MS = 250;
 
@@ -73,6 +77,8 @@ public enum RecordStreamAccess {
                 .sum();
         if (numSubscribers == 0) {
             try {
+                LOGGER.info("Stopping record stream access monitor (locations were {})", validatingListeners.keySet());
+                validatingListeners.clear();
                 // Will throw ISE if already stopped, ignore that
                 monitor.stop();
             } catch (Exception ignore) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -257,6 +257,7 @@ public class ContractCallSuite extends HapiSuite {
                 repeatedCreate2FailsWithInterpretableActionSidecars());
     }
 
+    @HapiTest
     final HapiSpec repeatedCreate2FailsWithInterpretableActionSidecars() {
         final var contract = "Create2PrecompileUser";
         final var salt = unhex(SALT);
@@ -280,6 +281,7 @@ public class ContractCallSuite extends HapiSuite {
                 .then();
     }
 
+    @HapiTest
     final HapiSpec hollowCreationFailsCleanly() {
         final var contract = "HollowAccountCreator";
         return defaultHapiSpec("HollowCreationFailsCleanly")


### PR DESCRIPTION
**Description**:
 - Closes #10520 by enabling two passing specs
 - Stabilizes CI by:
     1. Clearing `RECORD_STREAM_ACCESS`'s map of listeners so it will reconstruct watchers as needed.
     2. Setting the end-of-staking period memo on the *record* of the synthetic `NodeStakeUpdateTransaction` so these transactions will be correctly skipped in `getTxnRecord()` child record assertions.