### PR TITLE
feat: adding getter to RecordStreamEntry for TransactionRecord

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordStreamEntry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordStreamEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordStreamEntry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordStreamEntry.java
@@ -46,6 +46,10 @@ public record RecordStreamEntry(TxnAccessor accessor, TransactionRecord txnRecor
         return accessor.getFunction();
     }
 
+    public TransactionRecord transactionRecord() {
+        return txnRecord;
+    }
+
     @Override
     public String toString() {
         return String.format(


### PR DESCRIPTION
**Description**:
 Adding getter to `RecordStreamEntry` for `TransactionRecord`.
We are trying to enhance a new feature that the local node has  -> debug command. It takes consensus timestamp and outputs the corresponding record file to the command line.
We are trying to filter all the unnecessary records form the output but we need some more data to be accessible in the `RecordStreamEntry` entity.


**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/10702