### PR TITLE
chore: Misc contract cleanup and fixes

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -56,6 +56,7 @@ import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.records.BlockRecordManager;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
+import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.records.ChildRecordFinalizer;
 import com.hedera.node.app.service.token.records.CryptoUpdateRecordBuilder;
 import com.hedera.node.app.service.token.records.ParentRecordFinalizer;
@@ -367,6 +368,7 @@ public class HandleWorkflow {
 
             // Calculate the fee
             fees = dispatcher.dispatchComputeFees(context);
+            logger.info("Fee computed for transaction {} is {}", transactionInfo.functionality(), fees);
 
             // Run all pre-checks
             final var validationResult = validate(
@@ -426,6 +428,11 @@ public class HandleWorkflow {
                     if (!hasWaivedFees) {
                         // privileged transactions are not charged fees
                         feeAccumulator.chargeFees(payer, creator.accountId(), fees);
+                        logger.info(
+                                "Modified after charging fees {}",
+                                tokenServiceContext
+                                        .writableStore(WritableAccountStore.class)
+                                        .modifiedAccountsInState());
                     }
 
                     if (networkUtilizationManager.wasLastTxnGasThrottled()) {
@@ -472,8 +479,19 @@ public class HandleWorkflow {
                     dualStateUpdateFacility.handleTxBody(stack, dualState, txBody);
 
                 } catch (final HandleException e) {
+                    logger.info("Caught HandleException", e);
+                    logger.info(
+                            "Modified before rollback {}",
+                            tokenServiceContext
+                                    .writableStore(WritableAccountStore.class)
+                                    .modifiedAccountsInState());
                     // In case of a ContractCall when it reverts, the gas charged should not be rolled back
                     rollback(e.shouldRollbackStack(), e.getStatus(), stack, recordListBuilder);
+                    logger.info(
+                            "Modified after rollback {}",
+                            tokenServiceContext
+                                    .writableStore(WritableAccountStore.class)
+                                    .modifiedAccountsInState());
                     if (!hasWaivedFees && e.shouldRollbackStack()) {
                         // Only re-charge fees if we rolled back the stack
                         feeAccumulator.chargeFees(payer, creator.accountId(), fees);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
@@ -109,6 +109,8 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
                     result.recipientId(),
                     result.gasPrice());
         } catch (AbortException e) {
+            // Commit any HAPI fees that were charged before aborting
+            rootProxyWorldUpdater.commit();
             final var result = HederaEvmTransactionResult.fromAborted(e.senderId(), hevmTransaction, e.getStatus());
             return new CallOutcome(
                     result.asProtoResultOf(ethTxDataIfApplicable(), rootProxyWorldUpdater),

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/AbortException.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/AbortException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.exec.failure;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.node.app.spi.workflows.HandleException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An exception thrown when a transaction is aborted before entering the EVM.
+ *
+ * <p>Includes the effective Hedera id of the sender.
+ */
+public class AbortException extends HandleException {
+    private final AccountID senderId;
+
+    public AbortException(@NonNull final ResponseCodeEnum status, @NonNull final AccountID senderId) {
+        super(status);
+        this.senderId = requireNonNull(senderId);
+    }
+
+    /**
+     * Returns the effective Hedera id of the sender.
+     *
+     * @return the effective Hedera id of the sender
+     */
+    public AccountID senderId() {
+        return senderId;
+    }
+
+    /**
+     * Throws an {@code AbortException} if the given flag is {@code false}.
+     *
+     * @param flag the flag to check
+     * @param status the status to use if the flag is {@code false}
+     * @param senderId the effective Hedera id of the sender
+     */
+    public static void validateTrueOrAbort(
+            final boolean flag, @NonNull final ResponseCodeEnum status, @NonNull final AccountID senderId) {
+        if (!flag) {
+            throw new AbortException(status, senderId);
+        }
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -19,10 +19,8 @@ package com.hedera.node.app.service.contract.impl.handlers;
 import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.WRONG_NONCE;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.throwIfUnsuccessful;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
-import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +33,6 @@ import com.hedera.node.app.service.contract.impl.infra.EthereumCallDataHydration
 import com.hedera.node.app.service.contract.impl.records.EthereumTransactionRecordBuilder;
 import com.hedera.node.app.service.file.ReadableFileStore;
 import com.hedera.node.app.service.mono.fees.calculation.ethereum.txns.EthereumTransactionResourceUsage;
-import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -46,7 +43,6 @@ import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -93,12 +89,6 @@ public class EthereumTransactionHandler implements TransactionHandler {
         // Create the transaction-scoped component
         final var component = provider.get().create(context, ETHEREUM_TRANSACTION);
 
-        final var hevmTransactionFactory = component.contextTransactionProcessor().hevmTransactionFactory;
-        final var hevmTransaction = hevmTransactionFactory.fromHapiTransaction(context.body());
-
-        final var accountStore = context.readableStore(ReadableAccountStore.class);
-        final var sender = accountStore.getAccountById(Objects.requireNonNull(hevmTransaction.senderId()));
-
         // Assemble the appropriate top-level record for the result
         final var ethTxData =
                 requireNonNull(requireNonNull(component.hydratedEthTxData()).ethTxData());
@@ -108,9 +98,7 @@ public class EthereumTransactionHandler implements TransactionHandler {
 
         final var recordBuilder = context.recordBuilder(EthereumTransactionRecordBuilder.class)
                 .ethereumHash(Bytes.wrap(ethTxData.getEthereumHash()))
-                .status(outcome.status())
-                .feeChargedToPayer(outcome.tinybarGasCost());
-
+                .status(outcome.status());
         if (ethTxData.hasToAddress()) {
             // The Ethereum transaction was a top-level MESSAGE_CALL
             recordBuilder.contractID(outcome.recipientId()).contractCallResult(outcome.result());
@@ -118,8 +106,7 @@ public class EthereumTransactionHandler implements TransactionHandler {
             // The Ethereum transaction was a top-level CONTRACT_CREATION
             recordBuilder.contractID(outcome.recipientIdIfCreated()).contractCreateResult(outcome.result());
         }
-
-        validateTrue(sender.ethereumNonce() == ethTxData.nonce(), WRONG_NONCE);
+        recordBuilder.withTinybarGasFee(outcome.tinybarGasCost());
 
         throwIfUnsuccessful(outcome.status());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionResult.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionResult.java
@@ -18,12 +18,14 @@ package com.hedera.node.app.service.contract.impl.hevm;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_CONTRACT_STORAGE_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.WRONG_NONCE;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.errorMessageFor;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.accessTrackerFor;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.proxyUpdaterFor;
@@ -77,6 +79,8 @@ public record HederaEvmTransactionResult(
     private static final Bytes INVALID_CONTRACT_REASON = Bytes.wrap(INVALID_CONTRACT_ID.name());
     private static final Bytes MAX_CHILD_RECORDS_EXCEEDED_REASON = Bytes.wrap(MAX_CHILD_RECORDS_EXCEEDED.name());
     private static final Bytes INSUFFICIENT_TX_FEE_REASON = Bytes.wrap(INSUFFICIENT_TX_FEE.name());
+    private static final Bytes INSUFFICIENT_PAYER_BALANCE_REASON = Bytes.wrap(INSUFFICIENT_PAYER_BALANCE.name());
+    private static final Bytes WRONG_NONCE_REASON = Bytes.wrap(WRONG_NONCE.name());
 
     /**
      * Converts this result to a {@link ContractFunctionResult} for a transaction based on the given
@@ -145,6 +149,10 @@ public record HederaEvmTransactionResult(
                 return MAX_CHILD_RECORDS_EXCEEDED;
             } else if (revertReason.equals(INSUFFICIENT_TX_FEE_REASON)) {
                 return INSUFFICIENT_TX_FEE;
+            } else if (revertReason.equals(WRONG_NONCE_REASON)) {
+                return WRONG_NONCE;
+            } else if (revertReason.equals(INSUFFICIENT_PAYER_BALANCE_REASON)) {
+                return INSUFFICIENT_PAYER_BALANCE;
             } else {
                 return CONTRACT_REVERT_EXECUTED;
             }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
@@ -19,13 +19,12 @@ package com.hedera.node.app.service.contract.impl.infra;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction.NOT_APPLICABLE;
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.EVM_ADDRESS_LENGTH_AS_LONG;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asPriorityId;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 import static org.apache.tuweni.bytes.Bytes.EMPTY;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.contract.ContractCallLocalQuery;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.node.app.service.contract.impl.annotations.QueryScope;
@@ -70,13 +69,8 @@ public class HevmStaticTransactionFactory {
         final var op = query.contractCallLocalOrThrow();
         assertValidCall(op);
         final var senderId = op.hasSenderId() ? op.senderIdOrThrow() : payerId;
-        var targetId = op.contractIDOrThrow();
         // For mono-service fidelity, allow calls using 0.0.X id even to contracts with a priority EVM address
-        final var maybeContract =
-                context.createStore(ReadableAccountStore.class).getContractById(targetId);
-        if (maybeContract != null && maybeContract.alias().length() == EVM_ADDRESS_LENGTH_AS_LONG) {
-            targetId = ContractID.newBuilder().evmAddress(maybeContract.alias()).build();
-        }
+        final var targetId = asPriorityId(op.contractIDOrThrow(), context.createStore(ReadableAccountStore.class));
         return new HederaEvmTransaction(
                 senderId, null, targetId, NOT_APPLICABLE, op.functionParameters(), null, 0L, op.gas(), 1L, 0L, null);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
@@ -36,6 +36,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SERIALIZATION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.WRONG_CHAIN_ID;
 import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction.NOT_APPLICABLE;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asChainIdBytes;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asPriorityId;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.synthEthTxCreation;
 import static com.hedera.node.app.spi.key.KeyUtils.isEmpty;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
@@ -168,7 +169,7 @@ public class HevmTransactionFactory {
         return new HederaEvmTransaction(
                 payer,
                 null,
-                body.contractIDOrThrow(),
+                asPriorityId(body.contractIDOrThrow(), accountStore),
                 NOT_APPLICABLE,
                 body.functionParameters(),
                 null,
@@ -198,7 +199,11 @@ public class HevmTransactionFactory {
         return new HederaEvmTransaction(
                 senderId,
                 relayerId,
-                ContractID.newBuilder().evmAddress(Bytes.wrap(ethTxData.to())).build(),
+                asPriorityId(
+                        ContractID.newBuilder()
+                                .evmAddress(Bytes.wrap(ethTxData.to()))
+                                .build(),
+                        accountStore),
                 ethTxData.nonce(),
                 ethTxData.hasCallData() ? Bytes.wrap(ethTxData.callData()) : Bytes.EMPTY,
                 Bytes.wrap(ethTxData.chainId()),

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/EthereumTransactionRecordBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/EthereumTransactionRecordBuilder.java
@@ -23,7 +23,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public interface EthereumTransactionRecordBuilder {
+public interface EthereumTransactionRecordBuilder extends GasFeeRecordBuilder {
     /**
      * Tracks the final status of a HAPI Ethereum transaction.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
@@ -218,6 +218,11 @@ public class DispatchingEvmFrameState implements EvmFrameState {
         return validatedAccount(number).ethereumNonce();
     }
 
+    @Override
+    public com.hedera.hapi.node.state.token.Account getNativeAccount(final long number) {
+        return validatedAccount(number);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameState.java
@@ -189,6 +189,14 @@ public interface EvmFrameState {
     Hash getTokenRedirectCodeHash(@NonNull Address address);
 
     /**
+     * Returns the native account with the given number.
+     *
+     * @param number the account number
+     * @return the native account
+     */
+    com.hedera.hapi.node.state.token.Account getNativeAccount(long number);
+
+    /**
      * Returns the nonce for the account with the given number.
      *
      * @param number the account number

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/HederaEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/HederaEvmAccount.java
@@ -25,6 +25,13 @@ import org.hyperledger.besu.evm.account.MutableAccount;
 
 public interface HederaEvmAccount extends MutableAccount {
     /**
+     * Returns a native Hedera account representation of this account.
+     *
+     * @return the native Hedera account
+     */
+    com.hedera.hapi.node.state.token.Account toNativeAccount();
+
+    /**
      * Returns whether this account is an ERC-20/ERC-721 facade for a Hedera token.
      *
      * @return whether this account is token facade

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
@@ -58,6 +58,11 @@ public class ProxyEvmAccount extends AbstractMutableEvmAccount {
     }
 
     @Override
+    public com.hedera.hapi.node.state.token.Account toNativeAccount() {
+        return state.getNativeAccount(number);
+    }
+
+    @Override
     public long getNonce() {
         return state.getNonce(number);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/TokenEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/TokenEvmAccount.java
@@ -95,6 +95,14 @@ public class TokenEvmAccount extends AbstractMutableEvmAccount {
         return UInt256.ZERO;
     }
 
+    /**
+     * Since a token is not actually a native Hedera account, always throws {@link UnsupportedOperationException}.
+     */
+    @Override
+    public com.hedera.hapi.node.state.token.Account toNativeAccount() {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public boolean isEmpty() {
         return false;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -26,8 +26,10 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.Duration;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
 import com.hedera.hapi.node.contract.ContractLoginfo;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.ExchangeRate;
@@ -37,6 +39,7 @@ import com.hedera.hapi.streams.StorageChange;
 import com.hedera.node.app.service.contract.impl.exec.scope.HandleHederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.state.StorageAccesses;
+import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.workflows.HandleException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -127,6 +130,7 @@ public class ConversionUtils {
 
     /**
      * Given a {@link AccountID}, returns its address as a headlong address.
+     *
      * @param accountID the account id
      * @return the headlong address
      */
@@ -140,6 +144,7 @@ public class ConversionUtils {
 
     /**
      * Given a {@link ContractID}, returns its address as a headlong address.
+     *
      * @param contractId the contract id
      * @return the headlong address
      */
@@ -153,6 +158,7 @@ public class ConversionUtils {
 
     /**
      * Given a {@link TokenID}, returns its address as a headlong address.
+     *
      * @param tokenId
      * @return
      */
@@ -170,6 +176,26 @@ public class ConversionUtils {
     public static Address priorityAddressOf(@NonNull final Account account) {
         requireNonNull(account);
         return Address.wrap(Bytes.wrap(explicitAddressOf(account)));
+    }
+
+    /**
+     * Given a contract id, returns its "priority" form if the id refers to an extant contract with an
+     * EVM address outside the long-zero subspace.
+     *
+     * <p>If there is no such contract; or if the id refers to a contract with an EVM address within the
+     * long-zero subspace; then returns the given contract id.
+     *
+     * @param contractID the contract id
+     * @param accountStore the account store
+     * @return the priority form of the contract id
+     */
+    public static ContractID asPriorityId(
+            @NonNull final ContractID contractID, @NonNull final ReadableAccountStore accountStore) {
+        final var maybeContract = accountStore.getContractById(contractID);
+        if (maybeContract != null && maybeContract.alias().length() == EVM_ADDRESS_LENGTH_AS_LONG) {
+            return ContractID.newBuilder().evmAddress(maybeContract.alias()).build();
+        }
+        return contractID;
     }
 
     /**
@@ -307,7 +333,7 @@ public class ConversionUtils {
     /**
      * Given a {@link MessageFrame}, returns the id number of the given address's Hedera id.
      *
-     * @param frame   the {@link MessageFrame}
+     * @param frame the {@link MessageFrame}
      * @param address the address to get the id number of
      * @return the id number of the given address's Hedera id
      */
@@ -333,7 +359,7 @@ public class ConversionUtils {
      * if the address does not correspond to a known Hedera entity; or {@link HederaNativeOperations#NON_CANONICAL_REFERENCE_NUMBER}
      * if the address references an account by its "non-priority" long-zero address.
      *
-     * @param address       the EVM address
+     * @param address the EVM address
      * @param nativeOperations the {@link HandleHederaNativeOperations} to use for resolving aliases
      * @return the number of the corresponding Hedera entity, if it exists and has this priority address
      */
@@ -360,7 +386,7 @@ public class ConversionUtils {
      * within the given {@link HandleHederaNativeOperations}; or {@link HederaNativeOperations#MISSING_ENTITY_NUMBER}
      * if the address is not long-zero and does not correspond to a known Hedera entity.
      *
-     * @param address       the EVM address
+     * @param address the EVM address
      * @param nativeOperations the {@link HandleHederaNativeOperations} to use for resolving aliases
      * @return the number of the corresponding Hedera entity, if it exists
      */
@@ -682,12 +708,59 @@ public class ConversionUtils {
         return Address.fromHexString(address.toString());
     }
 
+    /**
+     * Given an exchange rate and a tinycent amount, returns the equivalent tinybar amount.
+     *
+     * @param exchangeRate the exchange rate
+     * @param tinycents the tinycent amount
+     * @return the equivalent tinybar amount
+     */
     public static long fromTinycentsToTinybars(final ExchangeRate exchangeRate, final long tinycents) {
         return fromAToB(BigInteger.valueOf(tinycents), exchangeRate.hbarEquiv(), exchangeRate.centEquiv())
                 .longValueExact();
     }
 
+    /**
+     * Given an amount in one unit and its conversion rate to another unit, returns the equivalent amount
+     * in the other unit.
+     *
+     * @param aAmount the amount in one unit
+     * @param bEquiv the numerator of the conversion rate
+     * @param aEquiv the denominator of the conversion rate
+     * @return the equivalent amount in the other unit
+     */
     public static @NonNull BigInteger fromAToB(@NonNull final BigInteger aAmount, final int bEquiv, final int aEquiv) {
         return aAmount.multiply(BigInteger.valueOf(bEquiv)).divide(BigInteger.valueOf(aEquiv));
+    }
+
+    /**
+     * Given a {@link ContractCreateTransactionBody} and a sponsor {@link Account}, returns a creation body
+     * fully customized with the sponsor's properties.
+     *
+     * @param op the creation body
+     * @param sponsor the sponsor
+     * @return the fully customized creation body
+     */
+    public static @NonNull ContractCreateTransactionBody sponsorCustomizedCreation(
+            @NonNull final ContractCreateTransactionBody op, @NonNull final Account sponsor) {
+        requireNonNull(op);
+        requireNonNull(sponsor);
+        final var builder = op.copyBuilder();
+        if (sponsor.memo() != null) {
+            builder.memo(sponsor.memo());
+        }
+        if (sponsor.autoRenewAccountId() != null) {
+            builder.autoRenewAccountId(sponsor.autoRenewAccountId());
+        }
+        if (sponsor.stakedAccountId() != null) {
+            builder.stakedAccountId(sponsor.stakedAccountId());
+        }
+        if (sponsor.autoRenewSeconds() > 0) {
+            builder.autoRenewPeriod(
+                    Duration.newBuilder().seconds(sponsor.autoRenewSeconds()).build());
+        }
+        return builder.maxAutomaticTokenAssociations(sponsor.maxAutoAssociations())
+                .declineReward(sponsor.declineReward())
+                .build();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/ContextTransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/ContextTransactionProcessorTest.java
@@ -16,20 +16,24 @@
 
 package com.hedera.node.app.service.contract.impl.test.exec;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_038;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.ETH_DATA_WITH_TO_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.HEVM_CREATION;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertFailsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.TransactionProcessor;
+import com.hedera.node.app.service.contract.impl.exec.failure.AbortException;
 import com.hedera.node.app.service.contract.impl.hevm.ActionSidecarContentTracer;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
@@ -67,7 +71,7 @@ class ContextTransactionProcessorTest {
     private TransactionProcessor processor;
 
     @Mock
-    private RootProxyWorldUpdater baseProxyWorldUpdater;
+    private RootProxyWorldUpdater rootProxyWorldUpdater;
 
     @Mock
     private Supplier<HederaWorldUpdater> feesOnlyUpdater;
@@ -83,7 +87,7 @@ class ContextTransactionProcessorTest {
                 CONFIGURATION,
                 hederaEvmContext,
                 tracer,
-                baseProxyWorldUpdater,
+                rootProxyWorldUpdater,
                 hevmTransactionFactory,
                 feesOnlyUpdater,
                 processors);
@@ -92,10 +96,10 @@ class ContextTransactionProcessorTest {
         given(hevmTransactionFactory.fromHapiTransaction(TransactionBody.DEFAULT))
                 .willReturn(HEVM_CREATION);
         given(processor.processTransaction(
-                        HEVM_CREATION, baseProxyWorldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, CONFIGURATION))
+                        HEVM_CREATION, rootProxyWorldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, CONFIGURATION))
                 .willReturn(SUCCESS_RESULT);
 
-        final var protoResult = SUCCESS_RESULT.asProtoResultOf(ETH_DATA_WITH_TO_ADDRESS, baseProxyWorldUpdater);
+        final var protoResult = SUCCESS_RESULT.asProtoResultOf(ETH_DATA_WITH_TO_ADDRESS, rootProxyWorldUpdater);
         final var expectedResult =
                 new CallOutcome(protoResult, SUCCESS, HEVM_CREATION.contractId(), SUCCESS_RESULT.gasPrice());
         assertEquals(expectedResult, subject.call());
@@ -112,7 +116,7 @@ class ContextTransactionProcessorTest {
                 CONFIGURATION,
                 hederaEvmContext,
                 tracer,
-                baseProxyWorldUpdater,
+                rootProxyWorldUpdater,
                 hevmTransactionFactory,
                 feesOnlyUpdater,
                 processors);
@@ -121,13 +125,41 @@ class ContextTransactionProcessorTest {
         given(hevmTransactionFactory.fromHapiTransaction(TransactionBody.DEFAULT))
                 .willReturn(HEVM_CREATION);
         given(processor.processTransaction(
-                        HEVM_CREATION, baseProxyWorldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, CONFIGURATION))
+                        HEVM_CREATION, rootProxyWorldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, CONFIGURATION))
                 .willReturn(SUCCESS_RESULT);
 
-        final var protoResult = SUCCESS_RESULT.asProtoResultOf(null, baseProxyWorldUpdater);
+        final var protoResult = SUCCESS_RESULT.asProtoResultOf(null, rootProxyWorldUpdater);
         final var expectedResult =
                 new CallOutcome(protoResult, SUCCESS, HEVM_CREATION.contractId(), SUCCESS_RESULT.gasPrice());
         assertEquals(expectedResult, subject.call());
+    }
+
+    @Test
+    void stillChargesHapiFeesOnAbort() {
+        final var contractsConfig = CONFIGURATION.getConfigData(ContractsConfig.class);
+        final var processors = Map.of(VERSION_038, processor);
+        final var subject = new ContextTransactionProcessor(
+                null,
+                context,
+                contractsConfig,
+                CONFIGURATION,
+                hederaEvmContext,
+                tracer,
+                rootProxyWorldUpdater,
+                hevmTransactionFactory,
+                feesOnlyUpdater,
+                processors);
+
+        given(context.body()).willReturn(TransactionBody.DEFAULT);
+        given(hevmTransactionFactory.fromHapiTransaction(TransactionBody.DEFAULT))
+                .willReturn(HEVM_CREATION);
+        given(processor.processTransaction(
+                        HEVM_CREATION, rootProxyWorldUpdater, feesOnlyUpdater, hederaEvmContext, tracer, CONFIGURATION))
+                .willThrow(new AbortException(INVALID_CONTRACT_ID, SENDER_ID));
+
+        subject.call();
+
+        verify(rootProxyWorldUpdater).commit();
     }
 
     @Test
@@ -141,7 +173,7 @@ class ContextTransactionProcessorTest {
                 CONFIGURATION,
                 hederaEvmContext,
                 tracer,
-                baseProxyWorldUpdater,
+                rootProxyWorldUpdater,
                 hevmTransactionFactory,
                 feesOnlyUpdater,
                 processors);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
@@ -220,7 +220,6 @@ class TransactionProcessorTest {
                         expectedToAddress,
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
-        given(senderAccount.hederaId()).willReturn(SENDER_ID);
         given(senderAccount.getNonce()).willReturn(NONCE);
         given(frameRunner.runToCompletion(
                         transaction.gasLimit(),
@@ -276,7 +275,6 @@ class TransactionProcessorTest {
                         expectedToAddress,
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
-        given(senderAccount.hederaId()).willReturn(SENDER_ID);
         given(senderAccount.getNonce()).willReturn(NONCE);
         given(frameRunner.runToCompletion(
                         transaction.gasLimit(),
@@ -352,7 +350,6 @@ class TransactionProcessorTest {
                         NON_SYSTEM_LONG_ZERO_ADDRESS,
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
-        given(senderAccount.hederaId()).willReturn(SENDER_ID);
         given(frameRunner.runToCompletion(
                         transaction.gasLimit(),
                         SENDER_ID,
@@ -420,7 +417,6 @@ class TransactionProcessorTest {
                         NON_SYSTEM_LONG_ZERO_ADDRESS,
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
-        given(senderAccount.hederaId()).willReturn(SENDER_ID);
         given(frameRunner.runToCompletion(
                         eq(transaction.gasLimit()),
                         eq(SENDER_ID),
@@ -480,7 +476,6 @@ class TransactionProcessorTest {
         given(gasCharging.chargeForGas(senderAccount, relayerAccount, context, worldUpdater, transaction))
                 .willReturn(CHARGING_RESULT);
         given(senderAccount.getAddress()).willReturn(EIP_1014_ADDRESS);
-        given(senderAccount.hederaId()).willReturn(SENDER_ID);
         given(senderAccount.getNonce()).willReturn(NONCE);
         given(receiverAccount.getAddress()).willReturn(NON_SYSTEM_LONG_ZERO_ADDRESS);
         given(frameBuilder.buildInitialFrameWith(
@@ -539,7 +534,6 @@ class TransactionProcessorTest {
                         NON_SYSTEM_LONG_ZERO_ADDRESS,
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
-        given(senderAccount.hederaId()).willReturn(SENDER_ID);
         willThrow(new ResourceExhaustedException(MAX_CHILD_RECORDS_EXCEEDED))
                 .given(frameRunner)
                 .runToCompletion(
@@ -590,6 +584,7 @@ class TransactionProcessorTest {
 
     private void givenSenderAccount() {
         given(worldUpdater.getHederaAccount(SENDER_ID)).willReturn(senderAccount);
+        given(senderAccount.hederaId()).willReturn(SENDER_ID);
     }
 
     private void givenRelayerAccount() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
@@ -221,6 +221,7 @@ class TransactionProcessorTest {
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
         given(senderAccount.hederaId()).willReturn(SENDER_ID);
+        given(senderAccount.getNonce()).willReturn(NONCE);
         given(frameRunner.runToCompletion(
                         transaction.gasLimit(),
                         SENDER_ID,
@@ -276,6 +277,7 @@ class TransactionProcessorTest {
                         CHARGING_RESULT.intrinsicGas()))
                 .willReturn(initialFrame);
         given(senderAccount.hederaId()).willReturn(SENDER_ID);
+        given(senderAccount.getNonce()).willReturn(NONCE);
         given(frameRunner.runToCompletion(
                         transaction.gasLimit(),
                         SENDER_ID,
@@ -284,12 +286,9 @@ class TransactionProcessorTest {
                         messageCallProcessor,
                         contractCreationProcessor))
                 .willReturn(SUCCESS_RESULT);
-        given(worldUpdater.enhancement()).willReturn(enhancement);
-        given(enhancement.nativeOperations()).willReturn(nativeOperations);
-        given(nativeOperations.readableAccountStore()).willReturn(readableAccountStore);
         final var parsedAccount =
                 Account.newBuilder().accountId(senderAccount.hederaId()).build();
-        given(readableAccountStore.getAccountById(SENDER_ID)).willReturn(parsedAccount);
+        given(senderAccount.toNativeAccount()).willReturn(parsedAccount);
         given(initialFrame.getSelfDestructs()).willReturn(Set.of(NON_SYSTEM_LONG_ZERO_ADDRESS));
 
         final var result =
@@ -410,6 +409,7 @@ class TransactionProcessorTest {
         given(gasCharging.chargeForGas(senderAccount, relayerAccount, context, worldUpdater, transaction))
                 .willReturn(CHARGING_RESULT);
         given(senderAccount.getAddress()).willReturn(EIP_1014_ADDRESS);
+        given(senderAccount.getNonce()).willReturn(NONCE);
         given(receiverAccount.getAddress()).willReturn(NON_SYSTEM_LONG_ZERO_ADDRESS);
         given(frameBuilder.buildInitialFrameWith(
                         transaction,
@@ -481,6 +481,7 @@ class TransactionProcessorTest {
                 .willReturn(CHARGING_RESULT);
         given(senderAccount.getAddress()).willReturn(EIP_1014_ADDRESS);
         given(senderAccount.hederaId()).willReturn(SENDER_ID);
+        given(senderAccount.getNonce()).willReturn(NONCE);
         given(receiverAccount.getAddress()).willReturn(NON_SYSTEM_LONG_ZERO_ADDRESS);
         given(frameBuilder.buildInitialFrameWith(
                         transaction,
@@ -527,6 +528,7 @@ class TransactionProcessorTest {
         given(gasCharging.chargeForGas(senderAccount, relayerAccount, context, worldUpdater, transaction))
                 .willReturn(CHARGING_RESULT);
         given(senderAccount.getAddress()).willReturn(EIP_1014_ADDRESS);
+        given(senderAccount.getNonce()).willReturn(NONCE);
         given(receiverAccount.getAddress()).willReturn(NON_SYSTEM_LONG_ZERO_ADDRESS);
         given(frameBuilder.buildInitialFrameWith(
                         transaction,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
@@ -259,6 +259,8 @@ class CustomGasChargingTest {
         final var gasCost = transaction.gasCostGiven(NETWORK_GAS_PRICE);
         given(relayer.getBalance()).willReturn(Wei.of(gasCost));
         given(relayer.hederaId()).willReturn(RELAYER_ID);
+        given(sender.getBalance()).willReturn(Wei.of(transaction.value()));
+        given(sender.hederaId()).willReturn(SENDER_ID);
         final var chargingResult = subject.chargeForGas(
                 sender,
                 relayer,
@@ -274,8 +276,10 @@ class CustomGasChargingTest {
         givenWellKnownIntrinsicGasCost();
         final var transaction = wellKnownRelayedHapiCallWithUserGasPriceAndMaxAllowance(NETWORK_GAS_PRICE, 0);
         final var gasCost = transaction.gasCostGiven(NETWORK_GAS_PRICE);
-        given(sender.getBalance()).willReturn(Wei.of(gasCost));
+        given(sender.getBalance()).willReturn(Wei.of(gasCost + transaction.value()));
         given(sender.hederaId()).willReturn(SENDER_ID);
+        given(relayer.hederaId()).willReturn(RELAYER_ID);
+        given(relayer.getBalance()).willReturn(Wei.ZERO);
         final var chargingResult = subject.chargeForGas(
                 sender,
                 relayer,
@@ -287,11 +291,29 @@ class CustomGasChargingTest {
     }
 
     @Test
+    void requiresSenderToCoverGasCost() {
+        givenWellKnownIntrinsicGasCost();
+        final var transaction = wellKnownRelayedHapiCallWithUserGasPriceAndMaxAllowance(NETWORK_GAS_PRICE, 0);
+        final var gasCost = transaction.gasCostGiven(NETWORK_GAS_PRICE);
+        given(sender.getBalance()).willReturn(Wei.of(gasCost + transaction.value() - 1));
+        given(relayer.getBalance()).willReturn(Wei.ZERO);
+        assertFailsWith(
+                INSUFFICIENT_PAYER_BALANCE,
+                () -> subject.chargeForGas(
+                        sender,
+                        relayer,
+                        wellKnownContextWith(blocks, tinybarValues, systemContractGasCalculator),
+                        worldUpdater,
+                        transaction));
+    }
+
+    @Test
     void rejectsIfSenderCannotCoverOfferedGasCost() {
         givenWellKnownIntrinsicGasCost();
         final var transaction =
                 wellKnownRelayedHapiCallWithUserGasPriceAndMaxAllowance(NETWORK_GAS_PRICE / 2, Long.MAX_VALUE);
         given(sender.getBalance()).willReturn(Wei.of(transaction.offeredGasCost() - 1));
+        given(relayer.getBalance()).willReturn(Wei.of(Long.MAX_VALUE));
         assertFailsWith(
                 INSUFFICIENT_PAYER_BALANCE,
                 () -> subject.chargeForGas(
@@ -307,7 +329,6 @@ class CustomGasChargingTest {
         givenWellKnownIntrinsicGasCost();
         final var transaction =
                 wellKnownRelayedHapiCallWithUserGasPriceAndMaxAllowance(NETWORK_GAS_PRICE / 2, Long.MAX_VALUE);
-        given(sender.getBalance()).willReturn(Wei.of(transaction.offeredGasCost()));
         given(relayer.getBalance()).willReturn(Wei.ZERO);
         assertFailsWith(
                 INSUFFICIENT_PAYER_BALANCE,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -32,9 +32,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.contract.EthereumTransactionBody;
-import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
@@ -140,11 +138,6 @@ class EthereumTransactionHandlerTest {
         given(component.contextTransactionProcessor()).willReturn(contextTransactionProcessor);
         given(hevmTransactionFactory.fromHapiTransaction(handleContext.body())).willReturn(HEVM_CREATION);
 
-        final AccountID senderId = HEVM_CREATION.senderId();
-        final var parsedAccount = Account.newBuilder().accountId(senderId).build();
-
-        given(handleContext.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
-        given(readableAccountStore.getAccountById(HEVM_CREATION.senderId())).willReturn(parsedAccount);
         given(transactionProcessor.processTransaction(
                         HEVM_CREATION,
                         baseProxyWorldUpdater,
@@ -170,7 +163,7 @@ class EthereumTransactionHandlerTest {
         given(recordBuilder.contractCallResult(expectedResult)).willReturn(recordBuilder);
         given(recordBuilder.ethereumHash(Bytes.wrap(ETH_DATA_WITH_TO_ADDRESS.getEthereumHash())))
                 .willReturn(recordBuilder);
-        given(recordBuilder.feeChargedToPayer(expectedOutcome.tinybarGasCost())).willReturn(recordBuilder);
+        given(recordBuilder.withTinybarGasFee(expectedOutcome.tinybarGasCost())).willReturn(recordBuilder);
 
         assertDoesNotThrow(() -> subject.handle(handleContext));
     }
@@ -192,7 +185,7 @@ class EthereumTransactionHandlerTest {
         given(recordBuilder.contractCreateResult(expectedResult)).willReturn(recordBuilder);
         given(recordBuilder.ethereumHash(Bytes.wrap(ETH_DATA_WITHOUT_TO_ADDRESS.getEthereumHash())))
                 .willReturn(recordBuilder);
-        given(recordBuilder.feeChargedToPayer(expectedOutcome.tinybarGasCost())).willReturn(recordBuilder);
+        given(recordBuilder.withTinybarGasFee(expectedOutcome.tinybarGasCost())).willReturn(recordBuilder);
 
         assertDoesNotThrow(() -> subject.handle(handleContext));
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionResultTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionResultTest.java
@@ -17,8 +17,10 @@
 package com.hedera.node.app.service.contract.impl.test.hevm;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OBTAINER_SAME_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.WRONG_NONCE;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.SELF_DESTRUCT_TO_SELF;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.BESU_LOGS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_EVM_ADDRESS;
@@ -33,6 +35,7 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SOME_RE
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SOME_STORAGE_ACCESSES;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.TWO_STORAGE_ACCESSES;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.WEI_NETWORK_GAS_PRICE;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.wellKnownHapiCall;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.bloomForAll;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjLogsFrom;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjToTuweniBytes;
@@ -54,7 +57,6 @@ import java.util.List;
 import java.util.Optional;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -77,14 +79,9 @@ class HederaEvmTransactionResultTest {
     @Mock
     private StorageAccessTracker accessTracker;
 
-    @BeforeEach
-    void setUp() {
-        given(frame.getMessageFrameStack()).willReturn(stack);
-        given(stack.isEmpty()).willReturn(true);
-    }
-
     @Test
     void finalStatusFromHaltUsesCorrespondingStatusIfFromCustom() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getExceptionalHaltReason()).willReturn(Optional.of(SELF_DESTRUCT_TO_SELF));
         final var subject = HederaEvmTransactionResult.failureFrom(GAS_LIMIT / 2, SENDER_ID, frame, null);
@@ -95,6 +92,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void finalStatusFromHaltUsesCorrespondingStatusIfFromStandard() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getExceptionalHaltReason()).willReturn(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
         final var subject = HederaEvmTransactionResult.failureFrom(GAS_LIMIT / 2, SENDER_ID, frame, null);
@@ -105,6 +103,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void finalStatusFromInsufficientGasHaltImplemented() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getExceptionalHaltReason()).willReturn(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
         final var subject = HederaEvmTransactionResult.failureFrom(GAS_LIMIT / 2, SENDER_ID, frame, null);
@@ -113,6 +112,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void finalStatusFromMissingAddressHaltImplemented() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getExceptionalHaltReason())
                 .willReturn(Optional.of(CustomExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
@@ -121,7 +121,21 @@ class HederaEvmTransactionResultTest {
     }
 
     @Test
+    void finalStatusFromWrongNonceAbortTranslated() {
+        final var subject = HederaEvmTransactionResult.fromAborted(SENDER_ID, wellKnownHapiCall(), WRONG_NONCE);
+        assertEquals(WRONG_NONCE, subject.finalStatus());
+    }
+
+    @Test
+    void finalStatusFromIpbAbortTranslated() {
+        final var subject =
+                HederaEvmTransactionResult.fromAborted(SENDER_ID, wellKnownHapiCall(), INSUFFICIENT_PAYER_BALANCE);
+        assertEquals(INSUFFICIENT_PAYER_BALANCE, subject.finalStatus());
+    }
+
+    @Test
     void givenAccessTrackerIncludesFullContractStorageChangesAndNonNullNoncesOnSuccess() {
+        withFrameSetup();
         given(frame.getContextVariable(FrameUtils.TRACKER_CONTEXT_VARIABLE)).willReturn(accessTracker);
         given(frame.getWorldUpdater()).willReturn(proxyWorldUpdater);
         final var pendingWrites = List.of(TWO_STORAGE_ACCESSES);
@@ -155,6 +169,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void givenEthTxDataIncludesSpecialFields() {
+        withFrameSetup();
         given(frame.getContextVariable(FrameUtils.TRACKER_CONTEXT_VARIABLE)).willReturn(accessTracker);
         given(frame.getWorldUpdater()).willReturn(proxyWorldUpdater);
         final var pendingWrites = List.of(TWO_STORAGE_ACCESSES);
@@ -193,6 +208,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void givenAccessTrackerIncludesReadStorageAccessesOnlyOnFailure() {
+        withFrameSetup();
         given(frame.getContextVariable(FrameUtils.TRACKER_CONTEXT_VARIABLE)).willReturn(accessTracker);
         given(accessTracker.getJustReads()).willReturn(SOME_STORAGE_ACCESSES);
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
@@ -205,6 +221,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void withoutAccessTrackerReturnsNullStateChanges() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getOutputData()).willReturn(pbjToTuweniBytes(OUTPUT_DATA));
 
@@ -216,6 +233,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void QueryResultOnSuccess() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getLogs()).willReturn(BESU_LOGS);
         given(frame.getOutputData()).willReturn(pbjToTuweniBytes(OUTPUT_DATA));
@@ -234,6 +252,7 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void QueryResultOnHalt() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getExceptionalHaltReason()).willReturn(Optional.of(ExceptionalHaltReason.INVALID_OPERATION));
 
@@ -244,11 +263,17 @@ class HederaEvmTransactionResultTest {
 
     @Test
     void QueryResultOnRevert() {
+        withFrameSetup();
         given(frame.getGasPrice()).willReturn(WEI_NETWORK_GAS_PRICE);
         given(frame.getRevertReason()).willReturn(Optional.of(SOME_REVERT_REASON));
 
         final var result = HederaEvmTransactionResult.failureFrom(GAS_LIMIT / 2, SENDER_ID, frame, null);
         final var protoResult = result.asQueryResult();
         assertEquals(SOME_REVERT_REASON.toString(), protoResult.errorMessage());
+    }
+
+    private void withFrameSetup() {
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.isEmpty()).willReturn(true);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -470,9 +470,6 @@ public class EthereumSuite extends HapiSuite {
                                 .exposingNumTo(num -> contractID.set(asHexedSolidityAddress(0, 0, num)))
                                 .gasLimit(1_000_000L)
                                 .hasKnownStatus(SUCCESS),
-                        withOpContext((spec, opLog) -> {
-                            opLog.info("contractID created 0.0.{}", contractID.get());
-                        }),
                         ethereumCall(PAY_RECEIVABLE_CONTRACT, "getBalance")
                                 .type(EthTxData.EthTransactionType.EIP1559)
                                 .signingWith(SECP_256K1_SOURCE_KEY)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -29,6 +29,7 @@ import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.re
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.logWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.includingDeduction;
 import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
@@ -207,7 +208,9 @@ public class EthereumSuite extends HapiSuite {
                                     .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE);
                             allRunFor(spec, call);
                         }),
-                        getTxnRecord("createTokenTxn").logged());
+                        // Quick assertion to verify top-level HAPI fees were still charged after aborting
+                        getTxnRecord("createTokenTxn")
+                                .hasPriority(recordWith().transfers(includingDeduction("HAPI fees", RELAYER))));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Closes #10599 by refactoring as suggested.
 - Adds `AbortException` to eliminate duplication of computing the effective `senderId`; now the exception thrown from an aborted `processTransaction()` call includes the `senderId` from `computeInvolvedParties()`.
 - Since we no longer need to use the `feesOnlyUpdater` after an abort, this also lets us easily preserve the HAPI fees charged by the workflow by just committing the root updater after an abort.
    * Avoids partial gas charges by refactoring `CustomGasCharging` to only charge _any_ fee if _all_ fees are payable.
 - Removes unreachable `try`/`catch (ResourceExhaustedException)` around `runToCompletion()`.
 - For mono-service fidelity, allows long-zero addresses to be used in top-level HAPI operations even when the referenced contract has an EVM address outside the long-zero subspace (accomplished via `asPriorityId()` calls in `HevmTransactionFactory`).
 - Enables last two specs in `EthereumSuite`.