### PR TITLE
chore(ci): reduce macOS runner usage footprint

### DIFF
--- a/.github/workflows/support/scripts/generate-docker-artifact-baseline.sh
+++ b/.github/workflows/support/scripts/generate-docker-artifact-baseline.sh
@@ -2,8 +2,6 @@
 set -o pipefail
 set +e
 
-readonly RELEASE_LIB_PATH="hedera-node/data/lib"
-readonly RELEASE_APPS_PATH="hedera-node/data/apps"
 readonly DOCKER_IMAGE_NAME="main-network-node"
 
 GROUP_ACTIVE="false"
@@ -113,14 +111,6 @@ start_group "Configuring Environment"
       fail "ERROR (Exit Code: ${?})" "${?}"
     fi
   end_task "DONE (Found: ${JQ})"
-
-  start_task "Checking for prebuilt libraries"
-    ls -al "${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}"/*.jar >/dev/null 2>&1 || fail "ERROR (Exit Code: ${?})" "${?}"
-  end_task "FOUND (Path: ${GITHUB_WORKSPACE}/${RELEASE_LIB_PATH}/*.jar)"
-
-  start_task "Checking for prebuilt applications"
-    ls -al "${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}"/*.jar >/dev/null 2>&1 || fail "ERROR (Exit Code: ${?})" "${?}"
-  end_task "FOUND (Path: ${GITHUB_WORKSPACE}/${RELEASE_APPS_PATH}/*.jar)"
 end_group
 
 start_group "Prepare the Docker Image Information"

--- a/.github/workflows/support/scripts/generate-docker-artifact-baseline.sh
+++ b/.github/workflows/support/scripts/generate-docker-artifact-baseline.sh
@@ -156,12 +156,14 @@ end_group
 start_group "Generating Final Release Manifests"
 
   start_task "Generating the manifest archive"
-  tar -czf "${TEMP_DIR}/manifest.tar.gz" -C "${TEMP_DIR}" linux-amd64.manifest.json linux-amd64.layers.json linux-amd64.comparable.json linux-arm64.manifest.json linux-arm64.layers.json linux-arm64.comparable.json >/dev/null 2>&1 || fail "TAR ERROR (Exit Code: ${?})" "${?}"
+    MANIFEST_FILES=("linux-amd64.manifest.json" "linux-amd64.layers.json" "linux-amd64.comparable.json")
+    MANIFEST_FILES+=("linux-arm64.manifest.json" "linux-arm64.layers.json" "linux-arm64.comparable.json")
+    tar -czf "${TEMP_DIR}/manifest.tar.gz" -C "${TEMP_DIR}" "${MANIFEST_FILES[@]}" >/dev/null 2>&1 || fail "TAR ERROR (Exit Code: ${?})" "${?}"
   end_task
 
   start_task "Copying the manifest files"
-  cp "${TEMP_DIR}/manifest.tar.gz" "${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
-  cp "${TEMP_DIR}"/*.json "${MANIFEST_PATH}/" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
+    cp "${TEMP_DIR}/manifest.tar.gz" "${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
+    cp "${TEMP_DIR}"/*.json "${MANIFEST_PATH}/" || fail "COPY ERROR (Exit Code: ${?})" "${?}"
   end_task "DONE (Path: ${MANIFEST_PATH}/${GITHUB_SHA}.tar.gz)"
 
   start_task "Setting Step Outputs"

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -193,7 +193,7 @@ jobs:
         run: |
           EXTRACTED_FILE_NAME="${{ steps.commit.outputs.sha }}.tar"
           gunzip "${{ steps.manifest.outputs.name }}"
-          tar -rzvf "${EXTRACTED_FILE_NAME}" -C "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}" sdk
+          tar -rvf "${EXTRACTED_FILE_NAME}" -C "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}" sdk
           gzip "${EXTRACTED_FILE_NAME}"
 
       - name: Upload Baseline

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -308,18 +308,6 @@ jobs:
       - name: Show Docker Info
         run: docker info
 
-      - name: Prepare for Docker Build
-        run: |
-          mkdir -p "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}/sdk/data"
-
-          echo "::group::Copying Library Artifacts"
-            cp -Rvf "${{ github.workspace }}/hedera-node/data/lib" "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}/sdk/data/"
-          echo "::endgroup::"
-
-          echo "::group::Copying Application Artifacts"
-            cp -Rvf "${{ github.workspace }}/hedera-node/data/apps" "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}/sdk/data/"
-          echo "::endgroup::"
-
       - name: Build Docker Image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         env:

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -187,6 +187,10 @@ jobs:
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: ${{ env.DOCKER_MANIFEST_GENERATOR }}
 
+      - name: Amend Manifest with Gradle Artifacts
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        run: tar -rzvf "${{ steps.manifest.outputs.file }}" -C "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}" sdk
+
       - name: Upload Baseline
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.file }}"
@@ -205,11 +209,12 @@ jobs:
         # builds to be non-deterministic. Self-hosted runners using Ubuntu 22.04 are unaffected.
         # The Self Hosted Large instance is temporarily disabled because it is running no longer supported version of
         # Ubuntu 18.04. The Large instance will be upgraded to Ubuntu 22.04 in the near future.
+        # Disabled macos-11 runner to minimize the number of concurrent macOS builds due to concurrency issues.
         os:
           #- ubuntu-22.04
           - ubuntu-20.04
           - macos-12
-          - macos-11
+          #- macos-11
           #- windows-2022
           #- windows-2019
           - [self-hosted, Linux, medium, ephemeral]
@@ -229,17 +234,6 @@ jobs:
         uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: 3.9
-
-      - name: Setup Java
-        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
-        with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          cache-disabled: true
 
       - name: Install Skopeo and JQ (Linux)
         if: ${{ runner.os == 'Linux' }}
@@ -281,10 +275,7 @@ jobs:
           cd "${DOCKER_MANIFEST_PATH}"
           gsutil cp "${{ needs.generate-baseline.outputs.file }}" .
           tar -xzf "${{ needs.generate-baseline.outputs.name }}"
-
-      - name: Build Artifacts
-        id: gradle-build
-        run: ./gradlew assemble --scan --no-build-cache
+          mv "sdk" "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}/"
 
       - name: Set up Docker
         uses: crazy-max/ghaction-setup-docker@d9be6cade441568ba10037bce5221b8f564981f1 # v3.0.0

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -189,7 +189,12 @@ jobs:
 
       - name: Amend Manifest with Gradle Artifacts
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        run: tar -rzvf "${{ steps.manifest.outputs.file }}" -C "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}" sdk
+        working-directory: ${{ github.workspace }}/${{ env.DOCKER_MANIFEST_PATH }}
+        run: |
+          EXTRACTED_FILE_NAME="${{ steps.commit.outputs.sha }}.tar"
+          gunzip "${{ steps.manifest.outputs.name }}"
+          tar -rzvf "${EXTRACTED_FILE_NAME}" -C "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}" sdk
+          gzip "${EXTRACTED_FILE_NAME}"
 
       - name: Upload Baseline
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Amend Manifest with Gradle Artifacts
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        working-directory: ${{ github.workspace }}/${{ env.DOCKER_MANIFEST_PATH }}
+        working-directory: ${{ env.DOCKER_MANIFEST_PATH }}
         run: |
           EXTRACTED_FILE_NAME="${{ steps.commit.outputs.sha }}.tar"
           gunzip "${{ steps.manifest.outputs.name }}"

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -137,11 +137,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Disabled MacOS runner testing due to concurrency issues with the Github hosted runners.
         os:
           - ubuntu-22.04
           - ubuntu-20.04
-          - macos-12
-          - macos-11
+          #- macos-12
+          #- macos-11
           - windows-2022
           - windows-2019
           - [self-hosted, Linux, medium, ephemeral]


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the Artifact Determinism CI pipelines with the following changes:
  - Reduces the number of concurrent macOS runners from 4 to 1 concurrent runner per job.
  - Increases the speed of the docker verification pipelines by avoiding Gradle rebuilds. 

### Related Issues

- Closes #10675 