### PR TITLE
fix: Mark prehandle as complete in legacy intake pipeline

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntake.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,7 +238,10 @@ public class EventIntake {
      */
     @NonNull
     private Runnable buildPrehandleTask(@NonNull final EventImpl event) {
-        return () -> prehandleEvent.accept(event);
+        return () -> {
+            prehandleEvent.accept(event);
+            event.getBaseEvent().signalPrehandleCompletion();
+        };
     }
 
     /**


### PR DESCRIPTION
- closes #10705
- must be cherry picked into 46