### PR TITLE
chore: fix mutability exception in pre-handle; stabilize CI

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import com.hedera.hapi.node.state.recordcache.TransactionRecordEntry;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.spi.state.CommittableWritableStates;
 import com.hedera.node.app.spi.state.ReadableQueueState;
-import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.WritableQueueState;
 import com.hedera.node.app.spi.state.WritableStates;
 import com.hedera.node.app.spi.validation.TruePredicate;
@@ -360,7 +359,7 @@ public class RecordCacheImpl implements HederaRecordCache {
 
     /** Utility method that get the readable queue from the working state */
     private ReadableQueueState<TransactionRecordEntry> getReadableQueue() {
-        final ReadableStates states = getWritableState();
+        final var states = requireNonNull(workingStateAccessor.getHederaState()).createReadableStates(NAME);
         return states.getQueue(TXN_RECORD_QUEUE);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION;
@@ -83,6 +84,7 @@ import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
+import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.consensus.HapiMessageSubmit;
 import com.hedera.services.bdd.spec.transactions.contract.HapiContractCall;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
@@ -1445,6 +1447,44 @@ public class UtilVerbs {
 
     public static TransferListBuilder transferList() {
         return new TransferListBuilder();
+    }
+
+    /**
+     * Returns an operation that attempts to execute the given transaction passing the
+     * provided name to {@link HapiTxnOp#via(String)}; and accepting either
+     * {@link com.hedera.hapi.node.base.ResponseCodeEnum#SUCCESS} or
+     * {@link com.hedera.hapi.node.base.ResponseCodeEnum#MAX_CHILD_RECORDS_EXCEEDED}
+     * as the final status.
+     *
+     * <p>On success, executes the remaining operations. This lets us stabilize operations
+     * in CI that need to use all preceding child records to succeed; and hence fail if
+     * their transaction triggers an end-of-day staking record.
+     *
+     * @param txnRequiringMaxChildRecords the transaction requiring all child records
+     * @param name the transaction name to use
+     * @param onSuccess the operations to run on success
+     * @return the operation doing this conditional execution
+     */
+    public static HapiSpecOperation assumingNoStakingChildRecordCausesMaxChildRecordsExceeded(
+            @NonNull final HapiTxnOp<?> txnRequiringMaxChildRecords,
+            @NonNull final String name,
+            @NonNull final HapiSpecOperation... onSuccess) {
+        return blockingOrder(
+                txnRequiringMaxChildRecords
+                        .via(name)
+                        // In CI this could fail due to an end-of-staking period record already
+                        // being added as a child to this transaction before its auto-creations
+                        .hasKnownStatusFrom(SUCCESS, MAX_CHILD_RECORDS_EXCEEDED),
+                withOpContext((spec, opLog) -> {
+                    final var lookup = getTxnRecord(name);
+                    allRunFor(spec, lookup);
+                    final var actualStatus =
+                            lookup.getResponseRecord().getReceipt().getStatus();
+                    // Continue with more assertions given the normal case the preceding transfer succeeded
+                    if (actualStatus == SUCCESS) {
+                        allRunFor(spec, onSuccess);
+                    }
+                }));
     }
 
     public static class TransferListBuilder {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assumingNoStakingChildRecordCausesMaxChildRecordsExceeded;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
@@ -83,7 +84,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_S
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.TokenSupplyType.FINITE;
@@ -724,7 +724,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
                             final var sponsor = spec.registry().getAccountID(DEFAULT_PAYER);
                             final var payer = spec.registry().getAccountID(CIVILIAN);
                             final var parent = lookup.getResponseRecord();
-                            final var child = lookup.getChildRecord(0);
+                            final var child = lookup.getFirstNonStakingChildRecord();
                             assertAliasBalanceAndFeeInChildRecord(parent, child, sponsor, payer, 0L, approxTransferFee);
                         }))
                 .then(
@@ -1331,43 +1331,28 @@ public class AutoAccountCreationSuite extends HapiSuite {
                         newKeyNamed(ALIAS_2),
                         newKeyNamed("alias3"),
                         newKeyNamed("alias4"),
-                        newKeyNamed("alias5"),
+                        newKeyNamed("alias5"))
+                .then(assumingNoStakingChildRecordCausesMaxChildRecordsExceeded(
                         cryptoTransfer(
-                                        tinyBarsFromToWithAlias(PAYER, "alias1", ONE_HUNDRED_HBARS),
-                                        tinyBarsFromToWithAlias(PAYER, ALIAS_2, ONE_HUNDRED_HBARS),
-                                        tinyBarsFromToWithAlias(PAYER, "alias3", ONE_HUNDRED_HBARS))
-                                .via("multipleAutoAccountCreates")
-                                // In CI this could fail due to an end-of-staking period record already
-                                // being added as a child to this transaction before its auto-creations
-                                .hasKnownStatusFrom(SUCCESS, MAX_CHILD_RECORDS_EXCEEDED))
-                .then(withOpContext((spec, opLog) -> {
-                    final var lookup = getTxnRecord("multipleAutoAccountCreates");
-                    allRunFor(spec, lookup);
-                    final var actualStatus =
-                            lookup.getResponseRecord().getReceipt().getStatus();
-                    // Continue with more assertions given the normal case the preceding transfer succeeded
-                    if (actualStatus == SUCCESS) {
-                        allRunFor(
-                                spec,
-                                getTxnRecord("multipleAutoAccountCreates")
-                                        .hasNonStakingChildRecordCount(3)
-                                        .logged(),
-                                getAccountInfo(PAYER)
-                                        .has(accountWith()
-                                                .balance((INITIAL_BALANCE * ONE_HBAR) - 3 * ONE_HUNDRED_HBARS)),
-                                cryptoTransfer(
-                                                tinyBarsFromToWithAlias(PAYER, "alias4", 7 * ONE_HUNDRED_HBARS),
-                                                tinyBarsFromToWithAlias(PAYER, "alias5", 100))
-                                        .via("failedAutoCreate")
-                                        .hasKnownStatus(INSUFFICIENT_ACCOUNT_BALANCE),
-                                getTxnRecord("failedAutoCreate")
-                                        .hasNonStakingChildRecordCount(0)
-                                        .logged(),
-                                getAccountInfo(PAYER)
-                                        .has(accountWith()
-                                                .balance((INITIAL_BALANCE * ONE_HBAR) - 3 * ONE_HUNDRED_HBARS)));
-                    }
-                }));
+                                tinyBarsFromToWithAlias(PAYER, "alias1", ONE_HUNDRED_HBARS),
+                                tinyBarsFromToWithAlias(PAYER, ALIAS_2, ONE_HUNDRED_HBARS),
+                                tinyBarsFromToWithAlias(PAYER, "alias3", ONE_HUNDRED_HBARS)),
+                        "multipleAutoAccountCreates",
+                        getTxnRecord("multipleAutoAccountCreates")
+                                .hasNonStakingChildRecordCount(3)
+                                .logged(),
+                        getAccountInfo(PAYER)
+                                .has(accountWith().balance((INITIAL_BALANCE * ONE_HBAR) - 3 * ONE_HUNDRED_HBARS)),
+                        cryptoTransfer(
+                                        tinyBarsFromToWithAlias(PAYER, "alias4", 7 * ONE_HUNDRED_HBARS),
+                                        tinyBarsFromToWithAlias(PAYER, "alias5", 100))
+                                .via("failedAutoCreate")
+                                .hasKnownStatus(INSUFFICIENT_ACCOUNT_BALANCE),
+                        getTxnRecord("failedAutoCreate")
+                                .hasNonStakingChildRecordCount(0)
+                                .logged(),
+                        getAccountInfo(PAYER)
+                                .has(accountWith().balance((INITIAL_BALANCE * ONE_HBAR) - 3 * ONE_HUNDRED_HBARS))));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfe
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.accountAmount;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assumingNoStakingChildRecordCausesMaxChildRecordsExceeded;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
@@ -797,40 +798,48 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
                 }))
                 .then(withOpContext((spec, opLog) -> {
-                    // send a crypto transfer from the hollow payer
-                    // also sending hbars from the other hollow account
-                    final var op3 = cryptoTransfer(sendFromEvmAddressFromECDSAKey(
-                                            spec,
-                                            spec.registry().getKey(recipientKey).toByteString(),
-                                            ecdsaKey2)
-                                    .toArray(Function[]::new))
-                            .payingWith(SECP_256K1_SOURCE_KEY)
-                            .signedBy(SECP_256K1_SOURCE_KEY, ecdsaKey2)
-                            .sigMapPrefixes(uniqueWithFullPrefixesFor(SECP_256K1_SOURCE_KEY, ecdsaKey2))
-                            .hasKnownStatus(SUCCESS)
-                            .via(TRANSFER_TXN_2);
-                    final var childRecordCheck = childRecordsCheck(
+                    final var op = assumingNoStakingChildRecordCausesMaxChildRecordsExceeded(
+                            // send a crypto transfer from the hollow payer
+                            // also sending hbars from the other hollow account
+                            cryptoTransfer(sendFromEvmAddressFromECDSAKey(
+                                                    spec,
+                                                    spec.registry()
+                                                            .getKey(recipientKey)
+                                                            .toByteString(),
+                                                    ecdsaKey2)
+                                            .toArray(Function[]::new))
+                                    .payingWith(SECP_256K1_SOURCE_KEY)
+                                    .signedBy(SECP_256K1_SOURCE_KEY, ecdsaKey2)
+                                    .sigMapPrefixes(uniqueWithFullPrefixesFor(SECP_256K1_SOURCE_KEY, ecdsaKey2)),
                             TRANSFER_TXN_2,
-                            SUCCESS,
-                            recordWith().status(SUCCESS),
-                            recordWith().status(SUCCESS),
-                            recordWith().status(SUCCESS));
-                    // assert that the payer has been finalized
-                    final var ecdsaKey = spec.registry().getKey(SECP_256K1_SOURCE_KEY);
-                    final var payerEvmAddress = ByteString.copyFrom(recoverAddressFromPubKey(
-                            ecdsaKey.getECDSASecp256K1().toByteArray()));
-                    final var op4 = getAliasedAccountInfo(payerEvmAddress)
-                            .has(accountWith()
-                                    .key(SECP_256K1_SOURCE_KEY)
-                                    .noAlias()
-                                    .evmAddress(payerEvmAddress));
-                    // assert that the other hollow account has been finalized
-                    final var otherEcdsaKey = spec.registry().getKey(ecdsaKey2);
-                    final var otherEvmAddress = ByteString.copyFrom(recoverAddressFromPubKey(
-                            otherEcdsaKey.getECDSASecp256K1().toByteArray()));
-                    final var op5 = getAliasedAccountInfo(otherEvmAddress)
-                            .has(accountWith().key(ecdsaKey2).noAlias().evmAddress(otherEvmAddress));
-                    allRunFor(spec, op3, childRecordCheck, op4, op5);
+                            childRecordsCheck(
+                                    TRANSFER_TXN_2,
+                                    SUCCESS,
+                                    recordWith().status(SUCCESS),
+                                    recordWith().status(SUCCESS),
+                                    recordWith().status(SUCCESS)),
+                            withOpContext((ignoredSpec, ignoredOpLog) -> {
+                                final var ecdsaKey = spec.registry().getKey(SECP_256K1_SOURCE_KEY);
+                                final var payerEvmAddress = ByteString.copyFrom(recoverAddressFromPubKey(
+                                        ecdsaKey.getECDSASecp256K1().toByteArray()));
+                                // assert that the payer has been finalized
+                                final var op4 = getAliasedAccountInfo(payerEvmAddress)
+                                        .has(accountWith()
+                                                .key(SECP_256K1_SOURCE_KEY)
+                                                .noAlias()
+                                                .evmAddress(payerEvmAddress));
+                                // assert that the other hollow account has been finalized
+                                final var otherEcdsaKey = spec.registry().getKey(ecdsaKey2);
+                                final var otherEvmAddress = ByteString.copyFrom(recoverAddressFromPubKey(
+                                        otherEcdsaKey.getECDSASecp256K1().toByteArray()));
+                                final var op5 = getAliasedAccountInfo(otherEvmAddress)
+                                        .has(accountWith()
+                                                .key(ecdsaKey2)
+                                                .noAlias()
+                                                .evmAddress(otherEvmAddress));
+                                allRunFor(spec, op4, op5);
+                            }));
+                    allRunFor(spec, op);
                 }));
     }
 


### PR DESCRIPTION
**Description**:
 - Fixes unintentional use of `WritableStates` in `RecordCacheImpl#getReadableQueue()`.
 - Stabilizes `canAutoCreateWithFungibleTokenTransfersToAlias()` in presence of end-of-day staking records by using `getFirstNonStakingChildRecord()`.
 - Creates a utility method `assumingNoStakingChildRecordCausesMaxChildRecordsExceeded()` that allows transactions requiring all preceding child records to be used in CI; uses it to stabilize two specs.