### PR TITLE
fix: Improving error message for when properties file not found

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -55,7 +55,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.6")
+    version("com.hedera.pbj.runtime", "0.7.11")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertyConfigSource.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertyConfigSource.java
@@ -63,8 +63,9 @@ public class PropertyConfigSource implements ConfigSource {
         // It is important to use the Thread's context class loader because the resource we want to load might
         // be part of another module.
         try (final var in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
-            if(in == null) {
-                throw new UncheckedIOException("Property file " + resourceName + " could not be found", new IOException());
+            if (in == null) {
+                throw new UncheckedIOException(
+                        "Property file " + resourceName + " could not be found", new IOException());
             }
             final var props = new Properties();
             props.load(in);

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertyConfigSource.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertyConfigSource.java
@@ -63,6 +63,9 @@ public class PropertyConfigSource implements ConfigSource {
         // It is important to use the Thread's context class loader because the resource we want to load might
         // be part of another module.
         try (final var in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
+            if(in == null) {
+                throw new UncheckedIOException("Property file " + resourceName + " could not be found", new IOException());
+            }
             final var props = new Properties();
             props.load(in);
             return props;

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
@@ -5,14 +5,13 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.hedera.node.config.sources;
@@ -38,13 +37,13 @@ class PropertyConfigSourceTest {
 
     @Test
     void testExistentPropertyConfigSource() {
-        //given
-        int ordinal = 1;        // used to determine priority of config source
+        // given
+        int ordinal = 1; // used to determine priority of config source
 
-        //when
+        // when
         PropertyConfigSource propertyConfigSource = new PropertyConfigSource(properties, ordinal);
 
-        //then
+        // then
         assertEquals(2, propertyConfigSource.getPropertyNames().size());
         assertEquals("value1", propertyConfigSource.getValue("key1"));
         assertEquals("value2", propertyConfigSource.getValue("key2"));
@@ -53,10 +52,10 @@ class PropertyConfigSourceTest {
 
     @Test
     void testPropertyConfigSourceWhenPropertyFileNotFound() {
-        //given
+        // given
         String nonExistentFile = "non-existent-file.properties";
 
-        //then
+        // then
         assertThrows(UncheckedIOException.class, () -> new PropertyConfigSource(nonExistentFile, 1));
     }
 
@@ -64,5 +63,4 @@ class PropertyConfigSourceTest {
     void tearDown() {
         properties = null;
     }
-
 }

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.config.sources;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +58,22 @@ class PropertyConfigSourceTest {
 
         // then
         assertThrows(UncheckedIOException.class, () -> new PropertyConfigSource(nonExistentFile, 1));
+    }
+
+    @Test
+    void testLoadProperties() throws Exception {
+        // given
+        String existingFile = "bootstrap.properties";
+        String nonExistentFile = "non-existent-file.properties";
+
+        // when
+        Method method = PropertyConfigSource.class.getDeclaredMethod("loadProperties", String.class);
+        method.setAccessible(true);
+
+        // then
+        // Test successful path
+        Properties properties = (Properties) method.invoke(null, existingFile);
+        assertNotNull(properties);
     }
 
     @AfterEach

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hedera.node.config.sources;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.UncheckedIOException;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PropertyConfigSourceTest {
+
+    private Properties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new Properties();
+        properties.setProperty("key1", "value1");
+        properties.setProperty("key2", "value2");
+    }
+
+    @Test
+    void testExistentPropertyConfigSource() {
+        //given
+        int ordinal = 1;        // used to determine priority of config source
+
+        //when
+        PropertyConfigSource propertyConfigSource = new PropertyConfigSource(properties, ordinal);
+
+        //then
+        assertEquals(2, propertyConfigSource.getPropertyNames().size());
+        assertEquals("value1", propertyConfigSource.getValue("key1"));
+        assertEquals("value2", propertyConfigSource.getValue("key2"));
+        assertEquals(ordinal, propertyConfigSource.getOrdinal());
+    }
+
+    @Test
+    void testPropertyConfigSourceWhenPropertyFileNotFound() {
+        //given
+        String nonExistentFile = "non-existent-file.properties";
+
+        //then
+        assertThrows(UncheckedIOException.class, () -> new PropertyConfigSource(nonExistentFile, 1));
+    }
+
+    @AfterEach
+    void tearDown() {
+        properties = null;
+    }
+
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
@@ -32,8 +32,6 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
-import com.hedera.node.app.service.contract.impl.state.ProxyEvmAccount;
-import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.spi.workflows.HandleException;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -112,9 +110,6 @@ public class HtsSystemContract extends AbstractFullContract implements HederaSys
 
                 if (responseCode == SUCCESS) {
                     final var output = pricedResult.fullResult().result().getOutput();
-                    var updater = (ProxyWorldUpdater) frame.getWorldUpdater();
-                    final var senderId = ((ProxyEvmAccount) updater.getAccount(frame.getSenderAddress())).hederaId();
-
                     enhancement
                             .systemOperations()
                             .externalizeResult(
@@ -123,7 +118,7 @@ public class HtsSystemContract extends AbstractFullContract implements HederaSys
                                             output,
                                             frame.getRemainingGas(),
                                             frame.getInputData(),
-                                            senderId),
+                                            attempt.senderId()),
                                     responseCode);
                 } else {
                     enhancement

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.haltResult;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.contractsConfigOf;
@@ -26,6 +27,7 @@ import static com.hedera.node.app.service.contract.impl.utils.SystemContractUtil
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
@@ -135,8 +137,7 @@ public class HtsSystemContract extends AbstractFullContract implements HederaSys
                 }
             }
         } catch (final HandleException handleException) {
-            // TODO - this is almost certainly not the right way to handle this!
-            throw handleException;
+            return haltHandleException(handleException, frame.getRemainingGas());
         } catch (final Exception internal) {
             log.error("Unhandled failure for input {} to HTS system contract", input, internal);
             return haltResult(ExceptionalHaltReason.PRECOMPILE_ERROR, frame.getRemainingGas());
@@ -145,5 +146,13 @@ public class HtsSystemContract extends AbstractFullContract implements HederaSys
             throw new AssertionError("Not implemented");
         }
         return pricedResult.fullResult();
+    }
+
+    // potentially other cases could be handled here if necessary
+    private static FullResult haltHandleException(final HandleException handleException, long remainingGas) {
+        if (handleException.getStatus().equals(MAX_CHILD_RECORDS_EXCEEDED)) {
+            return haltResult(CustomExceptionalHaltReason.INSUFFICIENT_CHILD_RECORDS, remainingGas);
+        }
+        throw handleException;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HtsSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HtsSystemContractTest.java
@@ -27,10 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCall;
@@ -38,11 +36,9 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.state.ProxyEvmAccount;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import java.nio.ByteBuffer;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -98,7 +94,7 @@ class HtsSystemContractTest {
 
     @Test
     void returnsResultFromImpliedCall() {
-        messageFrameMock();
+        commonMocks();
         givenValidCallAttempt();
 
         final var pricedResult = gasOnly(successResult(ByteBuffer.allocate(1), 123L), SUCCESS, true);
@@ -128,7 +124,7 @@ class HtsSystemContractTest {
 
     @Test
     void callWithNonGasCostNotImplemented() {
-        messageFrameMock();
+        commonMocks();
 
         givenValidCallAttempt();
         final var pricedResult =
@@ -147,18 +143,9 @@ class HtsSystemContractTest {
         given(attempt.asExecutableCall()).willReturn(call);
     }
 
-    private void messageFrameMock() {
-        final var worldUpdater = mock(ProxyWorldUpdater.class);
-        final var address = Address.fromHexString("0x100");
+    private void commonMocks() {
         final var remainingGas = 10000L;
-        when(frame.getWorldUpdater()).thenReturn(worldUpdater);
-        when(frame.getSenderAddress()).thenReturn(address);
         when(frame.getRemainingGas()).thenReturn(remainingGas);
         when(frame.getInputData()).thenReturn(org.apache.tuweni.bytes.Bytes.EMPTY);
-
-        final var mutableAccount = mock(ProxyEvmAccount.class);
-        final var accountID = mock(AccountID.class);
-        when(worldUpdater.getAccount(address)).thenReturn(mutableAccount);
-        when(mutableAccount.hederaId()).thenReturn(accountID);
     }
 }

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandler.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandler.java
@@ -16,7 +16,7 @@
 
 package com.swirlds.demo.virtualmerkle.transaction.handler;
 
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
+import static com.swirlds.logging.legacy.LogMarker.DEMO_INFO;
 import static com.swirlds.merkle.map.test.lifecycle.TransactionState.HANDLED;
 import static com.swirlds.merkle.map.test.lifecycle.TransactionType.Create;
 import static com.swirlds.merkle.map.test.lifecycle.TransactionType.CreateExistingAccount;
@@ -60,7 +60,6 @@ public class VirtualMerkleTransactionHandler {
 
     private static final Logger logger = LogManager.getLogger(VirtualMerkleTransactionHandler.class);
     private static final Marker LOGM_DEMO_INFO = LogMarker.DEMO_INFO.getMarker();
-    private static final Marker ERROR = LogMarker.ERROR.getMarker();
 
     /**
      * This method handles all the transactions that perform changes on the {@link VirtualMap} instances
@@ -160,8 +159,8 @@ public class VirtualMerkleTransactionHandler {
                 smartContractByteCodeVirtualMap.get(byteCodeKey);
 
         if (smartContractByteCodeMapValue == null) {
-            logger.error(
-                    EXCEPTION.getMarker(),
+            logger.warn(
+                    DEMO_INFO.getMarker(),
                     "Value for key {} was not found inside smart contract bytecode map.",
                     byteCodeKey);
             return;
@@ -171,8 +170,8 @@ public class VirtualMerkleTransactionHandler {
 
         final SmartContractMapValue smartContractKeyValuePairsCounter = smartContractVirtualMap.get(contractKey);
         if (smartContractKeyValuePairsCounter == null) {
-            logger.error(
-                    EXCEPTION.getMarker(), "Value for key {} was not found inside smart contract map.", contractKey);
+            logger.warn(
+                    DEMO_INFO.getMarker(), "Value for key {} was not found inside smart contract map.", contractKey);
             return;
         }
         final long totalKeyValuePairs = smartContractKeyValuePairsCounter.getValueAsLong();
@@ -184,8 +183,8 @@ public class VirtualMerkleTransactionHandler {
                     new SmartContractMapKey(methodExecution.getContractId(), keyValuePairIdx);
             final SmartContractMapValue smartContractMapValue = smartContractVirtualMap.get(smartContractMapKey);
             if (smartContractMapValue == null) {
-                logger.error(
-                        EXCEPTION.getMarker(),
+                logger.warn(
+                        DEMO_INFO.getMarker(),
                         "Value for key {} was not found inside smart contract map.",
                         smartContractMapKey);
                 return;
@@ -198,8 +197,8 @@ public class VirtualMerkleTransactionHandler {
                     new SmartContractMapKey(methodExecution.getContractId(), keyValuePairIdx);
             final SmartContractMapValue smartContractMapValue = smartContractVirtualMap.get(smartContractMapKey);
             if (smartContractMapValue == null) {
-                logger.error(
-                        EXCEPTION.getMarker(),
+                logger.warn(
+                        DEMO_INFO.getMarker(),
                         "Value for key {} was not found inside smart contract map.",
                         smartContractMapKey);
                 return;
@@ -376,8 +375,8 @@ public class VirtualMerkleTransactionHandler {
                 final AccountVirtualMapValue virtualMapValue = virtualMap.get(accountVirtualMapKey);
                 if (virtualMapValue == null) {
                     notMismatching.set(false);
-                    logger.error(
-                            EXCEPTION.getMarker(), "An account from the expected map is not present inside the state.");
+                    logger.warn(
+                            DEMO_INFO.getMarker(), "An account from the expected map is not present inside the state.");
                     return;
                 }
                 final MapValueData mapValueData = new MapValueData(
@@ -393,14 +392,14 @@ public class VirtualMerkleTransactionHandler {
             } else if (lastTransactionType == CreateExistingAccount) {
                 if (!virtualMap.containsKey(accountVirtualMapKey)) {
                     notMismatching.set(false);
-                    logger.error(EXCEPTION.getMarker(), "A created account does not exist inside the state.");
+                    logger.warn(DEMO_INFO.getMarker(), "A created account does not exist inside the state.");
                 }
             } else if (lastTransactionType == Delete
                     || lastTransactionType == DeleteNotExistentAccount
                     || lastTransactionType == UpdateNotExistentAccount) {
                 if (virtualMap.containsKey(accountVirtualMapKey)) {
                     notMismatching.set(false);
-                    logger.error(EXCEPTION.getMarker(), "A deleted account is still present inside the state.");
+                    logger.warn(DEMO_INFO.getMarker(), "A deleted account is still present inside the state.");
                 }
             }
         });

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -467,7 +467,8 @@ class DataFileCollectionCompactionTest {
         final Future<?> f = exec.submit(() -> {
             try {
                 final List<DataFileReader<?>> filesToMerge = getFilesToMerge(store);
-                assertEquals(numFiles, filesToMerge.size());
+                // Data file collection may create a new file before the compaction starts
+                assertTrue(filesToMerge.size() == numFiles || filesToMerge.size() == numFiles + 1);
                 compactor.compactFiles(index, filesToMerge, 1);
                 // Wait for the new file to be available. Without this wait, there
                 // may be 1 or 2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -147,6 +147,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.6")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.11")
     }
 }


### PR DESCRIPTION
**Description**:
This PR modifies PropertyConfigSource in order to handle the case when the resource file does not exist
Includes a new Unit Test class for supporting the change. 

**Related issue(s)**:

Fixes #9689 

**Notes for reviewer**:

**Checklist**

- [ x ] Documented (Code comments, README, etc.)
- [ x ] Tested (unit, integration, etc.)
