### PR TITLE
fix: Add a feature flag for token balances and token relationships and enable them

### DIFF
--- a/hedera-node/configuration/dev/bootstrap.properties
+++ b/hedera-node/configuration/dev/bootstrap.properties
@@ -3,6 +3,7 @@ accounts.storeOnDisk=true
 tokens.storeRelsOnDisk=true
 tokens.nfts.useVirtualMerkle=true
 accounts.blocklist.enabled=false
+tokens.balancesInQueries.enabled=true
 accounts.blocklist.path=
 
 contracts.knownBlockHash=

--- a/hedera-node/configuration/dev/bootstrap.properties
+++ b/hedera-node/configuration/dev/bootstrap.properties
@@ -3,7 +3,6 @@ accounts.storeOnDisk=true
 tokens.storeRelsOnDisk=true
 tokens.nfts.useVirtualMerkle=true
 accounts.blocklist.enabled=false
-tokens.balancesInQueries.enabled=true
 accounts.blocklist.path=
 
 contracts.knownBlockHash=

--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -12,3 +12,4 @@ tokens.nfts.useVirtualMerkle=true
 records.useConsolidatedFcq=true
 cache.cryptoTransfer.warmThreads=30
 contracts.maxNumWithHapiSigsAccess=0
+tokens.balancesInQueries.enabled=true

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
@@ -48,4 +48,6 @@ public record TokensConfig(
         @ConfigProperty(value = "nfts.useVirtualMerkle", defaultValue = "true") @NetworkProperty
                 boolean nftsUseVirtualMerkle,
         @ConfigProperty(value = "autoCreations.isEnabled", defaultValue = "true") @NetworkProperty
-                boolean autoCreationsIsEnabled) {}
+                boolean autoCreationsIsEnabled,
+        @ConfigProperty(value = "balancesInQueries.enabled", defaultValue = "true") @NetworkProperty
+                boolean balancesInQueriesEnabled) {}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/StateView.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/StateView.java
@@ -392,7 +392,11 @@ public class StateView {
     }
 
     public Optional<CryptoGetInfoResponse.AccountInfo> infoForAccount(
-            final AccountID id, final AliasManager aliasManager, final RewardCalculator rewardCalculator) {
+            final AccountID id,
+            final AliasManager aliasManager,
+            final int maxTokensForAccountInfo,
+            final RewardCalculator rewardCalculator,
+            final boolean areTokenBalancesEnabledInQueries) {
         final var accountNum = id.getAlias().isEmpty() ? fromAccountId(id) : aliasManager.lookupIdBy(id.getAlias());
         final var account = accounts().get(accountNum);
         if (account == null) {
@@ -417,6 +421,12 @@ public class StateView {
         Optional.ofNullable(account.getProxy()).map(EntityId::toGrpcAccountId).ifPresent(info::setProxyAccountID);
         if (!isOfEvmAddressSize(account.getAlias())) {
             info.setAlias(account.getAlias());
+        }
+        if (areTokenBalancesEnabledInQueries) {
+            final var tokenRels = tokenRels(this, account, maxTokensForAccountInfo);
+            if (!tokenRels.isEmpty()) {
+                info.addAllTokenRelationships(tokenRels);
+            }
         }
         info.setStakingInfo(stakingInfo(account, rewardCalculator));
 
@@ -539,7 +549,11 @@ public class StateView {
     }
 
     public Optional<ContractGetInfoResponse.ContractInfo> infoForContract(
-            final ContractID id, final AliasManager aliasManager, final RewardCalculator rewardCalculator) {
+            final ContractID id,
+            final AliasManager aliasManager,
+            final int maxTokensForAccountInfo,
+            final RewardCalculator rewardCalculator,
+            final boolean areTokenBalancesEnabledInQueries) {
         final var contractId = EntityIdUtils.unaliased(id, aliasManager);
         final var contract = contracts().get(contractId);
         if (contract == null) {
@@ -567,6 +581,12 @@ public class StateView {
             info.setContractAccountID(hex(contract.getAlias().toByteArray()));
         } else {
             info.setContractAccountID(asHexedEvmAddress(mirrorId));
+        }
+        if (areTokenBalancesEnabledInQueries) {
+            final var tokenRels = tokenRels(this, contract, maxTokensForAccountInfo);
+            if (!tokenRels.isEmpty()) {
+                info.addAllTokenRelationships(tokenRels);
+            }
         }
         info.setStakingInfo(stakingInfo(contract, rewardCalculator));
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -231,6 +231,7 @@ import static com.hedera.node.app.service.mono.context.properties.PropertyNames.
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_USE_TREASURY_WILD_CARDS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_USE_VIRTUAL_MERKLE;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_STORE_RELS_ON_DISK;
+import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKEN_BALANCES_ENABLED_IN_QUERIES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOPICS_MAX_NUM;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MAX_EXPORTS_PER_CONS_SEC;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MIN_FREE_TO_USED_GAS_THROTTLE_RATIO;
@@ -569,7 +570,8 @@ public final class BootstrapProperties implements PropertySource {
             TOKENS_AUTO_CREATIONS_ENABLED,
             ACCOUNTS_BLOCKLIST_ENABLED,
             ACCOUNTS_BLOCKLIST_PATH,
-            CACHE_CRYPTO_TRANSFER_WARM_THREADS);
+            CACHE_CRYPTO_TRANSFER_WARM_THREADS,
+            TOKEN_BALANCES_ENABLED_IN_QUERIES);
 
     static final Set<String> NODE_PROPS = Set.of(
             DEV_ONLY_DEFAULT_NODE_LISTENS,
@@ -826,5 +828,6 @@ public final class BootstrapProperties implements PropertySource {
             entry(ACCOUNTS_BLOCKLIST_ENABLED, AS_BOOLEAN),
             entry(ACCOUNTS_BLOCKLIST_PATH, AS_STRING),
             entry(CACHE_CRYPTO_TRANSFER_WARM_THREADS, AS_INT),
-            entry(CONFIG_VERSION, AS_INT));
+            entry(CONFIG_VERSION, AS_INT),
+            entry(TOKEN_BALANCES_ENABLED_IN_QUERIES, AS_BOOLEAN));
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
@@ -138,6 +138,7 @@ import static com.hedera.node.app.service.mono.context.properties.PropertyNames.
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_MAX_QUERY_RANGE;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_MINT_THORTTLE_SCALE_FACTOR;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_USE_TREASURY_WILDCARDS;
+import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKEN_BALANCES_ENABLED_IN_QUERIES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOPICS_MAX_NUM;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MAX_EXPORTS_PER_CONS_SEC;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MIN_FREE_TO_USED_GAS_THROTTLE_RATIO;
@@ -303,6 +304,7 @@ public class GlobalDynamicProperties implements EvmProperties {
     private int sumOfConsensusWeights;
     private int cacheWarmThreads;
     private int configVersion;
+    private boolean tokenBalancesEnabledInQueries;
 
     @Inject
     public GlobalDynamicProperties(final HederaNumbers hederaNums, @CompositeProps final PropertySource properties) {
@@ -457,6 +459,7 @@ public class GlobalDynamicProperties implements EvmProperties {
         maxAutoAssociations = properties.getIntProperty(LEDGER_MAX_AUTO_ASSOCIATIONS);
         sumOfConsensusWeights = properties.getIntProperty(STAKING_SUM_OF_CONSENSUS_WEIGHTS);
         cacheWarmThreads = properties.getIntProperty(CACHE_CRYPTO_TRANSFER_WARM_THREADS);
+        tokenBalancesEnabledInQueries = properties.getBooleanProperty(TOKEN_BALANCES_ENABLED_IN_QUERIES);
     }
 
     public int sumOfConsensusWeights() {
@@ -991,5 +994,9 @@ public class GlobalDynamicProperties implements EvmProperties {
      */
     public long stakingRewardBalanceThreshold() {
         return stakingRewardBalanceThreshold;
+    }
+
+    public boolean areTokenBalancesEnabledInQueries() {
+        return tokenBalancesEnabledInQueries;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
@@ -215,6 +215,7 @@ public class PropertyNames {
     public static final String HEDERA_RECORD_STREAM_COMPRESS_FILES_ON_CREATION =
             "hedera.recordStream.compressFilesOnCreation";
     public static final String TOKENS_AUTO_CREATIONS_ENABLED = "tokens.autoCreations.isEnabled";
+    public static final String TOKEN_BALANCES_ENABLED_IN_QUERIES = "tokens.balancesInQueries.enabled";
 
     /* ---- Node properties ----- */
     public static final String DEV_ONLY_DEFAULT_NODE_LISTENS = "dev.onlyDefaultNodeListens";

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsage.java
@@ -59,7 +59,12 @@ public final class GetContractInfoResourceUsage implements QueryResourceUsageEst
     @Override
     public FeeData usageGiven(final Query query, final StateView view, @Nullable final Map<String, Object> queryCtx) {
         final var op = query.getContractGetInfo();
-        final var tentativeInfo = view.infoForContract(op.getContractID(), aliasManager, rewardCalculator);
+        final var tentativeInfo = view.infoForContract(
+                op.getContractID(),
+                aliasManager,
+                dynamicProperties.maxTokensRelsPerInfoQuery(),
+                rewardCalculator,
+                dynamicProperties.areTokenBalancesEnabledInQueries());
         if (tentativeInfo.isPresent()) {
             final var info = tentativeInfo.get();
             putIfNotNull(queryCtx, CONTRACT_INFO_CTX_KEY, info);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
@@ -22,6 +22,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage;
 import com.hedera.node.app.hapi.fees.usage.crypto.ExtantCryptoContext;
 import com.hedera.node.app.service.mono.context.primitives.StateView;
+import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.fees.calculation.QueryResourceUsageEstimator;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.ledger.accounts.staking.RewardCalculator;
@@ -36,15 +37,18 @@ import javax.inject.Singleton;
 public final class GetAccountInfoResourceUsage implements QueryResourceUsageEstimator {
     private final CryptoOpsUsage cryptoOpsUsage;
     private final AliasManager aliasManager;
+    private final GlobalDynamicProperties dynamicProperties;
     private final RewardCalculator rewardCalculator;
 
     @Inject
     public GetAccountInfoResourceUsage(
             final CryptoOpsUsage cryptoOpsUsage,
             final AliasManager aliasManager,
+            final GlobalDynamicProperties dynamicProperties,
             final RewardCalculator rewardCalculator) {
         this.cryptoOpsUsage = cryptoOpsUsage;
         this.aliasManager = aliasManager;
+        this.dynamicProperties = dynamicProperties;
         this.rewardCalculator = rewardCalculator;
     }
 
@@ -58,7 +62,12 @@ public final class GetAccountInfoResourceUsage implements QueryResourceUsageEsti
         final var op = query.getCryptoGetInfo();
 
         final var account = op.getAccountID();
-        final var info = view.infoForAccount(account, aliasManager, rewardCalculator);
+        final var info = view.infoForAccount(
+                account,
+                aliasManager,
+                dynamicProperties.maxTokensRelsPerInfoQuery(),
+                rewardCalculator,
+                dynamicProperties.areTokenBalancesEnabledInQueries());
         /* Given the test in {@code GetAccountInfoAnswer.checkValidity}, this can only be empty
          * under the extraordinary circumstance that the desired account expired during the query
          * answer flow (which will now fail downstream with an appropriate status code); so

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswer.java
@@ -25,6 +25,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
 
 import com.hedera.node.app.service.mono.context.primitives.StateView;
+import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.ledger.accounts.staking.RewardCalculator;
 import com.hedera.node.app.service.mono.queries.AnswerService;
@@ -53,13 +54,18 @@ public class GetContractInfoAnswer implements AnswerService {
 
     private final AliasManager aliasManager;
     private final OptionValidator validator;
+    private final GlobalDynamicProperties dynamicProperties;
     private final RewardCalculator rewardCalculator;
 
     @Inject
     public GetContractInfoAnswer(
-            final AliasManager aliasManager, final OptionValidator validator, final RewardCalculator rewardCalculator) {
+            final AliasManager aliasManager,
+            final OptionValidator validator,
+            final GlobalDynamicProperties dynamicProperties,
+            final RewardCalculator rewardCalculator) {
         this.aliasManager = aliasManager;
         this.validator = validator;
+        this.dynamicProperties = dynamicProperties;
         this.rewardCalculator = rewardCalculator;
     }
 
@@ -153,7 +159,12 @@ public class GetContractInfoAnswer implements AnswerService {
                 response.setContractInfo((ContractGetInfoResponse.ContractInfo) ctx.get(CONTRACT_INFO_CTX_KEY));
             }
         } else {
-            final var info = view.infoForContract(op.getContractID(), aliasManager, rewardCalculator);
+            final var info = view.infoForContract(
+                    op.getContractID(),
+                    aliasManager,
+                    dynamicProperties.maxTokensRelsPerInfoQuery(),
+                    rewardCalculator,
+                    dynamicProperties.areTokenBalancesEnabledInQueries());
             if (info.isEmpty()) {
                 response.setHeader(answerOnlyHeader(INVALID_CONTRACT_ID));
             } else {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswer.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.mono.queries.crypto;
 
+import static com.hedera.node.app.service.mono.context.primitives.StateView.doBoundedIteration;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.asAccount;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.isAlias;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoGetAccountBalance;
@@ -23,6 +24,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 import com.hedera.node.app.service.mono.context.primitives.StateView;
+import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.queries.AnswerService;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
@@ -37,6 +39,7 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenBalance;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,11 +54,16 @@ import javax.inject.Singleton;
 public class GetAccountBalanceAnswer implements AnswerService {
     private final AliasManager aliasManager;
     private final OptionValidator optionValidator;
+    private final GlobalDynamicProperties dynamicProperties;
 
     @Inject
-    public GetAccountBalanceAnswer(final AliasManager aliasManager, final OptionValidator optionValidator) {
+    public GetAccountBalanceAnswer(
+            final AliasManager aliasManager,
+            final OptionValidator optionValidator,
+            final GlobalDynamicProperties dynamicProperties) {
         this.aliasManager = aliasManager;
         this.optionValidator = optionValidator;
+        this.dynamicProperties = dynamicProperties;
     }
 
     @Override
@@ -90,6 +98,20 @@ public class GetAccountBalanceAnswer implements AnswerService {
             final var key = EntityNum.fromAccountId(id);
             final var account = accounts.get(key);
             opAnswer.setBalance(account.getBalance());
+            if (dynamicProperties.areTokenBalancesEnabledInQueries()) {
+                final var maxRels = dynamicProperties.maxTokensRelsPerInfoQuery();
+                final var firstRel = account.getLatestAssociation();
+                doBoundedIteration(
+                        view.tokenAssociations(),
+                        view.tokens(),
+                        firstRel,
+                        maxRels,
+                        (token, rel) -> opAnswer.addTokenBalances(TokenBalance.newBuilder()
+                                .setTokenId(token.grpcId())
+                                .setDecimals(token.decimals())
+                                .setBalance(rel.getBalance())
+                                .build()));
+            }
         }
 
         return Response.newBuilder().setCryptogetAccountBalance(opAnswer).build();

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -229,3 +229,4 @@ accounts.blocklist.path=
 staking.sumOfConsensusWeights=500
 cache.cryptoTransfer.warmThreads=30
 hedera.config.version=0
+tokens.balancesInQueries.enabled=true

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.context.primitives;
 
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.node.app.service.mono.context.BasicTransactionContext.EMPTY_KEY;
+import static com.hedera.node.app.service.mono.context.primitives.StateView.REMOVED_TOKEN;
 import static com.hedera.node.app.service.mono.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.node.app.service.mono.state.submerkle.RichInstant.fromJava;
 import static com.hedera.node.app.service.mono.txns.crypto.helpers.AllowanceHelpers.getCryptoGrantedAllowancesList;
@@ -52,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.argThat;
 import static org.mockito.BDDMockito.given;
@@ -125,6 +127,7 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenFreezeStatus;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenKycStatus;
+import com.hederahashgraph.api.proto.java.TokenRelationship;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.utility.CommonUtils;
@@ -153,6 +156,7 @@ class StateViewTest {
     private final RichInstant now =
             RichInstant.fromGrpc(Timestamp.newBuilder().setNanos(123123213).build());
     private final int maxTokensFprAccountInfo = 10;
+    private final boolean aretokenBalancesEnabledInQueries = true;
     private final long expiry = 2_000_000L;
     private final byte[] data = "SOMETHING".getBytes();
     private final byte[] expectedBytecode = "A Supermarket in California".getBytes();
@@ -615,10 +619,20 @@ class StateViewTest {
         final var expectedTotalStorage = StateView.BYTES_PER_EVM_KEY_VALUE_PAIR * wellKnownNumKvPairs;
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
+        List<TokenRelationship> rels = List.of(TokenRelationship.newBuilder()
+                .setTokenId(TokenID.newBuilder().setTokenNum(123L))
+                .setFreezeStatus(TokenFreezeStatus.FreezeNotApplicable)
+                .setKycStatus(TokenKycStatus.KycNotApplicable)
+                .setBalance(321L)
+                .build());
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, contract, maxTokensFprAccountInfo))
+                .thenReturn(rels);
 
-        final var info =
-                subject.infoForContract(cid, aliasManager, rewardCalculator).get();
+        final var info = subject.infoForContract(
+                        cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator, aretokenBalancesEnabledInQueries)
+                .get();
 
         assertEquals(cid, info.getContractID());
         assertEquals(asAccount(cid), info.getAccountID());
@@ -629,6 +643,7 @@ class StateViewTest {
         assertEquals(CommonUtils.hex(create2Address.toByteArray()), info.getContractAccountID());
         assertEquals(contract.getExpiry(), info.getExpirationTime().getSeconds());
         assertEquals(EntityId.fromIdentityCode(4), contract.getAutoRenewAccount());
+        assertEquals(rels, info.getTokenRelationshipsList());
         assertEquals(ledgerId, info.getLedgerId());
         assertTrue(info.getDeleted());
         assertEquals(expectedTotalStorage, info.getStorage());
@@ -638,15 +653,26 @@ class StateViewTest {
 
     @Test
     void getsContractInfoWithoutCreate2Address() throws Exception {
+        final var target = EntityNum.fromContractId(cid);
         given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
         contract.setAlias(ByteString.EMPTY);
         final var expectedTotalStorage = StateView.BYTES_PER_EVM_KEY_VALUE_PAIR * wellKnownNumKvPairs;
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
+        List<TokenRelationship> rels = List.of(TokenRelationship.newBuilder()
+                .setTokenId(TokenID.newBuilder().setTokenNum(123L))
+                .setFreezeStatus(TokenFreezeStatus.FreezeNotApplicable)
+                .setKycStatus(TokenKycStatus.KycNotApplicable)
+                .setBalance(321L)
+                .build());
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, contract, maxTokensFprAccountInfo))
+                .thenReturn(rels);
 
-        final var info =
-                subject.infoForContract(cid, aliasManager, rewardCalculator).get();
+        final var info = subject.infoForContract(
+                        cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator, aretokenBalancesEnabledInQueries)
+                .get();
 
         assertEquals(cid, info.getContractID());
         assertEquals(asAccount(cid), info.getAccountID());
@@ -656,10 +682,42 @@ class StateViewTest {
         assertEquals(contract.getBalance(), info.getBalance());
         assertEquals(EntityIdUtils.asHexedEvmAddress(asAccount(cid)), info.getContractAccountID());
         assertEquals(contract.getExpiry(), info.getExpirationTime().getSeconds());
+        assertEquals(rels, info.getTokenRelationshipsList());
         assertEquals(ledgerId, info.getLedgerId());
         assertTrue(info.getDeleted());
         assertEquals(expectedTotalStorage, info.getStorage());
         mockedStatic.close();
+    }
+
+    @Test
+    void getTokenRelationship() {
+        given(tokens.getOrDefault(tokenNum, REMOVED_TOKEN)).willReturn(token);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(nftTokenId), REMOVED_TOKEN))
+                .willReturn(nft);
+
+        List<TokenRelationship> expectedRels = List.of(
+                TokenRelationship.newBuilder()
+                        .setTokenId(tokenId)
+                        .setSymbol("UnfrozenToken")
+                        .setBalance(123L)
+                        .setKycStatus(TokenKycStatus.Granted)
+                        .setFreezeStatus(TokenFreezeStatus.Unfrozen)
+                        .setAutomaticAssociation(true)
+                        .setDecimals(1)
+                        .build(),
+                TokenRelationship.newBuilder()
+                        .setTokenId(nftTokenId)
+                        .setSymbol("UnfrozenToken")
+                        .setBalance(2L)
+                        .setKycStatus(TokenKycStatus.Granted)
+                        .setFreezeStatus(TokenFreezeStatus.Unfrozen)
+                        .setAutomaticAssociation(false)
+                        .setDecimals(1)
+                        .build());
+
+        final var actualRels = StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo);
+
+        assertEquals(expectedRels, actualRels);
     }
 
     @Test
@@ -701,6 +759,9 @@ class StateViewTest {
         given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
 
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
         final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
@@ -724,7 +785,12 @@ class StateViewTest {
                         .build())
                 .build();
 
-        final var actualResponse = subject.infoForAccount(tokenAccountId, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                tokenAccountId,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
 
         assertEquals(expectedResponse, actualResponse.get());
         mockedStatic.close();
@@ -745,6 +811,9 @@ class StateViewTest {
         given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
 
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
         final var expectedResponse = StakingInfo.newBuilder()
@@ -753,7 +822,12 @@ class StateViewTest {
                 .setStakePeriodStart(Timestamp.newBuilder().setSeconds(1_234_567L))
                 .build();
 
-        final var actualResponse = subject.infoForAccount(tokenAccountId, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                tokenAccountId,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
 
         assertEquals(expectedResponse, actualResponse.get().getStakingInfo());
         mockedStatic.close();
@@ -767,6 +841,9 @@ class StateViewTest {
         final var expectedAddress = CommonUtils.hex(recoverAddressFromPubKey(ecdsaKey));
 
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
         final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
@@ -790,7 +867,12 @@ class StateViewTest {
                         .build())
                 .build();
 
-        final var actualResponse = subject.infoForAccount(tokenAccountId, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                tokenAccountId,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
         mockedStatic.close();
 
         assertEquals(expectedResponse, actualResponse.get());
@@ -805,6 +887,9 @@ class StateViewTest {
         final var expectedAddress = CommonUtils.hex(pretendAddress);
 
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
         final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
@@ -827,7 +912,12 @@ class StateViewTest {
                         .build())
                 .build();
 
-        final var actualResponse = subject.infoForAccount(tokenAccountId, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                tokenAccountId,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
         mockedStatic.close();
 
         assertEquals(expectedResponse, actualResponse.get());
@@ -872,6 +962,9 @@ class StateViewTest {
         given(aliasManager.lookupIdBy(any())).willReturn(EntityNum.fromAccountId(tokenAccountId));
         given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
         final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
@@ -895,7 +988,12 @@ class StateViewTest {
                         .build())
                 .build();
 
-        final var actualResponse = subject.infoForAccount(accountWithAlias, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                accountWithAlias,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
         mockedStatic.close();
         assertEquals(expectedResponse, actualResponse.get());
     }
@@ -906,6 +1004,9 @@ class StateViewTest {
         given(aliasManager.lookupIdBy(any())).willReturn(EntityNum.fromAccountId(tokenAccountId));
         given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
         given(networkInfo.ledgerId()).willReturn(ledgerId);
 
         tokenAccount.setAlias(ByteStringUtils.wrapUnsafely(pretendAddress));
@@ -929,7 +1030,12 @@ class StateViewTest {
                         .build())
                 .build();
 
-        final var actualResponse = subject.infoForAccount(accountWithAlias, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                accountWithAlias,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
         mockedStatic.close();
         assertEquals(expectedResponse, actualResponse.get());
     }
@@ -945,7 +1051,12 @@ class StateViewTest {
     void infoForMissingAccount() {
         given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(null);
 
-        final var actualResponse = subject.infoForAccount(tokenAccountId, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                tokenAccountId,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
 
         assertEquals(Optional.empty(), actualResponse);
     }
@@ -957,7 +1068,12 @@ class StateViewTest {
         given(aliasManager.lookupIdBy(any())).willReturn(mockedEntityNum);
         given(contracts.get(mockedEntityNum)).willReturn(null);
 
-        final var actualResponse = subject.infoForAccount(accountWithAlias, aliasManager, rewardCalculator);
+        final var actualResponse = subject.infoForAccount(
+                accountWithAlias,
+                aliasManager,
+                maxTokensFprAccountInfo,
+                rewardCalculator,
+                aretokenBalancesEnabledInQueries);
         assertEquals(Optional.empty(), actualResponse);
     }
 
@@ -1024,7 +1140,9 @@ class StateViewTest {
     void returnsEmptyOptionalIfContractMissing() {
         given(contracts.get(any())).willReturn(null);
 
-        assertTrue(subject.infoForContract(cid, aliasManager, rewardCalculator).isEmpty());
+        assertTrue(subject.infoForContract(
+                        cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator, aretokenBalancesEnabledInQueries)
+                .isEmpty());
     }
 
     @Test
@@ -1032,10 +1150,12 @@ class StateViewTest {
         given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
         given(networkInfo.ledgerId()).willReturn(ledgerId);
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic.when(() -> StateView.tokenRels(any(), any(), anyInt())).thenReturn(Collections.emptyList());
         contract.setAccountKey(null);
 
-        final var info =
-                subject.infoForContract(cid, aliasManager, rewardCalculator).get();
+        final var info = subject.infoForContract(
+                        cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator, aretokenBalancesEnabledInQueries)
+                .get();
 
         assertFalse(info.hasAdminKey());
         mockedStatic.close();
@@ -1046,10 +1166,12 @@ class StateViewTest {
         given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
         given(networkInfo.ledgerId()).willReturn(ledgerId);
         mockedStatic = mockStatic(StateView.class);
+        mockedStatic.when(() -> StateView.tokenRels(any(), any(), anyInt())).thenReturn(Collections.emptyList());
         contract.setAutoRenewAccount(null);
 
-        final var info =
-                subject.infoForContract(cid, aliasManager, rewardCalculator).get();
+        final var info = subject.infoForContract(
+                        cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator, aretokenBalancesEnabledInQueries)
+                .get();
 
         assertFalse(info.hasAutoRenewAccountId());
         mockedStatic.close();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -231,6 +231,7 @@ import static com.hedera.node.app.service.mono.context.properties.PropertyNames.
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_USE_TREASURY_WILD_CARDS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_USE_VIRTUAL_MERKLE;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_STORE_RELS_ON_DISK;
+import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKEN_BALANCES_ENABLED_IN_QUERIES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOPICS_MAX_NUM;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MAX_EXPORTS_PER_CONS_SEC;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MIN_FREE_TO_USED_GAS_THROTTLE_RATIO;
@@ -558,7 +559,8 @@ class BootstrapPropertiesTest {
             entry(STAKING_SUM_OF_CONSENSUS_WEIGHTS, 500),
             entry(CACHE_CRYPTO_TRANSFER_WARM_THREADS, 30),
             entry(CONFIG_VERSION, 10),
-            entry(RECORDS_USE_CONSOLIDATED_FCQ, true));
+            entry(RECORDS_USE_CONSOLIDATED_FCQ, true),
+            entry(TOKEN_BALANCES_ENABLED_IN_QUERIES, true));
 
     @Test
     void containsProperty() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicPropertiesTest.java
@@ -132,6 +132,7 @@ import static com.hedera.node.app.service.mono.context.properties.PropertyNames.
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_MAX_METADATA_BYTES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_MAX_QUERY_RANGE;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKENS_NFTS_MINT_THORTTLE_SCALE_FACTOR;
+import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOKEN_BALANCES_ENABLED_IN_QUERIES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TOPICS_MAX_NUM;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MAX_EXPORTS_PER_CONS_SEC;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.TRACEABILITY_MIN_FREE_TO_USED_GAS_THROTTLE_RATIO;
@@ -698,6 +699,7 @@ class GlobalDynamicPropertiesTest {
         given(properties.getLongProperty(STAKING_MAX_STAKE_REWARDED)).willReturn(i + 100L);
         given(properties.getLongProperty(STAKING_REWARD_BALANCE_THRESHOLD)).willReturn(i + 101L);
         given(properties.getBooleanProperty(HEDERA_TXN_EIP2930_ENABLED)).willReturn(i % 2 == 0);
+        given(properties.getBooleanProperty(TOKEN_BALANCES_ENABLED_IN_QUERIES)).willReturn((i + 102) % 2 == 0);
     }
 
     private Set<EntityType> typesFor(final int i) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
@@ -90,7 +90,8 @@ class GetContractInfoResourceUsageTest {
 
         view = mock(StateView.class);
         given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokensPerContractInfo);
-        given(view.infoForContract(target, aliasManager, rewardCalculator)).willReturn(Optional.of(info));
+        given(view.infoForContract(target, aliasManager, maxTokensPerContractInfo, rewardCalculator, true))
+                .willReturn(Optional.of(info));
 
         estimator = mock(ContractGetInfoUsage.class);
         mockedStatic = mockStatic(ContractGetInfoUsage.class);
@@ -142,7 +143,8 @@ class GetContractInfoResourceUsageTest {
     @Test
     void onlySetsContractInfoInQueryCxtIfFound() {
         final var queryCtx = new HashMap<String, Object>();
-        given(view.infoForContract(target, aliasManager, rewardCalculator)).willReturn(Optional.empty());
+        given(view.infoForContract(target, aliasManager, maxTokensPerContractInfo, rewardCalculator, true))
+                .willReturn(Optional.empty());
 
         final var actual = subject.usageGiven(satisfiableAnswerOnly, view, queryCtx);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
@@ -90,6 +90,7 @@ class GetContractInfoResourceUsageTest {
 
         view = mock(StateView.class);
         given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokensPerContractInfo);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
         given(view.infoForContract(target, aliasManager, maxTokensPerContractInfo, rewardCalculator, true))
                 .willReturn(Optional.of(info));
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
@@ -95,7 +95,7 @@ class GetAccountInfoResourceUsageTest {
 
     @BeforeEach
     void setup() {
-        subject = new GetAccountInfoResourceUsage(cryptoOpsUsage, aliasManager, rewardCalculator);
+        subject = new GetAccountInfoResourceUsage(cryptoOpsUsage, aliasManager, dynamicProperties, rewardCalculator);
     }
 
     @Test
@@ -113,7 +113,13 @@ class GetAccountInfoResourceUsageTest {
                 .setMaxAutomaticTokenAssociations(maxAutomaticAssociations)
                 .build();
         final var query = accountInfoQuery(a, ANSWER_ONLY);
-        given(view.infoForAccount(queryTarget, aliasManager, rewardCalculator)).willReturn(Optional.of(info));
+        given(view.infoForAccount(
+                        queryTarget,
+                        aliasManager,
+                        dynamicProperties.maxTokensRelsPerInfoQuery(),
+                        rewardCalculator,
+                        dynamicProperties.areTokenBalancesEnabledInQueries()))
+                .willReturn(Optional.of(info));
         given(cryptoOpsUsage.cryptoInfoUsage(any(), any())).willReturn(expected);
 
         final var usage = subject.usageGiven(query, view);
@@ -135,7 +141,13 @@ class GetAccountInfoResourceUsageTest {
 
     @Test
     void returnsDefaultIfNoSuchAccount() {
-        given(view.infoForAccount(queryTarget, aliasManager, rewardCalculator)).willReturn(Optional.empty());
+        given(view.infoForAccount(
+                        queryTarget,
+                        aliasManager,
+                        dynamicProperties.maxTokensRelsPerInfoQuery(),
+                        rewardCalculator,
+                        dynamicProperties.areTokenBalancesEnabledInQueries()))
+                .willReturn(Optional.empty());
 
         final var usage = subject.usageGiven(accountInfoQuery(a, ANSWER_ONLY), view);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswerTest.java
@@ -30,6 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
@@ -38,6 +40,7 @@ import static org.mockito.Mockito.never;
 
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.mono.context.primitives.StateView;
+import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.ledger.accounts.staking.RewardCalculator;
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
@@ -72,6 +75,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class GetContractInfoAnswerTest {
     private Transaction paymentTxn;
     private final int maxTokenPerContractInfo = 10;
+    private final boolean areTokenBalancesEnabledInQueries = true;
     private final String node = "0.0.3";
     private final String payer = "0.0.12345";
     private final String target = "0.0.123";
@@ -91,6 +95,9 @@ class GetContractInfoAnswerTest {
     private MerkleMap<EntityNum, MerkleAccount> contracts;
 
     @Mock
+    private GlobalDynamicProperties dynamicProperties;
+
+    @Mock
     private RewardCalculator rewardCalculator;
 
     ContractGetInfoResponse.ContractInfo info;
@@ -99,7 +106,6 @@ class GetContractInfoAnswerTest {
 
     @BeforeEach
     void setup() {
-        // we don't return the token relationships data anymore, since the field it is deprecated
         info = ContractGetInfoResponse.ContractInfo.newBuilder()
                 .setLedgerId(ledgerId)
                 .setContractID(asContract(target))
@@ -115,14 +121,21 @@ class GetContractInfoAnswerTest {
                         .build())
                 .build();
 
-        subject = new GetContractInfoAnswer(aliasManager, optionValidator, rewardCalculator);
+        subject = new GetContractInfoAnswer(aliasManager, optionValidator, dynamicProperties, rewardCalculator);
     }
 
     @Test
     void getsTheInfo() throws Throwable {
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokenPerContractInfo);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
         final Query query = validQuery(ANSWER_ONLY, fee, target);
 
-        given(view.infoForContract(asContract(target), aliasManager, rewardCalculator))
+        given(view.infoForContract(
+                        asContract(target),
+                        aliasManager,
+                        maxTokenPerContractInfo,
+                        rewardCalculator,
+                        areTokenBalancesEnabledInQueries))
                 .willReturn(Optional.of(info));
 
         // when:
@@ -164,14 +177,21 @@ class GetContractInfoAnswerTest {
         assertEquals(OK, opResponse.getHeader().getNodeTransactionPrecheckCode());
         assertSame(info, opResponse.getContractInfo());
         // and:
-        verify(view, never()).infoForContract(any(), any(), any());
+        verify(view, never()).infoForContract(any(), any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
     void recognizesMissingInfoWhenNoCtxGiven() throws Throwable {
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokenPerContractInfo);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
         final Query sensibleQuery = validQuery(ANSWER_ONLY, 5L, target);
 
-        given(view.infoForContract(asContract(target), aliasManager, rewardCalculator))
+        given(view.infoForContract(
+                        asContract(target),
+                        aliasManager,
+                        maxTokenPerContractInfo,
+                        rewardCalculator,
+                        areTokenBalancesEnabledInQueries))
                 .willReturn(Optional.empty());
 
         // when:
@@ -195,7 +215,7 @@ class GetContractInfoAnswerTest {
         final ContractGetInfoResponse opResponse = response.getContractGetInfo();
         assertTrue(opResponse.hasHeader(), "Missing response header!");
         assertEquals(INVALID_CONTRACT_ID, opResponse.getHeader().getNodeTransactionPrecheckCode());
-        verify(view, never()).infoForContract(any(), any(), any());
+        verify(view, never()).infoForContract(any(), any(), anyInt(), any(), anyBoolean());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswerTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.mono.queries.crypto;
 import static com.hedera.node.app.service.mono.utils.EntityNumPair.fromAccountTokenRel;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.IdUtils.asContract;
+import static com.hedera.test.utils.IdUtils.tokenBalanceWith;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoGetAccountBalance;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
@@ -36,6 +37,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.node.app.service.mono.context.MutableStateChildren;
 import com.hedera.node.app.service.mono.context.primitives.StateView;
+import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JEd25519Key;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
@@ -62,7 +64,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ResponseType;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.merkle.map.MerkleMap;
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,6 +77,9 @@ class GetAccountBalanceAnswerTest {
     private AccountStorageAdapter accounts;
 
     @Mock
+    private GlobalDynamicProperties dynamicProperties;
+
+    @Mock
     private OptionValidator optionValidator;
 
     @Mock
@@ -84,7 +89,7 @@ class GetAccountBalanceAnswerTest {
 
     @BeforeEach
     void setup() {
-        subject = new GetAccountBalanceAnswer(aliasManager, optionValidator);
+        subject = new GetAccountBalanceAnswer(aliasManager, optionValidator, dynamicProperties);
     }
 
     @Test
@@ -231,6 +236,8 @@ class GetAccountBalanceAnswerTest {
         given(aliasManager.lookupIdBy(aliasId.getAlias())).willReturn(wellKnownId);
         accountV.setKey(EntityNum.fromAccountId(asAccount(accountIdLit)));
         given(accounts.get(wellKnownId)).willReturn(accountV);
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokenRels);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
 
         final CryptoGetAccountBalanceQuery op =
                 CryptoGetAccountBalanceQuery.newBuilder().setAccountID(aliasId).build();
@@ -243,7 +250,12 @@ class GetAccountBalanceAnswerTest {
 
         assertTrue(response.getCryptogetAccountBalance().hasHeader(), "Missing response header!");
         assertEquals(
-                Collections.emptyList(), response.getCryptogetAccountBalance().getTokenBalancesList());
+                List.of(
+                        tokenBalanceWith(aToken, aBalance, 1),
+                        tokenBalanceWith(bToken, bBalance, 2),
+                        tokenBalanceWith(cToken, cBalance, 123),
+                        tokenBalanceWith(dToken, dBalance, 123)),
+                response.getCryptogetAccountBalance().getTokenBalancesList());
         assertEquals(OK, status);
         assertEquals(balance, answer);
         assertEquals(
@@ -258,6 +270,8 @@ class GetAccountBalanceAnswerTest {
         final var wellKnownId = EntityNum.fromLong(12345L);
         accountV.setKey(EntityNum.fromAccountId(asAccount(accountIdLit)));
         given(accounts.get(wellKnownId)).willReturn(accountV);
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokenRels);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
 
         // when:
         final Response response = subject.responseGiven(query, wellKnownView(), OK);
@@ -267,9 +281,13 @@ class GetAccountBalanceAnswerTest {
 
         // expect:
         assertTrue(response.getCryptogetAccountBalance().hasHeader(), "Missing response header!");
-        // we don't return token balances data in the query anymore since it is deprecated
         assertEquals(
-                Collections.emptyList(), response.getCryptogetAccountBalance().getTokenBalancesList());
+                List.of(
+                        tokenBalanceWith(aToken, aBalance, 1),
+                        tokenBalanceWith(bToken, bBalance, 2),
+                        tokenBalanceWith(cToken, cBalance, 123),
+                        tokenBalanceWith(dToken, dBalance, 123)),
+                response.getCryptogetAccountBalance().getTokenBalancesList());
         assertEquals(OK, status);
         assertEquals(balance, answer);
         assertEquals(id, response.getCryptogetAccountBalance().getAccountID());
@@ -283,6 +301,8 @@ class GetAccountBalanceAnswerTest {
         accountV.setKey(EntityNum.fromAccountId(asAccount(accountIdLit)));
         final var view = wellKnownView();
         given(accounts.get(EntityNum.fromContractId(id))).willReturn(accountV);
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokenRels);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
 
         // when:
         final Response response = subject.responseGiven(query, view, OK);
@@ -293,7 +313,12 @@ class GetAccountBalanceAnswerTest {
         // expect:
         assertTrue(response.getCryptogetAccountBalance().hasHeader(), "Missing response header!");
         assertEquals(
-                Collections.emptyList(), response.getCryptogetAccountBalance().getTokenBalancesList());
+                List.of(
+                        tokenBalanceWith(aToken, aBalance, 1),
+                        tokenBalanceWith(bToken, bBalance, 2),
+                        tokenBalanceWith(cToken, cBalance, 123),
+                        tokenBalanceWith(dToken, dBalance, 123)),
+                response.getCryptogetAccountBalance().getTokenBalancesList());
         assertEquals(OK, status);
         assertEquals(balance, answer);
         assertEquals(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswerTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.mono.queries.crypto;
 
+import static com.hedera.node.app.service.mono.context.primitives.StateView.REMOVED_TOKEN;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.asEvmAddress;
 import static com.hedera.node.app.service.mono.utils.EntityNumPair.fromAccountTokenRel;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
@@ -34,6 +35,8 @@ import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -55,6 +58,7 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.FcTokenAllowanceId;
+import com.hedera.node.app.service.mono.state.submerkle.RawTokenRelationship;
 import com.hedera.node.app.service.mono.store.schedule.ScheduleStore;
 import com.hedera.node.app.service.mono.txns.validation.OptionValidator;
 import com.hedera.node.app.service.mono.utils.EntityNum;
@@ -73,7 +77,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.merkle.map.MerkleMap;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -210,7 +214,7 @@ class GetAccountInfoAnswerTest {
 
         view = new StateView(scheduleStore, children, networkInfo);
 
-        subject = new GetAccountInfoAnswer(optionValidator, aliasManager, rewardCalculator);
+        subject = new GetAccountInfoAnswer(optionValidator, aliasManager, dynamicProperties, rewardCalculator);
     }
 
     @Test
@@ -245,11 +249,12 @@ class GetAccountInfoAnswerTest {
 
     @Test
     void identifiesFailInvalid() throws Throwable {
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokensPerAccountInfo);
         final Query query = validQuery(ANSWER_ONLY, fee, target);
         // and:
         final StateView view = mock(StateView.class);
 
-        given(view.infoForAccount(any(), any(), any())).willReturn(Optional.empty());
+        given(view.infoForAccount(any(), any(), anyInt(), any(), anyBoolean())).willReturn(Optional.empty());
 
         // when:
         final Response response = subject.responseGiven(query, view, OK, fee);
@@ -263,12 +268,36 @@ class GetAccountInfoAnswerTest {
     @Test
     @SuppressWarnings("unchecked")
     void getsTheAccountInfo() throws Throwable {
-
+        given(dynamicProperties.maxTokensRelsPerInfoQuery()).willReturn(maxTokensPerAccountInfo);
+        given(dynamicProperties.areTokenBalancesEnabledInQueries()).willReturn(true);
         final MerkleMap<EntityNum, MerkleToken> tokens = mock(MerkleMap.class);
         children.setTokens(MerkleMapLike.from(tokens));
+
+        given(token.hasKycKey()).willReturn(true);
+        given(token.hasFreezeKey()).willReturn(true);
+        given(token.decimals())
+                .willReturn(1)
+                .willReturn(2)
+                .willReturn(3)
+                .willReturn(1)
+                .willReturn(2)
+                .willReturn(3);
+        given(deletedToken.decimals()).willReturn(4);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(firstToken), REMOVED_TOKEN))
+                .willReturn(token);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(secondToken), REMOVED_TOKEN))
+                .willReturn(token);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(thirdToken), REMOVED_TOKEN))
+                .willReturn(token);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(fourthToken), REMOVED_TOKEN))
+                .willReturn(deletedToken);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(missingToken), REMOVED_TOKEN))
+                .willReturn(REMOVED_TOKEN);
         payerAccount.setKey(EntityNum.fromAccountId(payerId));
         payerAccount.setHeadTokenId(firstToken.getTokenNum());
 
+        given(token.symbol()).willReturn("HEYMA");
+        given(deletedToken.symbol()).willReturn("THEWAY");
         given(accounts.get(EntityNum.fromAccountId(asAccount(target)))).willReturn(payerAccount);
         given(networkInfo.ledgerId()).willReturn(ledgerId);
         given(rewardCalculator.epochSecondAtStartOfPeriod(12345678L)).willReturn(12345678L);
@@ -305,8 +334,20 @@ class GetAccountInfoAnswerTest {
         assertEquals(12345678L, info.getStakingInfo().getStakePeriodStart().getSeconds());
         assertEquals(0L, info.getStakingInfo().getStakedToMe());
 
-        // We no more return token association details in the response
-        assertEquals(Collections.emptyList(), info.getTokenRelationshipsList());
+        // and:
+        assertEquals(
+                List.of(
+                        new RawTokenRelationship(firstBalance, 0, 0, firstToken.getTokenNum(), true, true, true)
+                                .asGrpcFor(token),
+                        new RawTokenRelationship(secondBalance, 0, 0, secondToken.getTokenNum(), false, false, true)
+                                .asGrpcFor(token),
+                        new RawTokenRelationship(thirdBalance, 0, 0, thirdToken.getTokenNum(), true, true, false)
+                                .asGrpcFor(token),
+                        new RawTokenRelationship(fourthBalance, 0, 0, fourthToken.getTokenNum(), false, false, true)
+                                .asGrpcFor(deletedToken),
+                        new RawTokenRelationship(missingBalance, 0, 0, missingToken.getTokenNum(), false, false, false)
+                                .asGrpcFor(REMOVED_TOKEN)),
+                info.getTokenRelationshipsList());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -226,3 +226,4 @@ accounts.blocklist.path=hedera-node/data/onboard/evm-addresses-blocklist.csv
 staking.sumOfConsensusWeights=500
 cache.cryptoTransfer.warmThreads=30
 hedera.config.version=0
+tokens.balancesInQueries.enabled=true

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -224,3 +224,4 @@ accounts.blocklist.path=hedera-node/data/onboard/evm-addresses-blocklist.csv
 staking.sumOfConsensusWeights=500
 cache.cryptoTransfer.warmThreads=30
 hedera.config.version=10
+tokens.balancesInQueries.enabled=true

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
@@ -21,6 +21,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseType.ANSWER_ONLY;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.hexedEvmAddressOf;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.summarizeStakingInfo;
+import static com.hedera.node.app.service.token.api.AccountSummariesApi.tokenRelationshipsOf;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
@@ -38,12 +39,15 @@ import com.hedera.hapi.node.transaction.Response;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.ReadableStakingInfoStore;
+import com.hedera.node.app.service.token.ReadableTokenRelationStore;
+import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.StakingConfig;
+import com.hedera.node.config.data.TokensConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
@@ -51,7 +55,6 @@ import javax.inject.Singleton;
 
 /**
  * This class contains all workflow-related functionality regarding {@link HederaFunctionality#CONTRACT_GET_INFO}.
- * The token relationships field is deprecated and is no more returned by this query.
  */
 @Singleton
 public class ContractGetInfoHandler extends PaidQueryHandler {
@@ -91,9 +94,12 @@ public class ContractGetInfoHandler extends PaidQueryHandler {
             final var config = context.configuration();
             contractGetInfo.contractInfo(infoFor(
                     contract,
+                    config.getConfigData(TokensConfig.class),
                     config.getConfigData(LedgerConfig.class),
                     config.getConfigData(StakingConfig.class),
+                    context.createStore(ReadableTokenStore.class),
                     context.createStore(ReadableStakingInfoStore.class),
+                    context.createStore(ReadableTokenRelationStore.class),
                     context.createStore(ReadableNetworkStakingRewardsStore.class)));
         }
         return Response.newBuilder().contractGetInfo(contractGetInfo).build();
@@ -101,9 +107,12 @@ public class ContractGetInfoHandler extends PaidQueryHandler {
 
     private ContractInfo infoFor(
             @NonNull final Account contract,
+            @NonNull final TokensConfig tokensConfig,
             @NonNull final LedgerConfig ledgerConfig,
             @NonNull final StakingConfig stakingConfig,
+            @NonNull final ReadableTokenStore tokenStore,
             @NonNull final ReadableStakingInfoStore stakingInfoStore,
+            @NonNull final ReadableTokenRelationStore tokenRelationStore,
             @NonNull final ReadableNetworkStakingRewardsStore stakingRewardsStore) {
         final var accountId = contract.accountIdOrThrow();
         final var stakingInfo = summarizeStakingInfo(
@@ -112,7 +121,8 @@ public class ContractGetInfoHandler extends PaidQueryHandler {
                 stakingRewardsStore.isStakingRewardsActivated(),
                 contract,
                 stakingInfoStore);
-        return ContractInfo.newBuilder()
+        final var maxReturnedRels = tokensConfig.maxRelsPerInfoQuery();
+        final var builder = ContractInfo.newBuilder()
                 .ledgerId(ledgerConfig.id())
                 .accountID(accountId)
                 .contractID(ContractID.newBuilder().contractNum(accountId.accountNumOrThrow()))
@@ -126,8 +136,11 @@ public class ContractGetInfoHandler extends PaidQueryHandler {
                 .expirationTime(Timestamp.newBuilder().seconds(contract.expirationSecond()))
                 .maxAutomaticTokenAssociations(contract.maxAutoAssociations())
                 .contractAccountID(hexedEvmAddressOf(contract))
-                .stakingInfo(stakingInfo)
-                .build();
+                .stakingInfo(stakingInfo);
+        if (tokensConfig.balancesInQueriesEnabled()) {
+            builder.tokenRelationships(tokenRelationshipsOf(contract, tokenStore, tokenRelationStore, maxReturnedRels));
+        }
+        return builder.build();
     }
 
     private @Nullable Account contractFrom(@NonNull final QueryContext context) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountBalanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountBalanceHandler.java
@@ -24,9 +24,15 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseHeader;
+import com.hedera.hapi.node.base.TokenBalance;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.CryptoGetAccountBalanceQuery;
 import com.hedera.hapi.node.token.CryptoGetAccountBalanceResponse;
 import com.hedera.hapi.node.transaction.Query;
@@ -39,13 +45,14 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.TokensConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
  * This class contains all workflow-related functionality regarding {@link
  * HederaFunctionality#CRYPTO_GET_ACCOUNT_BALANCE}.
- * The token balances field is deprecated and is no more returned by this query.
  */
 @Singleton
 public class CryptoGetAccountBalanceHandler extends FreeQueryHandler {
@@ -107,8 +114,54 @@ public class CryptoGetAccountBalanceHandler extends FreeQueryHandler {
                     : accountStore.getContractById(op.contractIDOrThrow());
             requireNonNull(account);
             response.accountID(account.accountIdOrThrow()).balance(account.tinybarBalance());
+            if (config.balancesInQueriesEnabled()) {
+                response.tokenBalances(getTokenBalances(config, account, tokenStore, tokenRelationStore));
+            }
         }
 
         return Response.newBuilder().cryptogetAccountBalance(response).build();
+    }
+
+    /**
+     * Calculate TokenBalance of an Account
+     *
+     * @param tokenConfig use TokenConfig to get maxRelsPerInfoQuery value
+     * @param account the account to be calculated from
+     * @param readableTokenStore readable token store
+     * @param tokenRelationStore token relation store
+     * @return ArrayList of TokenBalance object
+     */
+    private List<TokenBalance> getTokenBalances(
+            @NonNull final TokensConfig tokenConfig,
+            @NonNull final Account account,
+            @NonNull final ReadableTokenStore readableTokenStore,
+            @NonNull final ReadableTokenRelationStore tokenRelationStore) {
+        final var ret = new ArrayList<TokenBalance>();
+        var tokenId = account.headTokenId();
+        int count = 0;
+        TokenRelation tokenRelation;
+        Token token; // token from readableToken store by tokenID
+        AccountID accountID; // build from accountNumber
+        TokenBalance tokenBalance; // created TokenBalance object
+        while (tokenId != null && !tokenId.equals(TokenID.DEFAULT) && count < tokenConfig.maxRelsPerInfoQuery()) {
+            accountID = account.accountId();
+            tokenRelation = tokenRelationStore.get(accountID, tokenId);
+            if (tokenRelation != null) {
+                token = readableTokenStore.get(tokenId);
+                if (token != null) {
+                    tokenBalance = TokenBalance.newBuilder()
+                            .tokenId(tokenId)
+                            .balance(tokenRelation.balance())
+                            .decimals(token.decimals())
+                            .build();
+                    ret.add(tokenBalance);
+                }
+                tokenId = tokenRelation.nextToken();
+            } else {
+                break;
+            }
+            count++;
+        }
+        return ret;
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -21,6 +21,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseType.COST_ANSWER;
+import static com.hedera.node.app.service.token.api.AccountSummariesApi.tokenRelationshipsOf;
 import static com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl.isOfEvmAddressSize;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
@@ -41,6 +42,8 @@ import com.hedera.node.app.service.mono.fees.calculation.crypto.queries.GetAccou
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.ReadableStakingInfoStore;
+import com.hedera.node.app.service.token.ReadableTokenRelationStore;
+import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.api.AccountSummariesApi;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
@@ -48,6 +51,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.StakingConfig;
+import com.hedera.node.config.data.TokensConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -56,7 +60,6 @@ import javax.inject.Singleton;
 /**
  * This class contains all workflow-related functionality regarding {@link
  * HederaFunctionality#CRYPTO_GET_INFO}.
- * The token relationships field is deprecated and is no more returned by this query.
  */
 @Singleton
 public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
@@ -133,9 +136,12 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
         requireNonNull(accountID);
         requireNonNull(context);
 
+        final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
         final var ledgerConfig = context.configuration().getConfigData(LedgerConfig.class);
         final var stakingConfig = context.configuration().getConfigData(StakingConfig.class);
         final var accountStore = context.createStore(ReadableAccountStore.class);
+        final var tokenRelationStore = context.createStore(ReadableTokenRelationStore.class);
+        final var tokenStore = context.createStore(ReadableTokenStore.class);
         final var stakingInfoStore = context.createStore(ReadableStakingInfoStore.class);
         final var stakingRewardsStore = context.createStore(ReadableNetworkStakingRewardsStore.class);
 
@@ -160,8 +166,13 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
             info.ownedNfts(account.numberOwnedNfts());
             info.maxAutomaticTokenAssociations(account.maxAutoAssociations());
             info.ethereumNonce(account.ethereumNonce());
+            //  info.proxyAccountID(); Deprecated
             if (!isOfEvmAddressSize(account.alias())) {
                 info.alias(account.alias());
+            }
+            if (tokensConfig.balancesInQueriesEnabled()) {
+                info.tokenRelationships(tokenRelationshipsOf(
+                        account, tokenStore, tokenRelationStore, tokensConfig.maxRelsPerInfoQuery()));
             }
             info.stakingInfo(AccountSummariesApi.summarizeStakingInfo(
                     stakingConfig.rewardHistoryNumStoredPeriods(),
@@ -183,7 +194,7 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
         final var account = accountStore.getAccountById(accountId);
 
         return queryContext.feeCalculator().legacyCalculate(sigValueObj -> new GetAccountInfoResourceUsage(
-                        cryptoOpsUsage, null, null)
+                        cryptoOpsUsage, null, null, null)
                 .usageGiven(query, account));
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountBalanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountBalanceHandlerTest.java
@@ -20,10 +20,10 @@ import static com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler.a
 import static com.hedera.node.app.service.token.impl.test.handlers.util.StateBuilderUtil.TOKENS;
 import static com.hedera.node.app.service.token.impl.test.handlers.util.StateBuilderUtil.TOKEN_RELS;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
@@ -34,6 +34,7 @@ import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.ResponseHeader;
+import com.hedera.hapi.node.base.TokenBalance;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.Account;
@@ -56,6 +57,8 @@ import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -263,6 +266,7 @@ class CryptoGetAccountBalanceHandlerTest extends CryptoHandlerTestBase {
         given(readableStates1.<AccountID, Account>get(ACCOUNTS)).willReturn(readableAccounts);
         ReadableAccountStore ReadableAccountStore = new ReadableAccountStoreImpl(readableStates1);
 
+        given(token1.decimals()).willReturn(100);
         final var readableToken = MapReadableKVState.<TokenID, Token>builder(TOKENS)
                 .value(asToken(3L), token1)
                 .build();
@@ -306,12 +310,12 @@ class CryptoGetAccountBalanceHandlerTest extends CryptoHandlerTestBase {
         final var accountBalanceResponse = response.cryptogetAccountBalance();
         assertEquals(ResponseCodeEnum.OK, accountBalanceResponse.header().nodeTransactionPrecheckCode());
         assertEquals(expectedInfo.tinybarBalance(), accountBalanceResponse.balance());
-        assertThat(accountBalanceResponse.tokenBalances()).isEmpty();
+        assertIterableEquals(getExpectedTokenBalance(3L), accountBalanceResponse.tokenBalances());
     }
 
     @Test
-    @DisplayName("Returns empty token relations in response")
-    void returnEmptyRelations() {
+    @DisplayName("check maxRelsPerInfoQuery in TokenConfig is correctly handled")
+    void checkConfigmaxRelsPerInfoQuery() {
         givenValidAccount(accountNum);
         final var responseHeader = ResponseHeader.newBuilder()
                 .nodeTransactionPrecheckCode(ResponseCodeEnum.OK)
@@ -324,6 +328,8 @@ class CryptoGetAccountBalanceHandlerTest extends CryptoHandlerTestBase {
         given(readableStates1.<AccountID, Account>get(ACCOUNTS)).willReturn(readableAccounts);
         ReadableAccountStore ReadableAccountStore = new ReadableAccountStoreImpl(readableStates1);
 
+        given(token1.decimals()).willReturn(100);
+        given(token2.decimals()).willReturn(50);
         final var readableToken = MapReadableKVState.<TokenID, Token>builder(TOKENS)
                 .value(asToken(3L), token1)
                 .value(asToken(4L), token2)
@@ -403,11 +409,40 @@ class CryptoGetAccountBalanceHandlerTest extends CryptoHandlerTestBase {
         final var accountBalanceResponse = response.cryptogetAccountBalance();
         assertEquals(ResponseCodeEnum.OK, accountBalanceResponse.header().nodeTransactionPrecheckCode());
         assertEquals(expectedInfo.tinybarBalance(), accountBalanceResponse.balance());
-        assertThat(accountBalanceResponse.tokenBalances()).isEmpty();
+        assertIterableEquals(getExpectedTokenBalances(), accountBalanceResponse.tokenBalances());
+        assertEquals(2, accountBalanceResponse.tokenBalances().size());
     }
 
     private Account getExpectedInfo() {
         return Account.newBuilder().accountId(id).tinybarBalance(payerBalance).build();
+    }
+
+    private List<TokenBalance> getExpectedTokenBalance(long tokenNum) {
+        var ret = new ArrayList<TokenBalance>();
+        final var tokenBalance = TokenBalance.newBuilder()
+                .tokenId(TokenID.newBuilder().tokenNum(tokenNum).build())
+                .balance(1000)
+                .decimals(100)
+                .build();
+        ret.add(tokenBalance);
+        return ret;
+    }
+
+    private List<TokenBalance> getExpectedTokenBalances() {
+        var ret = new ArrayList<TokenBalance>();
+        final var tokenBalance1 = TokenBalance.newBuilder()
+                .tokenId(TokenID.newBuilder().tokenNum(3L).build())
+                .balance(1000)
+                .decimals(100)
+                .build();
+        final var tokenBalance2 = TokenBalance.newBuilder()
+                .tokenId(TokenID.newBuilder().tokenNum(4L).build())
+                .balance(100)
+                .decimals(50)
+                .build();
+        ret.add(tokenBalance1);
+        ret.add(tokenBalance2);
+        return ret;
     }
 
     private Query createGetAccountBalanceQuery(final long accountId) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
@@ -18,6 +18,8 @@ package com.hedera.node.app.service.token.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseType.ANSWER_ONLY;
+import static com.hedera.hapi.node.base.TokenFreezeStatus.FREEZE_NOT_APPLICABLE;
+import static com.hedera.hapi.node.base.TokenKycStatus.KYC_NOT_APPLICABLE;
 import static com.hedera.node.app.service.token.impl.TokenServiceImpl.ACCOUNTS_KEY;
 import static com.hedera.node.app.service.token.impl.TokenServiceImpl.STAKING_INFO_KEY;
 import static com.hedera.node.app.service.token.impl.TokenServiceImpl.TOKENS_KEY;
@@ -25,7 +27,6 @@ import static com.hedera.node.app.service.token.impl.TokenServiceImpl.TOKEN_RELS
 import static com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler.asToken;
 import static com.hedera.node.app.service.token.impl.test.handlers.util.StateBuilderUtil.NETWORK_REWARDS;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,6 +42,7 @@ import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.base.StakingInfo;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenRelationship;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.NetworkStakingRewards;
@@ -75,6 +77,8 @@ import com.hedera.node.config.converter.BytesConverter;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.CommonUtils;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -243,6 +247,8 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         account = account.copyBuilder().stakedNodeId(0).declineReward(false).build();
         setupAccountStore();
 
+        given(token1.decimals()).willReturn(100);
+        given(token1.symbol()).willReturn("FOO");
         given(token1.tokenId()).willReturn(asToken(3L));
         setupTokenStore(token1);
 
@@ -271,14 +277,18 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
     }
 
     @Test
-    @DisplayName("returns empty token relations list")
-    void returnsEmptyTokenRelations() {
+    @DisplayName("check multiple token relations list")
+    void checkMulitpleTokenRelations() {
         final var responseHeader = getOkResponse();
         final var expectedInfo = getExpectedAccountInfos();
 
         account = account.copyBuilder().stakedNodeId(0).declineReward(false).build();
         setupAccountStore();
 
+        given(token1.decimals()).willReturn(100);
+        given(token2.decimals()).willReturn(50);
+        given(token1.symbol()).willReturn("FOO");
+        given(token2.symbol()).willReturn("BAR");
         given(token1.tokenId()).willReturn(asToken(3L));
         given(token2.tokenId()).willReturn(asToken(4L));
         setupTokenStore(token1, token2);
@@ -329,8 +339,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
 
         assertEquals(ResponseCodeEnum.OK, cryptoGetInfoResponse.header().nodeTransactionPrecheckCode());
         assertEquals(expectedInfo, cryptoGetInfoResponse.accountInfo());
-        // We don't return token relationships information in queries
-        assertThat(cryptoGetInfoResponse.accountInfo().tokenRelationships()).isEmpty();
+        assertEquals(2, cryptoGetInfoResponse.accountInfo().tokenRelationships().size());
     }
 
     @Test
@@ -344,6 +353,8 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .build();
         setupAccountStore();
 
+        given(token1.decimals()).willReturn(100);
+        given(token1.symbol()).willReturn("FOO");
         given(token1.tokenId()).willReturn(asToken(3L));
         setupTokenStore(token1);
 
@@ -384,6 +395,8 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .build();
         setupAccountStore();
 
+        given(token1.decimals()).willReturn(100);
+        given(token1.symbol()).willReturn("FOO");
         given(token1.tokenId()).willReturn(asToken(3L));
         setupTokenStore(token1);
 
@@ -487,6 +500,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .ethereumNonce(0)
                 .alias(alias.alias())
                 .contractAccountID("0000000000000000000000000000000000000003")
+                .tokenRelationships(getExpectedTokenRelationship())
                 .stakingInfo(getExpectedStakingInfo())
                 .build();
     }
@@ -507,6 +521,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .ethereumNonce(0)
                 .alias(alias.alias())
                 .contractAccountID("0000000000000000000000000000000000000003")
+                .tokenRelationships(getExpectedTokenRelationship())
                 .stakingInfo(getExpectedStakingInfo2())
                 .build();
     }
@@ -526,6 +541,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .maxAutomaticTokenAssociations(10)
                 .ethereumNonce(0)
                 .contractAccountID("6aeb3773ea468a814d954e6dec795bfee7d76e26")
+                .tokenRelationships(getExpectedTokenRelationship())
                 .stakingInfo(getExpectedStakingInfo())
                 .build();
     }
@@ -546,8 +562,50 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .ethereumNonce(0)
                 .alias(alias.alias())
                 .contractAccountID("0000000000000000000000000000000000000003")
+                .tokenRelationships(getExpectedTokenRelationships())
                 .stakingInfo(getExpectedStakingInfo())
                 .build();
+    }
+
+    private List<TokenRelationship> getExpectedTokenRelationship() {
+        var ret = new ArrayList<TokenRelationship>();
+        final var tokenRelationship1 = TokenRelationship.newBuilder()
+                .tokenId(TokenID.newBuilder().tokenNum(3L).build())
+                .symbol("FOO")
+                .balance(1000)
+                .decimals(100)
+                .kycStatus(KYC_NOT_APPLICABLE)
+                .freezeStatus(FREEZE_NOT_APPLICABLE)
+                .automaticAssociation(true)
+                .build();
+        ret.add(tokenRelationship1);
+        return ret;
+    }
+
+    private List<TokenRelationship> getExpectedTokenRelationships() {
+        var ret = new ArrayList<TokenRelationship>();
+        final var tokenRelationship1 = TokenRelationship.newBuilder()
+                .tokenId(TokenID.newBuilder().tokenNum(3L).build())
+                .symbol("FOO")
+                .balance(1000)
+                .decimals(100)
+                .kycStatus(KYC_NOT_APPLICABLE)
+                .freezeStatus(FREEZE_NOT_APPLICABLE)
+                .automaticAssociation(true)
+                .build();
+        final var tokenRelationship2 = TokenRelationship.newBuilder()
+                .tokenId(TokenID.newBuilder().tokenNum(4L).build())
+                .symbol("BAR")
+                .balance(100)
+                .decimals(50)
+                .kycStatus(KYC_NOT_APPLICABLE)
+                .freezeStatus(FREEZE_NOT_APPLICABLE)
+                .automaticAssociation(true)
+                .build();
+
+        ret.add(tokenRelationship1);
+        ret.add(tokenRelationship2);
+        return ret;
     }
 
     private StakingInfo getExpectedStakingInfo() {

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/AccountSummariesApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/AccountSummariesApi.java
@@ -16,6 +16,12 @@
 
 package com.hedera.node.app.service.token.api;
 
+import static com.hedera.hapi.node.base.TokenFreezeStatus.FREEZE_NOT_APPLICABLE;
+import static com.hedera.hapi.node.base.TokenFreezeStatus.FROZEN;
+import static com.hedera.hapi.node.base.TokenFreezeStatus.UNFROZEN;
+import static com.hedera.hapi.node.base.TokenKycStatus.GRANTED;
+import static com.hedera.hapi.node.base.TokenKycStatus.KYC_NOT_APPLICABLE;
+import static com.hedera.hapi.node.base.TokenKycStatus.REVOKED;
 import static com.hedera.node.app.hapi.utils.CommonUtils.asEvmAddress;
 import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.EVM_ADDRESS_LEN;
 import static com.hedera.node.app.service.token.api.StakingRewardsApi.epochSecondAtStartOfPeriod;
@@ -28,12 +34,22 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.StakingInfo;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TokenFreezeStatus;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenKycStatus;
+import com.hedera.hapi.node.base.TokenRelationship;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.node.app.service.evm.utils.EthSigsUtils;
 import com.hedera.node.app.service.token.ReadableStakingInfoStore;
+import com.hedera.node.app.service.token.ReadableTokenRelationStore;
+import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.UnaryOperator;
 
 /**
@@ -63,6 +79,72 @@ public interface AccountSummariesApi {
         } else {
             return hex(asEvmAddress(account.accountIdOrThrow().accountNumOrThrow()));
         }
+    }
+
+    /**
+     * Returns up to the given limit of token relationships for the given account, relative to the provided
+     * {@link ReadableTokenStore} and {@link ReadableTokenRelationStore}.
+     *
+     * @param account the account to get token relationships for
+     * @param readableTokenStore the readable token store
+     * @param tokenRelationStore the readable token relation store
+     * @param limit the maximum number of token relationships to return
+     * @return the token relationships for the given account
+     */
+    static List<TokenRelationship> tokenRelationshipsOf(
+            @NonNull final Account account,
+            @NonNull final ReadableTokenStore readableTokenStore,
+            @NonNull final ReadableTokenRelationStore tokenRelationStore,
+            final long limit) {
+        requireNonNull(account);
+        requireNonNull(tokenRelationStore);
+        requireNonNull(readableTokenStore);
+
+        final var ret = new ArrayList<TokenRelationship>();
+        var tokenId = account.headTokenId();
+        int count = 0;
+        TokenRelation tokenRelation;
+        Token token; // token from readableToken store by tokenID
+        AccountID accountID; // build from accountNumber
+        while (tokenId != null && !tokenId.equals(TokenID.DEFAULT) && count < limit) {
+            accountID = account.accountId();
+            tokenRelation = tokenRelationStore.get(accountID, tokenId);
+            if (tokenRelation != null) {
+                token = readableTokenStore.get(tokenId);
+                if (token != null) {
+                    addTokenRelation(ret, token, tokenRelation, tokenId);
+                }
+                tokenId = tokenRelation.nextToken();
+            } else {
+                break;
+            }
+            count++;
+        }
+        return ret;
+    }
+
+    private static void addTokenRelation(
+            ArrayList<TokenRelationship> ret, Token token, TokenRelation tokenRelation, TokenID tokenId) {
+        TokenFreezeStatus freezeStatus = FREEZE_NOT_APPLICABLE;
+        if (token.hasFreezeKey()) {
+            freezeStatus = tokenRelation.frozen() ? FROZEN : UNFROZEN;
+        }
+
+        TokenKycStatus kycStatus = KYC_NOT_APPLICABLE;
+        if (token.hasKycKey()) {
+            kycStatus = tokenRelation.kycGranted() ? GRANTED : REVOKED;
+        }
+
+        final var tokenRelationship = TokenRelationship.newBuilder()
+                .tokenId(tokenId)
+                .symbol(token.symbol())
+                .balance(tokenRelation.balance())
+                .decimals(token.decimals())
+                .kycStatus(kycStatus)
+                .freezeStatus(freezeStatus)
+                .automaticAssociation(tokenRelation.automaticAssociation())
+                .build();
+        ret.add(tokenRelationship);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractInfo.java
@@ -159,6 +159,7 @@ public class HapiGetContractInfo extends HapiQueryOp<HapiGetContractInfo> {
             assertExpectedRels(contract, relationships, actualTokenRels, spec);
             assertNoUnexpectedRels(contract, absentRelationships, actualTokenRels, spec);
             actualInfo = actualInfo.toBuilder()
+                    .clearTokenRelationships()
                     .addAllTokenRelationships(actualTokenRels)
                     .build();
         }


### PR DESCRIPTION
Reverts this PR https://github.com/hashgraph/hedera-services/pull/10149

Adds a feature flag `tokens.balancesInQueries.enabled` to enable/disable the token balances and token relationships information to be returned in queries