### PR TITLE
build: merge 'Sync' tasks that wrote into the same destination

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -141,32 +141,6 @@ tasks.jar {
     }
 }
 
-// Define build directory
-val buildDir = layout.projectDirectory.dir("./build/node")
-
-// Copy everything from hedera-node/data
-val copyNodeData =
-    tasks.register<Sync>("copyNodeData") {
-        dependsOn(copyLib)
-        dependsOn(copyApp)
-        from(layout.projectDirectory.dir("../data/keys")) { into("data/keys") }
-        from(layout.projectDirectory.dir("../data"))
-        into(buildDir)
-        exclude("config", "keys") // Exclude config directory
-        shouldRunAfter(tasks.named("copyApp"))
-        shouldRunAfter(tasks.named("copyLib"))
-    }
-
-//// Copy hedera-node/configuration/dev as hedera-node/hedera-app/build/node/data/config  }
-val copyConfig =
-    tasks.register<Copy>("copyConfig") {
-        from(layout.projectDirectory.dir("../configuration/dev")) { into("data/config") }
-        from(layout.projectDirectory.file("../config.txt"))
-        from(layout.projectDirectory.file("../log4j2.xml"))
-        into(buildDir)
-        shouldRunAfter(tasks.named("copyNodeData"))
-    }
-
 // Copy dependencies into `data/lib`
 val copyLib =
     tasks.register<Sync>("copyLib") {
@@ -183,18 +157,36 @@ val copyApp =
         shouldRunAfter(tasks.named("copyLib"))
     }
 
+// Working directory for 'run' tasks
+val nodeWorkingDir = layout.buildDirectory.dir("node")
+
+val copyNodeData =
+    tasks.register<Sync>("copyNodeDataAndConfig") {
+        into(nodeWorkingDir)
+
+        // Copy things from hedera-node/data
+        into("lib") { from(copyLib) }
+        into("apps") { from(copyApp) }
+        into("onboard") { from(layout.projectDirectory.dir("../data/onboard")) }
+        into("data/keys") { from(layout.projectDirectory.dir("../data/keys")) }
+
+        // Copy hedera-node/configuration/dev as hedera-node/hedera-app/build/node/data/config  }
+        from(layout.projectDirectory.dir("../configuration/dev")) { into("data/config") }
+        from(layout.projectDirectory.file("../config.txt"))
+        from(layout.projectDirectory.file("../log4j2.xml"))
+    }
+
 tasks.assemble {
     dependsOn(copyLib)
     dependsOn(copyApp)
     dependsOn(copyNodeData)
-    dependsOn(copyConfig)
 }
 
 // Create the "run" task for running a Hedera consensus node
 tasks.register<JavaExec>("run") {
     group = "application"
     dependsOn(tasks.assemble)
-    workingDir = layout.projectDirectory.dir("./build/node").asFile
+    workingDir = nodeWorkingDir.get().asFile
     jvmArgs = listOf("-cp", "lib/*")
     mainClass.set("com.swirlds.platform.Browser")
 }
@@ -202,7 +194,7 @@ tasks.register<JavaExec>("run") {
 tasks.register<JavaExec>("modrun") {
     group = "application"
     dependsOn(tasks.assemble)
-    workingDir = layout.projectDirectory.dir("./build/node").asFile
+    workingDir = nodeWorkingDir.get().asFile
     jvmArgs = listOf("-cp", "lib/*:apps/*", "-Dhedera.workflows.enabled=true")
     mainClass.set("com.hedera.node.app.ServicesMain")
 }

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -165,15 +165,16 @@ val copyNodeData =
         into(nodeWorkingDir)
 
         // Copy things from hedera-node/data
-        into("lib") { from(copyLib) }
-        into("apps") { from(copyApp) }
-        into("onboard") { from(layout.projectDirectory.dir("../data/onboard")) }
+        into("data/lib") { from(copyLib) }
+        into("data/apps") { from(copyApp) }
+        into("data/onboard") { from(layout.projectDirectory.dir("../data/onboard")) }
         into("data/keys") { from(layout.projectDirectory.dir("../data/keys")) }
 
         // Copy hedera-node/configuration/dev as hedera-node/hedera-app/build/node/data/config  }
         from(layout.projectDirectory.dir("../configuration/dev")) { into("data/config") }
         from(layout.projectDirectory.file("../config.txt"))
         from(layout.projectDirectory.file("../log4j2.xml"))
+        from(layout.projectDirectory.file("../configuration/dev/settings.txt"))
     }
 
 tasks.assemble {
@@ -187,7 +188,7 @@ tasks.register<JavaExec>("run") {
     group = "application"
     dependsOn(tasks.assemble)
     workingDir = nodeWorkingDir.get().asFile
-    jvmArgs = listOf("-cp", "lib/*")
+    jvmArgs = listOf("-cp", "data/lib/*")
     mainClass.set("com.swirlds.platform.Browser")
 }
 
@@ -195,7 +196,7 @@ tasks.register<JavaExec>("modrun") {
     group = "application"
     dependsOn(tasks.assemble)
     workingDir = nodeWorkingDir.get().asFile
-    jvmArgs = listOf("-cp", "lib/*:apps/*", "-Dhedera.workflows.enabled=true")
+    jvmArgs = listOf("-cp", "data/lib/*:data/apps/*", "-Dhedera.workflows.enabled=true")
     mainClass.set("com.hedera.node.app.ServicesMain")
 }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Follow up to: #10249
Fixes that multiple tasks overwrite each other (one task deleting files the other created).
**General Gradle rule:** Never have multiple Gradle tasks write into the same location.

@tinker-michaelj @nathanklick @jamesnguyentech The result from the copying into `build/node` is the same as before, just that is is now consistently working. But I am not sure if it is correct. For me the applications don't seem to start correctly. But I miss a lot of context. Could you please try locally:


`./gradlew clean :app:run`

`./gradlew clean :app:modrun`

See if things work as expected, and if not adjust details in this block that decides which files go where in the working directory:

```
        into("lib") {
            from(copyLib)
        }
        into("apps") {
            from(copyApp)
        }
        into("onboard") {
            from(layout.projectDirectory.dir("../data/onboard"))
        }
        into("data/keys") {
            from(layout.projectDirectory.dir("../data/keys"))
        }

        from(layout.projectDirectory.dir("../configuration/dev")) { into("data/config") }
        from(layout.projectDirectory.file("../config.txt"))
        from(layout.projectDirectory.file("../log4j2.xml"))
```

**Related issue(s)**:

Fixes #10521

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
