### PR TITLE
chore: Update copyrights to 2024 on the repo

### DIFF
--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/flow-node-performance-tests.yaml
+++ b/.github/workflows/flow-node-performance-tests.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-deploy-adhoc-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-adhoc-artifact.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-deploy-preview.yaml
+++ b/.github/workflows/node-flow-deploy-preview.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-fsts-custom-regression.yaml
+++ b/.github/workflows/node-flow-fsts-custom-regression.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-fsts-daily-interval-01.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-01.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-fsts-daily-interval-02.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-02.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-fsts-daily-interval-03.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-03.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-fsts-daily-interval-04.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-04.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-fsts-daily-interval-06.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-06.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-zxc-deploy-preview.yaml
+++ b/.github/workflows/node-zxc-deploy-preview.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-zxcron-develop-fsts-regression.yaml
+++ b/.github/workflows/node-zxcron-develop-fsts-regression.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-zxcron-release-branching.yaml
+++ b/.github/workflows/node-zxcron-release-branching.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/node-zxf-snyk-monitor.yaml
+++ b/.github/workflows/node-zxf-snyk-monitor.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-flow-deploy-adhoc-release.yaml
+++ b/.github/workflows/platform-flow-deploy-adhoc-release.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-flow-deploy-ea-release.yaml
+++ b/.github/workflows/platform-flow-deploy-ea-release.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-flow-deploy-mc-release.yaml
+++ b/.github/workflows/platform-flow-deploy-mc-release.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-flow-jrs-custom-regression.yaml
+++ b/.github/workflows/platform-flow-jrs-custom-regression.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-flow-jrs-daily-regression.yaml
+++ b/.github/workflows/platform-flow-jrs-daily-regression.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-pull-request-extended-checks.yaml
+++ b/.github/workflows/platform-pull-request-extended-checks.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxc-launch-jrs-workflow.yaml
+++ b/.github/workflows/platform-zxc-launch-jrs-workflow.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxc-release-internal.yaml
+++ b/.github/workflows/platform-zxc-release-internal.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxc-release-maven-central.yaml
+++ b/.github/workflows/platform-zxc-release-maven-central.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxcron-develop-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-develop-jrs-regression.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxf-jrs-daily-interval-01.yaml
+++ b/.github/workflows/platform-zxf-jrs-daily-interval-01.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxf-jrs-daily-interval-02.yaml
+++ b/.github/workflows/platform-zxf-jrs-daily-interval-02.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxf-jrs-daily-interval-03.yaml
+++ b/.github/workflows/platform-zxf-jrs-daily-interval-03.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxf-jrs-daily-interval-04.yaml
+++ b/.github/workflows/platform-zxf-jrs-daily-interval-04.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxf-jrs-daily-interval-05.yaml
+++ b/.github/workflows/platform-zxf-jrs-daily-interval-05.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/platform-zxf-jrs-daily-interval-06.yaml
+++ b/.github/workflows/platform-zxf-jrs-daily-interval-06.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2023 Hedera Hashgraph, LLC
+# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.aggregate-reports.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.aggregate-reports.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.application.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.application.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.benchmark-conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.benchmark-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.dependency-analysis.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.dependency-analysis.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.evm-maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.evm-maven-publish.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,10 @@ tasks.register("releaseEvmMavenCentral") {
 
 tasks.register("releaseEvmMavenCentralSnapshot") {
     group = "release"
-    dependsOn(project(":swirlds-common").tasks.named("publishMavenPublicationToSonatypeSnapshotRepository"))
+    dependsOn(
+        project(":swirlds-common")
+            .tasks
+            .named("publishMavenPublicationToSonatypeSnapshotRepository")
+    )
     dependsOn(tasks.named("publishMavenPublicationToSonatypeSnapshotRepository"))
 }

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.hapi.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.hapi.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-module-dependencies.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-module-dependencies.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.jpms-modules.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.maven-publish.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.platform-maven-publish.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.platform-maven-publish.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.repositories.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.repositories.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.root.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.root.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.sdk.conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.sdk.conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.shadow-jar.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.shadow-jar.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.spotless-conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.spotless-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.spotless-java-conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.spotless-java-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.spotless-kotlin-conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.spotless-kotlin-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.versions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.versions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/settings-plugins/build.gradle.kts
+++ b/build-logic/settings-plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
+++ b/build-logic/settings-plugins/src/main/kotlin/com.hedera.hashgraph.settings.settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/build.gradle.kts
+++ b/hedera-node/cli-clients/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/ContractCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/ContractCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassembleContractSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassembleContractSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassemblyOption.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/DisassemblyOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizer.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizerManager.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/CodeRecognizerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/MethodAnalysis.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/MethodAnalysis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLeafNodeEnd.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLeafNodeEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTableStart.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTableStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTreeInternalNode.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTSelectorTreeInternalNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTableEntryRecognizer.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/analysis/VTableEntryRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Code.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CodeLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CodeLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Columns.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Columns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CommentLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/CommentLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Constants.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DataPseudoOpLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DataPseudoOpLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DirectiveLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/DirectiveLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Disassembler.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Disassembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Editor.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Editor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/LabelLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/LabelLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Line.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Line.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/MacroLine.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/MacroLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Opcodes.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/contracts/assembly/Opcodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceSignCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceSignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceSigningUtils.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceSigningUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceType.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/AccountBalanceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/InvalidProtobufVersionException.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/InvalidProtobufVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamSignCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamSignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamSigningUtils.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamSigningUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamType.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/RecordStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/SignUtils.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/sign/SignUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpAccountsSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractBytecodesSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpContractStoresSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpFilesSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokenAssociationsSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokenAssociationsSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokensSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpTokensSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpUniqueTokensSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpUniqueTokensSubcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ByteArrayAsKey.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ByteArrayAsKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/HexToBytesConverter.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/HexToBytesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Range.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/ThingsToStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Writer.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/utils/Writer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/AccountBalanceSignCommandTest.java
+++ b/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/AccountBalanceSignCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/AccountBalanceSigningUtilsTest.java
+++ b/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/AccountBalanceSigningUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/RecordStreamSignCommandTest.java
+++ b/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/RecordStreamSignCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/RecordStreamSigningUtilsTest.java
+++ b/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/RecordStreamSigningUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/RecordStreamTypeTest.java
+++ b/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/RecordStreamTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/TestUtils.java
+++ b/hedera-node/cli-clients/src/test/java/com.hedera.services.cli.sign.test/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/build.gradle.kts
+++ b/hedera-node/hapi-fees/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalc.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/AssetsLoader.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/AssetsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/BaseOperationUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/BaseOperationUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/FeeSchedules.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/FeeSchedules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/RequiredPriceTypes.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/RequiredPriceTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/ResourceProvider.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/ResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/ScheduleGenerator.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/ScheduleGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/UsableResource.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/pricing/UsableResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/BaseTransactionMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/BaseTransactionMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/EstimatorFactory.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/EstimatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/EstimatorUtils.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/EstimatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/QueryUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/QueryUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/SigUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/SigUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/SingletonEstimatorUtils.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/SingletonEstimatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/SingletonUsageProperties.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/SingletonUsageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/TxnUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/TxnUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/TxnUsageEstimator.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/TxnUsageEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/UsageEstimate.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/UsageEstimate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/UsageProperties.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/UsageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/consensus/ConsensusOpsUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/consensus/ConsensusOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/consensus/SubmitMessageMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/consensus/SubmitMessageMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/contract/ContractGetInfoUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/contract/ContractGetInfoUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/contract/ExtantContractContext.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/contract/ExtantContractContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/contract/entities/ContractEntitySizes.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/contract/entities/ContractEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/AllowanceId.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/AllowanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoApproveAllowanceMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoApproveAllowanceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoContextUtils.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoCreateMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoCreateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoDeleteAllowanceMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoDeleteAllowanceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoGetInfoUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoGetInfoUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoOpsUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoTransferMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoTransferMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoUpdateMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoUpdateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/ExtantCryptoContext.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/ExtantCryptoContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/entities/CryptoEntitySizes.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/crypto/entities/CryptoEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/file/ExtantFileContext.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/file/ExtantFileContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/file/FileAppendMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/file/FileAppendMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/file/FileOpsUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/file/FileOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/schedule/ExtantScheduleContext.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/schedule/ExtantScheduleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/schedule/ScheduleOpsUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/schedule/ScheduleOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/schedule/entities/ScheduleEntitySizes.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/schedule/entities/ScheduleEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/state/UsageAccumulator.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/state/UsageAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenAssociateUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenAssociateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenCreateUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenCreateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenDeleteUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenDeleteUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenDissociateUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenDissociateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenFreezeUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenFreezeUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetAccountNftInfosUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetAccountNftInfosUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetInfoUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetInfoUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfoUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfoUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfosUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfosUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGrantKycUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenGrantKycUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsageUtils.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenRevokeKycUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenRevokeKycUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenTxnUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenTxnUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenUpdateUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/TokenUpdateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/entities/NftEntitySizes.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/entities/NftEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/entities/TokenEntitySizes.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/entities/TokenEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/ExtantFeeScheduleContext.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/ExtantFeeScheduleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/FeeScheduleUpdateMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/FeeScheduleUpdateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenBurnMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenBurnMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenBurnWipeMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenBurnWipeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenCreateMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenCreateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenFreezeMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenFreezeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenMintMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenMintMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenOpMetaBase.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenOpMetaBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenPauseMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenPauseMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenUnfreezeMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenUnfreezeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenUnpauseMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenUnpauseMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenWipeMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenWipeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/util/UtilOpsUsage.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/util/UtilOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/util/UtilPrngMeta.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/usage/util/UtilPrngMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/UtilsConstructorTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/UtilsConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalcTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/AssetsLoaderTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/AssetsLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/BaseOperationUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/BaseOperationUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/ConsensusFeeSchedulesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/ConsensusFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/ContractFeeSchedulesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/ContractFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/CryptoFeeSchedulesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/CryptoFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/FeeSchedulesTestHelper.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/FeeSchedulesTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/FileFeeSchedulesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/FileFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/RequiredPriceTypesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/RequiredPriceTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/ScheduleGeneratorTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/ScheduleGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/TokenFeeSchedulesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/TokenFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/UtilOpsSchedulesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/UtilOpsSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/AdapterUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/IdUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/IdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/KeyUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/SigUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/SigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/TxnUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/TxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/UsageUtils.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/test/UsageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/MetadataObjectContractsTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/MetadataObjectContractsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/SigUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/SigUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/SingletonEstimatorUtilsTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/SingletonEstimatorUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/TxnUsageEstimatorTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/TxnUsageEstimatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/consensus/ConsensusOpsUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/consensus/ConsensusOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/contract/ContractGetInfoUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/contract/ContractGetInfoUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/contract/ExtantContractContextTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/contract/ExtantContractContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/contract/entities/ContractEntitySizesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/contract/entities/ContractEntitySizesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoApproveAllowanceMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoApproveAllowanceMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoContextUtilsTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoContextUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoCreateMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoCreateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoDeleteAllowanceMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoDeleteAllowanceMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoGetInfoUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoGetInfoUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoOpsUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoTransferMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoTransferMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoUpdateMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/CryptoUpdateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/OpsTransferUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/OpsTransferUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/entities/CryptoEntitySizesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/crypto/entities/CryptoEntitySizesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/file/ExtantFileContextTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/file/ExtantFileContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/file/FileOpsUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/file/FileOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/schedule/ExtantScheduleContextTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/schedule/ExtantScheduleContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/schedule/ScheduleOpsUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/schedule/ScheduleOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/schedule/entities/ScheduleEntitySizesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/schedule/entities/ScheduleEntitySizesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/state/UsageAccumulatorTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/state/UsageAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenAssociateUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenAssociateUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenCreateUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenCreateUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenDeleteUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenDeleteUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenDissociateUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenDissociateUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetAccountNftInfosUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetAccountNftInfosUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetInfoUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetInfoUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfoUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfoUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfosUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfosUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGrantKycUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGrantKycUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsageUtilsTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenOpsUsageUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenRevokeKycUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenRevokeKycUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenUpdateUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenUpdateUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/entities/TokenEntitySizesTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/entities/TokenEntitySizesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/ExtantFeeScheduleContextTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/ExtantFeeScheduleContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/FeeScheduleUpdateMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/FeeScheduleUpdateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenBurnMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenBurnMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenCreateMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenCreateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenFreezeMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenFreezeMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenMintMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenMintMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenPauseMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenPauseMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenUnpauseMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenUnpauseMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenWipeMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/meta/TokenWipeMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/util/UtilOpsUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/util/UtilOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/util/UtilPrngMetaTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/util/UtilPrngMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/build.gradle.kts
+++ b/hedera-node/hapi-utils/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ByteStringUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ByteStringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/SignatureGenerator.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/SignatureGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/builder/RequestBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/builder/RequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/contracts/ParsingConstants.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/contracts/ParsingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exception/UnknownHederaFunctionality.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exception/UnknownHederaFunctionality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileCompressionUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileCompressionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileSignTool.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileSignTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/RecordBlockNumberTool.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/RecordBlockNumberTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/recordstreaming/RecordStreamingUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/recordstreaming/RecordStreamingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/ConsensusServiceFeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/ConsensusServiceFeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/CryptoFeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/CryptoFeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeObject.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FileFeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FileFeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/SigValueObj.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/SigValueObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/SmartContractFeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/SmartContractFeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Ed25519Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Ed25519Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/ParsingUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/ParsingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/KnownBlockValues.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/KnownBlockValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/HapiThrottleUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/HapiThrottleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ScaleFactor.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ScaleFactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleBucket.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleDefinitions.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleDefinitions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleGroup.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/FeesJsonToProtoSerde.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/FeesJsonToProtoSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/ThrottlesJsonToProtoSerde.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/ThrottlesJsonToProtoSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ErrorCodeUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ErrorCodeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ExpectedCustomThrottles.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ExpectedCustomThrottles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/CongestibleThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/CongestibleThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DiscreteLeakyBucket.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DiscreteLeakyBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ByteStringUtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ByteStringUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/CommonUtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/CommonUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/SignatureGeneratorTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/SignatureGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/TestUtils.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/UtilsConstructorTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/UtilsConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/builder/RequestBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/builder/RequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/contracts/ParsingConstantsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/contracts/ParsingConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/TestingConstants.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/TestingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/ConsensusServiceFeeBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/ConsensusServiceFeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/CryptoFeeBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/CryptoFeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/FeeBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/FeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/FileFeeBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/FileFeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/SmartContractFeeBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/SmartContractFeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/keys/Ed25519UtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/keys/Ed25519UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/recordstreaming/RecordStreamingUtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/recordstreaming/RecordStreamingUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/KnownBlockValuesTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/KnownBlockValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/HapiThrottleUtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/HapiThrottleUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ScaleFactorTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ScaleFactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleBucketTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleBucketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleDefinitionsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleDefinitionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/FeesJsonToProtoSerdeTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/FeesJsonToProtoSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/ThrottlesJsonToProtoSerdeTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/serdes/ThrottlesJsonToProtoSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ErrorCodeUtilsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ErrorCodeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ExpectedCustomThrottlesTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/sysfiles/validation/ExpectedCustomThrottlesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/ConcurrentThrottleTestHelper.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/ConcurrentThrottleTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DiscreteLeakyBucketTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DiscreteLeakyBucketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi/build.gradle.kts
+++ b/hedera-node/hapi/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi/src/testFixtures/java/com/hedera/node/hapi/fixtures/TransactionHelper.java
+++ b/hedera-node/hapi/src/testFixtures/java/com/hedera/node/hapi/fixtures/TransactionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/build.gradle.kts
+++ b/hedera-node/hedera-app-spi/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/Service.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/ServiceFactory.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/ServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/SigWaivers.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/SigWaivers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/UnknownHederaFunctionality.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/UnknownHederaFunctionality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/api/ServiceApiProvider.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/api/ServiceApiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/authorization/Authorizer.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/authorization/Authorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/authorization/SystemPrivilege.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/authorization/SystemPrivilege.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/ExchangeRateInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/ExchangeRateInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeAccumulator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCalculator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/Fees.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/Fees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NetworkInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NetworkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/NodeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/SelfNodeInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/info/SelfNodeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/HederaKey.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/HederaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyComparator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/key/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/numbers/HederaAccountNumbers.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/numbers/HederaAccountNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/numbers/HederaFileNumbers.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/numbers/HederaFileNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/BlockRecordInfo.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/BlockRecordInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/RecordCache.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/RecordCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/SignatureVerification.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/SignatureVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/VerificationAssistant.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/VerificationAssistant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/CommittableWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/CommittableWritableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyReadableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyWritableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredReadableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredWritableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableQueueState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableQueueState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableQueueStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableQueueStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/Schema.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/SchemaRegistry.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/SchemaRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/StateDefinition.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/StateDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedReadableKVState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedReadableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedWritableKVState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedWritableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedWritableQueueState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedWritableQueueState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedWritableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WrappedWritableSingletonState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableQueueState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableQueueState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableQueueStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableQueueStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/throttle/HandleThrottleParser.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/throttle/HandleThrottleParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/AttributeValidator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/AttributeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/EntityType.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/ExpiryMeta.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/ExpiryMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/ExpiryValidator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/ExpiryValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/TruePredicate.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/TruePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/Validations.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/Validations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/FreeQueryHandler.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/FreeQueryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/FunctionalityResourcePrices.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/FunctionalityResourcePrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientBalanceException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientBalanceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientNetworkFeeException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientNetworkFeeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientNonFeeDebitsException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientNonFeeDebitsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientServiceFeeException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/InsufficientServiceFeeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PaidQueryHandler.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PaidQueryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreCheckException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreCheckException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreHandleContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreHandleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreHandleDispatcher.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreHandleDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/QueryContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/QueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/QueryHandler.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/QueryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/ResourceExhaustedException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/ResourceExhaustedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/TransactionHandler.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/TransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/TransactionKeys.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/TransactionKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionRecordBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/ExternalizedRecordCustomizer.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/ExternalizedRecordCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/GenesisRecordsBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/GenesisRecordsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/RecordListCheckPoint.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/RecordListCheckPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/SingleTransactionRecordBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/SingleTransactionRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/HapiUtilsTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/HapiUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/key/KeyUtilsTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/key/KeyUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyReadableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyReadableStatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyWritableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyWritableStatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/FilteredReadableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/FilteredReadableStatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/FilteredWritableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/FilteredWritableStatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableKVStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableKVStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableQueueStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableQueueStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableSingletonStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableSingletonStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SchemaTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SingletonStateTestBase.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SingletonStateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/StateDefinitionTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/StateDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/StateTestBase.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/StateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WrappedReadableKVStateTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WrappedReadableKVStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WrappedWritableKVStateTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WrappedWritableKVStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WrappedWritableSingletonTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WrappedWritableSingletonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableKVStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableKVStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableQueueStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableQueueStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableSingletonStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableSingletonStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/test/numbers/HederaAccountNumbersTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/test/numbers/HederaAccountNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/test/numbers/HederaFileNumbersTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/test/numbers/HederaFileNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/validation/ExpiryMetaTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/validation/ExpiryMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/HandleContextTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/HandleContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/HandleExceptionTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/HandleExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/InsufficientBalanceExceptionTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/InsufficientBalanceExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/PreCheckExceptionTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/PreCheckExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/record/ExternalizedRecordCustomizerTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/record/ExternalizedRecordCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/Assertions.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/ImmediateExecutorService.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/ImmediateExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/Scenarios.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/Scenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestBase.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestKeyInfo.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestKeyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestNode.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestService.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestUser.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TestUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TransactionFactory.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/TransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeAccumulator.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeCalculator.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/info/FakeNetworkInfo.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/info/FakeNetworkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/numbers/FakeHederaNumbers.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/numbers/FakeHederaNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/ListReadableQueueState.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/ListReadableQueueState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/ListWritableQueueState.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/ListWritableQueueState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapReadableKVState.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapReadableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapReadableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapWritableKVState.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapWritableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/MapWritableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/NoOpGenesisRecordsBuilder.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/NoOpGenesisRecordsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/StateTestBase.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/StateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/TestSchema.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/state/TestSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/throttle/FakeHandleThrottleParser.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/throttle/FakeHandleThrottleParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LogCaptor.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LogCaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LogCaptureExtension.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LogCaptureExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LoggingSubject.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LoggingSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LoggingTarget.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/util/LoggingTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/workflows/ExceptionConditions.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/workflows/ExceptionConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/workflows/FakePreHandleContext.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/workflows/FakePreHandleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/itest/java/grpc/GrpcQueryTest.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/GrpcQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/itest/java/grpc/GrpcTransactionTest.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/GrpcTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/itest/java/grpc/NettyManagerTest.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/NettyManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/itest/java/signatures/SignatureVerificationTest.java
+++ b/hedera-node/hedera-app/src/itest/java/signatures/SignatureVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/DoNothingCryptoEngine.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/DoNothingCryptoEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/ExpansionBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/ExpansionBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/KeccakBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/KeccakBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/VerificationBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/signature/impl/VerificationBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/MonoServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/MonoServicesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/OrderedServiceMigrator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/OrderedServiceMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/annotations/CommonExecutor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/annotations/CommonExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/annotations/MaxSignedTxnSize.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/annotations/MaxSignedTxnSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/annotations/NodeSelfId.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/annotations/NodeSelfId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/AuthorizerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/AuthorizerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/AuthorizerInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/AuthorizerInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/PrivilegesVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/PrivilegesVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/components/IngestInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/components/IngestInjectionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/components/QueryInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/components/QueryInjectionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeAccumulatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeAccumulatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeCalculator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/congestion/ThrottleMultiplier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/congestion/ThrottleMultiplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/GrpcInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/GrpcInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/GrpcServerManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/GrpcServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/QueryMethod.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/QueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/TransactionMethod.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/TransactionMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/DataBufferMarshaller.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/DataBufferMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/GrpcServiceBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/GrpcServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/KnownLengthStream.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/KnownLengthStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ids/EntityIdService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ids/EntityIdService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ids/WritableEntityIdStore.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ids/WritableEntityIdStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/CurrentPlatformStatus.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/CurrentPlatformStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/CurrentPlatformStatusImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/CurrentPlatformStatusImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/HederaAccountNumbersImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/HederaAccountNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/InfoInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/InfoInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NetworkInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NetworkInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NodeInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NodeInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/SelfNodeInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/SelfNodeInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/meta/HandleScope.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/meta/HandleScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/meta/StoreModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/meta/StoreModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/metrics/MetricsInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/metrics/MetricsInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/JvmSystemExits.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/JvmSystemExits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/ReadableBlockRecordStore.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/ReadableBlockRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordInfoUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordInfoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordStreamProducer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordStreamProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/RunningHashesTranslator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/RunningHashesTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordFormat.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordWriterFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/SerializedSingleTransactionRecord.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/SerializedSingleTransactionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/BlockRecordWriterFactoryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/BlockRecordWriterFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordFormatV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordFormatV6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SidecarWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SidecarWriterV6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SignatureWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SignatureWriterV6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServiceScopeLookup.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServiceScopeLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/CompoundSignatureVerificationFuture.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/CompoundSignatureVerificationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/DefaultKeyVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/DefaultKeyVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/DelegateKeyVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/DelegateKeyVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/ExpandedSignaturePair.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/ExpandedSignaturePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/KeyVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/KeyVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/MonoSignaturePreparer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/MonoSignaturePreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SigExpansionResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SigExpansionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureExpander.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignaturePreparer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignaturePreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureVerificationFuture.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureVerificationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureExpanderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureExpanderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerificationFutureImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerificationFutureImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerificationImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerificationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerifierImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerifierImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HandleConsensusRoundListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HandleConsensusRoundListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HederaRecordCache.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HederaRecordCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HederaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HederaStateInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HederaStateInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/PreHandleListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/PreHandleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlyKVStateWrapper.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlyKVStateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlyQueueStateWrapper.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlyQueueStateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlySingletonStateWrapper.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlySingletonStateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlyStatesWrapper.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/ReadonlyStatesWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/SingleTransactionRecord.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/SingleTransactionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WorkingStateAccessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WorkingStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedHederaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedWritableStates.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedWritableStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/logging/TransactionStateLogger.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/logging/TransactionStateLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/OnStateInitialized.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/OnStateInitialized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/OnUpdateWeight.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/OnUpdateWeight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateMetadata.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/MerkleMapLikeAdapter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/MerkleMapLikeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/ScheduledTransactionsAdapter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/ScheduledTransactionsAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/VirtualMapLikeAdapter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/adapters/VirtualMapLikeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKey.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKeySerializer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableKVState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskValue.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskValueSerializer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableKVState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryKey.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryReadableKVState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryReadableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryValue.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryWritableKVState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/memory/InMemoryWritableKVState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/QueueNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/QueueNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/ReadableQueueStateImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/ReadableQueueStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/WritableQueueStateImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/WritableQueueStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ReadableSingletonStateImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ReadableSingletonStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/WritableSingletonStateImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/WritableSingletonStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/CongestionThrottleService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/CongestionThrottleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/FileUtilities.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/FileUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/HederaAsciiArt.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/HederaAsciiArt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/validation/ExpiryValidation.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/validation/ExpiryValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/version/HederaSoftwareVersion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/version/HederaSoftwareVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/SolvencyPreCheck.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/SolvencyPreCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionInfo.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/WorkflowsInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/WorkflowsInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/ServiceApiFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/ServiceApiFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/TransactionDispatcher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/TransactionDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/TransactionHandlers.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/TransactionHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/WritableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/WritableStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/ChildFinalizeContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/ChildFinalizeContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandlersInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandlersInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/PlatformStateUpdateFacility.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/PlatformStateUpdateFacility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/ScheduleExpirationHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/ScheduleExpirationHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/StakingPeriodTimeHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/StakingPeriodTimeHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacility.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/TokenContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/TokenContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/MigrationContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/MigrationContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordListBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableKVStateStack.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableKVStateStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableQueueStateStack.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableQueueStateStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableSingletonStateStack.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableSingletonStateStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableStatesStack.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableStatesStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/MonoExpiryValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/MonoExpiryValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/StandardizedAttributeValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/StandardizedAttributeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/StandardizedExpiryValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/StandardizedExpiryValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/DueDiligenceException.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/DueDiligenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/DummyPreHandleDispatcher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/DummyPreHandleDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryDispatcher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryHandlers.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/AppTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/AppTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/HederaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/HederaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/ServicesMainTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/ServicesMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/authorization/AuthorizerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/authorization/AuthorizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/authorization/PrivilegesVerifierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/authorization/PrivilegesVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/ConfigProviderImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/ConfigProviderImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ChildFeeContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ChildFeeContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/FeeCalculatorImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/FeeCalculatorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/EntityUtilizationMultiplierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/EntityUtilizationMultiplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/ThrottleMultiplierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/ThrottleMultiplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/QueryMethodTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/QueryMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/TransactionMethodTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/TransactionMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/DataBufferMarshallerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/DataBufferMarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/GrpcServiceBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/GrpcServiceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/KnownLengthStreamTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/KnownLengthStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/ids/WritableEntityIdStoreTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/ids/WritableEntityIdStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/ReadableBlockRecordStoreTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/ReadableBlockRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/codec/RunningHashesTranslatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/codec/RunningHashesTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/ServicesRegistryImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/ServicesRegistryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/CompoundSignatureVerificationFutureTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/CompoundSignatureVerificationFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DefaultKeyVerifierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DefaultKeyVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DelegateKeyVerifierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DelegateKeyVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/MonoSignaturePreparerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/MonoSignaturePreparerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureExpanderImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureExpanderImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureVerificationFutureImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureVerificationFutureImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureVerifierImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureVerifierImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/AddresBookUtils.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/AddresBookUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/ClassLoaderHelper.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/CryptoConfigUtils.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/CryptoConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleHederaStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleHederaStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateMetadataTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateUtilsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestLongCodec.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestLongCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestStringCodec.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestStringCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/adapters/ScheduledTransactionsAdapterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/adapters/ScheduledTransactionsAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/adapters/VirtualMapLikeAdapterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/adapters/VirtualMapLikeAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/memory/InMemoryReadableStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/memory/InMemoryReadableStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/memory/InMemoryWritableStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/memory/InMemoryWritableStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/StringLeafTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/StringLeafTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/ValueLeafTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/ValueLeafTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/DeduplicationCacheTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/DeduplicationCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/UtilsConstructorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/UtilsConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/LongLeaf.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/LongLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/LongMerkleLeaf.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/LongMerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/TestUtils.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/validation/ExpiryValidationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/validation/ExpiryValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/version/HederaSoftwareVersionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/version/HederaSoftwareVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/SolvencyPreCheckTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/SolvencyPreCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactoryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/ServiceApiFactoryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/ServiceApiFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/WritableStoreFactoryImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/WritableStoreFactoryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleDaggerWorkflowModuleTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleDaggerWorkflowModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/PlatformStateUpdateFacilityTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/PlatformStateUpdateFacilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/StakingPeriodTimeHookTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/StakingPeriodTimeHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/SystemFileUpdateFacilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHookTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordListBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordListBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordTestData.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordTestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordsInjectionModuleTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordsInjectionModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerConcurrentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerConcurrentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerSingleThreadedTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerSingleThreadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/BlockRecordFactoryImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/BlockRecordFactoryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordFormatV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordFormatV6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordReaderV6.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordReaderV6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/RecordStreamV6Verifier.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/RecordStreamV6Verifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/MonoExpiryValidatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/MonoExpiryValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/StandardizedAttributeValidatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/StandardizedAttributeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/FakeSignatureVerificationFuture.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/FakeSignatureVerificationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextListUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextListUpdatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleResultTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowModuleTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryDispatcherTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/signature/ExpandedSignaturePairFactory.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/signature/ExpandedSignaturePairFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeHederaState.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeHederaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/workflows/handle/record/SingleTransactionRecordConditions.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/workflows/handle/record/SingleTransactionRecordConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingModule.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/BaseScaffoldingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/common/CommonXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/CommonXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/AssociationsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/AssociationsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/AssociationsXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/AssociationsXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/AssortedOpsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/AssortedOpsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/AssortedOpsXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/AssortedOpsXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/BurnsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/ClassicViewsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ClassicViewsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/ClassicViewsXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ClassicViewsXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractLimitsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractLimitsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/ContractScaffoldingComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/CreatesERC20XTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/CreatesERC20XTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/CreatesERC721XTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/CreatesERC721XTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/CreatesXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/CreatesXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/DeleteXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/DeleteXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/Erc721XTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/Erc721XTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/Erc721XTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/Erc721XTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/FailedLazyCreationXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/FailedLazyCreationXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/FreezeUnfreezeXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/FreezeUnfreezeXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/FuseXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/FuseXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/GetAllowanceXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GetAllowanceXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/GetApprovedXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GetApprovedXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GrantApprovalXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/GrantRevokeKycXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/GrantRevokeKycXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/HtsErc20TransfersXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/HtsErc20TransfersXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/HtsErc721TransferFromXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/HtsErc721TransferFromXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/HtsErc721TransferXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/HtsErc721TransferXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/MintsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/MintsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/MiscClassicTransfersXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/MiscClassicTransfersXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/MiscClassicTransfersXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/MiscClassicTransfersXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/MiscViewsXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/MiscViewsXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/MiscViewsXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/MiscViewsXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/PausesXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/PausesXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/SetApprovalForAllXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/SetApprovalForAllXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/TestApproverXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/TestApproverXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/UpdatesExpiryXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/UpdatesExpiryXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/UpdatesKeysXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/UpdatesKeysXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/UpdatesXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/UpdatesXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/WipeXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/WipeXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/XTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/XTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/approvals/ApproveAllowanceXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/approvals/ApproveAllowanceXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/contract/approvals/ApproveAllowanceXTestConstants.java
+++ b/hedera-node/hedera-app/src/xtest/java/contract/approvals/ApproveAllowanceXTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/AbstractTokenXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/RoyaltyCollectorAutoAssociationXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
+++ b/hedera-node/hedera-app/src/xtest/java/token/TokenScaffoldingComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/build.gradle.kts
+++ b/hedera-node/hedera-config/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/ConfigProvider.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/ConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/NetworkProperty.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/NetworkProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/NodeProperty.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/NodeProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/Utils.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/VersionedConfigImpl.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/VersionedConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/VersionedConfiguration.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/VersionedConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/AccountIDConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/AccountIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/BytesConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/BytesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/CongestionMultipliersConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/CongestionMultipliersConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/ContractIDConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/ContractIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/EntityScaleFactorsConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/EntityScaleFactorsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/FileIDConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/FileIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/FunctionalitySetConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/FunctionalitySetConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/KeyValuePairConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/KeyValuePairConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/KnownBlockValuesConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/KnownBlockValuesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/LegacyContractIdActivationsConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/LegacyContractIdActivationsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/LongPairConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/LongPairConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/PermissionedAccountsRangeConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/PermissionedAccountsRangeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/ScaleFactorConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/ScaleFactorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/SemanticVersionConverter.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/converter/SemanticVersionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ApiPermissionConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ApiPermissionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AutoCreationConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AutoCreationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AutoRenew2Config.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AutoRenew2Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AutoRenewConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AutoRenewConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BalancesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BalancesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BootstrapConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BootstrapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/CacheConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/CacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ConsensusConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ConsensusConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/CryptoCreateWithAliasConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/CryptoCreateWithAliasConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/DevConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/DevConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/EntitiesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/EntitiesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ExpiryConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ExpiryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FeesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FeesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FilesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FilesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HederaConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HederaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LazyCreationConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LazyCreationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LedgerConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LedgerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NettyConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NettyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/RatesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/RatesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/SchedulingConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/SchedulingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/SigsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/SigsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/StakingConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/StakingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/StatsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/StatsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TopicsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TopicsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TraceabilityConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TraceabilityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/UpgradeConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/UpgradeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/UtilPrngConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/UtilPrngConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/VersionConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/VersionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/DynamicConfigSource.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/DynamicConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertyConfigSource.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertyConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertySourceBasedConfigSource.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/PropertySourceBasedConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/SettingsConfigSource.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/sources/SettingsConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/HederaFunctionalitySet.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/HederaFunctionalitySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/KeyValuePair.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/KeyValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/LongPair.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/LongPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/Profile.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/types/Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/validation/EmulatesMap.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/validation/EmulatesMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/validation/EmulatesMapValidator.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/validation/EmulatesMapValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/MixedAnnotatedConfig.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/MixedAnnotatedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/NoNetworkAnnotatedConfig.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/NoNetworkAnnotatedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/PropertySourceBasedConfigTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/PropertySourceBasedConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/UtilsTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/AccountIDConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/AccountIDConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/BytesConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/BytesConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/CongestionMultipliersConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/CongestionMultipliersConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/ContractIDConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/ContractIDConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/EntityScaleFactorsConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/EntityScaleFactorsConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/FileIDConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/FileIDConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/KeyValuePairConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/KeyValuePairConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/KnownBlockValuesConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/KnownBlockValuesConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/LegacyContractIdActivationsConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/LegacyContractIdActivationsConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/LongPairConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/LongPairConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/PermissionedAccountsRangeConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/PermissionedAccountsRangeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/ScaleFactorConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/ScaleFactorConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/SemanticVersionConverterTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/converter/SemanticVersionConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/ApiPermissionConfigTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/ApiPermissionConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/ConfigDataSupportTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/ConfigDataSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/DynamicConfigSourceTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/DynamicConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertyConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertySourceBasedConfigSourceTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/sources/PropertySourceBasedConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/validation/BadDefinedRecord.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/validation/BadDefinedRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/validation/CorrectDefinedRecord.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/validation/CorrectDefinedRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/validation/EmulatesMapValidatorTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/validation/EmulatesMapValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/testFixtures/java/com/hedera/node/config/testfixtures/HederaTestConfigBuilder.java
+++ b/hedera-node/hedera-config/src/testFixtures/java/com/hedera/node/config/testfixtures/HederaTestConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-consensus-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceInjectionModule.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ReadableTopicStoreImpl.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ReadableTopicStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/WritableTopicStore.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/WritableTopicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/codecs/ConsensusServiceStateTranslator.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/codecs/ConsensusServiceStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/codecs/EntityNumCodec.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/codecs/EntityNumCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusDeleteTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusDeleteTopicHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusGetTopicInfoHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusGetTopicInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusHandlers.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusCreateTopicRecordBuilder.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusCreateTopicRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusSubmitMessageRecordBuilder.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusSubmitMessageRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/EntityNumCodecTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/EntityNumCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ReadableTopicStoreImplTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ReadableTopicStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/WritableTopicStoreTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/WritableTopicStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/codecs/ConsensusServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/codecs/ConsensusServiceStateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/AdapterUtils.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicHandlerParityTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusDeleteTopicHandlerParityTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusDeleteTopicHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusDeleteTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusDeleteTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusGetTopicInfoTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusGetTopicInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageParityTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusTestBase.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusTestUtils.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service/build.gradle.kts
+++ b/hedera-node/hedera-consensus-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service/src/main/java/com/hedera/node/app/service/consensus/ConsensusService.java
+++ b/hedera-node/hedera-consensus-service/src/main/java/com/hedera/node/app/service/consensus/ConsensusService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service/src/main/java/com/hedera/node/app/service/consensus/ConsensusServiceDefinition.java
+++ b/hedera-node/hedera-consensus-service/src/main/java/com/hedera/node/app/service/consensus/ConsensusServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-consensus-service/src/main/java/com/hedera/node/app/service/consensus/ReadableTopicStore.java
+++ b/hedera-node/hedera-consensus-service/src/main/java/com/hedera/node/app/service/consensus/ReadableTopicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm-impl/build.gradle.kts
+++ b/hedera-node/hedera-evm-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm-impl/src/main/java/com/hedera/node/app/service/evm/impl/PlaceholderImplementation.java
+++ b/hedera-node/hedera-evm-impl/src/main/java/com/hedera/node/app/service/evm/impl/PlaceholderImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/build.gradle.kts
+++ b/hedera-node/hedera-evm/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/PlaceholderApi.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/PlaceholderApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/AccountAccessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/AccountAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/HederaEvmContractAliases.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/HederaEvmContractAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/BlockMetaSource.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/BlockMetaSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/EvmProperties.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/EvmProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaBlockValues.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaBlockValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTransactionProcessingResult.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTransactionProcessingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/PricesAndFeesProvider.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/PricesAndFeesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/StaticProperties.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/StaticProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/DefaultHederaTracer.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/DefaultHederaTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/AbstractEvmRecordingCreateOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/AbstractEvmRecordingCreateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/CreateOperationExternalizer.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/CreateOperationExternalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperationV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmChainIdOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmChainIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreate2Operation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreate2Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreateOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtil.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtilV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtilV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmSLoadOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmSLoadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExceptionalHaltReason.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExceptionalHaltReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperationV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperationV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperationV038.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/exceptions/InvalidTransactionException.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/exceptions/InvalidTransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/UpdateAccountTracker.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/UpdateAccountTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCache.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmEntityAccess.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmMutableWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmMutableWorldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTokenAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTokenAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/WorldStateAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/WorldStateAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/AbiConstants.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/AbiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/EvmHTSPrecompiledContract.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/EvmHTSPrecompiledContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/EvmInfrastructureFactory.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/EvmInfrastructureFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/BalanceOfWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/BalanceOfWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/CustomFee.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/CustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmDecodingFacade.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmDecodingFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmEncodingFacade.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmEncodingFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmKey.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmNftInfo.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmNftInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmTokenInfo.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmTokenInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/ExplicitRedirectForTokenWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/ExplicitRedirectForTokenWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/FixedFee.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/FixedFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/FractionalFee.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/FractionalFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetApprovedWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetApprovedWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenDefaultFreezeStatusWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenDefaultFreezeStatusWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenDefaultKycStatusWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenDefaultKycStatusWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenExpiryInfoWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenExpiryInfoWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenKeyWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GetTokenKeyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GrantRevokeKycWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/GrantRevokeKycWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/IsApproveForAllWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/IsApproveForAllWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/OwnerOfAndTokenURIWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/OwnerOfAndTokenURIWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/RoyaltyFee.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/RoyaltyFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenAllowanceWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenAllowanceWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenExpiryInfo.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenExpiryInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenFreezeUnfreezeWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenFreezeUnfreezeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenGetCustomFeesWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenGetCustomFeesWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenInfoWrapper.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenInfoWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenKeyType.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenKeyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmAllowancePrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmAllowancePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmBalanceOfPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmBalanceOfPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmFungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmFungibleTokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetApprovedPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetApprovedPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultFreezeStatus.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultFreezeStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultKycStatus.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultKycStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenExpiryInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenExpiryInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenKeyPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenKeyPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenTypePrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenTypePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsApprovedForAllPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsApprovedForAllPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsFrozenPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsFrozenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsKycPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsTokenPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmNonFungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmNonFungibleTokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmOwnerOfPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmOwnerOfPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmRedirectForTokenPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmRedirectForTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenGetCustomFeesPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenGetCustomFeesPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenURIPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenURIPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/RedirectTarget.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/RedirectTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/RedirectViewExecutor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/RedirectViewExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/ViewExecutor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/ViewExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/ViewGasCalculator.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/ViewGasCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/utils/BytesKey.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/utils/BytesKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/utils/DescriptorUtils.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/utils/DescriptorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/utils/EvmParsingConstants.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/utils/EvmParsingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/HederaEvmAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/HederaEvmAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdateTrackingAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdateTrackingAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/tokens/TokenAccessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/tokens/TokenAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/tokens/TokenType.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/tokens/TokenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/utils/EthSigsUtils.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/utils/EthSigsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/utils/ValidationUtils.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/utils/ValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/accounts/HederaEvmContractAliasesTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/accounts/HederaEvmContractAliasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/accounts/MockedHederaEvmContractAliases.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/accounts/MockedHederaEvmContractAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaBlockValuesTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaBlockValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTransactionProcessingResultTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTransactionProcessingResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/MockHederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/MockHederaEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/AbstractEvmRecordingCreateOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/AbstractEvmRecordingCreateOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperationV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaBalanceOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmChainIdOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmChainIdOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreate2OperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreate2OperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreateOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreateOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtilTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtilV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmOperationsUtilV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmSLoadOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmSLoadOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExceptionalHaltReasonTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExceptionalHaltReasonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperationV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeCopyOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperationV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeHashOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperationV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaExtCodeSizeOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCacheTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTokenAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTokenAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/MockAbstractCodeCache.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/MockAbstractCodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/MockEntityAccess.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/MockEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/WorldStateAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/WorldStateAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/EvmHTSPrecompiledContractTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/EvmHTSPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/CustomFeeTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/CustomFeeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmEncodingFacadeTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmEncodingFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmKeyTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/EvmKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenKeyTypeTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/codec/TokenKeyTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmAllowancePrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmAllowancePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmBalanceOfPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmBalanceOfPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmFungibleTokenInfoPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmFungibleTokenInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetApprovedPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetApprovedPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultFreezeStatusTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultFreezeStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultKycStatusTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultKycStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenExpiryInfoPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenExpiryInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenKeyPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenKeyPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenTypePrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenTypePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsApprovedForAllPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsApprovedForAllPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsFrozenPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsFrozenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsKycPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsKycPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsTokenPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmNonFungibleTokenInfoPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmNonFungibleTokenInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmOwnerOfPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmOwnerOfPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmRedirectForTokenPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmRedirectForTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenGetCustomFeesPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenGetCustomFeesPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenInfoPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenURIPrecompileTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenURIPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/EvmInfrastructureFactoryTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/EvmInfrastructureFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/RedirectViewExecutorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/RedirectViewExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/ViewExecutorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/precompile/proxy/ViewExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/utils/BytesKeyTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/utils/BytesKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/utils/DescriptorUtilsTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/utils/DescriptorUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockAccountAccessor.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockAccountAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockTokenAccessor.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockTokenAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdateTrackingAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdateTrackingAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/tokens/TokenTypeTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/tokens/TokenTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/utils/EthSigsUtilsTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/utils/EthSigsUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/utils/ValidationUtilsTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/utils/ValidationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-file-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceImpl.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceInjectionModule.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileStore.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/ReadableFileStoreImpl.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/ReadableFileStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/ReadableUpgradeFileStoreImpl.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/ReadableUpgradeFileStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/WritableFileStore.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/WritableFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/WritableUpgradeFileStore.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/WritableUpgradeFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/base/FileQueryBase.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/base/FileQueryBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/codec/FileServiceStateTranslator.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/codec/FileServiceStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileAppendHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileAppendHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileCreateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileCreateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileDeleteHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileGetContentsHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileGetContentsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileGetInfoHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileGetInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileHandlers.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileSystemDeleteHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileSystemDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileSystemUndeleteHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileSystemUndeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/records/CreateFileRecordBuilder.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/records/CreateFileRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/FileGenesisSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/FileGenesisSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/utils/FileServiceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileServiceImplTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileTestBase.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/FileTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/ReadableFileStoreImplTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/ReadableFileStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/ReadableUpgradeFileStoreImplTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/ReadableUpgradeFileStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/WritableFileStoreTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/WritableFileStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/WritableUpgradeFileStoreTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/WritableUpgradeFileStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileAppendTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileAppendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileCreateTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileCreateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetContentsTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetContentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetInfoTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemUndeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemUndeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileTestUtils.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileUpdateTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/schemas/FileSchemaTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/schemas/FileSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service/build.gradle.kts
+++ b/hedera-node/hedera-file-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/FileMetadata.java
+++ b/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/FileMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/FileService.java
+++ b/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/FileService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/FileServiceDefinition.java
+++ b/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/FileServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/ReadableFileStore.java
+++ b/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/ReadableFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/ReadableUpgradeFileStore.java
+++ b/hedera-node/hedera-file-service/src/main/java/com/hedera/node/app/service/file/ReadableUpgradeFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/build.gradle.kts
+++ b/hedera-node/hedera-mono-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/CurrencyAdjustmentsBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/CurrencyAdjustmentsBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/EvmFnResultBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/EvmFnResultBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/EvmResultRandomParams.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/EvmResultRandomParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/FullEvmResult.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/context/FullEvmResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/contracts/SizeLimitedStorageBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/contracts/SizeLimitedStorageBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/SimpleTransfersBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/SimpleTransfersBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/StakingActivityApp.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/StakingActivityApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/StakingActivityBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/StakingActivityBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/StakingActivityModule.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/ledger/StakingActivityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockAccountNumbers.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockAccountNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockAccountTracking.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockAccountTracking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockDynamicProperties.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockDynamicProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockEntityCreator.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockEntityCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockProps.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockRecordsHistorian.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockStorageLimits.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockStorageLimits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockTransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/NoopStorageFeeCharging.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/NoopStorageFeeCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/Constructables.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/Constructables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/EvmKeyValueSource.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/EvmKeyValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureBundle.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureInitializer.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureManager.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureType.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/InfrastructureType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/KvMutationBatch.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/KvMutationBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/stream/NonBlockingHandoffBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/stream/NonBlockingHandoffBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/submerkle/RandomFactory.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/submerkle/RandomFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesApp.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/Utils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/AccountNumbers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/AccountNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/ConfigModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/ConfigModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/EntityNumbers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/EntityNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/FileNumbers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/FileNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/HederaNumbers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/HederaNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/NetworkInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/config/NetworkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/AppsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/AppsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/BasicTransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/BasicTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ContextModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ContextModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ContextPlatformStatus.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ContextPlatformStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/CurrentPlatformStatus.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/CurrentPlatformStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ImmutableStateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ImmutableStateChildren.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/MutableStateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/MutableStateChildren.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/NodeInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/NodeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/SideEffectsTracker.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/SideEffectsTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildren.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildrenProvider.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildrenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/TransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/TransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/annotations/BootstrapProps.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/annotations/BootstrapProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/annotations/CompositeProps.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/annotations/CompositeProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/annotations/StaticAccountMemo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/annotations/StaticAccountMemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/process/TxnValidityAndFeeReq.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/process/TxnValidityAndFeeReq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/security/HapiOpPermissions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/security/HapiOpPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/security/PermissionFileUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/security/PermissionFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/security/PermissionedAccountsRange.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/security/PermissionedAccountsRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/trackers/ConsensusStatusCounts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/trackers/ConsensusStatusCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventStatus.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/ServicesInitFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/ServicesInitFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/StateInitializationFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/StateInitializationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/StoreInitializationFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/StoreInitializationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/StateView.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/StateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ActiveVersions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ActiveVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ChainedSources.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ChainedSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/CustomFeeType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/CustomFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/EntityType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalStaticProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalStaticProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/NodeLocalProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/NodeLocalProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/Profile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertiesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertiesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertySource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertySources.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertySources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ScreenedNodeFileProps.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ScreenedNodeFileProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ScreenedSysFileProps.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ScreenedSysFileProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SemanticVersions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SemanticVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/StandardizedPropertySources.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/StandardizedPropertySources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/StaticPropertiesHolder.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/StaticPropertiesHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SupplierMapPropertySource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SupplierMapPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ThrowingStreamProvider.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/ThrowingStreamProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_30Module.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_30Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_34Module.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_34Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_38Module.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_38Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/annotations/BytecodeSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/annotations/BytecodeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/annotations/StorageSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/annotations/StorageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/ChargingResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/ChargingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/InHandleBlockMetaSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/InHandleBlockMetaSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/LivePricesSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/LivePricesSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaProvider.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/TransactionProcessingResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/TransactionProcessingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/CallOperationType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/CallOperationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/ContractActionType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/ContractActionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaOperationTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaOperationTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaUtil.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV18.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV18.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV19.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV19.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV22.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV22.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV034.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV034.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCreateOperationExternalizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCreateOperationExternalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaLogOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtil.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtilV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtilV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaPrngSeedOperator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaPrngSeedOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSLoadOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSLoadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSStoreOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSStoreOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationV038.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/sources/AddressKeyedMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/sources/AddressKeyedMapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/sources/EvmSigsVerifier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/sources/EvmSigsVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/sources/TxnAwareEvmSigsVerifier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/sources/TxnAwareEvmSigsVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/DeletedAccountException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/DeletedAccountException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/DetachedAccountException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/DetachedAccountException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/InconsistentAdjustmentsException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/InconsistentAdjustmentsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/InsufficientFundsException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/InsufficientFundsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/MissingEntityException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/MissingEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/NegativeAccountBalanceException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/NegativeAccountBalanceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/NoValidSignedStateException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/NoValidSignedStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/NonZeroNetTransfersException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/NonZeroNetTransfersException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/ResourceLimitException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/ResourceLimitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/UnparseablePropertyException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/UnparseablePropertyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/BasicHbarCentExchange.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/BasicHbarCentExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/CustomFeePayerExemptions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/CustomFeePayerExemptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeCalculatorModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeCalculatorModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeExemptions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeExemptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/HbarCentExchange.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/HbarCentExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/StandardCustomPayerExemptions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/StandardCustomPayerExemptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/StandardExemptions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/StandardExemptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/TxnFeeType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/TxnFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/annotations/FunctionKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/annotations/FunctionKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/annotations/GasPriceMultiplier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/annotations/GasPriceMultiplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/annotations/GenericPriceMultiplier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/annotations/GenericPriceMultiplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/AutoRenewCalcs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/AutoRenewCalcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/BasicFcfsUsagePrices.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/BasicFcfsUsagePrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/CongestionMultipliers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/CongestionMultipliers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/EntityScaleFactors.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/EntityScaleFactors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/FeeCalcUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/FeeCalcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/QueryResourceUsageEstimator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/QueryResourceUsageEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/RenewAssessment.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/RenewAssessment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/RenewalFees.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/RenewalFees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/TxnResourceUsageEstimator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/TxnResourceUsageEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/UsageBasedFeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/UsagePricesProvider.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/UsagePricesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/UtilizationScaleFactors.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/UtilizationScaleFactors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/ConsensusFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/ConsensusFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetTopicInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetTopicInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/CreateTopicResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/CreateTopicResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/DeleteTopicResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/DeleteTopicResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateTopicResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateTopicResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/ContractFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/ContractFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetBytecodeResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetBytecodeResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCallResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCallResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCreateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCreateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractDeleteResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractDeleteResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/CryptoFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/CryptoFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetTxnRecordResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetTxnRecordResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/txns/CryptoDeleteResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/txns/CryptoDeleteResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/EthereumFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/EthereumFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/txns/EthereumTransactionResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/txns/EthereumTransactionResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/FileFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/FileFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileContentsResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileContentsResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileCreateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileCreateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileDeleteResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileDeleteResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileUpdateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileUpdateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemDeleteFileResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemDeleteFileResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemUndeleteFileResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemUndeleteFileResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/meta/FixedUsageEstimates.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/meta/FixedUsageEstimates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetExecTimeResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetExecTimeResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetVersionInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetVersionInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/ScheduleFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/ScheduleFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleCreateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleCreateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleDeleteResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleDeleteResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleSignResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleSignResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/FreezeResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/FreezeResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/UncheckedSubmitResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/UncheckedSubmitResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/TokenFeesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/TokenFeesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/AbstractTokenResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/AbstractTokenResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenCreateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenCreateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDeleteResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDeleteResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenGrantKycResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenGrantKycResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenRevokeKycResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenRevokeKycResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/AccessorBasedUsages.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/AccessorBasedUsages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/OpUsageCtxHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/OpUsageCtxHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/PricedUsageCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/PricedUsageCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/ResourceUsageSubtypeHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/ResourceUsageSubtypeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/TriggeredValuesParser.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/utils/TriggeredValuesParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/ContractStoragePriceTiers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/ContractStoragePriceTiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/FeeChargingPolicy.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/FeeChargingPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/FeeDistribution.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/FeeDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NarratedCharging.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NarratedCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerCharging.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NonHapiFeeCharging.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NonHapiFeeCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/RecordedStorageFeeCharging.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/RecordedStorageFeeCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/StorageFeeCharging.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/StorageFeeCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/TxnChargingPolicyAgent.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/TxnChargingPolicyAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/DelegatingMultiplierSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/DelegatingMultiplierSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/FeeMultiplierSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/FeeMultiplierSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/GasPriceMultiplierSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/GasPriceMultiplierSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/MultiplierSources.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/MultiplierSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/ThrottleMultiplierSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/ThrottleMultiplierSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/TxnRateFeeMultiplierSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/congestion/TxnRateFeeMultiplierSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/DataMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/DataMapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/EntityExpiryMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/EntityExpiryMapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/FileUpdateInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/FileUpdateInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/FilesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/FilesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HFileMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HFileMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HFileMetaSerde.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HFileMetaSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HederaFs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HederaFs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HybridResouceLoader.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/HybridResouceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/MetadataMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/MetadataMapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/SimpleUpdateResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/SimpleUpdateResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/SysFileCallbacks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/SysFileCallbacks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/TieredHederaFs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/TieredHederaFs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/annotations/PermissionsInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/annotations/PermissionsInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/annotations/PropertiesInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/annotations/PropertiesInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/ConfigListUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/ConfigListUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/FeeSchedulesManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/FeeSchedulesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/PureRatesValidation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/PureRatesValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/ThrottleDefsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/ThrottleDefsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/TxnAwareRatesManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/TxnAwareRatesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/ValidatingCallbackInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/interceptors/ValidatingCallbackInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/store/BytesStoreAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/store/BytesStoreAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/store/FcBlobsBytesStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/store/FcBlobsBytesStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/sysfiles/CurrencyCallbacks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/sysfiles/CurrencyCallbacks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/sysfiles/ThrottlesCallback.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/files/sysfiles/ThrottlesCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/ConfigDrivenNettyFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/ConfigDrivenNettyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/GrpcModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/GrpcModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/GrpcServerManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/GrpcServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/GrpcStarter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/GrpcStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/NettyBuilderFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/NettyBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/ConsensusController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/ConsensusController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/ContractController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/ContractController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/FileController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/FileController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/FreezeController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/FreezeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/NetworkController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/NetworkController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/ScheduleController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/ScheduleController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/TokenController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/TokenController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/UtilController.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/UtilController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AdjustmentUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AdjustmentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AliasResolver.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AliasResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AssessedCustomFeeWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AssessedCustomFeeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/BalanceChangeManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/BalanceChangeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomFeeMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomFeeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomSchedulesManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomSchedulesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FungibleAdjuster.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FungibleAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersMarshal.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/ActivationTest.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/ActivationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/CharacteristicsFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/CharacteristicsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/DefaultActivationCharacteristics.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/DefaultActivationCharacteristics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/HederaKeyActivation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/HederaKeyActivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/HederaKeyTraversal.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/HederaKeyTraversal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/InHandleActivationHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/InHandleActivationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/KeyActivationCharacteristics.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/KeyActivationCharacteristics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/KeysModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/KeysModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/LegacyContractIdActivations.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/LegacyContractIdActivations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/OnlyIfSigVerifiableValid.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/OnlyIfSigVerifiableValid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/RevocationServiceCharacteristics.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/keys/RevocationServiceCharacteristics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/BalanceChange.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/BalanceChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/CommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/CommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/EntityChangeSet.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/EntityChangeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/HederaLedger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/HederaLedger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/Ledger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/Ledger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/LedgerCheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/LedgerCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/LedgerModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/LedgerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/MerkleAccountScopedCheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/MerkleAccountScopedCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/PropertyChangeObserver.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/PropertyChangeObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/PureTransferSemanticChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/PureTransferSemanticChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/SigImpactHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/SigImpactHistorian.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransactionalLedger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransactionalLedger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransferLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/TransferLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AccountCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/ContractAliases.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/ContractAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/ContractCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/ContractCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/HederaAccountCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/HederaAccountCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/StackedContractAliases.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/StackedContractAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/SynthCreationCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/SynthCreationCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeChangeManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeChangeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeInfoManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeInfoManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakingUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccounts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingNfts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingNfts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRels.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokens.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccounts.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/ids/EntityIdSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/ids/EntityIdSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/ids/ExceptionalEntityIdSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/ids/ExceptionalEntityIdSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/ids/SeqNoEntityIdSource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/ids/SeqNoEntityIdSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/AccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/AccountsCommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/AutoAssocTokenRelsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/AutoAssocTokenRelsCommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareTokenRelsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareTokenRelsCommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/StakeChangeScenario.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/StakeChangeScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/StakingAccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/StakingAccountsCommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/TokenRelsLinkManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/TokenRelsLinkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/TokensCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/TokensCommitInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/UniqueTokensLinkManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/interceptors/UniqueTokensLinkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/AccountProperty.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/AccountProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/BeanProperty.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/BeanProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/ChangeSummaryManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/ChangeSummaryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/NftProperty.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/NftProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/TokenProperty.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/TokenProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/TokenRelProperty.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/properties/TokenRelProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractAliasKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractAliasKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JDelegatableContractAliasKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JDelegatableContractAliasKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JDelegatableContractIDKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JDelegatableContractIDKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSASecp256k1Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSASecp256k1Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSA_384Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSA_384Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JEd25519Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JEd25519Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyList.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JObjectType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JObjectType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JRSA_3072Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JRSA_3072Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JThresholdKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JThresholdKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JWildcardECDSAKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JWildcardECDSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceipt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/exception/InvalidAccountIDException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/exception/InvalidAccountIDException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/exception/KeyPrefixMismatchException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/exception/KeyPrefixMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/handler/SmartContractRequestHandler.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/handler/SmartContractRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/AbstractAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/AbstractAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/AnswerFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/AnswerFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/AnswerService.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/AnswerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/QueriesModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/QueriesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/AnswerFunctions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/AnswerFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/QueryHeaderValidity.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/QueryHeaderValidity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/QueryResponseHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/QueryResponseHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/StakeAwareAnswerFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/StakeAwareAnswerFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/StakedAnswerFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/StakedAnswerFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/ZeroStakeAnswerFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/answering/ZeroStakeAnswerFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/consensus/GetTopicInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/consensus/GetTopicInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/consensus/HcsAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/consensus/HcsAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/ContractAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/ContractAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetBySolidityIdAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetBySolidityIdAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetBytecodeAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetBytecodeAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetContractRecordsAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/contract/GetContractRecordsAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/CryptoAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/CryptoAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountRecordsAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountRecordsAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetLiveHashAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetLiveHashAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetStakersAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/crypto/GetStakersAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/file/FileAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/file/FileAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/file/GetFileContentsAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/file/GetFileContentsAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/file/GetFileInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/file/GetFileInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetAccountDetailsAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetAccountDetailsAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetExecTimeAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetExecTimeAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetFastTxnRecordAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetFastTxnRecordAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetTxnReceiptAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetTxnReceiptAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetVersionInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetVersionInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/MetaAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/MetaAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/schedule/GetScheduleInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/schedule/GetScheduleInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/schedule/ScheduleAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/schedule/ScheduleAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetAccountNftInfosAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetAccountNftInfosAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfosAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfosAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/TokenAnswers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/token/TokenAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/validation/QueryFeeCheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/validation/QueryFeeCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/ConsensusTimeTracker.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/ConsensusTimeTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/EarliestRecordExpiry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/EarliestRecordExpiry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/InProgressChildRecord.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/InProgressChildRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordCache.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordCacheFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordSubmissions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordSubmissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsHistorian.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TransactionRecordService.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TransactionRecordService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnIdRecentHistory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnIdRecentHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/EventExpansion.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/EventExpansion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/Expansion.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/Expansion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/ExpansionHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/ExpansionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/HederaToPlatformSigOps.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/HederaToPlatformSigOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/HollowScreening.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/HollowScreening.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/PlatformSigOps.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/PlatformSigOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/PlatformSigsCreationResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/PlatformSigsCreationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/PlatformSigsFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/PlatformSigsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/Rationalization.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/Rationalization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/SigsModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/SigsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/annotations/WorkingStateSigReqs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/annotations/WorkingStateSigReqs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/factories/PlatformSigFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/factories/PlatformSigFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/factories/ReusableBodySigningFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/factories/ReusableBodySigningFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/factories/TxnScopedPlatformSigFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/factories/TxnScopedPlatformSigFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/AccountSigningMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/AccountSigningMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/ContractSigningMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/ContractSigningMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/FileSigningMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/FileSigningMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/SafeLookupResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/SafeLookupResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/ScheduleSigningMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/ScheduleSigningMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/SigMetadataLookup.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/SigMetadataLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/StateChildrenSigMetadataLookup.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/StateChildrenSigMetadataLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/TokenMetaUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/TokenMetaUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/TokenSigningMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/TokenSigningMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/TopicSigningMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/TopicSigningMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/CodeOrderResultFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/CodeOrderResultFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/KeyOrderingFailure.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/KeyOrderingFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/LinkedRefs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/LinkedRefs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/PolicyBasedSigWaivers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/PolicyBasedSigWaivers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigReqsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigReqsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigRequirements.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigRequirements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SignatureWaivers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SignatureWaivers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigningOrderResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigningOrderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigningOrderResultFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigningOrderResultFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/KeyType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/KeyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMap.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMapPubKeyToSigBytes.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMapPubKeyToSigBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/PubKeyToSigBytes.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/PubKeyToSigBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/SigObserver.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/sourcing/SigObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/utils/ImmutableKeyUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/utils/ImmutableKeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/utils/MiscCryptoUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/utils/MiscCryptoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/utils/PrecheckUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/utils/PrecheckUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/InvalidPayerAccountException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/InvalidPayerAccountException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckKeyReqs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckKeyReqs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckVerifier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/SyncVerifier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/verification/SyncVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/EntityCreator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/EntityCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/PlatformStateAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/PlatformStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/StateModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/StateModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/adapters/MerkleMapLike.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/adapters/MerkleMapLike.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/adapters/VirtualMapLike.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/adapters/VirtualMapLike.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/annotations/RunTopLevelTransition.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/annotations/RunTopLevelTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/annotations/RunTriggeredTransition.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/annotations/RunTriggeredTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/CodecFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/CodecFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/MonoMapCodecAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/MonoMapCodecAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/PbjParser.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/PbjParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/PbjWriter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/PbjWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/enums/TokenSupplyType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/enums/TokenSupplyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiringCreations.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiringCreations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiringEntity.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiringEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryEvent.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryRecordsHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryRecordsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/KeyedExpirations.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/KeyedExpirations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/MonotonicFullQueueExpiries.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/MonotonicFullQueueExpiries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/PriorityQueueExpiries.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/PriorityQueueExpiries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/TokenRelsListMutation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/TokenRelsListMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/UniqueTokensListMutation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/UniqueTokensListMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/classification/ClassificationResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/classification/ClassificationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/classification/ClassificationWork.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/classification/ClassificationWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/classification/EntityLookup.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/classification/EntityLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/AccountGC.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/AccountGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/ContractGC.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/ContractGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/CryptoGcOutcome.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/CryptoGcOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/FungibleReturnOutcome.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/FungibleReturnOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/FungibleTreasuryReturns.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/FungibleTreasuryReturns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/NftReturnOutcome.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/NftReturnOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/NonFungibleTreasuryReturns.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/NonFungibleTreasuryReturns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/RemovalHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/RemovalHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/RemovalWork.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/RemovalWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/SlotRemovalOutcome.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/SlotRemovalOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturns.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/renewal/RenewalHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/renewal/RenewalHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/renewal/RenewalWork.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/renewal/RenewalWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/AccountsExporter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/AccountsExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/BalancesExporter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/BalancesExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/BalancesSummary.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/BalancesSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/DirectoryAssurance.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/DirectoryAssurance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/ExportingRecoveredStateListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/ExportingRecoveredStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/FileHashReader.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/FileHashReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/ServicesSignedStateListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/ServicesSignedStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/Sha384HashReader.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/Sha384HashReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/SigFileWriter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/SigFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/SignedStateBalancesExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/StandardSigFileWriter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/StandardSigFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/ToStringAccountsExporter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/exports/ToStringAccountsExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/HashLogger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/HashLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BlocklistAccountCreator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BlocklistAccountCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BlocklistNotFoundException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/BlocklistNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemAccountsCreator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemAccountsCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemFilesManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/SystemFilesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/TreasuryCloner.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/initialization/TreasuryCloner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/AwareNodeDiligenceScreen.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/AwareNodeDiligenceScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/BlockManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/BlockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/BlockNumberMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/BlockNumberMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/HandleLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/HandleLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/InvariantChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/InvariantChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/LastStepModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/LastStepModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/NetworkCtxManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/NetworkCtxManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/NetworkUtilization.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/NetworkUtilization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/NonPayerKeysScreen.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/NonPayerKeysScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/PayerSigValidity.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/PayerSigValidity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ProcessLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ProcessLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ReconnectListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ReconnectListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/RecordStreaming.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/RecordStreaming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/RequestedTransition.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/RequestedTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ScheduledTransactions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ScheduledTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/SigsAndPayerKeyScreen.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/SigsAndPayerKeyScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StandardProcessLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StandardProcessLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StateWriteToDiskListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StateWriteToDiskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StatusChangeListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StatusChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/TopLevelTransition.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/TopLevelTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/TriggeredTransition.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/TriggeredTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccount.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleEntityId.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleEntityId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerklePayerRecords.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerklePayerRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleSchedule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleSpecialFiles.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleSpecialFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleStakingInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleStakingInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleToken.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatus.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleTopic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueToken.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/BitPackUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/BitPackUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/BlobKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/BlobKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/ByteUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/ByteUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/BytesElement.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/internals/BytesElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/BrokenTransformationException.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/BrokenTransformationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ContractStateMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/HederaAccount.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/HederaAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/HederaTokenRel.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/HederaTokenRel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDisk.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/NftStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/NftStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/QueryableRecords.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/QueryableRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StakingInfoMapBuilder.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StakingInfoMapBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StakingNodeInfoStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StakingNodeInfoStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateChildIndices.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateChildIndices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateVersions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StorageStrategy.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StorageStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ToDiskMigrations.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/ToDiskMigrations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenRelStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenRelStorageAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenRelationStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenRelationStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenMapAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenMapAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokensMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokensMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/VirtualMapDataAccess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/VirtualMapDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/internal/ContractMigrationValidationCounters.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/internal/ContractMigrationValidationCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/org/StateMetadata.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/org/StateMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/IoReadingFunction.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/IoReadingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/IoUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/IoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/IoWritingConsumer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/IoWritingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/TopicSerde.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/serdes/TopicSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ContractNonceInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ContractNonceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustments.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/EntityId.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/EntityId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/EvmLog.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/EvmLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRates.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcAssessedCustomFee.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcAssessedCustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcCustomFee.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcCustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowance.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceId.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAssociation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAssociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FixedFeeSpec.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FixedFeeSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FractionalFeeSpec.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/FractionalFeeSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/NftAdjustments.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/NftAdjustments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/RawTokenRelationship.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/RawTokenRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/RichInstant.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/RichInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/RoyaltyFeeSpec.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/RoyaltyFeeSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/SequenceNumber.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/SequenceNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/TxnId.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/TxnId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTask.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTaskManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTaskManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTaskResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTaskResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TaskModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TaskModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/AccountUsageTracking.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/AccountUsageTracking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/BasedLedgerValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/BasedLedgerValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/ContractStorageLimits.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/ContractStorageLimits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/LedgerValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/LedgerValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/UsageLimits.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/validation/UsageLimits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractMerkleDbKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractStorageListMutation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractStorageListMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumMerkleDbKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableContractMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableContractMerkleDbValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableContractValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableContractValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableStorageUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableStorageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/KeyPackingUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/KeyPackingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskAccountMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskAccountMerkleDbValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskTokenRelMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskTokenRelMerkleDbValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/annotations/StateSetter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/annotations/StateSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccount.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskTokenRel.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskTokenRel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValue.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/CheckedConsumer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/CheckedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/CheckedConsumer2.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/CheckedConsumer2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/CheckedSupplier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/CheckedSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/EntityIoUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/utils/EntityIoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/EntityUtilGauges.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/EntityUtilGauges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ExecutionTimeTracker.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ExecutionTimeTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ExpiryStats.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ExpiryStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/HapiOpCounters.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/HapiOpCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/HapiOpSpeedometers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/HapiOpSpeedometers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/MiscRunningAvgs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/MiscRunningAvgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/MiscSpeedometers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/MiscSpeedometers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ServicesStatsConfig.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ServicesStatsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ServicesStatsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ServicesStatsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/StatsModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/StatsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ThrottleGauges.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ThrottleGauges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/UtilGauge.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/UtilGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/AccountStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/AccountStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/CreationResult.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/CreationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/HederaStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/HederaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/ReadOnlyTokenStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/ReadOnlyTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/Store.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/StoresModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/StoresModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/TopicStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/TopicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/TypedTokenStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/TypedTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/UpdateAccountTrackerImpl.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/UpdateAccountTrackerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractLedgerWorldUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractLedgerWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractStackedLedgerUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractStackedLedgerUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AccountAccessorImpl.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AccountAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/CodeCache.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/CodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/EntityAccess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/EntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaMutableWorldState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaMutableWorldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/KvUsageInfo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/KvUsageInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/MutableEntityAccess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/MutableEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/SizeLimitedStorage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/SizeLimitedStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/TokenAccessorImpl.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/TokenAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/AbiConstants.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/AbiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/ExchangeRatePrecompiledContract.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/ExchangeRatePrecompiledContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/Precompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/Precompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/PrngSystemPrecompiledContract.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/PrngSystemPrecompiledContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdateLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/ApproveWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/ApproveWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/Association.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/Association.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/BurnWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/BurnWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/CryptoTransferWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/CryptoTransferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DeleteWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DeleteWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/Dissociation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/Dissociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/EncodingFacade.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/EncodingFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/KeyValueWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/KeyValueWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/MintWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/MintWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/PauseWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/PauseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/SetApprovalForAllWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/SetApprovalForAllWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenExpiryWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenExpiryWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenKeyWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenKeyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenTransferWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenTransferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenUpdateExpiryInfoWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenUpdateExpiryInfoWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenUpdateKeysWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenUpdateKeysWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenUpdateWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenUpdateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TransferWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TransferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/UnpauseWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/UnpauseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/WipeWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/WipeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractAssociatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractAssociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractDissociatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractDissociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractFreezeUnfreezePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractFreezeUnfreezePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractGrantRevokeKycPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractGrantRevokeKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractReadOnlyPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractReadOnlyPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractWipePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractWipePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractWritePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractWritePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AllowancePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AllowancePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AssociatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AssociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BalanceOfPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BalanceOfPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BurnPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BurnPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/DecimalsPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/DecimalsPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/DeleteTokenPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/DeleteTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/DissociatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/DissociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/FreezeTokenPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/FreezeTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/FungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/FungibleTokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetApprovedPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetApprovedPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenDefaultFreezeStatus.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenDefaultFreezeStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenDefaultKycStatus.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenDefaultKycStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenExpiryInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenExpiryInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenKeyPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenKeyPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenTypePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GetTokenTypePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GrantKycPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/GrantKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsApprovedForAllPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsApprovedForAllPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsFrozenPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsFrozenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsKycPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsTokenPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/IsTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MintPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MintPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MultiAssociatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MultiAssociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MultiDissociatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MultiDissociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/NamePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/NamePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/NonFungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/NonFungibleTokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/OwnerOfPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/OwnerOfPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/PausePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/PausePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/RedirectPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/RedirectPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/RevokeKycPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/RevokeKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SymbolPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SymbolPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractAbis.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractAbis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractTypes.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenCreatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenCreatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenGetCustomFeesPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenGetCustomFeesPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenURIPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenURIPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenUpdateKeysPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenUpdateKeysPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenUpdatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TokenUpdatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TotalSupplyPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TotalSupplyPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/UnfreezeTokenPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/UnfreezeTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/UnpausePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/UnpausePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/UpdateTokenExpiryInfoPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/UpdateTokenExpiryInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/WipeFungiblePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/WipeFungiblePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/WipeNonFungiblePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/WipeNonFungiblePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/KeyValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/KeyValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/LegacyKeyValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/LegacyKeyValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/TokenCreateReqs.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/TokenCreateReqs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/KeyActivationTest.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/KeyActivationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/KeyActivationUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/KeyActivationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/LegacyActivationTest.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/LegacyActivationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/LegacyKeyActivationTest.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/LegacyKeyActivationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompilePricingUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompilePricingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompileUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Account.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Id.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/NftId.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/NftId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/OwnershipTracker.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/OwnershipTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Token.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/TokenRelationship.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/TokenRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Topic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Topic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/TopicConversion.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/TopicConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/UniqueToken.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/UniqueToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/schedule/HederaScheduleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/schedule/ScheduleStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/schedule/ScheduleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/TokenStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/TokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/annotations/AreTreasuryWildcardsEnabled.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/annotations/AreTreasuryWildcardsEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/CurrentRecordStreamType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/CurrentRecordStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/NonBlockingHandoff.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/NonBlockingHandoff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamFileWriter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamObject.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordsRunningHashLeaf.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecordsRunningHashLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecoveryRecordsWriter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stream/RecoveryRecordsWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ExpiryThrottle.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ExpiryThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ExpiryThrottlePojo.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ExpiryThrottlePojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/FunctionalityThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/FunctionalityThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/HapiThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/HapiThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/MapAccessType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/MapAccessType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ThrottlingModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/ThrottlingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TimedFunctionalityThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TimedFunctionalityThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TransactionThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TransactionThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottling.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/annotations/HandleThrottle.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/annotations/HandleThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/annotations/HapiThrottle.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/annotations/HapiThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/annotations/ScheduleThrottle.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/throttling/annotations/ScheduleThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/PreFetchableTransition.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/PreFetchableTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/ProcessLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/ProcessLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/SubmissionFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/SubmissionFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransactionLastStep.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransactionLastStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransactionsModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransactionsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransitionLogicLookup.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransitionLogicLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransitionRunner.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/TransitionRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/auth/SystemOpAuthorization.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/auth/SystemOpAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/auth/SystemOpPolicies.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/auth/SystemOpPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/ConsensusLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/ConsensusLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/SubmitMessageTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/SubmitMessageTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicDeleteTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicDeleteTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicUpdateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractDeleteTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractDeleteTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractSysDelTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractSysDelTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractSysUndelTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractSysUndelTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractUpdateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/AbstractAutoCreationLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/AbstractAutoCreationLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/ApproveAllowanceLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/ApproveAllowanceLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/AutoCreationLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/AutoCreationLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoApproveAllowanceTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoApproveAllowanceTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteAllowanceTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteAllowanceTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoTransferTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoTransferTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/DeleteAllowanceLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/DeleteAllowanceLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/EvmAutoCreationLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/EvmAutoCreationLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/helpers/AllowanceHelpers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/helpers/AllowanceHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/AllowanceChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/AllowanceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/ApproveAllowanceChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/ApproveAllowanceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/DeleteAllowanceChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/DeleteAllowanceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/customfees/CustomFeeSchedules.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/customfees/CustomFeeSchedules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/customfees/FcmCustomFeeSchedules.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/customfees/FcmCustomFeeSchedules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/customfees/LedgerCustomFeeSchedules.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/customfees/LedgerCustomFeeSchedules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/diligence/DuplicateClassification.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/diligence/DuplicateClassification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/ethereum/EthereumLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/ethereum/EthereumLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/ethereum/EthereumTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileAppendTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileAppendTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileDeleteTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileDeleteTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileSysDelTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileSysDelTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileSysUndelTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileSysUndelTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/FreezeTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/FreezeTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/NetworkLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/NetworkLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/UncheckedSubmitTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/UncheckedSubmitTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/UpgradeActions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/network/UpgradeActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/prefetch/PrefetchProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/prefetch/PrefetchProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleDeleteTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleDeleteTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleExecutor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleProcessing.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSignTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSignTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSigsVerifier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSigsVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/SigClassification.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/SigClassification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/SigMapScheduleClassifier.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/SigMapScheduleClassifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/SignatoryUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/schedule/SignatoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/EthTxExpansion.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/EthTxExpansion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpan.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpanMapAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpanMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/SpanMapManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/SpanMapManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/BasicSubmissionFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/BasicSubmissionFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/PlatformSubmissionManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/PlatformSubmissionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/PresolvencyFlaws.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/PresolvencyFlaws.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SemanticPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SemanticPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SolvencyPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SolvencyPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/StagedPrechecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/StagedPrechecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/StructuralPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/StructuralPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SubmissionModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SubmissionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SyntaxPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SyntaxPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SystemPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SystemPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/TransactionPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/TransactionPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/TxnResponseHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/TxnResponseHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/annotations/MaxProtoMsgDepth.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/annotations/MaxProtoMsgDepth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/annotations/MaxSignedTxnSize.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/annotations/MaxSignedTxnSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/AssociateLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/AssociateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/BurnLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/BurnLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/CreateLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/CreateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/DeleteLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/DeleteLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/DissociateLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/DissociateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/FreezeLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/FreezeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/GrantKycLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/GrantKycLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/MintLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/MintLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/PauseLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/PauseLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/RevokeKycLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/RevokeKycLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenAssociateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenAssociateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenBurnTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenBurnTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenDeleteTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenDeleteTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenDissociateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenDissociateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenFreezeTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenFreezeTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenGrantKycTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenGrantKycTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenMintTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenMintTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenOpsValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenOpsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenPauseTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenPauseTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenRevokeKycTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenRevokeKycTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenUnfreezeTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenUnfreezeTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenUnpauseTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenUnpauseTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenUpdateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenWipeTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/TokenWipeTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/UnfreezeLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/UnfreezeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/UnpauseLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/UnpauseLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/WipeLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/WipeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/Creation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/Creation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/Dissociation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/Dissociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/DissociationFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/DissociationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/NewRels.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/process/NewRels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/validators/CreateChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/token/validators/CreateChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/PrngLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/PrngLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/TokenUpdateValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/TokenUpdateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/UtilLogicModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/UtilLogicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/UtilPrngTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/util/UtilPrngTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/OptionValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/OptionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/PureValidation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/PureValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/TokenListChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/validation/TokenListChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityIdUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityIdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityNum.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityNum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityNumPair.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EntityNumPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EvmTokenUtil.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EvmTokenUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/HederaDateTimeFormatter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/HederaDateTimeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/JvmSystemExits.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/JvmSystemExits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MapValueListMutation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MapValueListMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MapValueListUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MapValueListUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/MiscUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/NamedDigestFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/NamedDigestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/NftNumPair.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/NftNumPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/NonAtomicReference.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/NonAtomicReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/Pause.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/Pause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/PendingCompletion.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/PendingCompletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/RationalizedSigMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/RationalizedSigMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/ResourceValidationUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/ResourceValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/ResponseCodeUtil.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/ResponseCodeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SerializationUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SidecarUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SidecarUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SleepingPause.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SleepingPause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SystemExits.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/SystemExits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/TokenTypesMapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/TokenTypesMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/Units.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/Units.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/UnzipUtility.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/UnzipUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/AccessorFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/AccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/PlatformTxnAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/PlatformTxnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SwirldsTxnAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/SwirldsTxnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/TokenWipeAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/TokenWipeAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/TxnAccessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/accessors/TxnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/DifferingEntries.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/DifferingEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/OrderedComparison.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/OrderedComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordParsers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordParsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordStreamEntry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/forensics/RecordStreamEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesAppTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/UtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/cache/EntityMapWarmerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/cache/EntityMapWarmerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/AccountNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/AccountNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/EntityNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/EntityNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/FileNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/FileNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/HederaNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/HederaNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/MockEntityNumbers.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/MockEntityNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/MockGlobalDynamicProps.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/MockGlobalDynamicProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/MockHederaNumbers.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/MockHederaNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/NetworkInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/NetworkInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/AppsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/AppsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/BasicTransactionContextTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/BasicTransactionContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/ContextPlatformStatusTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/ContextPlatformStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/ImmutableStateChildrenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/ImmutableStateChildrenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/MutableStateChildrenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/MutableStateChildrenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/NodeInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/NodeInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/SideEffectsTrackerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/SideEffectsTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/process/TxnValidityAndFeeReqTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/process/TxnValidityAndFeeReqTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/security/HapiOpPermissionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/security/HapiOpPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/security/PermissionFileUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/security/PermissionFileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/security/PermissionedAccountsRangeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/security/PermissionedAccountsRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/topic/MerkleTopicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/topic/MerkleTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/ConsensusStatusCountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/ConsensusStatusCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/ServicesInitFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/ServicesInitFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/StateInitializationFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/StateInitializationFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/StoreInitializationFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/StoreInitializationFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ChainedSourcesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ChainedSourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/EntityTypeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/EntityTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalStaticPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalStaticPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/NodeLocalPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/NodeLocalPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/PropUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/PropUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedNodeFilePropsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedNodeFilePropsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedSysFilePropsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedSysFilePropsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/SemanticVersionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/SemanticVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVersSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVersSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/StandardizedPropertySourcesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/StandardizedPropertySourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/StaticPropertiesHolderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/StaticPropertiesHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsTestComponent.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsTestComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsV032ModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsV032ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CommonProcessorSetup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CommonProcessorSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaTracerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/InHandleBlockMetaSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/InHandleBlockMetaSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/LivePricesSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/LivePricesSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaProviderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/StaticBlockMetaSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/TransactionProcessingResultTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/TransactionProcessingResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaUtilTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV18Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV18Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV19Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV19Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV22Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV22Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/CommonCallSetup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/CommonCallSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV034Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV034Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCreateOperationExternalizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCreateOperationExternalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaLogOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaLogOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtilTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtilV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaOperationUtilV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSLoadOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSLoadOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSStoreOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSStoreOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationV038Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/sources/AddressKeyedMapFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/sources/AddressKeyedMapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/sources/TxnAwareEvmSigsVerifierTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/sources/TxnAwareEvmSigsVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/exceptions/InvalidTransactionExceptionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/exceptions/InvalidTransactionExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/exceptions/ValidationUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/exceptions/ValidationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/BasicHbarCentExchangeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/BasicHbarCentExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/StandardCustomExemptionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/StandardCustomExemptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/StandardExemptionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/StandardExemptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/TxnRateFeeMultiplierSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/TxnRateFeeMultiplierSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/AccessorBasedUsagesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/AccessorBasedUsagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/AutoRenewCalcsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/AutoRenewCalcsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/BasicFcfsUsagePricesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/BasicFcfsUsagePricesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/CongestionMultipliersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/CongestionMultipliersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/EntityScaleFactorsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/EntityScaleFactorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/FeeCalcUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/FeeCalcUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/UtilizationScaleFactorsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/UtilizationScaleFactorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/CreateMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/CreateMerkleTopicResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/DeleteMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/DeleteMerkleTopicResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/TopicResourceUsageTestBase.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/TopicResourceUsageTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateMerkleTopicResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCallResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCallResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCreateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractDeleteResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/txns/CryptoDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/txns/CryptoDeleteResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/txns/ContractCallResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/txns/ContractCallResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileCreateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileDeleteResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileUpdateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemDeleteFileResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemDeleteFileResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemUndeleteFileResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemUndeleteFileResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/FixedUsageEstimatesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/FixedUsageEstimatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetAccountDetailsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetAccountDetailsResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetExecTimeResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetExecTimeResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetVersionInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetVersionInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleCreateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleDeleteResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleSignResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleSignResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/FreezeResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/FreezeResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/UncheckedSubmitResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/UncheckedSubmitResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenCreateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDeleteResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenGrantKycResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenGrantKycResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenRevokeKycResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenRevokeKycResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/utils/OpUsageCtxHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/utils/OpUsageCtxHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/utils/PricedUsageCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/utils/PricedUsageCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/utils/ResourceUsageSubtypeHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/utils/ResourceUsageSubtypeHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/ContractStoragePriceTiersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/ContractStoragePriceTiersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/FeeChargingPolicyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/FeeChargingPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerChargingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerChargingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/RecordedStorageFeeChargingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/RecordedStorageFeeChargingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/TxnChargingPolicyAgentTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/TxnChargingPolicyAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/congestion/DelegatingMultiplierSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/congestion/DelegatingMultiplierSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/congestion/MultiplierSourcesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/congestion/MultiplierSourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/DataMapFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/DataMapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/EntityExpiryMapFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/EntityExpiryMapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/HFileMetaSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/HFileMetaSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/HybridResouceLoaderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/HybridResouceLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/MetadataMapFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/MetadataMapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/SysFileCallbacksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/SysFileCallbacksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/TieredHederaFsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/TieredHederaFsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ConfigListUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ConfigListUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/FeeSchedulesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/FeeSchedulesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/MockFileNumbers.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/MockFileNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/PureRatesValidationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/PureRatesValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ThrottleDefsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ThrottleDefsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/TxnAwareRatesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/TxnAwareRatesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ValidatingCallbackInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ValidatingCallbackInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/BytesStoreAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/BytesStoreAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/FcBlobsBytesStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/FcBlobsBytesStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ConfigCallbacksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/CurrencyCallbacksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/CurrencyCallbacksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ThrottlesCallbackTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/sysfiles/ThrottlesCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/ConfigDrivenNettyFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/ConfigDrivenNettyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/GrpcStarterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/GrpcStarterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ConsensusControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ConsensusControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ContractControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ContractControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FileControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FileControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FreezeControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FreezeControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/NetworkControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/NetworkControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ScheduleControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ScheduleControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/TokenControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/TokenControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/UtilControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/UtilControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AdjustmentUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AdjustmentUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AliasResolverTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AliasResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AssessedCustomFeeWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AssessedCustomFeeWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/BalanceChangeManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/BalanceChangeManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomFeeMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomFeeMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomSchedulesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/CustomSchedulesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersMarshalTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/ImpliedTransfersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/CharacteristicsFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/CharacteristicsFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/DefaultActivationCharacteristicsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/DefaultActivationCharacteristicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/HederaKeyActivationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/HederaKeyActivationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/HederaKeyTraversalTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/HederaKeyTraversalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/InHandleActivationHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/InHandleActivationHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/KeysModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/KeysModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/LegacyContractIdActivationsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/LegacyContractIdActivationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/OnlyIfSigVerifiableValidTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/OnlyIfSigVerifiableValidTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/RevocationServiceCharacteristicsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/RevocationServiceCharacteristicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/BalanceChangeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/BalanceChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/BaseHederaLedgerTestHelper.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/BaseHederaLedgerTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/EntityChangeSetTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/EntityChangeSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerLiveTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerLiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokenXfersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokenXfersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokensTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokensTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerXfersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerXfersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/LedgerBalanceChangesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/LedgerImplBackingStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/LedgerImplBackingStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/MerkleAccountScopedCheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/MerkleAccountScopedCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/PureTransferSemanticChecksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/PureTransferSemanticChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/SigImpactHistorianTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/SigImpactHistorianTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TestAccountScopedCheck.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TestAccountScopedCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransactionalLedgerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransactionalLedgerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransferLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/TransferLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/AccountCustomizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/AccountCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/AliasManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/BackingTokensTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/BackingTokensTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/ContractCustomizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/ContractCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/HederaAccountCustomizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/HederaAccountCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/StackedContractAliasesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/StackedContractAliasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/SynthCreationCustomizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/SynthCreationCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/TestAccount.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/TestAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/TestAccountCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/TestAccountCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/PendingRewardsManagementTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/PendingRewardsManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardRateCalculationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardRateCalculationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/SmoothedStakingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/SmoothedStakingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeChangeManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeChangeManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeInfoManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeInfoManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakeStartupHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakingUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakingUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingNftsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingNftsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRelsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingAccounts.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingNfts.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingNfts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokenRels.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokenRels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokens.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapBackingTokens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapTestAccounts.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/HashMapTestAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/ids/SeqNoEntityIdSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/ids/SeqNoEntityIdSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/AccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/AccountsCommitInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/AutoAssocTokenRelsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/AutoAssocTokenRelsCommitInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareTokenRelsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareTokenRelsCommitInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/StakeChangeScenarioTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/StakeChangeScenarioTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/StakeChangesInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/StakeChangesInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/TokenRelsLinkManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/TokenRelsLinkManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/TokensCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/TokensCommitInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/UniqueTokensLinkManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/interceptors/UniqueTokensLinkManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/AccountPropertyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/AccountPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/ChangeSummaryManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/ChangeSummaryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/NftPropertyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/NftPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/TestAccountProperty.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/TestAccountProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/TokenPropertyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/TokenPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/TokenRelPropertyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/TokenRelPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/HFileMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/HFileMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractAliasKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractAliasKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JDelegatableContractIDKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JDelegatableContractIDKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSASecp256K1KeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSASecp256K1KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSA_384KeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JECDSA_384KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JEd25519KeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JEd25519KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyListTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyUtils.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JKeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JObjectTypeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JObjectTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JRSA_3072KeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JRSA_3072KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JThresholdKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JThresholdKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JWildcardECDSAKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/JWildcardECDSAKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptBuilderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/InvalidFileWACLException.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/InvalidFileWACLException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/StorageKeyNotFoundException.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/StorageKeyNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/TransactionRecordFeeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/TransactionRecordFeeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/serialization/JKeyAdditionalTypeSupportTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/unit/serialization/JKeyAdditionalTypeSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/pbj/PbjConverterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/pbj/PbjConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/properties/SupplierMapPropertySourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/properties/SupplierMapPropertySourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/AbstractAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/AbstractAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/AnswerServiceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/AnswerServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/AnswerFunctionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/AnswerFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/QueryHeaderValidityTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/QueryHeaderValidityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/QueryResponseHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/QueryResponseHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/StakeAwareAnswerFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/StakeAwareAnswerFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/StakedAnswerFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/StakedAnswerFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/ZeroStakeAnswerFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/ZeroStakeAnswerFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/consensus/GetMerkleTopicInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/consensus/GetMerkleTopicInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/consensus/HcsAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/consensus/HcsAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetBySolidityIdAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetBySolidityIdAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetBytecodeAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetBytecodeAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractRecordsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractRecordsAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/CryptoAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/CryptoAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountRecordsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountRecordsAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetLiveHashAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetLiveHashAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetStakersAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetStakersAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/FileAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/FileAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileContentsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileContentsAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetAccountDetailsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetAccountDetailsAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetExecTimeAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetExecTimeAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetFastTxnRecordAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetFastTxnRecordAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnReceiptAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnReceiptAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetVersionInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetVersionInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/MetaAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/MetaAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/GetScheduleInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/GetScheduleInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/ScheduleAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/ScheduleAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetAccountNftInfosAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetAccountNftInfosAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfosAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfosAnswerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/TokenAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/TokenAnswersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/validation/QueryFeeCheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/validation/QueryFeeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/ConsensusTimeTrackerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/ConsensusTimeTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/EarliestEntryExpiryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/EarliestEntryExpiryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/RecordCacheFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/RecordCacheFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/RecordCacheTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/RecordCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TransactionRecordServiceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TransactionRecordServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorianTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorianTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnIdRecentHistoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnIdRecentHistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/EventExpansionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/EventExpansionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/ExpandHandleHollowScreeningTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/ExpandHandleHollowScreeningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/ExpansionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/ExpansionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/HederaToPlatformSigOpsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/HederaToPlatformSigOpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/PlatformSigOpsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/PlatformSigOpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/RationalizationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/RationalizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/SigOpsRegressionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/SigOpsRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/SigVerifierRegressionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/SigVerifierRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/factories/PlatformSigFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/factories/PlatformSigFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/factories/ReusableBodySigningFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/factories/ReusableBodySigningFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/factories/TxnScopedPlatformSigFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/factories/TxnScopedPlatformSigFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/ContractSigningMetadataTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/ContractSigningMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/DelegatingSigMetadataLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/DelegatingSigMetadataLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/DelegatingSigMetadataLookupTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/DelegatingSigMetadataLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/ScheduleDelegatingSigMetadataLookupTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/ScheduleDelegatingSigMetadataLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/StateChildrenSigMetadataLookupTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/StateChildrenSigMetadataLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/TokenMetaUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/TokenMetaUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/AccountSigMetaLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/AccountSigMetaLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/ContractSigMetaLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/ContractSigMetaLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/DefaultAccountLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/DefaultAccountLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/DefaultContractLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/DefaultContractLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/DefaultTopicLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/DefaultTopicLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/FileSigMetaLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/FileSigMetaLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/HfsSigMetaLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/HfsSigMetaLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/TopicSigMetaLookup.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/lookups/TopicSigMetaLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/CodeOrderResultFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/CodeOrderResultFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/LinkedRefsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/LinkedRefsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/PolicyBasedSigWaiversTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/PolicyBasedSigWaiversTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigReqsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigReqsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigRequirementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigningOrderResultTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigningOrderResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMapPubKeyToSigBytesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMapPubKeyToSigBytesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMapTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/sourcing/PojoSigMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/utils/ImmutableKeyUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/utils/ImmutableKeyUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/utils/MiscCryptoUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/utils/MiscCryptoUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/utils/PrecheckUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/utils/PrecheckUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckKeyReqsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckVerifierTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/PlatformStateAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/PlatformStateAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/StateModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/StateModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/adapters/VirtualMapLikeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/adapters/VirtualMapLikeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/AbstractVirtualCodecTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/AbstractVirtualCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/CodecFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/CodecFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/DataBufferTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/DataBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/MonoMapCodecAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/MonoMapCodecAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/UtilsConstructorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/UtilsConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualBlobKey.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualBlobKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualBlobKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualBlobKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualBlobValue.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualBlobValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualKeySerdesAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualKeySerdesAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualValueSerdesAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/codec/VirtualValueSerdesAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringCreationsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringCreationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringEntityTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryEventTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcessTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryRecordsHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryRecordsHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/MonotonicFullQueueExpiriesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/MonotonicFullQueueExpiriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/PriorityQueueExpiriesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/PriorityQueueExpiriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/TokenRelsListMutationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/TokenRelsListMutationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/UniqueTokensListMutationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/UniqueTokensListMutationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/classification/ClassificationWorkTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/classification/ClassificationWorkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/AccountGCTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/AccountGCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/ContractGCTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/ContractGCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/CryptoGcOutcomeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/CryptoGcOutcomeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/RemovalHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/RemovalHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/renewal/RenewalHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/renewal/RenewalHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/ExportingRecoveredStateListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/ExportingRecoveredStateListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/ServicesSignedStateListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/ServicesSignedStateListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/Sha384HashReaderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/Sha384HashReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/SignedStateBalancesExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/StandardSigFileWriterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/StandardSigFileWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/ToStringAccountsExporterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/exports/ToStringAccountsExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/HashLoggerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/HashLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BlocklistAccountCreatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BlocklistAccountCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/TreasuryClonerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/TreasuryClonerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/AwareNodeDiligenceScreenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/AwareNodeDiligenceScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/BlockManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/BlockManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/InvariantChecksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/InvariantChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/NetworkCtxManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/NetworkCtxManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/NetworkUtilizationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/NetworkUtilizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/NonPayerKeysScreenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/NonPayerKeysScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ReconnectListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ReconnectListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/RecordStreamingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/RecordStreamingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/RequestedTransitionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/RequestedTransitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/SigsAndPayerKeyScreenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/SigsAndPayerKeyScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StandardProcessLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StandardProcessLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StateWriteToDiskListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StateWriteToDiskListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StatusChangeListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StatusChangeListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/TopLevelTransitionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/TopLevelTransitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/TriggeredTransitionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/TriggeredTransitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountStateSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountStateSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleEntityIdSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleEntityIdSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleEntityIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleEntityIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextBlockSyncTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextBlockSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerklePayerRecordsSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerklePayerRecordsSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerklePayerRecordsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerklePayerRecordsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduleSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduleSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsStateSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsStateSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleSpecialFilesSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleSpecialFilesSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleSpecialFilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleSpecialFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleStakingInfoSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleStakingInfoSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleStakingInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleStakingInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatusSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatusSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatusTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTopicSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTopicSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTopicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueTokenSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueTokenSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueTokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/StakeInfoManagementTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/StakeInfoManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BitPackUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BitPackUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BlobKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BlobKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/ByteUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/ByteUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BytesElementSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BytesElementSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BytesElementTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BytesElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDiskTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDiskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MigrationRecordsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/StakingInfoMapBuilderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/StakingInfoMapBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/TokenRelStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/TokenRelStorageAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenMapAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/UniqueTokenMapAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/UniqueTokensMigratorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/UniqueTokensMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/org/StateMetadataTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/org/StateMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ContractNonceInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ContractNonceInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustmentsSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustmentsSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustmentsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustmentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EntityIdSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EntityIdSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EntityIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EntityIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmLogSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmLogSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmLogTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRatesSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRatesSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRatesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordBuilderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordTestHelper.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcAssessedCustomFeeSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcAssessedCustomFeeSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcAssessedCustomFeeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcAssessedCustomFeeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcCustomFeeSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcCustomFeeSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcCustomFeeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceIdSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceIdSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAssociationSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAssociationSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAssociationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAssociationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FixedFeeSpecTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FixedFeeSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/NftAdjustmentsSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/NftAdjustmentsSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/NftAdjustmentsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/NftAdjustmentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RawTokenRelationshipTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RawTokenRelationshipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RichInstantTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RichInstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RoyaltyFeeSpecTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RoyaltyFeeSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/SequenceNumberTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/SequenceNumberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/TxnIdSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/TxnIdSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/TxnIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/TxnIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/tasks/SystemTaskManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/tasks/SystemTaskManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/tasks/TaskModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/tasks/TaskModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/validation/BasedLedgerValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/validation/BasedLedgerValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/validation/UsageLimitsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/validation/UsageLimitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeySerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeySerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractStorageListMutationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractStorageListMutationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractValueSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractValueSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/IterableContractValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/IterableContractValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/IterableStorageUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/IterableStorageUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeySerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeySerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValueSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValueSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualMapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccountCompatibilityTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccountCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccountMigrationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccountMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccountSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskAccountSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskTokenRelCompatabilityTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskTokenRelCompatabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskTokenRelSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/entities/OnDiskTokenRelSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeySerializerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/EntityUtilGaugesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/EntityUtilGaugesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ExecutionTimeTrackerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ExecutionTimeTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ExpiryStatsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ExpiryStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpCountersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpCountersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpSpeedometersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpSpeedometersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscRunningAvgsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscRunningAvgsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscSpeedometersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscSpeedometersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ServicesStatsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ServicesStatsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ThrottleGaugesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ThrottleGaugesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/AccountStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/AccountStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/ReadOnlyTokenStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/ReadOnlyTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/StoresModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/StoresModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/TopicStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/TopicStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/TypedTokenStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/TypedTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/AbstractLedgerWorldUpdaterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/AbstractLedgerWorldUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/AbstractStackedLedgerUpdaterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/AbstractStackedLedgerUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdaterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/KvUsageInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/KvUsageInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MockLedgerWorldUpdater.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MockLedgerWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MockStackedLedgerUpdater.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MockStackedLedgerUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MutableEntityAccessTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MutableEntityAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/SizeLimitedStorageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/SizeLimitedStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccessTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/StaticEntityAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/WorldLedgersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/AllowancePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/AllowancePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ApprovePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ApprovePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/AssociatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/BalanceOfPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/BalanceOfPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/BurnPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/BurnPrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/CreatePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/CreatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/DeleteTokenPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/DeleteTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/DissociatePrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/DissociatePrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC721PrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC721PrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERCTransferPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERCTransferPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ExchangeRatePrecompiledContractTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ExchangeRatePrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/FreezeTokenPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/FreezeTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetApprovedPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetApprovedPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenDefaultFreezeStatusTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenDefaultFreezeStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenDefaultKycStatusTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenDefaultKycStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenExpiryInfoPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenExpiryInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenInfoPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenInfoPrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenKeyPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenKeyPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenTypePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GetTokenTypePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GrantKycPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/GrantKycPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HRCPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HRCPrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContractTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSTestsUtil.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSTestsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/InvalidDelegateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/InvalidDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsApprovedForAllPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsApprovedForAllPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsFrozenPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsFrozenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsKycPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsKycPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsTokenPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/IsTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/MintPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/MintPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/OwnerOfPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/OwnerOfPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/PausePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/PausePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/PrecompileDefaultsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/PrecompileDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/PrngSystemPrecompiledContractTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/PrngSystemPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/RedirectPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/RedirectPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/RevokeKycPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/RevokeKycPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SetApprovalForAllPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SetApprovalForAllPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenExpiryWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenExpiryWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenGetCustomFeesPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenGetCustomFeesPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenPrecompileReadOperationsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenPrecompileReadOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenURIPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenURIPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdateKeysPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdateKeysPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdateLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdatePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenUpdatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesParameterizedTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UnfreezeTokenPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UnfreezeTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UnpausePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UnpausePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/WipeFungiblePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/WipeFungiblePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/WipeNonFungiblePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/WipeNonFungiblePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacadeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/EncodingFacadeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/EncodingFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenCreateWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenTransferWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TokenTransferWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TransferWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/TransferWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SynthApprovalRecordsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SynthApprovalRecordsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/TokenCreateReqsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/sigs/TokenCreateReqsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/RedirectViewExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/RedirectViewExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/KeyActivationUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/KeyActivationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompilePricingUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompilePricingUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompileUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/utils/PrecompileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/AccountTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/AccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/IdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/IdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/NftIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/NftIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/OwnershipTrackerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/OwnershipTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TokenRelationshipTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TokenRelationshipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TopicConversionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TopicConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TopicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/TopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/UniqueTokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/UniqueTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/schedule/HederaScheduleStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/LegacyTokenStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/LegacyTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/CurrentRecordStreamTypeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/CurrentRecordStreamTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/NonBlockingHandoffTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/NonBlockingHandoffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamFileParsingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamFileParsingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamFileWriterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamFileWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamObjectTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamRecoveryAndReplayTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamRecoveryAndReplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamTypeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordStreamTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordsRunningHashLeafSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordsRunningHashLeafSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordsRunningHashLeafTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecordsRunningHashLeafTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecoveryRSO.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecoveryRSO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecoveryRecordsWriterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/RecoveryRecordsWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/Release023xStreamType.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/Release023xStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/Release038xStreamType.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/Release038xStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/StreamFileRecognitionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stream/StreamFileRecognitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/DeterministicThrottlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ExpiryThrottleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ExpiryThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/HapiThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/HapiThrottlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ThrottleReqsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ThrottlingModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/ThrottlingModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TimedFunctionalityThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TimedFunctionalityThrottlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TransactionThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TransactionThrottlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TxnAwareHandleThrottlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/ProcessLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/ProcessLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/TransitionLogicLookupTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/TransitionLogicLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/TransitionRunnerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/TransitionRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/auth/SystemOpAuthorizationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/auth/SystemOpAuthorizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/auth/SystemOpPoliciesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/auth/SystemOpPoliciesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicDeleteTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/SubmitMessageTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/SubmitMessageTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractDeleteTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysDelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysDelTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysUndelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysUndelTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractUpdateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/AllowanceHelpersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/AllowanceHelpersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/ApproveAllowanceLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/ApproveAllowanceLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/AutoCreationLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoApproveAllowanceTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoApproveAllowanceTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteAllowanceTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteAllowanceTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/DeleteAllowanceLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/DeleteAllowanceLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/EvmAutoCreationLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/EvmAutoCreationLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/validators/ApproveAllowanceChecksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/validators/ApproveAllowanceChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/validators/DeleteAllowanceChecksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/validators/DeleteAllowanceChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/customfees/FcmCustomFeeSchedulesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/customfees/FcmCustomFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/customfees/LedgerCustomFeeSchedulesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/customfees/LedgerCustomFeeSchedulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/ethereum/EthereumTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/ethereum/EthereumTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/ethereum/TestingConstants.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/ethereum/TestingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileAppendTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileAppendTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileDeleteTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysDelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysDelTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysUndelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysUndelTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/FreezeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/FreezeTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/UncheckedSubmitTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/UncheckedSubmitTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/UpgradeActionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/UpgradeActionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/prefetch/PrefetchProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/prefetch/PrefetchProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleDeleteTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleProcessingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleProcessingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSignTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSignTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSigsVerifierTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSigsVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/SigMapScheduleClassifierTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/SigMapScheduleClassifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/SignatoryUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/SignatoryUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/EthereumSpanMapManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/EthereumSpanMapManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpanMapAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpanMapAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpanTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/SpanMapManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/SpanMapManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/BasicSubmissionFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/BasicSubmissionFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/PlatformSubmissionManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/PlatformSubmissionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SemanticPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SemanticPrecheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SolvencyPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SolvencyPrecheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/StructuralPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/StructuralPrecheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SyntaxPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SyntaxPrecheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SystemPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SystemPrecheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/TransactionPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/TransactionPrecheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/TxnResponseHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/TxnResponseHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/AssociateLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/AssociateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/BurnLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/BurnLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/DissociateLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/DissociateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/MintLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/MintLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/PauseLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/PauseLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenAssociateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenAssociateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenBurnTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenBurnTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenDeleteTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenDissociateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenDissociateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFreezeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFreezeTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenGrantKycTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenGrantKycTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenMintTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenOpsValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenOpsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenPauseTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenPauseTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenRevokeKycTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenRevokeKycTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnfreezeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnfreezeTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnpauseTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnpauseTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUpdateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenWipeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenWipeTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/UnpauseLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/UnpauseLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/WipeLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/WipeLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/process/CreationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/process/CreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/process/DissociationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/process/DissociationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/process/NewRelsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/process/NewRelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/util/UtilPrngTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/util/UtilPrngTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/PureValidationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/PureValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/TokenListChecksTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/TokenListChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityIdUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityIdUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityNumPairTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityNumPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityNumTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EntityNumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EvmTokenUtilTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/EvmTokenUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/FcLong.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/FcLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/HederaDateTimeFormatterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/HederaDateTimeFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/InPlaceHeadInsertionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/InPlaceHeadInsertionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/MapValueListUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/MapValueListUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/MiscUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/MiscUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/NftNumPairTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/NftNumPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/NonAtomicReferenceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/NonAtomicReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/RationalizedSigMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/RationalizedSigMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/ResponseCodeUtilTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/ResponseCodeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/SerializationUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/SerializationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/SidecarUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/SidecarUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/SleepingPauseTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/SleepingPauseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/TokenTypesMapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/TokenTypesMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/UnzipUtilityTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/UnzipUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/UtilsConstructorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/UtilsConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/AccessorFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/AccessorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/PlatformTxnAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/PlatformTxnAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/SignedTxnAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/TokenWipeAccessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/accessors/TokenWipeAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/forensics/OrderedComparisonTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/forensics/OrderedComparisonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/subjects/UniqueTokenValueSubject.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/subjects/UniqueTokenValueSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptor.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptureExtension.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptureExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingSubject.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingTarget.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/MockAppender.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/MockAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/TestContextValidator.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/TestContextValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/TestFeeMultiplierSource.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/TestFeeMultiplierSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/TestUsagePricesProvider.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/mocks/TestUsagePricesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/EqualityType.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/EqualityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/SelfSerializableDataTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/SelfSerializableDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/SerializedForms.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/SerializedForms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/VirtualValueDataTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/serde/VirtualValueDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/AccountIDConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/AccountIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ByteArrayConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ByteArrayConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ClassLoaderHelper.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ConverterUtils.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ConverterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/CryptoConfigUtils.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/CryptoConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/DurationConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/DurationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/Ed25519KeyConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/Ed25519KeyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/EntityIdConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/EntityIdConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/InstantConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/InstantConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/JEd25519KeyConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/JEd25519KeyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/QueryUtils.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/QueryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ResponsibleVMapUser.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/ResponsibleVMapUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/RichInstantConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/RichInstantConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/SeededPropertySource.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/SeededPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/TestFileUtils.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/TestFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/TopicIDConverter.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/utils/TopicIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/accounts/MerkleAccountFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/accounts/MerkleAccountFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/accounts/MockMMapFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/accounts/MockMMapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/fees/CustomFeeBuilder.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/fees/CustomFeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyGenerator.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTree.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeLeaf.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeListNode.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeListNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeNode.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeThresholdNode.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/KeyTreeThresholdNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/LeafFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/LeafFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/ListFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/ListFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/NodeFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/NodeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/OverlappingKeyGenerator.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/OverlappingKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/ThresholdFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/keys/ThresholdFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/BadPayerScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/BadPayerScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusCreateTopicScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusCreateTopicScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusDeleteTopicScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusDeleteTopicScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusSubmitMessageScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusSubmitMessageScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusUpdateTopicScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ConsensusUpdateTopicScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractCreateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractDeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ContractUpdateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoAllowanceScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoAllowanceScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoCreateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoDeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileAppendScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileAppendScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileDeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/FileUpdateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleCreateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleDeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleSignScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/ScheduleSignScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemDeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemUndeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/SystemUndeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenAssociateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenAssociateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenBurnScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenBurnScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDeleteScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDeleteScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDissociateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenDissociateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFeeScheduleUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFeeScheduleUpdateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFreezeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenFreezeScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycGrantScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycGrantScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycRevokeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenKycRevokeScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenMintScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenMintScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenPauseScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenPauseScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnfreezeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnfreezeScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnpauseScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUnpauseScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenUpdateScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenWipeScenarios.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TokenWipeScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SigFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SigFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SigMapGenerator.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SigMapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SigWrappers.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SigWrappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SyncVerifiers.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/sigs/SyncVerifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/topics/TopicFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/topics/TopicFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusCreateTopicFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusCreateTopicFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusDeleteTopicFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusDeleteTopicFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusSubmitMessageFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusSubmitMessageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusUpdateTopicFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ConsensusUpdateTopicFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractCallFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractCreateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractDeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractDeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ContractUpdateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoApproveAllowanceFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoApproveAllowanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoCreateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoDeleteAllowanceFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoDeleteAllowanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoDeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoDeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoTransferFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoTransferFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/CryptoUpdateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileAppendFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileAppendFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileCreateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileDeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileDeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/FileUpdateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleCreateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleDeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleDeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleSignFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleSignFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduledTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/ScheduledTxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SignedTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SignedTxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SystemDeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SystemDeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SystemUndeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/SystemUndeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TinyBarsFromTo.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TinyBarsFromTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenAssociateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenAssociateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenBurnFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenBurnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenCreateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenDeleteFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenDeleteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenDissociateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenDissociateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenFeeScheduleUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenFeeScheduleUpdateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenFreezeFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenFreezeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenGrantKycFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenGrantKycFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenMintFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenMintFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenPauseFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenPauseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenRevokeKycFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenRevokeKycFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenUnfreezeFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenUnfreezeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenUnpauseFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenUnpauseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenUpdateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenWipeFactory.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/factories/txns/TokenWipeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/mocks/MockAccountNumbers.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/mocks/MockAccountNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/mocks/MockFileNumbers.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/mocks/MockFileNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/AddresBookUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/AddresBookUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/IdUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/IdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/KeyUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/SemVerUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/SemVerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/SerdeUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/SerdeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/StateKeyAdapter.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/StateKeyAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/TestFixturesKeyLookup.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/TestFixturesKeyLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/TxnUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/TxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-network-admin-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/FreezeServiceImpl.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/FreezeServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkAdminServiceInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkServiceImpl.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/NetworkServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/ReadableFreezeStoreImpl.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/ReadableFreezeStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/WritableFreezeStore.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/WritableFreezeStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/codec/MonoSpecialFilesAdapterCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/codec/MonoSpecialFilesAdapterCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeUpgradeActions.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeUpgradeActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkAdminHandlers.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkAdminHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetAccountDetailsHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetAccountDetailsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetByKeyHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetByKeyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetExecutionTimeHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetExecutionTimeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetVersionInfoHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetVersionInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetFastRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetFastRecordHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetReceiptHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetReceiptHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/EntityNumCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/EntityNumCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoContextAdapterCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoContextAdapterCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoRunningHashesAdapterCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoRunningHashesAdapterCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/utils/NetworkAdminServiceUtil.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/utils/NetworkAdminServiceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/NetworkServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/NetworkServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/WritableFreezeStoreTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/WritableFreezeStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/codec/MonoSpecialFilesAdapterCodecTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/codec/MonoSpecialFilesAdapterCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradeActionsTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradeActionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetAccountDetailsHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetAccountDetailsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetByKeyHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetByKeyHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetExecutionTimeHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetExecutionTimeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetVersionInfoHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkGetVersionInfoHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetFastRecordHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetFastRecordHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetReceiptHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetReceiptHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetRecordHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetRecordHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkUncheckedSubmitHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkUncheckedSubmitHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/UnzipUtilityTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/UnzipUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/serdes/EntityNumSerdesTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/serdes/EntityNumSerdesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/serdes/MonoContextAdapterSerdesTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/serdes/MonoContextAdapterSerdesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/serdes/MonoRunningHashesAdapterSerdesTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/serdes/MonoRunningHashesAdapterSerdesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service/build.gradle.kts
+++ b/hedera-node/hedera-network-admin-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/FreezeService.java
+++ b/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/FreezeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/FreezeServiceDefinition.java
+++ b/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/FreezeServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/NetworkService.java
+++ b/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/NetworkService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/NetworkServiceDefinition.java
+++ b/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/NetworkServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/ReadableFreezeStore.java
+++ b/hedera-node/hedera-network-admin-service/src/main/java/com/hedera/node/app/service/networkadmin/ReadableFreezeStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-schedule-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceInjectionModule.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/codec/ScheduleServiceStateTranslator.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/codec/ScheduleServiceStateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/DispatchPredicate.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/DispatchPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleDeleteHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleGetInfoHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleGetInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlers.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleVerificationAssistant.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleVerificationAssistant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImplTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtilityTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduledTransactionFactory.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduledTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImplTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/codec/ScheduleServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/codec/ScheduleServiceStateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtilityTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleDeleteHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleDeleteHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleGetInfoHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleGetInfoHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/TestTransactionKeys.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/TestTransactionKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service/build.gradle.kts
+++ b/hedera-node/hedera-schedule-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleRecordBuilder.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleService.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleServiceDefinition.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/WritableScheduleStore.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/WritableScheduleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-smart-contract-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceComponent.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ChildTransactionResourcePrices.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ChildTransactionResourcePrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/InitialState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/InitialState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/InitialTokenServiceApi.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/InitialTokenServiceApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/QueryScope.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/QueryScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV030.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV030.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV034.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV034.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV038.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesVersionKey.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesVersionKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/TopLevelResourcePrices.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/TopLevelResourcePrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/TransactionScope.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/TransactionScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/AddressChecks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/AddressChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FeatureFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/QueryComponent.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/QueryComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionComponent.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionConfigModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionConfigModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionInitialStateModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionInitialStateModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/AbortException.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/AbortException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/CustomExceptionalHaltReason.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/CustomExceptionalHaltReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CanonicalDispatchPrices.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CanonicalDispatchPrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCharging.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCharging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/DispatchGasCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/DispatchGasCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/DispatchType.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/DispatchType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/GasCharges.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/GasCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/TinybarValues.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/TinybarValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/BasicCustomCallOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/BasicCustomCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomBalanceOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomBalanceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomCallCodeOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomCallCodeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomCallOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomChainIdOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomChainIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomCreateOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomCreateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomDelegateCallOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomDelegateCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomExtCodeCopyOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomExtCodeCopyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomExtCodeHashOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomExtCodeHashOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomExtCodeSizeOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomExtCodeSizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomLogOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomPrevRandaoOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomPrevRandaoOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSLoadOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSLoadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSStoreOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSStoreOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSelfDestructOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSelfDestructOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomStaticCallOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomStaticCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomizedOpcodes.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomizedOpcodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/DelegatingOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/DelegatingOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/utils/OpUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/utils/OpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/HtsTranslatorsModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/HtsTranslatorsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/ProcessorModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/ProcessorModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/ActiveContractVerificationStrategy.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/ActiveContractVerificationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/EitherOrVerificationStrategy.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/EitherOrVerificationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaNativeOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleSystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleSystemContractOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaNativeOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaNativeOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QuerySystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QuerySystemContractOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/ResultTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/ResultTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/SystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/SystemContractOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/VerificationStrategies.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/VerificationStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/VerificationStrategy.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/VerificationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/AbstractFullContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/AbstractFullContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HederaSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HederaSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsCallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsCallTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbiConstants.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractHtsCallTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractNftViewCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractNftViewCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractNonRevertibleTokenViewCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractNonRevertibleTokenViewCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractRevertibleTokenViewCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractRevertibleTokenViewCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractTokenViewCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AbstractTokenViewCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AddressIdConverter.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/AddressIdConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/DispatchForResponseCodeHtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/DispatchForResponseCodeHtsCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallAddressChecks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallAddressChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallAttempt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/LogBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/LogBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ReturnTypes.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ReturnTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/SyntheticIds.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/SyntheticIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/allowance/GetAllowanceCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/allowance/GetAllowanceCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/allowance/GetAllowanceTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/allowance/GetAllowanceTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/balanceof/BalanceOfCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/balanceof/BalanceOfCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/balanceof/BalanceOfTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/balanceof/BalanceOfTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/burn/BurnDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/burn/BurnDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/burn/BurnTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/burn/BurnTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/ClassicCreatesCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/ClassicCreatesCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateSyntheticTxnFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateSyntheticTxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/customfees/TokenCustomFeesCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/customfees/TokenCustomFeesCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/decimals/DecimalsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/decimals/DecimalsCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/decimals/DecimalsTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/decimals/DecimalsTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/delete/DeleteTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/delete/DeleteTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/freeze/FreezeUnfreezeDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/freeze/FreezeUnfreezeDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/getapproved/GetApprovedCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/getapproved/GetApprovedCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/getapproved/GetApprovedTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/getapproved/GetApprovedTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/GrantApprovalDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/GrantApprovalDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isapprovedforall/IsApprovedForAllCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isapprovedforall/IsApprovedForAllCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isapprovedforall/IsApprovedForAllTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isapprovedforall/IsApprovedForAllTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isfrozen/IsFrozenCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isfrozen/IsFrozenCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isfrozen/IsFrozenTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isfrozen/IsFrozenTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/iskyc/IsKycCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/iskyc/IsKycCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/iskyc/IsKycTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/iskyc/IsKycTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/mint/MintDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/mint/MintDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/mint/MintTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/mint/MintTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/name/NameCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/name/NameCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/name/NameTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/name/NameTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ownerof/OwnerOfCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ownerof/OwnerOfCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ownerof/OwnerOfTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ownerof/OwnerOfTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/pauses/PausesDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/pauses/PausesDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/pauses/PausesTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/pauses/PausesTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/symbol/SymbolCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/symbol/SymbolCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/symbol/SymbolTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/symbol/SymbolTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenexpiry/TokenExpiryCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenexpiry/TokenExpiryCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenkey/TokenKeyCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenkey/TokenKeyCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenkey/TokenKeyTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenkey/TokenKeyTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenuri/TokenUriCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenuri/TokenUriCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenuri/TokenUriTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenuri/TokenUriTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/totalsupply/TotalSupplyCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/totalsupply/TotalSupplyCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/totalsupply/TotalSupplyTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/totalsupply/TotalSupplyTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ApprovalSwitchHelper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ApprovalSwitchHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/CallStatusStandardizer.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/CallStatusStandardizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/SystemAccountCreditScreen.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/SystemAccountCreditScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferAuditTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferAuditTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferEventLoggingUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferEventLoggingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateExpiryTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateExpiryTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateKeysTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateKeysTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/wipe/WipeDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/wipe/WipeDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/wipe/WipeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/wipe/WipeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/ActionWrapper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/ActionWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/ActionsHelper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/ActionsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/KeyValueWrapper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/KeyValueWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenCreateWrapper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenCreateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenExpiryWrapper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenExpiryWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenKeyWrapper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenKeyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenUpdateWrapper.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/TokenUpdateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/Version030AddressChecks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/Version030AddressChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/Version030FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/Version030FeatureFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/Version034FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/Version034FeatureFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/Version038AddressChecks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/Version038AddressChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetBySolidityIDHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetBySolidityIDHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetBytecodeHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetBytecodeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetRecordsHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetRecordsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractHandlers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HandleContextHevmBlocks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HandleContextHevmBlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmBlocks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmBlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmVersion.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HevmBlockValues.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HevmBlockValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HevmPropagatedCallFailure.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HevmPropagatedCallFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HydratedEthTxData.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HydratedEthTxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/QueryContextHevmBlocks.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/QueryContextHevmBlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/EthTxSigsCache.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/EthTxSigsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/EthereumCallDataHydration.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/EthereumCallDataHydration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/IterableStorageManager.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/IterableStorageManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/RentCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/RentCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/StorageAccessTracker.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/StorageAccessTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/StorageSizeValidator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/StorageSizeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteRecordBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateRecordBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/AbstractMutableEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/AbstractMutableEvmAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ContractSchema.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ContractSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ContractStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameStateFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/EvmFrameStateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/HederaEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/HederaEvmAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/PendingCreation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/PendingCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ReadableContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ReadableContractStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/RentFactors.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/RentFactors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/RootProxyWorldUpdater.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/RootProxyWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ScopedEvmFrameStateFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ScopedEvmFrameStateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageAccess.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageAccesses.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageAccesses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageSizeChange.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/StorageSizeChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/TokenEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/TokenEvmAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/WritableContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/WritableContractStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/OpcodeUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/OpcodeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SystemContractUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SystemContractUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FeatureFlagsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FeatureFlagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/QueryModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/QueryModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionConfigModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionConfigModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionInitialStateModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionInitialStateModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/failure/CustomExceptionalHaltReasonTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/failure/CustomExceptionalHaltReasonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CanonicalDispatchPricesTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CanonicalDispatchPricesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasCalculatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/TinybarValuesTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/TinybarValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomBalanceOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomBalanceOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomCallCodeOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomCallCodeOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomCallOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomChainIdOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomChainIdOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomCreateOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomCreateOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomDelegateCallOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomDelegateCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomExtCodeCopyOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomExtCodeCopyOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomExtCodeHashOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomExtCodeHashOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomExtCodeSizeOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomExtCodeSizeOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomLogOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomLogOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomPrevRandaoOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomPrevRandaoOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSLoadOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSLoadOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSStoreOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSStoreOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSelfDestructOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSelfDestructOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomStaticCallOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomStaticCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/DelegatingOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/DelegatingOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/processors/ProcessorModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/processors/ProcessorModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/ActiveContractVerificationStrategyTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/ActiveContractVerificationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/EitherOrVerificationStrategyTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/EitherOrVerificationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleSystemContractOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleSystemContractOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaNativeOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaNativeOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QuerySystemContractOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QuerySystemContractOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/FullResultTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/FullResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HederaSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HederaSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HtsSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HtsSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/DispatchForResponseCodeHtsCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/DispatchForResponseCodeHtsCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallAddressChecksTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallAddressChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallAttemptTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallAttemptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallTestBase.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/SyntheticIdsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/SyntheticIdsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/allowance/GetAllowanceCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/allowance/GetAllowanceCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/allowance/GetAllowanceTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/allowance/GetAllowanceTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/associations/AssociationsDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/associations/AssociationsDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/associations/AssociationsTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/associations/AssociationsTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/balanceof/BalanceOfCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/balanceof/BalanceOfCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/burn/BurnDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/burn/BurnDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/burn/BurnTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/burn/BurnTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/ClassicCreatesCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/ClassicCreatesCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/CreateTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/CreateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/customfees/TokenCustomFeesCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/customfees/TokenCustomFeesCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/decimals/DecimalsCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/decimals/DecimalsCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/delete/DeleteTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/delete/DeleteTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/freeze/FreezeUnfreezeDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/freeze/FreezeUnfreezeDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/getapproved/GetApprovedCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/getapproved/GetApprovedCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/getapproved/GetApprovedTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/getapproved/GetApprovedTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isfrozen/IsFrozenCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isfrozen/IsFrozenCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isfrozen/IsFrozenTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isfrozen/IsFrozenTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/iskyc/IsKycCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/iskyc/IsKycCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/iskyc/IsKycTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/iskyc/IsKycTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isoperator/IsApprovedForAllCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isoperator/IsApprovedForAllCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/mint/MintDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/mint/MintDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/mint/MintTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/mint/MintTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/name/NameCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/name/NameCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/ownerof/OwnerOfCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/ownerof/OwnerOfCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/pauses/PausesDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/pauses/PausesDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/pauses/PausesTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/pauses/PausesTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/symbol/SymbolCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/symbol/SymbolCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenexpiry/TokenExpiryCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenexpiry/TokenExpiryCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokentype/TokenTypeCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokentype/TokenTypeCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokentype/TokenTypeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokentype/TokenTypeTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenuri/TokenUriCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenuri/TokenUriCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/totalsupply/TotalSupplyCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/totalsupply/TotalSupplyCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ApprovalSwitchHelperTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ApprovalSwitchHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/CallStatusStandardizerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/CallStatusStandardizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersGasCalcTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersGasCalcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/SystemAccountCreditScreenTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/SystemAccountCreditScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateExpiryTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateExpiryTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateKeysTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateKeysTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/ActionsHelperTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/ActionsHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v030/Version030AddressChecksTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v030/Version030AddressChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v030/Version030FeatureFlagsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v030/Version030FeatureFlagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v034/Version034FeatureFlagsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v034/Version034FeatureFlagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v038/Version038AddressChecksTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/v038/Version038AddressChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/AdapterUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerParityTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerParityTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractGetBytecodeHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractGetBytecodeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractGetInfoHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractGetInfoHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractGetRecordsHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractGetRecordsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractHandlerTestBase.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerParityTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HandleContextHevmBlocksTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HandleContextHevmBlocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionAbortResultTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionAbortResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/QueryContextHevmBlocksTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/QueryContextHevmBlocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/EthTxSigsCacheTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/EthTxSigsCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/IterableStorageManagerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/IterableStorageManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/RentCalculatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/RentCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/StorageAccessTrackerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/StorageAccessTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/StorageSizeValidatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/StorageSizeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/nfra/EthereumCallDataHydrationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/nfra/EthereumCallDataHydrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyEvmAccountTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyEvmAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ReadableContractStateStoreTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ReadableContractStateStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/RootProxyWorldUpdaterTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/RootProxyWorldUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/StorageAccessTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/StorageAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/StorageSizeChangeTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/StorageSizeChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/TokenEvmAccountTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/TokenEvmAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/WritableContractStateStoreTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/WritableContractStateStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/OpcodeUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/OpcodeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SystemContractUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SystemContractUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service/build.gradle.kts
+++ b/hedera-node/hedera-smart-contract-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/ContractService.java
+++ b/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/ContractService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/SmartContractServiceDefinition.java
+++ b/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/SmartContractServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-token-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/BlocklistParser.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/BlocklistParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/CryptoSignatureWaiversImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/CryptoSignatureWaiversImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableNetworkStakingRewardsStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableNetworkStakingRewardsStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableNftStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableNftStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableStakingInfoStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableStakingInfoStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableTokenRelationStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableTokenRelationStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableTokenStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableTokenStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/TokenServiceImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/TokenServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/TokenServiceInjectionModule.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/TokenServiceInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableAccountStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableAccountStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableNetworkStakingRewardsStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableNetworkStakingRewardsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableNftStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableNftStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableStakingInfoStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableStakingInfoStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableTokenRelationStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableTokenRelationStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableTokenStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiProvider.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/codec/NetworkingStakingTranslator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/codec/NetworkingStakingTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/comparator/TokenComparators.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/comparator/TokenComparators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseCryptoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseCryptoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteAllowanceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteLiveHashHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountBalanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountBalanceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountRecordsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountRecordsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetLiveHashHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetStakersHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetStakersHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFeeScheduleUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFeeScheduleUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFreezeAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFreezeAccountHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetAccountNftInfosHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetAccountNftInfosHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfosHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfosHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGrantKycToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGrantKycToAccountHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenHandlers.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRevokeKycFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRevokeKycFromAccountHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnfreezeAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnfreezeAccountHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeIdChangeType.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeIdChangeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakePeriodManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeRewardCalculator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeRewardCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeRewardCalculatorImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeRewardCalculatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingUtilities.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AdjustFungibleTokenChangesStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AdjustFungibleTokenChangesStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AdjustHbarChangesStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AdjustHbarChangesStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/EnsureAliasesStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/EnsureAliasesStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/NFTOwnersChangeStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/NFTOwnersChangeStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/ReplaceAliasesWithIDsInOp.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/ReplaceAliasesWithIDsInOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContext.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContextImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AdjustmentUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AdjustmentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AssessmentResult.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AssessmentResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFeeExemptions.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFeeExemptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFeeMeta.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFeeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFixedFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFixedFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFractionalFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFractionalFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomRoyaltyFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomRoyaltyFeeAssessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/SyntheticRecordsGenerator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/SyntheticRecordsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/TokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/TokenSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/serdes/EntityNumCodec.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/serdes/EntityNumCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenHandlerHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenHandlerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenRelListCalculator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenRelListCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/ApproveAllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/ApproveAllowanceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoCreateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CustomFeesValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CustomFeesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/DeleteAllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/DeleteAllowanceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/StakingValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/StakingValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAttributesValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAttributesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenCreateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenCreateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenListChecks.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenListChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenSupplyChangeOpsValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenSupplyChangeOpsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/BlocklistParserTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/BlocklistParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/CryptoSignatureWaiversImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/CryptoSignatureWaiversImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableAccountStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableAccountStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableNetworkStakingRewardsStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableNetworkStakingRewardsStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableStakingInfoStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableStakingInfoStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableTokenRelationStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableTokenRelationStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableTokenStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableTokenStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableAccountStoreTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableAccountStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableNetworkStakingRewardsStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableNetworkStakingRewardsStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableNftStoreTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableNftStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableStakingInfoStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableStakingInfoStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableTokenRelationStoreTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableTokenRelationStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableTokenStoreTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiProviderTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/codec/EntityNumCodecTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/codec/EntityNumCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/codec/NetworkingStakingTranslatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/codec/NetworkingStakingTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/comparator/TokenComparatorsTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/comparator/TokenComparatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeCryptoCreateRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeCryptoCreateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeCryptoTransferRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeCryptoTransferRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeNodeStakeUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/fixtures/FakeNodeStakeUpdateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoAddLiveHashHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoAddLiveHashHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteLiveHashHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteLiveHashHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountBalanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountBalanceHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountRecordsHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountRecordsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetLiveHashHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetLiveHashHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetStakersHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetStakersHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerPureChecksTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerPureChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeChildRecordHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeChildRecordHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeParentRecordHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeParentRecordHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandleParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandleParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDeleteHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDeleteHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDissociateFromAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDissociateFromAccountHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFreezeAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFreezeAccountHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetAccountNftInfosHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetAccountNftInfosHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetInfoHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetNftInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetNftInfoHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetNftInfosHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGetNftInfosHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGrantKycToAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGrantKycToAccountHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenRevokeKycFromAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenRevokeKycFromAccountHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnfreezeAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnfreezeAccountHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUtilsTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakeInfoHelperTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakeInfoHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakePeriodManagerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakePeriodManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakeRewardCalculatorImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakeRewardCalculatorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AccountAmountUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AccountAmountUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AutoAccountCreatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AutoAccountCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ChangeNFTOwnersStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ChangeNFTOwnersStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/TransferStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/TransferStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/AdapterUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/ParityTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/ParityTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/StateBuilderUtil.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/StateBuilderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/TestStoreFactory.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/TestStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/TokenHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/TokenHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/SyntheticAccountsData.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/SyntheticAccountsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/SyntheticRecordsGeneratorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/SyntheticRecordsGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/TokenSchemaTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/TokenSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/MetaAssertion.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/MetaAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/SigReqAdapterUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/SigReqAdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/TokenHandlerHelperTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/TokenHandlerHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/TokenRelListCalculatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/TokenRelListCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/AllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/AllowanceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/CryptoCreateValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/CryptoCreateValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/CustomFeesValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/CustomFeesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/DeleteAllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/DeleteAllowanceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/TokenAttributesValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/TokenAttributesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/TokenListChecksTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/TokenListChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/build.gradle.kts
+++ b/hedera-node/hedera-token-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/AliasUtils.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/AliasUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/CryptoServiceDefinition.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/CryptoServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/CryptoSignatureWaivers.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/CryptoSignatureWaivers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableNetworkStakingRewardsStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableNetworkStakingRewardsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableNftStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableNftStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableStakingInfoStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableStakingInfoStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableTokenRelationStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableTokenRelationStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableTokenStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/TokenService.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/TokenService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/TokenServiceDefinition.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/TokenServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/Units.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/Units.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/AccountSummariesApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/AccountSummariesApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/ContractChangeSummary.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/ContractChangeSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/FeeRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/FeeRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/StakingRewardsApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/StakingRewardsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildFinalizeContext.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildFinalizeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildRecordFinalizer.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildRecordFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoCreateRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoCreateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoTransferRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoTransferRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoUpdateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/FinalizeContext.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/FinalizeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ParentRecordFinalizer.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ParentRecordFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenAccountWipeRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenAccountWipeRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBurnRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBurnRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenContext.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenCreateRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenCreateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenMintRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenMintRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenUpdateRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenUpdateRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-token-service/src/testFixtures/java/com/hedera/node/app/service/token/fixtures/FakeFeeRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/testFixtures/java/com/hedera/node/app/service/token/fixtures/FakeFeeRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-util-service-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/UtilServiceImpl.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/UtilServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/UtilServiceInjectionModule.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/UtilServiceInjectionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/components/UtilComponent.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/components/UtilComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilHandlers.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilPrngHandler.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilPrngHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/records/PrngRecordBuilder.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/records/PrngRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/FakePrngRecordBuilder.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/FakePrngRecordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/UtilPrngHandlerTest.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/UtilPrngHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service/build.gradle.kts
+++ b/hedera-node/hedera-util-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service/src/main/java/com/hedera/node/app/service/util/UtilService.java
+++ b/hedera-node/hedera-util-service/src/main/java/com/hedera/node/app/service/util/UtilService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-util-service/src/main/java/com/hedera/node/app/service/util/UtilServiceDefinition.java
+++ b/hedera-node/hedera-util-service/src/main/java/com/hedera/node/app/service/util/UtilServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/eet/java/E2ETestBase.java
+++ b/hedera-node/test-clients/src/eet/java/E2ETestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/eet/java/EndToEndTests.java
+++ b/hedera-node/test-clients/src/eet/java/EndToEndTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/itest/java/AllIntegrationTests.java
+++ b/hedera-node/test-clients/src/itest/java/AllIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/itest/java/ConcurrentSuites.java
+++ b/hedera-node/test-clients/src/itest/java/ConcurrentSuites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/itest/java/DockerIntegrationTestBase.java
+++ b/hedera-node/test-clients/src/itest/java/DockerIntegrationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/itest/java/SequentialSuites.java
+++ b/hedera-node/test-clients/src/itest/java/SequentialSuites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/BalanceReconciliationValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/BalanceReconciliationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/ExpiryRecordsValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/ExpiryRecordsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngineExecutionContext.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEngineExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HapiTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HederaContainer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/HederaContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/InProcessHapiTestNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/InProcessHapiTestNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamAccess.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordStreamValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordWithSidecars.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/RecordWithSidecars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/StreamDataListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/StreamDataListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SubProcessHapiTestNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SubProcessHapiTestNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TestBase.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TestTags.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TestTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TokenReconciliationValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TokenReconciliationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TransactionBodyValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TransactionBodyValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/utils/AccountClassifier.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/utils/AccountClassifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/utils/TransactionBodyClassifier.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/utils/TransactionBodyClassifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/AccountExistenceValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/AccountExistenceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/AccountNumTokenNum.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/AccountNumTokenNum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/BlockNoValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/BlockNoValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/ContractExistenceValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/ContractExistenceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/HgcaaLogValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/QueryLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/validators/QueryLogValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOpFinisher.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOpFinisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/PropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/PropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/annotations/LeakyFeeSchedule.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/annotations/LeakyFeeSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountDetailsAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountDetailsAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AssertUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AssertUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AutoAssocAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AutoAssocAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/BaseErroringAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/BaseErroringAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/BaseErroringAssertsProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/BaseErroringAssertsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractLogAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractLogAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/EqualityAssertsProviderFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/EqualityAssertsProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ErroringAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ErroringAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ErroringAssertsProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ErroringAssertsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoFungibleTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoFungibleTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoNftTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoNftTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoTokenTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoTokenTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NonFungibleTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NonFungibleTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/SequentialID.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/SequentialID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/SomeFungibleTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/SomeFungibleTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/StateChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/StateChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/StorageChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/StorageChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiQueryCheckStateException.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiQueryCheckStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiQueryPrecheckStateException.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiQueryPrecheckStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiTxnCheckStateException.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiTxnCheckStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiTxnPrecheckStateException.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/exceptions/HapiTxnPrecheckStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/AdapterUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeeCalculator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/Payment.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/Payment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/ScheduleTypePatching.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/ScheduleTypePatching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/TinyBarTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/TinyBarTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/ChannelStubs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/ChannelStubs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/DelegatingOpFinisher.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/DelegatingOpFinisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/EntityNameProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/EntityNameProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/OpProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/OpProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/RegistryChangeContext.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/RegistryChangeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/RegistryChangeListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/RegistryChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/RegistryNotFound.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/RegistryNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/listeners/PresenceTrackingListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/listeners/PresenceTrackingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/listeners/TokenAccountRegistryRel.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/listeners/TokenAccountRegistryRel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/ActionableContractCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/ActionableContractCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/ActionableContractCallLocal.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/ActionableContractCallLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/ContractCallDetails.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/ContractCallDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/InitialAccountIdentifiers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/InitialAccountIdentifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/SupportedContract.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/SupportedContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/LookupUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/LookupUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/names/RegistrySourcedNameProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/names/RegistrySourcedNameProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/BiasedDelegatingProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/BiasedDelegatingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomMessageSubmit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomMessageSubmit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicCreation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomTopicUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomCallLocal.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomCallLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomContract.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomContractDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/contract/RandomContractDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/EthereumTransferToRandomEVMAddress.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/EthereumTransferToRandomEVMAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccount.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountRecords.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomAccountUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomTransfer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/RandomTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/TransferToRandomEVMAddress.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/TransferToRandomEVMAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/TransferToRandomKey.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/TransferToRandomKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomAppend.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomAppend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomContents.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomContents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFile.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFileDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFileDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFileInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFileUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/files/RandomFileUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomContractCallSignedBy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomContractCallSignedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomContractCreateSignedBy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomContractCreateSignedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomHollowAccount.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomHollowAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomHollowAccountDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomHollowAccountDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomOperationSignedBy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomOperationSignedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomTokenAssociateSignedBy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomTokenAssociateSignedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomTransferSignedBy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/hollow/RandomTransferSignedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/inventory/KeyInventoryCreation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/inventory/KeyInventoryCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/meta/RandomReceipt.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/meta/RandomReceipt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/meta/RandomRecord.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/meta/RandomRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomERC20TransferLazyCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomERC20TransferLazyCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomERC721TransferLazyCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomERC721TransferLazyCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomFungibleTransferLazyCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomFungibleTransferLazyCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomHbarTransferLazyCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomHbarTransferLazyCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomNonFungibleTransferLazyCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/precompile/RandomNonFungibleTransferLazyCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomSchedule.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomScheduleDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomScheduleDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomScheduleInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomScheduleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomScheduleSign.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/schedule/RandomScheduleSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomToken.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenAccountWipe.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenAccountWipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenAssociation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenAssociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenBurn.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenBurn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenDeletion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenDissociation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenDissociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenFreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenFreeze.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenKycGrant.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenKycGrant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenKycRevoke.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenKycRevoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenMint.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenMint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenTransfer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenUnfreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenUnfreeze.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/selectors/RandomSelector.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/selectors/RandomSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/ControlForKey.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/ControlForKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/DefaultKeyGen.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/DefaultKeyGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyLabel.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyShape.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/OverlappingKeyGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/OverlappingKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigControl.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigMapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Bip0032.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Bip0032.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Bip0039.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Bip0039.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Ed25519Factory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Ed25519Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Account.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Contract.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Contract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Entity.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/EntityId.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/EntityId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/EntityManager.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/EntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/File.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/File.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Schedule.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Schedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SimpleXfer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SimpleXfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SkipNullRepresenter.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SkipNullRepresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SpecKey.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SpecKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SpecKeyList.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SpecKeyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Token.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Topic.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/Topic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/JutilPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/JutilPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/MapPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/MapPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/NodeConnectInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/NodeConnectInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/consensus/HapiGetTopicInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/consensus/HapiGetTopicInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiContractCallLocal.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiContractCallLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractBytecode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractBytecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractRecords.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ExpectedTokenRel.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ExpectedTokenRel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountDetails.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountRecords.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ReferenceType.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ReferenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileContents.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileContents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetExecTime.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetExecTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetReceipt.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetReceipt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetVersionInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetVersionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetAccountNftInfos.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetAccountNftInfos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfos.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiTokenNftInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiTokenNftInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/HapiStats.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/HapiStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/OpObs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/OpObs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/QueryObs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/QueryObs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/ThroughputObs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/ThroughputObs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/TxnObs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/stats/TxnObs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiMessageSubmit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiMessageSubmit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiBaseCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiBaseCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiBaseContractCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiBaseContractCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiParserUtil.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiParserUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoApproveAllowance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoApproveAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoDeleteAllowance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoDeleteAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoTransfer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileAppend.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileAppend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/UploadProgress.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/UploadProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/network/HapiUncheckedSubmit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/network/HapiUncheckedSubmit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleSign.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/ScheduleFeeUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/ScheduleFeeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/system/HapiFreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/system/HapiFreeze.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/system/HapiSysDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/system/HapiSysDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/system/HapiSysUndelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/system/HapiSysUndelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenAssociate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenAssociate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenBurn.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenBurn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDissociate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDissociate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenPause.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenPause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnpause.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnpause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/TokenMovement.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/TokenMovement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/util/HapiUtilPrng.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/util/HapiUtilPrng.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BalanceSnapshot.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BalanceSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/ContextualActionOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/ContextualActionOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/ContextualSourcedOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/ContextualSourcedOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/FeatureFlags.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/FeatureFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LogMessage.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LogMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/NetworkTypeFilterOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/NetworkTypeFilterOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/NoOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/NoOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/ProviderRun.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/ProviderRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/RunLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/RunLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/SourcedOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/SourcedOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetAccountNftInfosNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetAccountNftInfosNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetBySolidityIdNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetBySolidityIdNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetFastRecordNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetFastRecordNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetLiveHashNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetLiveHashNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetStakersNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetStakersNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetTokenNftInfosNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetTokenNftInfosNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/EncodedItem.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/EncodedItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/ParsedItem.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/ParsedItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/RecordSnapshot.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/RecordSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/SuiteSnapshots.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/SuiteSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/grouping/InBlockingOrder.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/grouping/InBlockingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/grouping/ParallelSpecOps.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/grouping/ParallelSpecOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/NewSpecKey.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/NewSpecKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/NewSpecKeyList.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/NewSpecKeyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/RecordSystemProperty.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/RecordSystemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromEcdsaFile.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromEcdsaFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromFile.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromLiteral.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMnemonic.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMnemonic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMutation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromPem.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromPem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/UsableTxnId.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/UsableTxnId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/LifecycleOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/LifecycleOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/ShutDownNodesOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/ShutDownNodesOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/StartNodesOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/StartNodesOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForActiveOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForActiveOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForBehindOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForBehindOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForFreezeOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForFreezeOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForReconnectOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForReconnectOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForShutdownOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/ops/WaitForShutdownOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/NodeSelector.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/NodeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectAll.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectByName.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectByNodeId.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectByNodeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectByOperatorAccountId.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/lifecycle/selectors/SelectByOperatorAccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/HapiSpecSleep.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/HapiSpecSleep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/HapiSpecWaitUntil.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/HapiSpecWaitUntil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/NodeLivenessTimeout.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/NodeLivenessTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/AutoSnapshotModeOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/AutoSnapshotModeOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/AutoSnapshotRecordSource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/AutoSnapshotRecordSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotFileMeta.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotFileMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotMatchMode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotMatchMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotMode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotModeOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotModeOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/AssertionOutcome.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/AssertionOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/EventualAssertionResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/EventualAssertionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/RecordAssertions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/RecordAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/RecordFileChecker.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/RecordFileChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/RecordStreamVerification.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/RecordStreamVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/AssertingBiConsumer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/AssertingBiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/AssertionResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/AssertionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/BaseIdScreenedAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/BaseIdScreenedAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/CryptoCreateAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/CryptoCreateAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/EventualAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/EventualAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/RecordStreamAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/RecordStreamAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/TransactionBodyAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/TransactionBodyAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/ValidContractIdsAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/ValidContractIdsAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/throughput/FinishThroughputObs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/throughput/FinishThroughputObs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/throughput/StartThroughputObs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/throughput/StartThroughputObs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/NodeSignatureVerifier.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/NodeSignatureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/RecordFileParser.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/RecordFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/ExpectedSidecar.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/ExpectedSidecar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/MismatchedSidecar.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/MismatchedSidecar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddMethodIsNotATest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddMethodIsNotATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddTestNameDoesNotMatchMethodName.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddTestNameDoesNotMatchMethodName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/TargetNetworkType.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/TargetNetworkType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AccountAutoRenewalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AccountAutoRenewalSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AutoRemovalCasesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AutoRemovalCasesSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AutoRenewConfigChoices.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AutoRenewConfigChoices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/ContractAutoExpirySpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/ContractAutoExpirySpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/GracePeriodRestrictionsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/GracePeriodRestrictionsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/MacroFeesChargedSanityCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/MacroFeesChargedSanityCheckSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/NoGprIfNoAutoRenewSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/NoGprIfNoAutoRenewSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/TopicAutoRenewalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/TopicAutoRenewalSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/block/BlockSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/block/BlockSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/LocalNetworkCheck.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/LocalNetworkCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AssortedHcsOps.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AssortedHcsOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/ChunkingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/ChunkingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicDeleteSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicGetInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicGetInfoSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/AbstractFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/AbstractFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/AbstractFailableNonStaticCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/AbstractFailableNonStaticCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/AbstractFailableStaticCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/AbstractFailableStaticCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/CallResultsSnapshot.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/CallResultsSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/ClassicFailureMode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/ClassicFailureMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/ClassicInventory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/ClassicInventory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailableCallResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailableCallResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailableClassicCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailableClassicCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailableStaticCallResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailableStaticCallResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailureCharacterizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/FailureCharacterizationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/ApproveFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/ApproveFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/ApproveNftFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/ApproveNftFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/AssociateTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/AssociateTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/AssociateTokensFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/AssociateTokensFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/BurnTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/BurnTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateFungibleTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateFungibleTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateFungibleTokenWithCustomFeesFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateFungibleTokenWithCustomFeesFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateNonFungibleTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateNonFungibleTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateNonFungibleTokenWithCustomFeesFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CreateNonFungibleTokenWithCustomFeesFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CryptoTransferFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/CryptoTransferFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/DeleteTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/DeleteTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/DissociateTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/DissociateTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/DissociateTokensFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/DissociateTokensFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/FreezeFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/FreezeFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/MintTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/MintTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/PauseTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/PauseTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/RedirectForTokenMutationFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/RedirectForTokenMutationFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/RevokeKycFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/RevokeKycFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/SetApprovalForAllFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/SetApprovalForAllFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferFromNftFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferFromNftFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferNftFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferNftFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferNftsFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferNftsFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferTokensFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferTokensFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferUnitsFromFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/TransferUnitsFromFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UnfreezeFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UnfreezeFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UnpauseTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UnpauseTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UpdateTokenExpiryInfoFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UpdateTokenExpiryInfoFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UpdateTokenInfoFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UpdateTokenInfoFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UpdateTokenKeysFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/UpdateTokenKeysFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/WipeNftFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/WipeNftFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/WipeUnitsFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/mutations/WipeUnitsFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetAllowanceFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetAllowanceFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetApprovedFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetApprovedFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetCustomFeesFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetCustomFeesFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetFungibleTokenInfoFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetFungibleTokenInfoFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetNonFungibleTokenInfoFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetNonFungibleTokenInfoFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenDefaultFreezeStatusFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenDefaultFreezeStatusFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenDefaultKycStatusFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenDefaultKycStatusFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenExpiryInfoFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenExpiryInfoFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenInfoFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenInfoFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenKeyFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenKeyFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenTypeFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GetTokenTypeFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GrantKycFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/GrantKycFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsApprovedForAllFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsApprovedForAllFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsFrozenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsFrozenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsKycFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsKycFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsTokenFailableCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/classiccalls/views/IsTokenFailableCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetBytecodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetBytecodeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractMusicalChairsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractMusicalChairsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/BalanceOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/BalanceOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CallCodeOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CallCodeOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CallOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CallOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/DelegateCallOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/DelegateCallOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeCopyOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeCopyOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeHashOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeHashOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeSizeOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeSizeOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/GlobalPropertiesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/GlobalPropertiesSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PrngSeedOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PrngSeedOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PushZeroOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PushZeroOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SStoreSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SStoreSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SelfDestructSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SelfDestructSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/StaticCallOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/StaticCallOperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC20ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC20ContractInteractions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ApproveAllowanceSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysHTSV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DefaultTokenStatusSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DefaultTokenStatusSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DelegatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DelegatePrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DeleteTokenPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DeleteTokenPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DeleteTokenPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DeleteTokenPrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/FreezeUnfreezeTokenPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/FreezeUnfreezeTokenPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/FreezeUnfreezeTokenPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/FreezeUnfreezeTokenPrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/HRCPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/HRCPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/MixedHTSPrecompileTestsV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/MixedHTSPrecompileTestsV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PauseUnpauseTokenAccountPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PauseUnpauseTokenAccountPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PauseUnpauseTokenAccountPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PauseUnpauseTokenAccountPrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/RedirectPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/RedirectPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenAndTypeCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenAndTypeCheckSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenExpiryInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenExpiryInfoSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenExpiryInfoV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenExpiryInfoV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TopLevelSigsCanBeToggledByPrecompileTypeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TopLevelSigsCanBeToggledByPrecompileTypeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/V1SecurityModelOverrides.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/V1SecurityModelOverrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/LogsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/LogsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/RecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/RecordsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCornerCasesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCornerCasesSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetRecordsRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetRecordsRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CrytoCreateSuiteWithUTF8.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CrytoCreateSuiteWithUTF8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HelloWorldSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HelloWorldSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NewAccountRecordExists.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NewAccountRecordExists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NewContractRecordExists.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NewContractRecordExists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NftTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NftTransferSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnReceiptRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/UnsupportedQueriesRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/UnsupportedQueriesRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StartStaking.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StartStaking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumV1SecurityModelSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AllBaseOpFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AllBaseOpFeesSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CongestionPricingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CongestionPricingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CostOfEverythingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CostOfEverythingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CreateAndUpdateOps.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CreateAndUpdateOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/OverlappingKeysSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/OverlappingKeysSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/QueryPaymentExploitsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/QueryPaymentExploitsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/SpecialAccountsAreExempted.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/SpecialAccountsAreExempted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/DiverseStateCreation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/DiverseStateCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/DiverseStateValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/DiverseStateValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ExchangeRateControlSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ExchangeRateControlSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FetchSystemFiles.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FetchSystemFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileAppendSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileAppendSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileDeleteSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/MidnightUpdateRateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/MidnightUpdateRateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/PermissionSemanticsSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/PermissionSemanticsSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ProtectedFilesUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ProtectedFilesUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ValidateNewAddressBook.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ValidateNewAddressBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/AppendFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/AppendFailuresSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/CreateFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/CreateFailuresSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/DeleteFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/DeleteFailuresSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/QueryFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/QueryFailuresSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/UpdateFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/UpdateFailuresSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/positive/CreateSuccessSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/positive/CreateSuccessSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/positive/SysDelSysUndelSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/positive/SysDelSysUndelSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CommonUpgradeResources.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CommonUpgradeResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeAbort.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeAbort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeDockerNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeDockerNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeIntellijNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeIntellijNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeUpgrade.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeUpgrade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/PrepareUpgrade.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/PrepareUpgrade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpdateFileForUpgrade.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpdateFileForUpgrade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpdateServerFiles.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpdateServerFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/GeneralSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/GeneralSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/Hip796Verbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/Hip796Verbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/InterPartitionMovementSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/InterPartitionMovementSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/LockSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/LockSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/MiscSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/MiscSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/PartitionAssociationsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/PartitionAssociationsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/PartitionsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/PartitionsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/TokenKeysDefinitionSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/TokenKeysDefinitionSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/TransfersSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/TransfersSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/DesiredAccountTokenRelation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/DesiredAccountTokenRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/DesiredPartition.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/DesiredPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/TokenAttributeNames.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/TokenAttributeNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/TokenDefOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/TokenDefOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/TokenFeature.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip796/operations/TokenFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1741Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1741Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1742Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1744Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1744Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1758Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1758Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1765Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1765Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2098Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2143Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2143Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2150Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2150Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2319Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2319Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue310Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue310Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakySecurityModelV1Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakySecurityModelV1Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CannotDeleteSystemEntitiesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CannotDeleteSystemEntitiesSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ConsensusQueriesStressTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ConsensusQueriesStressTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ContractQueriesStressTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ContractQueriesStressTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CryptoQueriesStressTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CryptoQueriesStressTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FileQueriesStressTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FileQueriesStressTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FreezeRekeyedState.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FreezeRekeyedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/GuidedTourLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/GuidedTourLocalSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/GuidedTourRemoteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/GuidedTourRemoteSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/InvalidgRPCValuesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/InvalidgRPCValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/MemoValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/MemoValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/MixedOpsTransactionsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/MixedOpsTransactionsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/OneOfEveryTransaction.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/OneOfEveryTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PerpetualTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PerpetualTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PersistenceDevSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PersistenceDevSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/R5BugChecks.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/R5BugChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/RekeySavedStateTreasury.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/RekeySavedStateTreasury.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/UtilVerbChecks.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/UtilVerbChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ZeroStakeNodeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ZeroStakeNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AdjustFeeScheduleSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AdjustFeeScheduleSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/FileContractMemoPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/FileContractMemoPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/PerfTestLoadSettings.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/PerfTestLoadSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/PerfUtilOps.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/PerfUtilOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/QueryOnlyLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/QueryOnlyLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractCallLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractCallLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractCallLocalPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractCallLocalPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractCallPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractCallPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractPerformanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractPerformanceSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/FibonacciPlusLoadProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/FibonacciPlusLoadProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/MixedSmartContractOpsLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/MixedSmartContractOpsLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/opcodes/SStoreOperationLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/opcodes/SStoreOperationLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoAllowancePerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoAllowancePerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoCreatePerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoCreatePerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithAutoAccounts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithAutoAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithInvalidAccounts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithInvalidAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithStakedAccounts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferLoadTestWithStakedAccounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferPerfSuiteWOpProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/CryptoTransferPerfSuiteWOpProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/NWayDistNoHotspots.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/NWayDistNoHotspots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/SimpleXfersAvoidingHotspot.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/crypto/SimpleXfersAvoidingHotspot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileUpdateLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileUpdateLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/MixedFileOpsLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/MixedFileOpsLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedOpsLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedOpsLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedOpsMemoPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedOpsMemoPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedTransferAndSubmitLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedTransferAndSubmitLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedTransferCallAndSubmitLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/mixedops/MixedTransferCallAndSubmitLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/schedule/OnePendingSigScheduledXfersLoad.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/schedule/OnePendingSigScheduledXfersLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/schedule/ReadyToRunScheduledXfersLoad.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/schedule/ReadyToRunScheduledXfersLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenAssociationLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenAssociationLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenCreatePerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenCreatePerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenRelStatusChanges.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenRelStatusChanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransferBasicLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransferBasicLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransfersLoadProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransfersLoadProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/UniqueTokenStateSetup.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/UniqueTokenStateSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/CreateTopicPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/CreateTopicPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/HCSChunkingRealisticPerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/HCSChunkingRealisticPerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/SubmitMessageLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/SubmitMessageLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/SubmitMessagePerfSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/SubmitMessagePerfSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/createTopicLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/createTopicLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoAccountCreationValidationsAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoAccountCreationValidationsAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoAccountCreationsBeforeReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoAccountCreationsBeforeReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CheckUnavailableNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CheckUnavailableNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateAccountsBeforeReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateAccountsBeforeReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateFilesBeforeReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateFilesBeforeReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateSchedulesBeforeReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateSchedulesBeforeReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateTokensBeforeReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateTokensBeforeReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateTopicsBeforeReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/CreateTopicsBeforeReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/MixedValidationsAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/MixedValidationsAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SubmitMessagesForReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SubmitMessagesForReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdatePermissionsDuringReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdatePermissionsDuringReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateAppPropertiesStateAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateAppPropertiesStateAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateExchangeRateStateAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateExchangeRateStateAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateFeeScheduleStateAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateFeeScheduleStateAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidatePermissionStateAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidatePermissionStateAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensDeleteAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensDeleteAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/ClosingTime.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/ClosingTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/ContractRecordsSanityCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/ContractRecordsSanityCheckSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/CryptoRecordsSanityCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/CryptoRecordsSanityCheckSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/FileRecordsSanityCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/FileRecordsSanityCheckSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/RecordCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/RecordCreationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/SignedTransactionBytesRecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/SignedTransactionBytesRecordsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TokenBalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TokenBalanceValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TransactionBodyValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/TransactionBodyValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AddWellKnownEntities.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AddWellKnownEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AddressAliasIdFuzzing.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AddressAliasIdFuzzing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/HollowAccountCompletionFuzzing.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/HollowAccountCompletionFuzzing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/JrsRestartTestTemplate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/JrsRestartTestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/PrecompileMintThrottlingCheck.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/PrecompileMintThrottlingCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/SplittingThrottlesWorks.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/SplittingThrottlesWorks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/SteadyStateThrottlingCheck.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/SteadyStateThrottlingCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UmbrellaRedux.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UmbrellaRedux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UmbrellaReduxWithCustomNodes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UmbrellaReduxWithCustomNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UtilScalePricingCheck.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UtilScalePricingCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/AccountCompletionFuzzingFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/AccountCompletionFuzzingFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/IdFuzzingProviderFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/IdFuzzingProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/RegressionProviderFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/factories/RegressionProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOperations.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsRestartTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsRestartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RecordStreamValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RecordStreamValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RunTransfers.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/streaming/RunTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/GasLimitThrottlingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/GasLimitThrottlingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/PrivilegedOpsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/PrivilegedOpsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/ThrottleDefValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/ThrottleDefValidationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyAccountsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyAccountsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationV1SecurityModelSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationV1SecurityModelSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecsStateful.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecsStateful.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMiscOps.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMiscOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUnhappyAccountsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUnhappyAccountsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/util/UtilPrngSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/util/UtilPrngSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/ECDSAKeysUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/ECDSAKeysUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/MiscEETUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/MiscEETUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/RecordStreamType.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/RecordStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/ZipUtil.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/ZipUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/AddressResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/AddressResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/BoolResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/BoolResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/ContractCallResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/ContractCallResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/FunctionParameters.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/FunctionParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/SimpleBytesResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/SimpleBytesResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/precompile/HTSPrecompileResult.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/precompile/HTSPrecompileResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/precompile/TokenKeyType.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/precompile/TokenKeyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/AddressBookPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/AddressBookPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/BookEntryPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/BookEntryPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ExchangeRatesPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ExchangeRatesPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/FeeSchedulesListEntry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/FeeSchedulesListEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/RatePojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/RatePojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ResourcePricesPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ResourcePricesPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ScheduleEntryPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ScheduleEntryPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ScheduleEntryWrapperPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ScheduleEntryWrapperPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ScopedResourcePricesPojo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/ScopedResourcePricesPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/AddrBkJsonToGrpcBytes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/AddrBkJsonToGrpcBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/FeesJsonToGrpcBytes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/FeesJsonToGrpcBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/JutilPropsToSvcCfgBytes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/JutilPropsToSvcCfgBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/NodesJsonToGrpcBytes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/NodesJsonToGrpcBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/StandardSerdes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/StandardSerdes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/SysFileSerde.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/SysFileSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/ThrottleDefsLoader.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/ThrottleDefsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/ThrottlesJsonToGrpcBytes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/ThrottlesJsonToGrpcBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/XRatesJsonToGrpcBytes.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/XRatesJsonToGrpcBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/ConsensusScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/ConsensusScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/ContractScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/ContractScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/CryptoScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/CryptoScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/FeeSnapshotsScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/FeeSnapshotsScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/FileScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/FileScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/Network.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/Network.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/Node.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/PersistentContract.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/PersistentContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/PersistentFile.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/PersistentFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/Scenarios.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/Scenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/SnapshotOpsConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/SnapshotOpsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/StakingScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/StakingScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/SysFilesDownScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/SysFilesDownScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/SysFilesUpScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/SysFilesUpScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/UpdateAction.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/UpdateAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/ValidationConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/ValidationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/VersionInfoScenario.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/domain/VersionInfoScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/MiscConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/MiscConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/NetworkConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/NetworkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/NetworkNodeConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/NetworkNodeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/PostUpgradeValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/PostUpgradeValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/TokenPuvSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/TokenPuvSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/TopLevelConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/TopLevelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/YamlHelper.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/YamlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/legacy/core/CommonUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/legacy/core/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/AccountsCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/AccountsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/CreateCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/CreateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/InfoCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/InfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/SendCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/SendCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/SetupStakeCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/SetupStakeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/UpdateCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/UpdateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeeBasePriceCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeeBasePriceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeesCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SpecialFileHashCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SpecialFileHashCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SysFileDownloadCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SysFileDownloadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SysFileUploadCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SysFileUploadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SysFilesCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/files/SysFilesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/ExtractDetailsCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/ExtractDetailsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/ExtractPublicCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/ExtractPublicCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/KeysCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/KeysCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/NewPemCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/keys/NewPemCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/schedules/ScheduleCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/schedules/ScheduleCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/schedules/SignCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/schedules/SignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/FreezeAbortCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/FreezeAbortCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/FreezeOnlyCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/FreezeOnlyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/FreezeUpgradeCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/FreezeUpgradeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/TelemetryUpgradeCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/TelemetryUpgradeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/VersionInfoCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/VersionInfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/validation/ValidationCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/validation/ValidationCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/GlobalConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/GlobalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/NetConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/NetConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/NodeConfig.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/NodeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/output/CommonMessages.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/output/CommonMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/BalanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/BalanceSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/CostOfEveryThingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/CostOfEveryThingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/CreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/CreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/FreezeHelperSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/FreezeHelperSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/InfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/InfoSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/PayerFundingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/PayerFundingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/RekeySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/RekeySuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/ScheduleSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/ScheduleSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SchedulesValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SchedulesValidationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SendSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SendSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SpecialFileHashSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SpecialFileHashSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSetupSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSetupSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SysFileDownloadSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SysFileDownloadSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SysFileUploadSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/SysFileUploadSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/TokenValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/TokenValidationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/UpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/UpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/UpgradeHelperSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/UpgradeHelperSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/Utils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/test/java/EndToEndPackageRunner.java
+++ b/hedera-node/test-clients/src/test/java/EndToEndPackageRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/build.gradle.kts
+++ b/platform-sdk/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/build.gradle.kts
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoMain.java
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoState.java
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/HashgraphDemo/build.gradle.kts
+++ b/platform-sdk/platform-apps/demos/HashgraphDemo/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/HashgraphDemo/src/main/java/com/swirlds/demo/hashgraph/HashgraphDemoMain.java
+++ b/platform-sdk/platform-apps/demos/HashgraphDemo/src/main/java/com/swirlds/demo/hashgraph/HashgraphDemoMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/HashgraphDemo/src/main/java/com/swirlds/demo/hashgraph/HashgraphDemoState.java
+++ b/platform-sdk/platform-apps/demos/HashgraphDemo/src/main/java/com/swirlds/demo/hashgraph/HashgraphDemoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/build.gradle.kts
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoMain.java
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoState.java
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/StatsDemo/build.gradle.kts
+++ b/platform-sdk/platform-apps/demos/StatsDemo/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoMain.java
+++ b/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoState.java
+++ b/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestScenario.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/TransactionGenerator.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/TransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolRound.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolRound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/TransactionGenerator.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/TransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/TransactionHandlingHistory.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/TransactionHandlingHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/test/java/com/swirlds/demo/consistency/ConsistencyTestingToolRoundTests.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/test/java/com/swirlds/demo/consistency/ConsistencyTestingToolRoundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/test/java/com/swirlds/demo/consistency/TransactionHandlingHistoryTests.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/test/java/com/swirlds/demo/consistency/TransactionHandlingHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/IssTestingToolScratchpad.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/IssTestingToolScratchpad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedIncident.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedIncident.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedIss.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedIss.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedLogError.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedLogError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/TransactionGenerator.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/TransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/AccountID.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/AccountID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/FCTimestamp.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/FCTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/InternalValue.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/InternalValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MapKey.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MapValue.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolTransaction.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/TransactionGenerator.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/TransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/TransactionHash.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/TransactionHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/TransactionRecord.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/TransactionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapKey.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapKeySerializer.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapValue.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapValueSerializer.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/virtual/AccountVirtualMapValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMFamily.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMSequential.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMSequential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMTransactionHandler.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMTransactionPool.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMTransactionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMTransactionUtils.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/FCMTransactionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/MapValueData.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/MapValueData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/MapValueFCQ.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/MapValueFCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/DummyExpectedFCMFamily.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/DummyExpectedFCMFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamily.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamilyImpl.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamilyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/ExpectedMapUtils.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/merkle/map/internal/ExpectedMapUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/AppClient.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/AppClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/ControlAction.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/ControlAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/FCMQueryController.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/FCMQueryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/HotspotConfiguration.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/HotspotConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/NextSeqConsList.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/NextSeqConsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PAYLOAD_CATEGORY.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PAYLOAD_CATEGORY.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PAYLOAD_TYPE.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PAYLOAD_TYPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadCfgSimple.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadCfgSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadDistribution.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadProperty.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PayloadProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/ProgressCfg.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/ProgressCfg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PttTransactionPool.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PttTransactionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/QueryConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/QueryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/RandomDelayCfg.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/RandomDelayCfg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SigTypeConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SigTypeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SubmitConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SubmitConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SuperConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SuperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SyntheticBottleneckConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/SyntheticBottleneckConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionCounter.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionCounterList.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionCounterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionPoolConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionPoolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionSubmitter.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/TransactionSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/Triple.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/Triple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/UnsafeMutablePTTStateAccessor.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/UnsafeMutablePTTStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/WeightedRandomBag.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/WeightedRandomBag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/Action.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/QuorumResult.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/QuorumResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/QuorumTriggeredAction.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/QuorumTriggeredAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/Trigger.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/Trigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/TriggeredAction.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/actions/TriggeredAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/expiration/ExpirationRecordEntry.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/expiration/ExpirationRecordEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/expiration/ExpirationUtils.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/expiration/ExpirationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeTransactionHandler.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeUtil.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/fs/stresstest/Util.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/fs/stresstest/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/iss/IssConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/iss/IssConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/iss/IssLeaf.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/iss/IssLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/MerkleNftId.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/MerkleNftId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/Nft.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/Nft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftId.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftLedger.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftLedger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftLedgerStatistics.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftLedgerStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftQueryController.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftQueryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftSimpleQuerier.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/NftSimpleQuerier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/ReferenceNftLedger.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/ReferenceNftLedger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/config/NftConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/config/NftConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/config/NftQueryConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/config/NftQueryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/config/NftQueryType.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/nft/config/NftQueryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/stream/AccountBalanceExport.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/stream/AccountBalanceExport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/stream/ExportAccountObject.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/stream/ExportAccountObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/AssortedTransactionRequestSupplier.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/AssortedTransactionRequestSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/SequentialTransactionRequestSupplier.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/SequentialTransactionRequestSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/SmartContractConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/SmartContractConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/TransactionRequestConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/TransactionRequestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/TransactionRequestSupplierFactory.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/TransactionRequestSupplierFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/VirtualMerkleConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/config/VirtualMerkleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapKey.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapKeySerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapValue.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapValueSerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/account/AccountVirtualMapValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapKey.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapKeySerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValue.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValueSerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapKey.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapKeySerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapValue.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapValueSerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/random/PTTRandom.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/random/PTTRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/state/VirtualMerkleStateInitializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/state/VirtualMerkleStateInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandler.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/pool/AccountTransactionFactory.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/pool/AccountTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/pool/SmartContractTransactionFactory.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/pool/SmartContractTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/pool/VirtualMerkleTransactionPool.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/transaction/pool/VirtualMerkleTransactionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/FCMConfigTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/FCMConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/FCMTransactionUtilsTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/FCMTransactionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/SaveExpectedMapHandlerTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/SaveExpectedMapHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamilyTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamilyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/ControlActionTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/ControlActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/MapValueSerializableTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/MapValueSerializableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/NftLedgerTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/NftLedgerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/PlatformTestingToolStateTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/PlatformTestingToolStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/PttTransactionPoolTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/PttTransactionPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/SuperConfigTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/SuperConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/TestJsonConfig.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/TestJsonConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/TestUtil.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/freeze/FreezeUtilTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/freeze/FreezeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasherTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/config/VirtualMerkleConfigTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/config/VirtualMerkleConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandlerTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/pool/AccountTransactionFactoryTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/pool/AccountTransactionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/pool/SmartContractTransactionFactoryTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/pool/SmartContractTransactionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/SttTransactionPool.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/SttTransactionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/TransactionCodec.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/TransactionCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSecP256K1Algorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSecP256K1Algorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ECSigningAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ExtendedSignature.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/ExtendedSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/SigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/SigningAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/X25519SigningAlgorithm.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/algorithms/X25519SigningAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StressTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/TransactionPool.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/TransactionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/build.gradle.kts
+++ b/platform-sdk/swirlds-base/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/jmh/java/com.swirlds.base/ArgumentUtilsBenchmark.java
+++ b/platform-sdk/swirlds-base/src/jmh/java/com.swirlds.base/ArgumentUtilsBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/jmh/java/com.swirlds.base/ArgumentUtilsNullBenchmark.java
+++ b/platform-sdk/swirlds-base/src/jmh/java/com.swirlds.base/ArgumentUtilsNullBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/ArgumentUtils.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/ArgumentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/context/Context.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/context/internal/GlobalContext.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/context/internal/GlobalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/context/internal/ThreadLocalContext.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/context/internal/ThreadLocalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/function/BooleanFunction.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/function/BooleanFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/function/CheckedConsumer.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/function/CheckedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/function/CheckedFunction.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/function/CheckedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Lifecycle.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Lifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/LifecycleException.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/LifecycleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/LifecyclePhase.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/LifecyclePhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/MutabilityException.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/MutabilityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Mutable.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Mutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Startable.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Startable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Stoppable.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/state/Stoppable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/time/Time.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/time/Time.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/time/internal/OSTime.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/time/internal/OSTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/units/UnitConstants.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/units/UnitConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/Pair.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/ToStringBuilder.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/ToStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/context/ContextTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/context/ContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/context/GlobalContextTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/context/GlobalContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/context/ThreadLocalContextTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/context/ThreadLocalContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/function/CheckedConsumerTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/function/CheckedConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/function/CheckedFunctionTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/function/CheckedFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/utility/ToStringBuilderTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/utility/ToStringBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/TestExecutor.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/TestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/WithTestExecutor.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/WithTestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/internal/ConcurrentTestSupport.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/internal/ConcurrentTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/internal/TestExecutorExtension.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/concurrent/internal/TestExecutorExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/WithContext.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/WithContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/WithGlobalContext.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/WithGlobalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/WithThreadLocalContext.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/WithThreadLocalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/internal/GlobalContextExtension.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/internal/GlobalContextExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/internal/ThreadLocalContextExtension.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/context/internal/ThreadLocalContextExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/SystemErrProvider.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/SystemErrProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/SystemOutProvider.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/SystemOutProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/WithSystemError.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/WithSystemError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/WithSystemOut.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/WithSystemOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/internal/SystemErrorExtension.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/internal/SystemErrorExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/internal/SystemIoProvider.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/internal/SystemIoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/internal/SystemOutExtension.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/io/internal/SystemOutExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/time/FakeTime.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/time/FakeTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/util/TestInjector.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/util/TestInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/build.gradle.kts
+++ b/platform-sdk/swirlds-benchmarks/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkKey.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkKeySerializer.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkMetrics.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkRecord.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkRecordSerializer.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkRecordSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValue.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValueSerializer.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBenchMerkleDb.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBenchMerkleDb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/FCHashMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/FCHashMapBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/Main.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/Utils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/config/BenchmarkConfig.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/config/BenchmarkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/build.gradle.kts
+++ b/platform-sdk/swirlds-cli/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/PlatformCli.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/PlatformCli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/commands/EventStreamCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/commands/EventStreamCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/commands/LogCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/commands/LogCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/commands/StateCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/commands/StateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/CssDeclaration.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/CssDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/CssRuleSetFactory.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/CssRuleSetFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/DefaultFormattableString.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/DefaultFormattableString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/FormattableString.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/FormattableString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/HtmlColors.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/HtmlColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/HtmlGenerator.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/HtmlGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/HtmlTagFactory.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/HtmlTagFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogLine.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogOutputFormat.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogProcessingUtils.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogProcessingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogProcessor.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/NodeIdColorizer.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/NodeIdColorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/NonStandardLog.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/NonStandardLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/PlatformStatusLog.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/PlatformStatusLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/StdInOutColorize.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/StdInOutColorize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/AbstractCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/AbstractCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/CommandBuilder.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/CommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/ParameterizedClass.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/ParameterizedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/PlatformCliLogo.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/PlatformCliLogo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/PlatformCliPreParser.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/PlatformCliPreParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/SubcommandOf.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/utility/SubcommandOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/test/java/com/swirlds/cli/utility/LogLineTests.java
+++ b/platform-sdk/swirlds-cli/src/test/java/com/swirlds/cli/utility/LogLineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-cli/src/test/java/com/swirlds/cli/utility/PlatformStatusLogTests.java
+++ b/platform-sdk/swirlds-cli/src/test/java/com/swirlds/cli/utility/PlatformStatusLogTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/build.gradle.kts
+++ b/platform-sdk/swirlds-common/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/AbstractHashable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/AbstractHashable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/AutoCloseableNonThrowing.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/AutoCloseableNonThrowing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Console.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Copyable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Copyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/FastCopyable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/FastCopyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Releasable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Releasable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Reservable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/Reservable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/UniqueId.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/UniqueId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/BloomFilter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/BloomFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/BloomHasher.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/BloomHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/hasher/IntBloomHasher.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/hasher/IntBloomHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/hasher/LongBloomHasher.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/hasher/LongBloomHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/hasher/SelfSerializableBloomHasher.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/bloom/hasher/SelfSerializableBloomHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/BasicConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/BasicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/ConfigUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/ConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/TransactionConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/TransactionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/singleton/ConfigurationHolder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/singleton/ConfigurationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ClassConstructorPair.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ClassConstructorPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ClassIdFormatter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ClassIdFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableClass.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableIgnored.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableIgnored.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableRegistryException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableRegistryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableRegistryFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructableRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructorRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/ConstructorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/GenerateClassId.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/GenerateClassId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/NoArgsConstructor.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/NoArgsConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/RuntimeConstructable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/RuntimeConstructable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/URLClassLoaderWithLookup.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/URLClassLoaderWithLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/ConstructableClasses.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/ConstructableClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/ConstructableScanner.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/ConstructableScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/DefaultConstructableRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/DefaultConstructableRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/GenericClassConstructorPair.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/GenericClassConstructorPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/GenericConstructorRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/GenericConstructorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/MethodWrapper.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/constructable/internal/MethodWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/DefaultPlatformContext.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/DefaultPlatformContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/PlatformContext.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/PlatformContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/AbstractSerializableHashable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/AbstractSerializableHashable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Cryptography.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Cryptography.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/CryptographyException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/CryptographyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/CryptographyHolder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/CryptographyHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/DigestType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/DigestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/EmptyHashValueException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/EmptyHashValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/FutureHashable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/FutureHashable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/HashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/HashBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hashable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hashable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/HashingOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/HashingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/ImmutableHash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/ImmutableHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/InvalidDigestTypeException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/InvalidDigestTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/KeyType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/KeyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/KeyUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Message.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/RunningHash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/RunningHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/RunningHashable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/RunningHashable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/SerializableHashable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/SerializableHashable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/SerializablePublicKey.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/SerializablePublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Signature.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/SignatureType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/SignatureType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/TransactionSignature.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/TransactionSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/VerificationStatus.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/VerificationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/config/CryptoConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/config/CryptoConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/AsyncDigestHandler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/AsyncDigestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/AsyncOperationHandler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/AsyncOperationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/AsyncVerificationHandler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/AsyncVerificationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/CachingOperationProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/CachingOperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/CryptoEngine.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/CryptoEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/DelegatingVerificationProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/DelegatingVerificationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/DigestProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/DigestProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/EcdsaSecp256k1VerificationProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/EcdsaSecp256k1VerificationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/EcdsaSecp256k1Verifier.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/EcdsaSecp256k1Verifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/Ed25519VerificationProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/Ed25519VerificationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/IntakeDispatcher.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/IntakeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/OperationProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/OperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/RunningHashProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/RunningHashProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/SerializationDigestProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/SerializationDigestProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/WrappingLambdaFuture.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/engine/WrappingLambdaFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/internal/CryptoUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/internal/CryptoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ImmutableListException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ImmutableListException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ListDigestException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ListDigestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ListException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ListException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/NotImplementedException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/NotImplementedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/PlatformException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/PlatformException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ReferenceCountException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/exceptions/ReferenceCountException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/HorizontalAlignment.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/HorizontalAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/StringFormattingUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/StringFormattingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/TextEffect.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/TextEffect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/TextHistogram.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/TextHistogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/TextTable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/TextTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/UnitFormat.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/UnitFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/UnitFormatter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/formatting/UnitFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/ExternalSelfSerializable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/ExternalSelfSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/FunctionalSerialize.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/FunctionalSerialize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/IOIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/IOIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/OptionalSelfSerializable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/OptionalSelfSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/SelfSerializable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/SelfSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/SerializableDet.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/SerializableDet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/SerializableWithKnownLength.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/SerializableWithKnownLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/Versioned.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/Versioned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/RecycleBinConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/RecycleBinConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/TemporaryFileConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/TemporaryFileConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/BadIOException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/BadIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/ClassNotFoundException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/ClassNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/InvalidStreamPosition.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/InvalidStreamPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/InvalidVersionException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/InvalidVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/MerkleSerializationException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/exceptions/MerkleSerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/ExtendableInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/ExtendableInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/ExtendableOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/ExtendableOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/InputStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/InputStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/OutputStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/OutputStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/AbstractStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/AbstractStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/CountingStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/CountingStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/ExpiringStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/ExpiringStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/HashingStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/HashingStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/MaxSizeStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/MaxSizeStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/ThrottleStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/ThrottleStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/TimeoutStreamExtension.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/TimeoutStreamExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/Counter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/StandardCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/StandardCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/StreamTimeoutManager.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/StreamTimeoutManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/ThreadSafeCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/extendable/extensions/internal/ThreadSafeCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/AugmentedDataInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/AugmentedDataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/AugmentedDataOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/AugmentedDataOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/DebuggableMerkleDataInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/DebuggableMerkleDataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/MerkleDataInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/MerkleDataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/MerkleDataOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/MerkleDataOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableDataInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableDataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableDataOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableDataOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableStreamConstants.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/SerializableStreamConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/StreamDebugUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/StreamDebugUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/MerkleSerializationProtocol.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/MerkleSerializationProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/MerkleTreeSerializationOptions.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/MerkleTreeSerializationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/PartiallyConstructedMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/PartiallyConstructedMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationOperation.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationStack.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationStackElement.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationStackElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/FileUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/IOConsumer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/IOConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/IORunnable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/IORunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/IOSupplier.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/IOSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/RecycleBin.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/RecycleBin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/RecycleBinImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/RecycleBinImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/TemporaryFileBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/TemporaryFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/jackson/HashDeserializer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/jackson/HashDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/jackson/InstantDeserializer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/jackson/InstantDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleLeaf.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleNode.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/MerkleCopy.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/MerkleCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/MerklePathReplacement.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/MerklePathReplacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/NodeToCopy.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/NodeToCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/MerkleCryptoFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/MerkleCryptoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/MerkleCryptography.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/MerkleCryptography.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleCryptoEngine.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleCryptoEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleInternalDigestProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleInternalDigestProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/FailedRehashException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/FailedRehashException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildBoundsException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildBoundsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildCountException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildCountException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildHashException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildHashException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildIndexException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildIndexException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildTypeException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/IllegalChildTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/MerkleCopyException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/MerkleCopyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/MerkleRouteException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/exceptions/MerkleRouteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/FutureMerkleHash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/FutureMerkleHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashChecker.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/ComposedMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/ComposedMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/ComposedMerkleLeaf.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/ComposedMerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialBinaryMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialBinaryMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialMerkleLeaf.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialMerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialNaryMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/PartialNaryMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/destroyable/DestroyableBinaryMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/destroyable/DestroyableBinaryMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/destroyable/DestroyableMerkleLeaf.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/destroyable/DestroyableMerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/destroyable/DestroyableNaryMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/destroyable/DestroyableNaryMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/internal/AbstractMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/internal/AbstractMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/internal/AbstractMerkleNode.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/internal/AbstractMerkleNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/HasMerkleRoute.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/HasMerkleRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleMigratable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleMigratable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleParent.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleParent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleTraversable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleTraversable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/Rebuildable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/Rebuildable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/MerkleIterationOrder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/MerkleIterationOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/MerkleIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/MerkleIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/BreadthFirstAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/BreadthFirstAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/MerkleIterationAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/MerkleIterationAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/NullNode.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/NullNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PostOrderedDepthFirstAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PostOrderedDepthFirstAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PostOrderedDepthFirstRandomAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PostOrderedDepthFirstRandomAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PreOrderedDepthFirstAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PreOrderedDepthFirstAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/ReversePostOrderedDepthFirstAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/ReversePostOrderedDepthFirstAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRoute.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteFormatException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/MerkleRouteUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/ReverseMerkleRouteIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/ReverseMerkleRouteIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/AbstractMerkleRoute.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/AbstractMerkleRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/BinaryMerkleRoute.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/BinaryMerkleRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/BinaryMerkleRouteIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/BinaryMerkleRouteIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/UncompressedMerkleRoute.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/UncompressedMerkleRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/UncompressedMerkleRouteIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/route/internal/UncompressedMerkleRouteIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/CustomViewRootLesson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/CustomViewRootLesson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/ExpectedLesson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/ExpectedLesson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/InternalDataLesson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/InternalDataLesson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LeafDataLesson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LeafDataLesson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/Lesson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/Lesson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LessonType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LessonType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/NodeToSend.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/NodeToSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/QueryResponse.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/QueryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/ReconnectNodeCount.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/ReconnectNodeCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherReceivingThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherReceivingThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSendingThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSendingThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSubtree.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSubtree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/streams/AsyncInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/streams/AsyncInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/streams/AsyncOutputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/streams/AsyncOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/utility/MerkleSynchronizationException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/utility/MerkleSynchronizationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/CustomReconnectRoot.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/CustomReconnectRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerExpectedLessonQueue.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerExpectedLessonQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerInitializer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/MaybeCustomReconnectRoot.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/MaybeCustomReconnectRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/StandardLearnerTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/StandardLearnerTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/StandardTeacherTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/StandardTeacherTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherHandleQueue.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherHandleQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherResponseQueue.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherResponseQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherResponseTracker.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherResponseTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/AbstractListLeaf.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/AbstractListLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/DebugIterationEndpoint.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/DebugIterationEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/Keyed.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/Keyed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/KeyedMerkleLong.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/KeyedMerkleLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleConstants.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleLong.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleTreeVisualizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleTreeVisualizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/SerializableLong.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/SerializableLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/Counter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DoubleAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DoubleAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DoubleGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DoubleGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DurationGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DurationGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/FloatFormats.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/FloatFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/FunctionGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/FunctionGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerPairAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerPairAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/LongAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/LongAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/LongGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/LongGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/Metric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/MetricConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/MetricConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/MetricType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/MetricType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/Metrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/MetricsFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/MetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricsFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricsProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/RunningAverageMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/RunningAverageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/SpeedometerMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/SpeedometerMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/StatEntry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/StatEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/config/MetricsConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/config/MetricsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/CountPerSecond.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/CountPerSecond.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/FractionalTimer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/FractionalTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/NoOpFractionalTimer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/NoOpFractionalTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/PhaseTimer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/PhaseTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/PhaseTimerBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/PhaseTimerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/StandardFractionalTimer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/extensions/StandardFractionalTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/NoOpMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/NoOpMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/AbstractNoOpMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/AbstractNoOpMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDoubleAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDoubleAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDoubleGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDoubleGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDurationGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDurationGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpFunctionGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpFunctionGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerPairAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerPairAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpLongAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpLongAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpLongGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpLongGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpMetricsFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpRunningAverageMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpRunningAverageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpSpeedometerMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpSpeedometerMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpStatEntry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpStatEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpStatsBuffered.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpStatsBuffered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/AbstractDistributionMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/AbstractDistributionMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultDoubleAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultDoubleAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultDoubleGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultDoubleGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultDurationGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultDurationGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultFunctionGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultFunctionGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultIntegerAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultIntegerAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultIntegerGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultIntegerGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultIntegerPairAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultIntegerPairAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultLongAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultLongAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultLongGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultLongGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetricsFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetricsProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultMetricsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultRunningAverageMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultRunningAverageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultSpeedometerMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultSpeedometerMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultStatEntry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/DefaultStatEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/LegacyCsvWriter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/LegacyCsvWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricKeyRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricKeyRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricsEvent.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricsEventBus.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricsEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricsUpdateService.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/MetricsUpdateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/Snapshot.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/Snapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/SnapshotEvent.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/SnapshotEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/SnapshotService.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/SnapshotService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/AbstractMetricAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/AbstractMetricAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/BooleanAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/BooleanAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/CounterAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/CounterAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/DistributionAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/DistributionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/MetricAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/MetricAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/NameConverter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/NameConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/NumberAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/NumberAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/PrometheusConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/PrometheusConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpoint.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/StringAdapter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/prometheus/StringAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatSettings.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatSettingsFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatSettingsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsBuffered.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsBuffered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsRunningAverage.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsRunningAverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsSpeedometer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsSpeedometer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/internal/StatsBuffer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/internal/StatsBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/AbstractNotification.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/AbstractNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchMode.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchModel.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchOrder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/DispatchOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/Listener.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/NoListenersAvailableException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/NoListenersAvailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/Notification.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/Notification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/NotificationEngine.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/NotificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/NotificationResult.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/NotificationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/AbstractNotificationEngine.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/AbstractNotificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/AsyncNotificationEngine.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/AsyncNotificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/DispatchTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/DispatchTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/Dispatcher.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/notification/internal/Dispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/scratchpad/Scratchpad.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/scratchpad/Scratchpad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/scratchpad/ScratchpadType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/scratchpad/ScratchpadType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/scratchpad/internal/StandardScratchpad.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/scratchpad/internal/StandardScratchpad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/Shiftable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/Shiftable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/ConcurrentSequenceMap.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/ConcurrentSequenceMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/SequenceMap.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/SequenceMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/StandardSequenceMap.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/StandardSequenceMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/internal/AbstractSequenceMap.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/internal/AbstractSequenceMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/internal/SequenceKeySet.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/map/internal/SequenceKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/ConcurrentSequenceSet.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/ConcurrentSequenceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/SequenceSet.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/SequenceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/StandardSequenceSet.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/StandardSequenceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/internal/AbstractSequenceSet.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/sequence/set/internal/AbstractSequenceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/startup/Log4jSetup.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/startup/Log4jSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/EventStreamManager.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/EventStreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/EventStreamType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/EventStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/HashCalculatorForStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/HashCalculatorForStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/HashSigner.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/HashSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/LinkedObjectStreamUtilities.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/LinkedObjectStreamUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/MultiStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/MultiStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/QueueThreadObjectStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/QueueThreadObjectStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/QueueThreadObjectStreamConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/QueueThreadObjectStreamConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/RunningHashCalculatorForStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/RunningHashCalculatorForStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/Signer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/Signer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/StreamAligned.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/StreamAligned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/StreamType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/StreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/Timestamped.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/Timestamped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/Verifier.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/Verifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/AbstractLinkedObjectStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/AbstractLinkedObjectStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/InvalidStreamFileException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/InvalidStreamFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/LinkedObjectStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/LinkedObjectStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/LinkedObjectStreamValidateUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/LinkedObjectStreamValidateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/SingleStreamIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/SingleStreamIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/StreamFilesIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/StreamFilesIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/StreamTypeFromJson.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/StreamTypeFromJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/StreamValidationResult.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/StreamValidationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/TimestampStreamFileWriter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/stream/internal/TimestampStreamFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/BlockingResourceProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/BlockingResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/CountUpLatch.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/CountUpLatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/atomic/AtomicDouble.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/atomic/AtomicDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/atomic/AtomicIntPair.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/atomic/AtomicIntPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/BlockingQueueInserter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/BlockingQueueInserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/MultiQueueThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/MultiQueueThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/QueueThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/QueueThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/QueueThreadPool.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/QueueThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/Stoppable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/Stoppable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/StoppableThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/StoppableThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/ThreadSeed.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/ThreadSeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/TypedStoppableThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/TypedStoppableThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/MultiQueueThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/MultiQueueThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/QueueThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/QueueThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/QueueThreadMetricsConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/QueueThreadMetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/QueueThreadPoolConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/QueueThreadPoolConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/StoppableThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/StoppableThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/ThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/config/ThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractBlockingQueue.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractBlockingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractMultiQueueThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractMultiQueueThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadPoolConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadPoolConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractStoppableThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractStoppableThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractThreadConfiguration.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/AbstractThreadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/MeasuredBlockingQueue.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/MeasuredBlockingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/MultiQueueThreadImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/MultiQueueThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/QueueThreadImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/QueueThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/QueueThreadMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/QueueThreadMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/QueueThreadPoolImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/QueueThreadPoolImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/StoppableThreadImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/StoppableThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/ThreadBuildingUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/framework/internal/ThreadBuildingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/ConcurrentFuturePool.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/ConcurrentFuturePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/FuturePool.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/FuturePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/FutureUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/FutureUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/StandardFuture.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/futures/StandardFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/InterruptableConsumer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/InterruptableConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/InterruptableRunnable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/InterruptableRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/InterruptableSupplier.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/InterruptableSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/Uninterruptable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/interrupt/Uninterruptable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/AutoClosableLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/AutoClosableLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/AutoClosableResourceLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/AutoClosableResourceLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/IndexLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/IndexLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/Locks.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/Locks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AcquiredOnTry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AcquiredOnTry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AcquiredResource.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AcquiredResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AutoLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AutoLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AutoNoOpLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/AutoNoOpLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/DefaultIndexLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/DefaultIndexLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/NotAcquiredResource.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/NotAcquiredResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/ResourceLock.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/internal/ResourceLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/Locked.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/Locked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/LockedResource.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/LockedResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/MaybeLocked.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/MaybeLocked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/MaybeLockedResource.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/locks/locked/MaybeLockedResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/manager/AdHocThreadManager.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/manager/AdHocThreadManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/manager/StandardThreadManager.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/manager/StandardThreadManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/manager/ThreadManager.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/manager/ThreadManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/CachedPoolParallelExecutor.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/CachedPoolParallelExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/ParallelExecutionException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/ParallelExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/ParallelExecutor.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/ParallelExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/StandardWorkGroup.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/StandardWorkGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/SequenceCycle.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/SequenceCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/ThreadSleep.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/ThreadSleep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/ThreadUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/ThreadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/ThrowingRunnable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/utility/ThrowingRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/time/IntegerEpochTime.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/time/IntegerEpochTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/DataUnit.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/DataUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/FrequencyUnit.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/FrequencyUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/TimeUnit.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/TimeUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/Unit.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/Unit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/internal/UnitConverter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/units/internal/UnitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/AbstractReservable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/AbstractReservable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/AutoCloseableWrapper.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/AutoCloseableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/BinarySearch.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/BinarySearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ByteUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ByteUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Clearable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Clearable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Clearables.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Clearables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/CommonUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/CompareTo.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/CompareTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/DurationUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/DurationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/EmptyIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/EmptyIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/IntReference.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/IntReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/InvalidSemanticVersionException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/InvalidSemanticVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Labeled.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Labeled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/LoggingClearables.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/LoggingClearables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/LongRunningAverage.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/LongRunningAverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Mnemonics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Mnemonics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/NonCryptographicHashing.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/NonCryptographicHashing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RandomAccessDeque.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RandomAccessDeque.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ReferenceCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ReferenceCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RuntimeObjectRecord.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RuntimeObjectRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RuntimeObjectRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RuntimeObjectRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/SemanticVersion.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/SemanticVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/StackTrace.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/StackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/StopWatch.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/StopWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Threshold.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/Threshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ThresholdLimitingHandler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ThresholdLimitingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/UnmodifiableIterator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/UnmodifiableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ValueReference.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/ValueReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/MultiThrottle.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/MultiThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/RateLimitedLogger.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/RateLimitedLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/RateLimiter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/RateLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/Throttle.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/throttle/Throttle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/BackpressureBlocker.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/BackpressureBlocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/BackpressureObjectCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/BackpressureObjectCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/EmptyBlocker.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/EmptyBlocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/MultiObjectCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/MultiObjectCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/NoCapacityException.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/NoCapacityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/NoOpObjectCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/NoOpObjectCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/ObjectCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/ObjectCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/StandardObjectCounter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/counters/StandardObjectCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/ModelEdgeSubstitution.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/ModelEdgeSubstitution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/ModelGroup.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/ModelGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/ModelManualLink.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/ModelManualLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/WiringModel.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/WiringModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/CycleFinder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/CycleFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/DirectSchedulerChecks.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/DirectSchedulerChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/GroupVertex.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/GroupVertex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/InputWireChecks.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/InputWireChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/InputWireDescriptor.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/InputWireDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/MermaidNameShortener.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/MermaidNameShortener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/MermaidStyleManager.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/MermaidStyleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/ModelEdge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/ModelEdge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/ModelVertex.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/ModelVertex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/ModelVertexMetaType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/ModelVertexMetaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/StandardVertex.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/StandardVertex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/StandardWiringModel.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/StandardWiringModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/WiringFlowchart.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/WiringFlowchart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/TaskScheduler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/TaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/TaskSchedulerBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/TaskSchedulerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/TaskSchedulerMetricsBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/TaskSchedulerMetricsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/TaskSchedulerType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/TaskSchedulerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/AbstractTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/AbstractTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/ConcurrentTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/ConcurrentTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/ConcurrentTaskScheduler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/ConcurrentTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/DirectTaskScheduler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/DirectTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/HeartbeatScheduler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/HeartbeatScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/HeartbeatTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/HeartbeatTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialTaskScheduler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialThreadTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialThreadTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialThreadTaskScheduler.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/internal/SequentialThreadTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/AdvancedTransformation.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/AdvancedTransformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/WireFilter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/WireFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/WireListSplitter.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/WireListSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/WireTransformer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/WireTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/internal/AdvancedWireTransformer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/transformers/internal/AdvancedWireTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/SolderType.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/SolderType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/Bindable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/Bindable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/BindableInputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/BindableInputWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/InputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/InputWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/TaskSchedulerInput.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/input/TaskSchedulerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/OutputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/OutputWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/StandardOutputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/StandardOutputWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/internal/ForwardingOutputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/internal/ForwardingOutputWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/internal/TransformingOutputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/internal/TransformingOutputWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/bloom/BloomFilterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/bloom/BloomFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/BasicConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/BasicConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/ConfigUtilsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/ConfigUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/StateConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/StateConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/TransactionConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/TransactionConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/sub/TestConfig.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/sub/TestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/ConstructableRegistryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/ConstructableRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/ConstructorRegistryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/ConstructorRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/NoArgsConstructable.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/NoArgsConstructable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/NoArgsConstructableWithAnnotation.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/NoArgsConstructableWithAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/ConstructableExample.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/ConstructableExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/ConstructableRecord.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/ConstructableRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/PrimitiveAndObjectConstructable.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/PrimitiveAndObjectConstructable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/StringConstructable.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/StringConstructable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/subpackage/SubpackageConstructable.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructables/scannable/subpackage/SubpackageConstructable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/BadReturnTypeConstructor.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/BadReturnTypeConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/MultipleMethodsConstructor.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/MultipleMethodsConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/NotInterfaceConstructor.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/NotInterfaceConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/PrimitiveAndObjectConstructor.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/PrimitiveAndObjectConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/RecordConstructor.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/RecordConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/StringConstructor.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/constructable/constructors/StringConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/context/internal/DefaultPlatformContextTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/context/internal/DefaultPlatformContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/CryptographyBenchmarkTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/CryptographyBenchmarkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/CryptographyTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/CryptographyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/DetRandomTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/DetRandomTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/EcdsaSecp256k1VerifierTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/EcdsaSecp256k1VerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/HashTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/HashTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/MessageDigestTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/MessageDigestTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/RunningHashTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/RunningHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/SerializablePublicKeyTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/SerializablePublicKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/SignatureTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/SignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/SigningProviderTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/SigningProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/TransactionSignatureTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/TransactionSignatureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/config/CryptoConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/config/CryptoConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/HorizontalAlignmentTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/HorizontalAlignmentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/StringFormattingUtilsTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/StringFormattingUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/TextEffectTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/TextEffectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/UnitFormatterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/formatting/UnitFormatterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/SelfSerializableTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/SelfSerializableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/config/TemporaryFileConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/config/TemporaryFileConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/MultiExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/MultiExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/CountingStreamExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/CountingStreamExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/ExpiringStreamExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/ExpiringStreamExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/HashingStreamExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/HashingStreamExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/MaxSizeStreamExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/MaxSizeStreamExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/ThrottleStreamExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/ThrottleStreamExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/TimeoutStreamExtensionTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/extendable/extensions/TimeoutStreamExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/FileUtilsTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/FileUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/RecycleBinTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/RecycleBinTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/TemporaryFileBuilderTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/TemporaryFileBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/jackson/InstantDeserializerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/jackson/InstantDeserializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/merkle/synchronization/config/ReconnectConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/CounterConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/CounterConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/CounterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/CounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleAccumulatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleGaugeConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleGaugeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DoubleGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DurationGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/DurationGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/FunctionGaugeConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/FunctionGaugeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/FunctionGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/FunctionGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerAccumulatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerGaugeConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerGaugeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerPairAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerPairAccumulatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerPairAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerPairAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongAccumulatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongGaugeConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongGaugeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/LongGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/RunningAverageMetricConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/RunningAverageMetricConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/RunningAverageMetricTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/RunningAverageMetricTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/SpeedometerMetricConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/SpeedometerMetricConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/SpeedometerMetricTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/SpeedometerMetricTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/StatEntryConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/StatEntryConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/StatEntryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/StatEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/config/MetricsConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/config/MetricsConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/CountPerSecondTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/CountPerSecondTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/FractionalTimerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/FractionalTimerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/PhaseTimerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/PhaseTimerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/TestPhases.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/extensions/TestPhases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/noop/NoOpMetricsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/noop/NoOpMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultCounterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultDoubleAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultDoubleAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultDoubleGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultDoubleGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultDurationGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultDurationGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultFunctionGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultFunctionGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultIntegerAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultIntegerAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultIntegerGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultIntegerGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultIntegerPairAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultIntegerPairAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultLongAccumulatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultLongAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultLongGaugeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultLongGaugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultMetricsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultRunningAverageMetricTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultRunningAverageMetricTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultSpeedometerMetricTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultSpeedometerMetricTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultStatEntryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/DefaultStatEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/LegacyCsvWriterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/LegacyCsvWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricKeyRegistrationTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricKeyRegistrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricsEventBusTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricsEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/SnapshotServiceTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/SnapshotServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/SnapshotTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/SnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/BooleanAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/BooleanAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/CounterAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/CounterAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/DistributionAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/DistributionAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/NameConvertTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/NameConvertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/NumberAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/NumberAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpointTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/StringAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/StringAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/statistics/internal/StatsBufferTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/statistics/internal/StatsBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/AsyncOrderedIntegerListener.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/AsyncOrderedIntegerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/AsyncUnorderedIntegerListener.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/AsyncUnorderedIntegerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/DispatcherTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/DispatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/IntegerNotification.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/IntegerNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/IntegerNotificationTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/IntegerNotificationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/SyncOrderedIntegerListener.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/SyncOrderedIntegerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/SyncUnorderedIntegerListener.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/notification/SyncUnorderedIntegerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/scratchpad/ScratchpadTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/scratchpad/ScratchpadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/scratchpad/TestScratchpadType.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/scratchpad/TestScratchpadType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/sequence/map/SequenceMapTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/sequence/map/SequenceMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/sequence/set/SequenceSetTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/sequence/set/SequenceSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/set/RandomAccessSetTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/set/RandomAccessSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/CountDownLatchStreamTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/CountDownLatchStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/EventStreamManagerTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/EventStreamManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/HashCalculatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/HashCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/MultiStreamTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/MultiStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/ObjectForTestStreamTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/ObjectForTestStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/QueueThreadObjectStreamTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/QueueThreadObjectStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/RunningHashCalculatorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/RunningHashCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamObjectTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamTypeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamUtilitiesTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamUtilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamingPerformanceTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamingPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/TestStreamManager.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/TestStreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/TimestampStreamFileWriterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/TimestampStreamFileWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/BlockingResourceProviderTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/BlockingResourceProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/CachedPoolParallelExecutorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/CachedPoolParallelExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ControllableQueue.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ControllableQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/CountUpLatchTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/CountUpLatchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ExceptionSuppressingParallelExecutorTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ExceptionSuppressingParallelExecutorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/MultiQueueThreadTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/MultiQueueThreadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/QueueThreadPoolTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/QueueThreadPoolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/QueueThreadTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/QueueThreadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ReplaceSyncPhaseParallelExecutorTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ReplaceSyncPhaseParallelExecutorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/StoppableThreadTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/StoppableThreadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/SyncPhaseParallelExecutorTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/SyncPhaseParallelExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ThreadTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ThreadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/atomic/AtomicDoubleTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/atomic/AtomicDoubleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/atomic/AtomicIntPairTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/atomic/AtomicIntPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadConfigurationTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/MeasuredBlockingQueueConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/MeasuredBlockingQueueConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/MeasuredBlockingQueueTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/MeasuredBlockingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/futures/StandardFutureTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/futures/StandardFutureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/interrupt/UninterruptableTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/interrupt/UninterruptableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/locks/AutoclosableLockTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/locks/AutoclosableLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/locks/IndexLockTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/locks/IndexLockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/manager/ThreadManagerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/manager/ThreadManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/StandardWorkGroupTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/StandardWorkGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/ThreadPoolTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/ThreadPoolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/utility/SequenceCycleTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/utility/SequenceCycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/time/IntegerEpochTimeTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/time/IntegerEpochTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/units/UnitConstantsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/units/UnitConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/units/UnitTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/units/UnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/BinarySearchTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/BinarySearchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ByteUtilsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ByteUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ClearablesTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ClearablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/CommonUtilsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/CommonUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/CompareToTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/CompareToTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/DurationUtilsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/DurationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/LongRunningAverageTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/LongRunningAverageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/MnemonicsTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/MnemonicsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/NonCryptographicHashTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/NonCryptographicHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/RandomAccessDequeTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/RandomAccessDequeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ReferenceCounterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ReferenceCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/SemanticVersionTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/SemanticVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/StackTraceTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/StackTraceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/StopWatchTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/StopWatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ThresholdTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/ThresholdTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/UnmodifiableIteratorTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/UnmodifiableIteratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/BasicThrottleTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/BasicThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/MultiThrottleTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/MultiThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/RateLimitedLoggerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/RateLimitedLoggerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/RateLimiterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/throttle/RateLimiterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmark.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkEvent.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkEventPool.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkEventPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkEventVerifier.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkEventVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkGossip.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkGossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkTopologicalEventSorter.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/benchmark/WiringBenchmarkTopologicalEventSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/BackpressureObjectCounterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/BackpressureObjectCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/MultiObjectCounterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/MultiObjectCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/NoOpObjectCounterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/NoOpObjectCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/StandardObjectCounterTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/counters/StandardObjectCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/model/ModelTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/model/ModelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/ConcurrentTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/ConcurrentTaskSchedulerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/DirectTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/DirectTaskSchedulerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/HeartbeatSchedulerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/HeartbeatSchedulerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/SequentialTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/schedulers/SequentialTaskSchedulerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/transformers/TaskSchedulerTransformersTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/transformers/TaskSchedulerTransformersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/AssertionUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/AssertionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/DummySystemTransaction.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/DummySystemTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/NameUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/NameUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/RandomAddressBookGenerator.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/RandomAddressBookGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/RandomUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/RandomUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/ResettableRandom.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/ResettableRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/TestRecycleBin.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/TestRecycleBin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/TransactionGenerator.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/TransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/TransactionUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/TransactionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/WeightGenerator.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/WeightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/WeightGenerators.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/WeightGenerators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/AbstractBenchmarkOperation.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/AbstractBenchmarkOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/Benchmark.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/Benchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkConfiguration.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkMetadata.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkOperation.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkStatistic.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/BenchmarkStatistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/ImmutableStateManager.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/ImmutableStateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/MutableStateManager.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/MutableStateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/StateManager.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/benchmark/StateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/ECDSASigningProvider.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/ECDSASigningProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/ED25519SigningProvider.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/ED25519SigningProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/EcdsaSignedTxnPool.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/EcdsaSignedTxnPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/EcdsaUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/EcdsaUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/MessageDigestPool.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/MessageDigestPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/PreGeneratedPublicKeys.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/PreGeneratedPublicKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SerializableHashableDummy.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SerializableHashableDummy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SignaturePool.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SignaturePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SigningProvider.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SigningProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SliceConsumer.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/crypto/SliceConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/dummy/Key.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/dummy/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/dummy/MerkleKey.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/dummy/MerkleKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/dummy/Value.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/dummy/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/fcqueue/FCInt.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/fcqueue/FCInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/BlockingInputStream.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/BlockingInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/BlockingOutputStream.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/BlockingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/FileManipulation.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/FileManipulation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/InputOutputStream.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/InputOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/SelfSerializableExample.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/SelfSerializableExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/SerializationUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/SerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/extendable/StreamSanityChecks.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/io/extendable/StreamSanityChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/map/MapPair.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/map/MapPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/map/MapPairs.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/map/MapPairs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleSerializeUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleSerializeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/Hotspot.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/Hotspot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/HotspotHashSet.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/HotspotHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/HotspotSetIterator.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/HotspotSetIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/RandomAccessHashSet.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/RandomAccessHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/RandomAccessSet.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/set/RandomAccessSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/CountDownLatchStream.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/CountDownLatchStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/ObjectForTestStream.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/ObjectForTestStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/ObjectForTestStreamGenerator.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/ObjectForTestStreamGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/StreamFileSigner.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/StreamFileSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/StreamObjectWorker.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/StreamObjectWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/TestStreamType.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/TestStreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/WriteToStreamConsumer.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/WriteToStreamConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/ConcurrentTesting.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/ConcurrentTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/ExceptionSuppressingParallelExecutor.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/ExceptionSuppressingParallelExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/ReplaceSyncPhaseParallelExecutor.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/ReplaceSyncPhaseParallelExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/SyncPhaseParallelExecutor.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/threading/SyncPhaseParallelExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/build.gradle.kts
+++ b/platform-sdk/swirlds-config-api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/ConfigData.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/ConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/ConfigProperty.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/ConfigProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/Configuration.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/ConfigurationBuilder.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/ConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/converter/ConfigConverter.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/converter/ConfigConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/intern/ConfigurationProvider.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/intern/ConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/source/ConfigSource.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/source/ConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/spi/ConfigurationBuilderFactory.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/spi/ConfigurationBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigPropertyConstraint.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigPropertyConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigValidator.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigViolation.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigViolationException.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/ConfigViolationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/PropertyMetadata.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/PropertyMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/ConstraintMethod.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/ConstraintMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Max.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Max.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Min.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Min.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Negative.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Negative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Positive.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/validation/annotation/Positive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/build.gradle.kts
+++ b/platform-sdk/swirlds-config-extensions/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/export/ConfigExport.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/export/ConfigExport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/reflection/ConfigReflectionUtils.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/reflection/ConfigReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/AbstractConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/AbstractConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ConfigMapping.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ConfigMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ConfigSourceOrdinalConstants.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ConfigSourceOrdinalConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/LegacyFileConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/LegacyFileConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/MappedConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/MappedConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/PropertyFileConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/PropertyFileConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/SimpleConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/SimpleConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/SystemEnvironmentConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/SystemEnvironmentConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/SystemPropertiesConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/SystemPropertiesConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ThreadCountPropertyConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ThreadCountPropertyConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/validators/DefaultConfigViolation.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/validators/DefaultConfigViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/MappedConfigSourceTest.java
+++ b/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/MappedConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/PropertyFileConfigSourceTest.java
+++ b/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/PropertyFileConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/SimpleConfigSourceTest.java
+++ b/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/SimpleConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/export/ConfigExportTest.java
+++ b/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/export/ConfigExportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/build.gradle.kts
+++ b/platform-sdk/swirlds-config-impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/jmh/java/com/swirlds/config/benchmark/ConfigBenchmark.java
+++ b/platform-sdk/swirlds-config-impl/src/jmh/java/com/swirlds/config/benchmark/ConfigBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/jmh/java/com/swirlds/config/benchmark/ConfigUtilsBenchmark.java
+++ b/platform-sdk/swirlds-config-impl/src/jmh/java/com/swirlds/config/benchmark/ConfigUtilsBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/BigDecimalConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/BigDecimalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/BigIntegerConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/BigIntegerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/BooleanConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/BooleanConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ByteConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ByteConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ChronoUnitConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ChronoUnitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/DoubleConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/DoubleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/DurationConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/DurationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/EnumConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/EnumConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/FileConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/FileConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/FloatConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/FloatConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/IntegerConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/IntegerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/LongConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/PathConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/PathConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ShortConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ShortConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/StringConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/StringConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/UriConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/UriConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/UrlConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/UrlConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ZonedDateTimeConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/converters/ZonedDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigDataFactory.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigDataService.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigDataService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigLifecycle.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigNumberUtils.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigNumberUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigPropertiesService.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigPropertiesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigSourceService.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigSourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigValidationService.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigValidationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationBuilderFactoryImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationBuilderFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationBuilderImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConstraintValidator.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConstraintValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConverterService.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConverterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/PropertyMetadataImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/PropertyMetadataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/DefaultConfigViolation.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/DefaultConfigViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/MinConstraint.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/MinConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/MinLengthConstraint.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/MinLengthConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/PropertyExistsConstraint.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/PropertyExistsConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/PropertyValueConvertableConstraint.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/PropertyValueConvertableConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/ConstraintMethodConstraintsValidation.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/ConstraintMethodConstraintsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/MaxConstraintsValidation.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/MaxConstraintsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/MinConstraintsValidation.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/MinConstraintsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/NegativeConstraintsValidation.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/NegativeConstraintsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/PositiveConstraintsValidation.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/validators/annotation/internal/PositiveConstraintsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiListTests.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiListTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiRecordsTests.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiRecordsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiSetTests.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiTests.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/EmptyCollectionConfig.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/EmptyCollectionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/NetworkConfig.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/NetworkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/NullConfig.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/NullConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/TestDateConverter.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/TestDateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/BigDecimalConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/BigDecimalConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/BigIntegerConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/BigIntegerConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/BooleanConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/BooleanConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ByteConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ByteConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ChronoUnitConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ChronoUnitConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/DoubleConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/DoubleConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/DurationConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/DurationConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/EnumConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/EnumConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/FileConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/FileConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/FloatConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/FloatConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/IntegerConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/IntegerConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/LongConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/LongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/PathConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/PathConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ShortConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ShortConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/UriConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/UriConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/UrlConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/UrlConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ZonedDateTimeConverterTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/converters/ZonedDateTimeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/internal/ConfigNumberUtilsTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/internal/ConfigNumberUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/internal/ConfigurationBuilderFactoryImplTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/internal/ConfigurationBuilderFactoryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/internal/ConverterServiceTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/internal/ConverterServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/DummyMetadata.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/DummyMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/MinConstraintTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/MinConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/MinLengthConstraintTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/MinLengthConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/PropertyExistsConstraintTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/PropertyExistsConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/PropertyValueConvertableConstraintTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/PropertyValueConvertableConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/BrokenConstraintMethodConfigData.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/BrokenConstraintMethodConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/ConstraintMethodConfigData.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/ConstraintMethodConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/ConstraintMethodTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/ConstraintMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MaxTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MaxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MaxTestConfigData.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MaxTestConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MinTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MinTestConfigData.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/MinTestConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/NegativeConfigData.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/NegativeConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/NegativeTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/NegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/PositiveConfigData.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/PositiveConfigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/PositiveTest.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/validators/annotation/PositiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/build.gradle.kts
+++ b/platform-sdk/swirlds-config-processor/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataAnnotationProcessor.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataAnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataPropertyDefinition.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataPropertyDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataRecordDefinition.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataRecordDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigProcessorConstants.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigProcessorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConstantClassFactory.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConstantClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/DocumentationFactory.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/DocumentationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/MarkdownSyntax.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/MarkdownSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/AntlrConfigRecordParser.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/AntlrConfigRecordParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/AntlrUtils.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/AntlrUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaLexer.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaLexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaParser.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaParserBaseListener.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaParserBaseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaParserListener.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavaParserListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocLexer.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocLexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocParser.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocParserBaseListener.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocParserBaseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocParserListener.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/antlr/generated/JavadocParserListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-config-processor/src/test/java/com/swirlds/config/processor/DocumentationFactoryTest.java
+++ b/platform-sdk/swirlds-config-processor/src/test/java/com/swirlds/config/processor/DocumentationFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/build.gradle.kts
+++ b/platform-sdk/swirlds-fchashmap/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/FCHashMap.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/FCHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/FCInvertibleHashMap.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/FCInvertibleHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/FCOneToManyRelation.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/FCOneToManyRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/ModifiableValue.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/ModifiableValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/config/FCHashMapConfig.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/config/FCHashMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCHashMapEntrySet.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCHashMapEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCHashMapEntrySetIterator.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCHashMapEntrySetIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCHashMapFamily.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCHashMapFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCOneToManyRelationIterator.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/FCOneToManyRelationIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/KeyIndexPair.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/KeyIndexPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/KeyValuePair.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/KeyValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/Mutation.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/Mutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/PurgingEvent.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/PurgingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/UnPurgedMap.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/com/swirlds/fchashmap/internal/UnPurgedMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapConfigTest.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapGarbageCollectorTest.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapGarbageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapSeries.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapSeries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapTests.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCHashMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCInvertibleHashMapTests.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCInvertibleHashMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCOneToManyRelationTests.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/FCOneToManyRelationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/RandomFCHashMapTests.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/RandomFCHashMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/VerifiedFCHashMapSeries.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/VerifiedFCHashMapSeries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/config/FCHashMapConfigTest.java
+++ b/platform-sdk/swirlds-fchashmap/src/test/java/com/swirlds/fchashmap/config/FCHashMapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/build.gradle.kts
+++ b/platform-sdk/swirlds-fcqueue/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/main/java/com/swirlds/fcqueue/FCQueue.java
+++ b/platform-sdk/swirlds-fcqueue/src/main/java/com/swirlds/fcqueue/FCQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/main/java/com/swirlds/fcqueue/FCQueueStatistics.java
+++ b/platform-sdk/swirlds-fcqueue/src/main/java/com/swirlds/fcqueue/FCQueueStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/AccessibleFCQueue.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/AccessibleFCQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueGraphTest.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueIterator.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueStatisticsTest.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueTest.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/FCQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/MockFCQueue.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/MockFCQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/MockFCQueueTest.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/MockFCQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/SlowMockFCQueue.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/SlowMockFCQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/internal/FCQHashAlgorithm.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/internal/FCQHashAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/internal/FCQueueNode.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/internal/FCQueueNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/internal/FCQueueNodeIterator.java
+++ b/platform-sdk/swirlds-fcqueue/src/test/java/com/swirlds/fcqueue/internal/FCQueueNodeIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/build.gradle.kts
+++ b/platform-sdk/swirlds-jasperdb/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/jmh/java/com/swirlds/benchmark/LongListBenchmark.java
+++ b/platform-sdk/swirlds-jasperdb/src/jmh/java/com/swirlds/benchmark/LongListBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/DataSourceValidator.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/DataSourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/FileStatisticAware.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/FileStatisticAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/KeyRange.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/KeyRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbPaths.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatisticsUpdater.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatisticsUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbTableConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbTableConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/NanoClock.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/NanoClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/Snapshotable.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/Snapshotable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/CASableLongIndex.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/CASableLongIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/HashList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/HashList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/HashListBufferedWrapper.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/HashListBufferedWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/HashListByteBuffer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/HashListByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingMap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/IndexedObject.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/IndexedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListHeap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListSpliterator.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListSpliterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/OffHeapUser.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/OffHeapUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ThreeLongsList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/ThreeLongsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCommon.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileIterator.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileMetadata.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileOutputStream.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStore.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/VirtualHashRecordSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/VirtualHashRecordSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/VirtualLeafRecordSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/VirtualLeafRecordSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/Bucket.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/Bucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/BucketMutation.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/BucketMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/BucketSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/BucketSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySet.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPool.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/VirtualKeySetSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/VirtualKeySetSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/AbstractFixedSizeKeySerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/AbstractFixedSizeKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/BaseSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/BaseSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/DataItemHeader.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/DataItemHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/DataItemSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/DataItemSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/KeyIndexType.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/KeyIndexType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/KeySerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/KeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/ValueSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/serialize/ValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/utilities/HashTools.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/utilities/HashTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/utilities/MerkleDbFileUtils.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/utilities/MerkleDbFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CloseFlushTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CloseFlushTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/DataSourceValidatorTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/DataSourceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleByteArrayVirtualValue.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleByteArrayVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleFixedSizeVirtualValue.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleFixedSizeVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleFixedSizeVirtualValueSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleFixedSizeVirtualValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongKeyFixedSize.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongKeyFixedSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongKeyVariableSize.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongKeyVariableSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongLongKeyFixedSize.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongLongKeyFixedSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongLongKeyVariableSize.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleLongLongKeyVariableSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleVariableSizeVirtualValue.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleVariableSizeVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleVariableSizeVirtualValueSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/ExampleVariableSizeVirtualValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/KeyRangeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/KeyRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTestUtils.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MigrationTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/TestType.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/TestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/VirtualHashRecordSerializerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/VirtualHashRecordSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/VirtualLeafRecordSerializerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/VirtualLeafRecordSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/HashListByteBufferTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/HashListByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArrayTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingMapTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListDiskTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListDiskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListHeapTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListHeapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListOffHeapTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListOffHeapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListValidRangeTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListValidRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/ThreeLongsListTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/ThreeLongsListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/config/MerkleDbConfigTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/config/MerkleDbConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionHammerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCommonTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCommonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCompactorTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCompactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileLowLevelTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileLowLevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileMetadataTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderHammerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileWriterTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataItemHeaderTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataItemHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/ExampleFixedSizeDataSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/ExampleFixedSizeDataSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/ExampleVariableSizeDataSerializer.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/ExampleVariableSizeDataSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/FilesTestType.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/FilesTestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketMutationTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketMutationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySetTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskVirtualKeySetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPoolTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/utilities/HashToolsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/utilities/HashToolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/utilities/MerkleDBFileUtilsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/utilities/MerkleDBFileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/utilities/SmartContractKeyHashingTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/utilities/SmartContractKeyHashingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/build.gradle.kts
+++ b/platform-sdk/swirlds-logging/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/Level.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/Level.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/Marker.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/Marker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/emergency/EmergencyLogger.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/emergency/EmergencyLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/emergency/EmergencyLoggerProvider.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/emergency/EmergencyLoggerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/LogEvent.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/LogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/LogEventConsumer.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/LogEventConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/LogMessage.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/LogMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/ParameterizedLogMessage.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/ParameterizedLogMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/SimpleLogMessage.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/extensions/event/SimpleLogMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/internal/emergency/EmergencyLoggerImpl.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/internal/emergency/EmergencyLoggerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/internal/format/LineBasedFormat.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/internal/format/LineBasedFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/FilterActionPair.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/FilterActionPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarker.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarkerType.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarkerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LoggingUtils.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LoggingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/PlatformLogMessages.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/PlatformLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/SwirldsLogFileReader.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/SwirldsLogFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/SwirldsLogParser.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/SwirldsLogParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/SwirldsLogReader.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/SwirldsLogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasAnyExceptionFilter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasAnyExceptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasErrorMarkerFilter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasErrorMarkerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasExceptionFilter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasExceptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasMarkerFilter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/HasMarkerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/JsonLogEntry.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/JsonLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/JsonParser.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/JsonParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/PayloadTypeFilter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/json/PayloadTypeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/AbstractLogPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/AbstractLogPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ActiveStateThresholdPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ActiveStateThresholdPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ApplicationDualStatePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ApplicationDualStatePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ApplicationFinishedPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ApplicationFinishedPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/CreateTransactionFailedPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/CreateTransactionFailedPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/FatalErrorPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/FatalErrorPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/GarbageCollectionQueuePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/GarbageCollectionQueuePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/InsufficientSignaturesPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/InsufficientSignaturesPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/IssPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/IssPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/IssResolvedPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/IssResolvedPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/LogPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/LogPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/NodeAddressMismatchPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/NodeAddressMismatchPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/NodeStartPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/NodeStartPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/PayloadParsingException.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/PayloadParsingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/PlatformStatusPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/PlatformStatusPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectDataUsagePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectDataUsagePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectFailurePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectFailurePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectFinishPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectFinishPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectLoadFailurePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectLoadFailurePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectPeerInfoPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectPeerInfoPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectStartPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/ReconnectStartPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/RecoveredStateSavedPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/RecoveredStateSavedPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SavedStateLoadedPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SavedStateLoadedPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SetFreezeTimePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SetFreezeTimePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SetLastFrozenTimePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SetLastFrozenTimePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SoftwareVersionPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SoftwareVersionPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/StateSavedToDiskPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/StateSavedToDiskPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/StreamParseErrorPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/StreamParseErrorPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SynchronizationCompletePayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SynchronizationCompletePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SyntheticBottleneckFinishPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SyntheticBottleneckFinishPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SyntheticBottleneckStartPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SyntheticBottleneckStartPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SystemExitPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/SystemExitPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/UnableToReconnectPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/UnableToReconnectPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/AbstractLogPayloadTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/AbstractLogPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/FreezeTimePayloadTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/FreezeTimePayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/ReconnectPeerInfoPayloadTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/ReconnectPeerInfoPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/DummyLogBuilder.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/DummyLogBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/DummyLogReader.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/DummyLogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/LoggingTests.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/LoggingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/LoggingUtilsTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/LoggingUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/v2/LevelTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/v2/LevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/v2/MarkerTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/v2/MarkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/v2/emergency/EmergencyLoggerTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/v2/emergency/EmergencyLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/build.gradle.kts
+++ b/platform-sdk/swirlds-merkle/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/MerkleMap.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/MerkleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/MerkleMapMetrics.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/MerkleMapMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntry.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntryKey.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntryKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntrySet.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntrySetIterator.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapEntrySetIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapInfo.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/map/internal/MerkleMapInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/tree/MerkleBinaryTree.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/tree/MerkleBinaryTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/tree/MerkleTreeInternalNode.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/tree/MerkleTreeInternalNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/tree/internal/BitUtil.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/com/swirlds/merkle/tree/internal/BitUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestKey.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestKeySerializer.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestValue.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestValueSerializer.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/TestValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/map/MapTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/map/MapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenVirtualMapTeacherView.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenVirtualMapTeacherView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualMap.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualRootNode.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualRootNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapLargeReconnectTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapLargeReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AppStartParams.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AppStartParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ApplicationDefinition.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ApplicationDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ApplicationDefinitionLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ApplicationDefinitionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/CommandLineArgs.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/CommandLineArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Consensus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Consensus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/CryptoMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/CryptoMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/EventStrings.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/EventStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/FreezePeriodChecker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/FreezePeriodChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/JVMPauseDetectorThread.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/JVMPauseDetectorThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/JvmAnchor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/JvmAnchor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ParameterProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ParameterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/PlatformBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateSigner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StaticPlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StaticPlatformBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldTransactionSubmitter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldTransactionSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ThreadDumpGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ThreadDumpGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2017-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/BrowseCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/BrowseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CleanCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CleanCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamInfoCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamInfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRecoverCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRecoverCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRepairCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRepairCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamSignCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamSignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/FormatSwirldsLogCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/FormatSwirldsLogCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenerateUidCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenerateUidCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderRenderCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderRenderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderReportCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderReportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderScapeCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/JrsTestReaderScapeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesCompactCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesCompactCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesRecoveryCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesRecoveryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/SignCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/SignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/StateEditorCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/StateEditorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateManifestFileCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateManifestFileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateStateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/utils/JtrUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/utils/JtrUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntakeMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/EventIntakeMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/LinkedEventIntake.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/LinkedEventIntake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/PlatformComponent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/PlatformComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/SavedStateController.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/SavedStateController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/appcomm/AppCommunicationComponent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/appcomm/AppCommunicationComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/appcomm/WiringConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/appcomm/WiringConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/FatalErrorConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/FatalErrorConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/NewSignedStateFromTransactionsConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/NewSignedStateFromTransactionsConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/SignedStateToLoadConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/SignedStateToLoadConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/StateSignature.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/output/StateSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/query/SystemTransactionSubmitter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/common/query/SystemTransactionSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/DefaultStateManagementComponent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/DefaultStateManagementComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/StateManagementComponent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/StateManagementComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/IssConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/IssConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/NewLatestCompleteStateConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/NewLatestCompleteStateConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/StateHasEnoughSignaturesConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/StateHasEnoughSignaturesConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/StateLacksSignaturesConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/state/output/StateLacksSignaturesConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/TransactionSupplier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/TransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/ConsensusSystemTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/ConsensusSystemTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/ConsensusSystemTransactionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/ConsensusSystemTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/PreconsensusSystemTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/PreconsensusSystemTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/PreconsensusSystemTransactionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/PreconsensusSystemTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/ScopedSystemTransaction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/ScopedSystemTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/SystemTransactionExtractor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/transaction/system/SystemTransactionExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/DefaultConfiguration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/DefaultConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/PathsConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/PathsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/ThreadConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/ThreadConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/internal/ConfigMappings.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/internal/ConfigMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/internal/PlatformConfigUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/internal/PlatformConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/ConfigurationException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/ConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/JarAppConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/JarAppConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigProperties.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/AncestorIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/AncestorIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/AncestorSearch.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/AncestorSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/CandidateWitness.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/CandidateWitness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusRounds.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusRounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusSnapshot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusSorter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/CountingVote.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/CountingVote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/EventVisitedMark.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/EventVisitedMark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/GraphGenerations.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/GraphGenerations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/InitJudges.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/InitJudges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/NonAncientEventWindow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/NonAncientEventWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundCalculationUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundCalculationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundElections.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundElections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundNumberProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundNumberProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SequentialRingBuffer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SequentialRingBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SyntheticSnapshot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SyntheticSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ThreadSafeConsensusInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ThreadSafeConsensusInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyCertPurpose.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyCertPurpose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyGeneratingException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyGeneratingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyLoadingException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyLoadingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeysAndCerts.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeysAndCerts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/PlatformSigner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/PlatformSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/PublicStores.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/PublicStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/SignatureVerifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/SignatureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/DispatchBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/DispatchBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/DispatchConfiguration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/DispatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/Observer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/Observer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/ObserverComment.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/ObserverComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/Trigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/Trigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/flowchart/CommentedTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/flowchart/CommentedTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/flowchart/DispatchFlowchart.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/flowchart/DispatchFlowchart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/control/HaltRequestedConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/control/HaltRequestedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/control/ShutdownRequestedTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/control/ShutdownRequestedTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/error/CatastrophicIssTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/error/CatastrophicIssTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/error/DeadlockTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/error/DeadlockTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/error/SelfIssTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/error/SelfIssTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/DiskStateLoadedTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/DiskStateLoadedTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/ReconnectStateLoadedTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/ReconnectStateLoadedTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/StateHashValidityTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/StateHashValidityTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/StateHashedTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/flow/StateHashedTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/transaction/PostConsensusStateSignatureTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/transaction/PostConsensusStateSignatureTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/transaction/PreConsensusStateSignatureTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/triggers/transaction/PreConsensusStateSignatureTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerEight.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerEight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerFive.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerFive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerFour.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerFour.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerNine.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerNine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerOne.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerSeven.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerSeven.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerSix.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerSix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerTen.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerTen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerThree.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerThree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerTwo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerZero.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/dispatch/types/TriggerZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventCounter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventStringBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/EventUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/GossipEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/GossipEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/AsyncEventCreationManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/AsyncEventCreationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationManagerFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/EventCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/SyncEventCreationManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/SyncEventCreationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/AggregateEventCreationRules.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/AggregateEventCreationRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/BackpressureRule.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/BackpressureRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/EventCreationRule.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/EventCreationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/MaximumRateRule.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/MaximumRateRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/PlatformStatusRule.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/rules/PlatformStatusRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/ChildlessEventTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/ChildlessEventTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/Tipset.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/Tipset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetAdvancementWeight.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetAdvancementWeight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetEventCreator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetEventCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetWeightCalculator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/creation/tipset/TipsetWeightCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/deduplication/EventDeduplicator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/deduplication/EventDeduplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/hashing/EventHasher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/hashing/EventHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/AbstractEventLinker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/AbstractEventLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/ChildEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/ChildEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/EventLinker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/EventLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/InOrderLinker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/InOrderLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/OrphanBufferingLinker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/OrphanBufferingLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/ParentDescriptor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/ParentDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/ParentFinder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/ParentFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/OrphanBuffer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/OrphanBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/OrphanedEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/OrphanedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/ParentAndOrphans.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/ParentAndOrphans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/ParentIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/orphan/ParentIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/AsyncPreconsensusEventWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/AsyncPreconsensusEventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/BestEffortPreconsensusEventFileCopy.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/BestEffortPreconsensusEventFileCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/EventDurabilityNexus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/EventDurabilityNexus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/NoOpPreconsensusEventWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/NoOpPreconsensusEventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesUtilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventFile.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventFileManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventMultiFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventMultiFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventMutableFile.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventMutableFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventReplayPipeline.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventReplayPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventReplayWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventReplayWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventStreamConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventStreamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventStreamSequencer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventStreamSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventUtilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PreconsensusEventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/SyncPreconsensusEventWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/SyncPreconsensusEventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamMultiNodeReport.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamMultiNodeReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamReport.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamScanner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/EventStreamScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/RoundRunningHash.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/report/RoundRunningHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/AddressBookUpdate.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/AddressBookUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/AncientValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/AncientValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventDeduplication.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventDeduplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventSignatureValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventSignatureValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/GossipEventValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/GossipEventValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/GossipEventValidators.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/GossipEventValidators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/InternalEventValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/InternalEventValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/SignatureValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/SignatureValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/StaticValidators.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/StaticValidators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/TransactionSizeValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/TransactionSizeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/ConsensusQueue.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/ConsensusQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/ConsensusRoundHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/ConsensusRoundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/EventConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/EventConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/PreConsensusEventHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/PreConsensusEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPool.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPoolMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/AbstractGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/AbstractGossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/DefaultIntakeEventCounter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/DefaultIntakeEventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManagerImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/Gossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/Gossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/GossipFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/GossipFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/IntakeEventCounter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/IntakeEventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/NoOpIntakeEventCounter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/NoOpIntakeEventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/ProtocolConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/ProtocolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncPermitProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncPermitProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterGossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterNotifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterSyncProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/ChatterSyncProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/PrepareChatterEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/PrepareChatterEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/communication/ChatterProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/communication/ChatterProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/communication/Constants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/communication/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/config/ChatterConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/config/ChatterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/ChatterConnectionState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/ChatterConnectionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/ChatterCore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/ChatterCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/MessageHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/MessageProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/MessageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/PeerMessageException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/PeerMessageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/PeerMessageHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/PeerMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatMessage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatResponder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatResponder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatSendReceive.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatSendReceive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatSender.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatSent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/heartbeat/HeartbeatSent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/InputDelegate.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/InputDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/InputDelegateBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/InputDelegateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/MessageTypeHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/MessageTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/MessageTypeHandlerBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/input/MessageTypeHandlerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/messages/ChatterEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/messages/ChatterEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/MessageOutput.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/MessageOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/OtherEventDelay.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/OtherEventDelay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/PriorityOutputAggregator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/PriorityOutputAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/SendAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/SendAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/SendCheck.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/SendCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/TimeDelay.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/TimeDelay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/VariableTimeDelay.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/VariableTimeDelay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/queue/QueueOutputMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/queue/QueueOutputMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/queue/QueueOutputPeer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/output/queue/QueueOutputPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/CommunicationState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/CommunicationState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/LoggingCommunicationState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/LoggingCommunicationState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/PeerGossipState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/PeerGossipState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/PeerInstance.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/peer/PeerInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/processing/ProcessingTimeMessage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/processing/ProcessingTimeMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/processing/ProcessingTimeSendReceive.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/chatter/protocol/processing/ProcessingTimeSendReceive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/GenerationReservation.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/GenerationReservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/GenerationReservationImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/GenerationReservationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/Generations.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/Generations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/InsertableStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/InsertableStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/LatestEventTipsetTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/LatestEventTipsetTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraph.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraphEventObserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraphEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraphInsertionException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraphInsertionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraphSynchronizer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowGraphSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncFallenBehindStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncFallenBehindStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncLogging.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncResult.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncTimeoutException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncTiming.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncTiming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/TheirTipsAndGenerations.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/TheirTipsAndGenerations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SingleNodeSyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SingleNodeSyncGossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncGossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncInputStream.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncManagerImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncOutputStream.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/protocol/PeerAgnosticSyncChecks.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/protocol/PeerAgnosticSyncChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/protocol/SyncProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/protocol/SyncProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiPlatformAccessor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiPlatformAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/SwirldsGui.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/SwirldsGui.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/WindowConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/WindowConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/Chart.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/Chart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/ChartLabelModel.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/ChartLabelModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/PrePaintableJPanel.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/PrePaintableJPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/ScrollableJPanel.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/components/ScrollableJPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphGui.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphGui.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphGuiConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphGuiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphGuiSource.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphGuiSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphPictureOptions.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/HashgraphPictureOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/AddressBookMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/AddressBookMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/CachingGuiSource.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/CachingGuiSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/FinalShadowgraphGuiSource.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/FinalShadowgraphGuiSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/HashgraphGuiControls.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/HashgraphGuiControls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/HashgraphGuiUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/HashgraphGuiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/HashgraphPicture.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/HashgraphPicture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/PictureMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/PictureMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/ShadowgraphGuiSource.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/hashgraph/internal/ShadowgraphGuiSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/BrowserWindowManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/BrowserWindowManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/PlatformHashgraphGuiSource.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/PlatformHashgraphGuiSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/StateHierarchy.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/StateHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2017-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/SwirldMenu.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/SwirldMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinBrowser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2017-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTab2Consensus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTab2Consensus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTab2Stats.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTab2Stats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabAddresses.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabAddresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabCalls.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabCalls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabNetwork.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabPosts.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabPosts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabSecurity.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabSwirlds.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabSwirlds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/GuiModel.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/GuiModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoApp.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoEntity.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoMember.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoSwirld.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/InfoSwirld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/Reference.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/WordList.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/model/WordList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheck.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthChecker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/clock/OSClockSourceSpeedCheck.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/clock/OSClockSourceSpeedCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/clock/OSClockSpeedSourceChecker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/clock/OSClockSpeedSourceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/EntropySource.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/EntropySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/OSEntropyCheck.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/OSEntropyCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/OSEntropyChecker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/OSEntropyChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/SecureRandomSupplier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/entropy/SecureRandomSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/filesystem/OSFileSystemCheck.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/filesystem/OSFileSystemCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/filesystem/OSFileSystemChecker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/filesystem/OSFileSystemChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/heartbeats/HeartbeatProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/heartbeats/HeartbeatProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/intake/EventIntakePhase.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/intake/EventIntakePhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ArrayLimitExceededException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ArrayLimitExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ConsensusRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ConsensusRound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/Deserializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/EventImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/EventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/Serializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/SignedStateLoadingException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/SignedStateLoadingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/SubSetting.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/SubSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/PlatformStatusChangeListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/PlatformStatusChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/PlatformStatusChangeNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/PlatformStatusChangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/ReconnectCompleteListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/ReconnectCompleteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/ReconnectCompleteNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/ReconnectCompleteNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateLoadedFromDiskCompleteListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateLoadedFromDiskCompleteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateLoadedFromDiskNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateLoadedFromDiskNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateWriteToDiskCompleteListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateWriteToDiskCompleteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateWriteToDiskCompleteNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/listeners/StateWriteToDiskCompleteNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/AddedEventMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/AddedEventMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ConsensusHandlingMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ConsensusHandlingMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ConsensusMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ConsensusMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ConsensusMetricsImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ConsensusMetricsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/EventIntakeMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/EventIntakeMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/IssMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/IssMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ReconnectMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ReconnectMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/RuntimeMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/RuntimeMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/SwirldStateMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/SwirldStateMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/SyncMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/SyncMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/TransactionMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/TransactionMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ByteConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ByteConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/Connection.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ConnectionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ConnectionTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ConnectionTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ExternalIpAddress.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ExternalIpAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/InboundConnectionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/InboundConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/IpAddressStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/IpAddressStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/Network.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/Network.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkProtocolException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkProtocolException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkStatsTransmitter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkStatsTransmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/OutboundConnectionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/OutboundConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/RandomGraph.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/RandomGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConnection.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiationException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiationProtocols.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiationProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/Negotiator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/Negotiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiatorBytes.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiatorBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiatorThread.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiatorThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/handshake/HandshakeException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/handshake/HandshakeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/handshake/HashCompareHandshake.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/handshake/HashCompareHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/handshake/VersionCompareHandshake.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/handshake/VersionCompareHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/InitialState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/InitialState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/NegotiationState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/NegotiationState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/NegotiationStateWithDescription.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/NegotiationStateWithDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/ProtocolNegotiated.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/ProtocolNegotiated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/ReceivedInitiate.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/ReceivedInitiate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/SentInitiate.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/SentInitiate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/SentKeepalive.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/SentKeepalive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/Sleep.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/Sleep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/WaitForAcceptReject.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/states/WaitForAcceptReject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connection/NotConnectedConnection.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connection/NotConnectedConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/ConnectionServer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/ConnectionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/InboundConnectionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/InboundConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/OutboundConnectionCreator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/OutboundConnectionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/SocketFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/SocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/TcpFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/TcpFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/TlsFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/TlsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/Protocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ProtocolRunnable.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ProtocolRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/topology/NetworkTopology.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/topology/NetworkTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/topology/StaticConnectionManagers.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/topology/StaticConnectionManagers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/topology/StaticTopology.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/topology/StaticTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/ConsensusRoundObserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/ConsensusRoundObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/EventAddedObserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/EventAddedObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/EventObserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/EventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/EventObserverDispatcher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/EventObserverDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/PreConsensusEventObserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/PreConsensusEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/StaleEventObserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/observers/StaleEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/SignatureVerifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/SignatureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/StateProof.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/StateProof.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/NodeSignature.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/NodeSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofSerialization.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofTreeBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofTreeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/algorithms/StateProofUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/AbstractStateProofNode.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/AbstractStateProofNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofInternalNode.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofInternalNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofNode.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofOpaqueNode.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofOpaqueNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofPayload.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/proof/tree/StateProofPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/DefaultSignedStateValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/DefaultSignedStateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectController.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerThrottle.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectThrottle.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectLearner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTeacher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTeacher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencySignedStateValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/emergency/EmergencySignedStateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EmergencyRecoveryManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EmergencyRecoveryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/RecoveryScratchpad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/RecoveryScratchpad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Bootstrap.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Bootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/EmergencyRecoveryFile.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/EmergencyRecoveryFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Intervals.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Intervals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Location.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Location.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Package.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Package.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Recovery.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Recovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Stream.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/emergencyfile/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamLowerBound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamLowerBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamMultiFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamMultiFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamPathIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamPathIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamRoundIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamRoundIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamRoundLowerBound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamRoundLowerBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamSingleFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamSingleFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamSingleFileRepairIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamSingleFileRepairIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamSingleFileRepairer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamSingleFileRepairer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamTimestampLowerBound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamTimestampLowerBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/MultiFileRunningHashIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/MultiFileRunningHashIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/ObjectStreamIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/ObjectStreamIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveredState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveredState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/StreamedRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/StreamedRound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/Roster.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/Roster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterDiff.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterDiffGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterDiffGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterEntry.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/UpdatedRoster.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/UpdatedRoster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/legacy/AddressBookRoster.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/legacy/AddressBookRoster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/legacy/AddressRosterEntry.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/legacy/AddressRosterEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/DualStateImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/DualStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/GenesisStateBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/GenesisStateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/LegacyPlatformState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/LegacyPlatformState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MinGenInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MinGenInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookNetworkUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookNetworkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCat.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCd.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorClear.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorClear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCp.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorExec.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorExec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorExit.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorHash.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorHelp.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLs.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorOperation.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorPwd.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorPwd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRehash.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRehash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorResize.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRm.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSwap.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSwap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/ConsensusHashManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/ConsensusHashManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssScratchpad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssScratchpad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/ConsensusHashFinder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/ConsensusHashFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/ConsensusHashStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/ConsensusHashStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/HashPartition.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/HashPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/HashValidityStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/HashValidityStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/RoundHashValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/RoundHashValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/EmergencyStateNexus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/EmergencyStateNexus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/LatestCompleteStateNexus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/LatestCompleteStateNexus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/SignedStateNexus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/SignedStateNexus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateHasEnoughSignaturesListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateHasEnoughSignaturesListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateHasEnoughSignaturesNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateHasEnoughSignaturesNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateLacksSignaturesListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateLacksSignaturesListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateLacksSignaturesNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateLacksSignaturesNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateSelfSignedListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateSelfSignedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateSelfSignedNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/notifications/StateSelfSignedNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/DeserializedSignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/DeserializedSignedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/LoadableFromSignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/LoadableFromSignedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/MismatchedNodes.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/MismatchedNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/PreconsensusEventFileRenamed.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/PreconsensusEventFileRenamed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/ReservedSignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/ReservedSignedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateMetadataField.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateMetadataField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SigSet.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SigSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignatureSummary.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignatureSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateComparison.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFilePath.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFilePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFinder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateGarbageCollector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateGarbageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateHasher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateHistory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateInvalidException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateInvalidException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2017-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateMap.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateReference.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateSentinel.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateSentinel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidationData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SourceOfSignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SourceOfSignedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StateDumpRequest.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StateDumpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StateSavingResult.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StateSavingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StateToDiskReason.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StateToDiskReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AtomicAverage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AtomicAverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AtomicMax.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AtomicMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageAndMax.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageAndMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageAndMaxTimeStat.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageAndMaxTimeStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageStat.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageTimeStat.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/AverageTimeStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/CycleTimingStat.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/CycleTimingStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/MaxStat.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/MaxStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/StatConstructor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/StatConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/atomic/AtomicSumAndCount.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/atomic/AtomicSumAndCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/AccumulatedCycleMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/AccumulatedCycleMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleBusyTime.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleBusyTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleDefinition.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/CycleTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/IntervalPercentageMetric.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/IntervalPercentageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/PercentageMetric.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/cycle/PercentageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/simple/AccumulatedAverageTime.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/stats/simple/AccumulatedAverageTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/swirldapp/AppLoaderException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/swirldapp/AppLoaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/swirldapp/SwirldAppLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/swirldapp/SwirldAppLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/BasicSoftwareVersion.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/BasicSoftwareVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/InitTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/InitTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Platform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/PlatformConstructionException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/PlatformConstructionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/PlatformIdentity.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/PlatformIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/PlatformStatNames.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/PlatformStatNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/ReachedConsensus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/ReachedConsensus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Round.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Round.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Shutdown.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Shutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SoftwareVersion.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SoftwareVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/StateAccessor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/StateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SystemExitCode.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SystemExitCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SystemExitUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SystemExitUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/TransactionSubmitter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/TransactionSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/UptimeData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/UptimeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/Address.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBook.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/internal/AddressBookIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/internal/AddressBookIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/BaseEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/BaseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/BaseEventHashedData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/BaseEventHashedData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/BaseEventUnhashedData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/BaseEventUnhashedData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/ConsensusData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/ConsensusData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/ConsensusEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/ConsensusEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DetailedConsensusEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DetailedConsensusEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/Event.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventConstants.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventDescriptor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventSerializationOptions.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventSerializationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/PlatformEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/PlatformEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/IssListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/IssListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/IssNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/IssNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewRecoveredStateListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewRecoveredStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewRecoveredStateNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewRecoveredStateNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewSignedStateListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewSignedStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewSignedStateNotification.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/NewSignedStateNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/IllegalPlatformStatusException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/IllegalPlatformStatusException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusGetter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusStateMachine.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/StatusActionSubmitter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/StatusActionSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/CatastrophicFailureAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/CatastrophicFailureAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/DoneReplayingEventsAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/DoneReplayingEventsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/EmergencyReconnectStartedAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/EmergencyReconnectStartedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/FallenBehindAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/FallenBehindAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/FreezePeriodEnteredAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/FreezePeriodEnteredAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/PlatformStatusAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/PlatformStatusAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/ReconnectCompleteAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/ReconnectCompleteAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/SelfEventReachedConsensusAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/SelfEventReachedConsensusAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/StartedReplayingEventsAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/StartedReplayingEventsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/StateWrittenToDiskAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/StateWrittenToDiskAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/TimeElapsedAction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/TimeElapsedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ActiveStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ActiveStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/BehindStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/BehindStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/CatastrophicFailureStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/CatastrophicFailureStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/CheckingStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/CheckingStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/FreezeCompleteStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/FreezeCompleteStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/FreezingStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/FreezingStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ObservingStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ObservingStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/PlatformStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/PlatformStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReplayingEventsStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReplayingEventsStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/StartingUpStatusLogic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/StartingUpStatusLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/ConsensusTransaction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/ConsensusTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/ConsensusTransactionImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/ConsensusTransactionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/StateSignatureTransaction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/StateSignatureTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SwirldTransaction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SwirldTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransaction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransactionBitsPerSecond.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransactionBitsPerSecond.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransactionPing.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransactionPing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransactionType.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/SystemTransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/Transaction.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/transaction/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsReportData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsReportData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestIdentifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestReportGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestReportGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestReportRow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestReportRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestResult.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/JrsTestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/TestStatus.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/testreader/TestStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/threading/PauseAndClear.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/threading/PauseAndClear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/threading/PauseAndLoad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/threading/PauseAndLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/MutableUptimeData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/MutableUptimeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/NodeUptimeData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/NodeUptimeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeDataImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeTracker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/uptime/UptimeTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/CommandResult.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/CommandResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/DeadlockSentinel.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/DeadlockSentinel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/EventStreamSigningUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/EventStreamSigningUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/FileSigningUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/FileSigningUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/HashLogger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/HashLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MetricsDocUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MetricsDocUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/PlatformComponents.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/PlatformComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/ProgressIndicator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/ProgressIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/VirtualTerminal.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/VirtualTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/iterator/SkippingIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/iterator/SkippingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/iterator/TypedIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/iterator/TypedIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/ClearTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/ClearTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/EventDeduplicatorWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/EventDeduplicatorWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/EventSignatureValidatorWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/EventSignatureValidatorWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/InOrderLinkerWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/InOrderLinkerWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/InternalEventValidatorWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/InternalEventValidatorWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/LinkedEventIntakeWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/LinkedEventIntakeWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/OrphanBufferWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/OrphanBufferWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulers.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulersConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulersConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/SignedStateFileManagerWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/SignedStateFileManagerWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/SignedStateReserver.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/SignedStateReserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/StateSignerWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/StateSignerWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ApplicationTransactionPrehandlerWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ApplicationTransactionPrehandlerWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/DoneStreamingPcesTrigger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/DoneStreamingPcesTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/EventCreationManagerWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/EventCreationManagerWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/EventHasherWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/EventHasherWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/StateSignatureCollectorWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/StateSignatureCollectorWiring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/constructable/ConstructableRegistryTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/constructable/ConstructableRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ApplicationDefinitionLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ApplicationDefinitionLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ConsensusImplTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ConsensusImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ConsensusRoundTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ConsensusRoundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DispatchBuilderUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DispatchBuilderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DispatchFlowchartTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DispatchFlowchartTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DispatchTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DispatchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyEventQueue.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyEventQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyHashgraph.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyHashgraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyMessageDigest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/DummyMessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/EventImplTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/EventImplTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/NetworkTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/NetworkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ReconnectThrottleTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ReconnectThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SerializableStreamTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SerializableStreamTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StatsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SwirldStateManagerFreezePeriodCheckerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SwirldStateManagerFreezePeriodCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SwirldTransactionSubmitterTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SwirldTransactionSubmitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SyncManagerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SyncManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/TestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/UserEventParserTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/UserEventParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/UtilitiesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/UtilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/chatter/config/ChatterConfigTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/chatter/config/ChatterConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/chatter/protocol/output/OtherEventDelayTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/chatter/protocol/output/OtherEventDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/appcomm/AppCommComponentTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/appcomm/AppCommComponentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/StateManagementComponentTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/StateManagementComponentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/StateToDiskAttempt.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/StateToDiskAttempt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/TestPrioritySystemTransactionConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/TestPrioritySystemTransactionConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/TestSavedStateController.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/TestSavedStateController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/TestSignedStateWrapperConsumer.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/state/TestSignedStateWrapperConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/AddressBookConfigTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/AddressBookConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/ConfigMappingsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/ConfigMappingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/SequentialRingBufferTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/SequentialRingBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/KeysAndCertsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/KeysAndCertsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/DetGenerateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/DetGenerateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/DetailedConsensusEventTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/DetailedConsensusEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/EventDeduplicatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/EventDeduplicatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/orphan/OrphanBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/orphan/OrphanBufferTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/InternalEventValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/InternalEventValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/SignatureValidatorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/SignatureValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/AbstractEventHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/AbstractEventHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusQueueTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusQueueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusRoundHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusRoundHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/PreConsensusEventHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/PreConsensusEventHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/exceptions/ExceptionAssertions.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/exceptions/ExceptionAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/exceptions/ExceptionTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/exceptions/ExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/DefaultIntakeEventCounterTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/DefaultIntakeEventCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/SyncPermitProviderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/SyncPermitProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSClockSourceSpeedCheckTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSClockSourceSpeedCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSEntropyCheckTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSEntropyCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSFileSystemCheckTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSFileSystemCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSHealthCheckUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/health/OSHealthCheckUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/heartbeat/HeartbeatProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/heartbeat/HeartbeatProtocolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/SocketFactoryTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/SocketFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/proof/FakeSignatureBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/proof/FakeSignatureBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/proof/StateProofTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/proof/StateProofTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DummyConnection.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DummyConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/RandomVirtualMapReconnectTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/RandomVirtualMapReconnectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestKey.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestKeySerializer.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestValue.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestValueSerializer.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/TestValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectProtocolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencySignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencySignedStateValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventRecoveryWorkflowTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventRecoveryWorkflowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamMultiFileIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamMultiFileIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamPathIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamPathIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamRoundIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamRoundIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamSingleFileIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamSingleFileIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/ObjectStreamIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/ObjectStreamIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/RecoveryTestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/RecoveryTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterDiffGeneratorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterDiffGeneratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/legacy/AddressBookRosterTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/legacy/AddressBookRosterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/EmergencyRecoveryFileTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/EmergencyRecoveryFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/RandomSignedStateGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SigSetTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SigSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateManagerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateManagerTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateMapTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateReferenceTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateReferenceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/TransactionHandlerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/TransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AbstractSignedStateManagerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AbstractSignedStateManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AddIncompleteStateTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AddIncompleteStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/EarlySignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/EarlySignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SignedStateManagerBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SignedStateManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SignedStateManagerTestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SignedStateManagerTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/nexus/SignedStateNexusTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/nexus/SignedStateNexusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/ReservedSignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/ReservedSignedStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/stats/CycleTimingStatTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/stats/CycleTimingStatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/PeerAgnosticSyncChecksTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/PeerAgnosticSyncChecksTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/SyncProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/SyncProtocolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/BasicSoftwareVersionTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/BasicSoftwareVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/PlatformStatusStateMachineTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/PlatformStatusStateMachineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ActiveStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ActiveStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/BehindStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/BehindStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/CatastrophicFailureStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/CatastrophicFailureStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/CheckingStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/CheckingStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/FreezeCompleteStateStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/FreezeCompleteStateStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/FreezingStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/FreezingStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ObservingStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ObservingStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ReplayingEventsStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/ReplayingEventsStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/StartingUpStatusLogicTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/StartingUpStatusLogicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/StatusLogicTestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/status/logic/StatusLogicTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/transaction/TransactionTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/transaction/TransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/transaction/internal/TransactionSerializationTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/transaction/internal/TransactionSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/DeadlockSentinelTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/DeadlockSentinelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/EventStreamSigningUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/EventStreamSigningUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/HashLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/MetricsDocUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/MetricsDocUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/VirtualTerminalTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/VirtualTerminalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/iterator/SkippingIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/iterator/SkippingIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/iterator/TypedIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/iterator/TypedIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/SimpleScratchpad.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/SimpleScratchpad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/DynamicValue.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/DynamicValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/DynamicValueGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/DynamicValueGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/EventUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/EventUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/IndexedEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/IndexedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/RandomEventUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/RandomEventUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/AbstractGraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/AbstractGraphGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/GraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/GraphGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/source/AbstractEventSource.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/source/AbstractEventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/source/EventSource.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/source/EventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/source/StandardEventSource.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/source/StandardEventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/AbstractDummySwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/AbstractDummySwirldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/DummySwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/DummySwirldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/stream/StreamUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/stream/StreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-sign-tool/build.gradle.kts
+++ b/platform-sdk/swirlds-sign-tool/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-sign-tool/src/main/java/com/swirlds/signingtool/FileSignTool.java
+++ b/platform-sdk/swirlds-sign-tool/src/main/java/com/swirlds/signingtool/FileSignTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-sign-tool/src/test/java/com/swirlds/signingtool/FileSignToolTest.java
+++ b/platform-sdk/swirlds-sign-tool/src/test/java/com/swirlds/signingtool/FileSignToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/logging/MockAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/BlockingInputStream.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/BlockingInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/BlockingOutputStream.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/BlockingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyBinaryMerkleInternal.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyBinaryMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyCustomReconnectRoot.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyCustomReconnectRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyLearnerTreeView.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyLearnerTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyListLeaf.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyListLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleExternalLeaf.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleExternalLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleInternal.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleInternal2.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleInternal2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleLeaf.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleLeaf2.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleLeaf2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleNode.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyMerkleNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyTeacherTreeView.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/DummyTeacherTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/SelfHashingDummyMerkleLeaf.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/dummy/SelfHashingDummyMerkleLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/AverageLeafDepth.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/AverageLeafDepth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/LaggingAsyncOutputStream.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/LaggingAsyncOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/LaggingLearningSynchronizer.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/LaggingLearningSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/LaggingTeachingSynchronizer.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/LaggingTeachingSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/MerkleTestUtils.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/MerkleTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/PairedStreams.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/main/java/com/swirlds/common/test/merkle/util/PairedStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/AbstractListLeafTest.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/AbstractListLeafTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/AsyncStreamTest.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/AsyncStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/ExplodingSelfSerializable.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/ExplodingSelfSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleCopyTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleCopyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleHashBenchmarks.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleHashBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleHashTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleHashTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleIterationTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleIterationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleMemoryEstimator.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleMemoryEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleMetaTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleMetaTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerklePathReplacementTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerklePathReplacementTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleReferenceCountingTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleReferenceCountingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleRehashTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleRehashTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleRouteTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleRouteTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleSynchronizationBenchmarks.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleSynchronizationBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleSynchronizationTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/MerkleSynchronizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/PartialNodeTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/PartialNodeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/dummy/SelfHashingDummyMerkleLeafTest.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/merkle/dummy/SelfHashingDummyMerkleLeafTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/ResourceLoader.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/ResourceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/ResourceNotFoundException.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/ResourceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestComponentTags.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestComponentTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestQualifierTags.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestQualifierTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestTypeTags.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestTypeTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestWiringModelBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/TestWiringModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/config/TestConfigBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/config/TestConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/context/TestPlatformContextBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/context/TestPlatformContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/NoOpConsensusMetrics.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/NoOpConsensusMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/PlatformStateUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/PlatformStateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SignedStateUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SignedStateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SimpleEventGenerator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SimpleEventGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/ChatterWrapper.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/ChatterWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/EventDedup.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/EventDedup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/GossipEventObserver.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/GossipEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/GossipPayload.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/GossipPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/PayloadHandler.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/PayloadHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/PayloadProvider.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/PayloadProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/SimulatedChatter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/SimulatedChatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/SimulatedChatterFactories.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/SimulatedChatterFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/SimulatedChatterFactory.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/SimulatedChatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/EventTracker.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/EventTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipCSV.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipCSV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipSimulation.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipSimulation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipSimulationBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipSimulationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipSimulationUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/GossipSimulationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedEvent.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedMessage.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedNetwork.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedNetworkStatistics.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedNetworkStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedNode.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SimulatedNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SourceDestinationPair.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/SourceDestinationPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/TrackedEvent.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/chatter/simulator/TrackedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/ConsensusUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/ConsensusUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/GenerateConsensus.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/GenerateConsensus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusOutput.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestNode.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestOrchestrator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestOrchestrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/OrchestratorBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/OrchestratorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/TestInput.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/TestInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/ConsensusOutputValidation.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/ConsensusOutputValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/ConsensusRoundValidation.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/ConsensusRoundValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/EventRatioValidation.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/EventRatioValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/InputEventsValidation.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/InputEventsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/NoEventsLost.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/NoEventsLost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/TimestampChecker.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/TimestampChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/Validations.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/validation/Validations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/SimpleEvent.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/SimpleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/AbstractEventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/AbstractEventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/BufferingEventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/BufferingEventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/CollectingEventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/CollectingEventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/EventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/EventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/EventEmitterFactory.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/EventEmitterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/EventEmitterGenerator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/EventEmitterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/PriorityEventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/PriorityEventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/ShuffledEventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/ShuffledEventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/StandardEventEmitter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/emitter/StandardEventEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/source/EventSourceFactory.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/source/EventSourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/source/ForkingEventSource.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/source/ForkingEventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/source/WeightedGraphGenerator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/event/source/WeightedGraphGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/gui/HashgraphGuiRunner.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/gui/HashgraphGuiRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/gui/TestGuiSource.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/gui/TestGuiSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/AddedAndStale.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/AddedAndStale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/AddedObserver.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/AddedObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/ConsRound.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/ConsRound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/ObservationType.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/ObservationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/PreConsensusObserver.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/PreConsensusObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/SimpleConsensusRoundTracker.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/SimpleConsensusRoundTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/SimpleEventTracker.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/SimpleEventTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/StaleObserver.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/observers/StaleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/GossipMessage.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/GossipMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/GossipMessageHandler.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/GossipMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/Latency.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/Latency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/NetworkLatency.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/NetworkLatency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/RandomSigner.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/RandomSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/SimpleSimulatedGossip.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/SimpleSimulatedGossip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/MapBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/MapBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/NetworkConfig.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/NetworkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/NodeConfig.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/NodeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/NodeConfigBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/NodeConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/system/NoExitSecurityManager.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/system/NoExitSecurityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/system/SystemExitException.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/system/SystemExitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/utils/EqualsVerifier.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/utils/EqualsVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/DispatchBuilderUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/DispatchBuilderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/EventStringsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/EventStringsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformDataTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformDataTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformStateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SerializationDebugTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SerializationDebugTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SerializationTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SignedStateSynchronizationTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SignedStateSynchronizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SocketConnectionTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SocketConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterCoreTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterCoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterNotifierTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterNotifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterProtocolTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterSyncTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/GossipBenchmarksTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/GossipBenchmarksTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/NetworkTestChatter.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/NetworkTestChatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/PrepareChatterEventTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/PrepareChatterEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/SimulatorTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/SimulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/ChatterSimulationTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/ChatterSimulationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/CountingChatterEvent.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/CountingChatterEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/CountingEventDescriptor.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/CountingEventDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/DelayableIntakeQueue.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/DelayableIntakeQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/EventDeduper.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/EventDeduper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/GossipEventTracker.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/GossipEventTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/InOrderOrphanBuffer.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/InOrderOrphanBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/NoOpSimulatedEventPipeline.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/NoOpSimulatedEventPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/TimedEventCreator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/TimedEventCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/AbstractSimulatedEventPipeline.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/AbstractSimulatedEventPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/ChatterInstance.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/ChatterInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/Network.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/Network.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NetworkSimulator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NetworkSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NetworkSimulatorParams.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NetworkSimulatorParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/Node.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NodeBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NodeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NodeConfigurable.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/NodeConfigurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedChatterEvent.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedChatterEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedEventCreator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedEventCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedEventPipeline.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedEventPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedEventPipelineBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/network/framework/SimulatedEventPipelineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/heartbeat/HeartbeatTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/heartbeat/HeartbeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/heartbeat/PingChecker.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/heartbeat/PingChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/input/InputDelegateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/input/InputDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/messages/EventDescriptorTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/messages/EventDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/output/TimeDelayTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/output/TimeDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/output/VariableTimeDelayTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/output/VariableTimeDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/peer/CommunicationStateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/peer/CommunicationStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/processing/ProcessingTimeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/protocol/processing/ProcessingTimeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamReportingToolTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamReportingToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamSingleFileRepairTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamSingleFileRepairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/ConsensusSystemTransactionManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/ConsensusSystemTransactionManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/EventIntakeTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/EventIntakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/EventObserverDispatcherTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/EventObserverDispatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/EventUtilsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/EventUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/MockRandom.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/MockRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/PreConsensusSystemTransactionManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/PreConsensusSystemTransactionManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/TransactionHandlingTestUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/components/TransactionHandlingTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/AncestorSearchTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/AncestorSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestArgs.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestDefinitions.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestDefinitions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestParams.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestRunner.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/EventEmitterTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/EventEmitterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/GraphGeneratorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/GraphGeneratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/IntakeAndConsensusTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/IntakeAndConsensusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/RoundNumberProviderTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/RoundNumberProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventImplTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventMocks.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventMocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventUtilsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/GossipEventBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/GossipEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/GossipEventTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/GossipEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/creation/EventCreationExpectedResults.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/creation/EventCreationExpectedResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/creation/EventCreationSimulationParams.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/creation/EventCreationSimulationParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/creation/EventCreationSimulationResults.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/creation/EventCreationSimulationResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/intake/OrphanEventsIntakeTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/intake/OrphanEventsIntakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/linking/OrphanBufferTester.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/linking/OrphanBufferTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/linking/OrphanBufferingLinkerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/linking/OrphanBufferingLinkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/AsyncPreconsensusEventWriterTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/AsyncPreconsensusEventWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesWriterTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventFileManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventFileManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventFileTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventReadWriteTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventReadWriteTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventReplayPipelineTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventReplayPipelineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventReplayWorkflowTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventReplayWorkflowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventStreamSequencerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PreconsensusEventStreamSequencerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/SyncPreconsensusEventWriterTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/SyncPreconsensusEventWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/ChildlessEventTrackerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/ChildlessEventTrackerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/EventCreationManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/EventCreationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/EventCreationRulesTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/EventCreationRulesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/SyncEventCreationManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/SyncEventCreationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetAdvancementWeightTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetAdvancementWeightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetEventCreatorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetEventCreatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetTrackerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetTrackerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetWeightCalculatorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetWeightCalculatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/validation/EventValidatorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/validation/EventValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/validation/TestGossipEventValidator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/validation/TestGossipEventValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/OtherParentMatrixFactory.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/OtherParentMatrixFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/PartitionedGraphCreator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/PartitionedGraphCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/SimpleGraphs.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/SimpleGraphs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/SplitForkGraphCreator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/SplitForkGraphCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/gui/HashgraphGuiTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/gui/HashgraphGuiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/ConnectionServerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/ConnectionServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/ConnectionTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/FakeConnection.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/FakeConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/InboundConnectionManagerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/InboundConnectionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/NetworkUtilsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/NetworkUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionCreatorTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionManagerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/StaticConnectionManagersTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/StaticConnectionManagersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/TopologyTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/TopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/InvalidNegotiationsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/InvalidNegotiationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/NegotiationProtocolsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/NegotiationProtocolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/NegotiatorStateTransitionTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/NegotiatorStateTransitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/NegotiatorTestSuite.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/NegotiatorTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/OutputCheck.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/OutputCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/ReadWriteFakeConnection.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/ReadWriteFakeConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/TestInput.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/TestInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/TestProtocol.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/TestProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/HashHandshakeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/HashHandshakeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/VersionHandshakeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/VersionHandshakeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ChatterNetworkTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ChatterNetworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ExpiringConnection.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ExpiringConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorMultithreadedTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorMultithreadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorPair.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ReturnOnceConnectionManager.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ReturnOnceConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/TestNegotiator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/TestNegotiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/reconnect/FallenBehindManagerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/reconnect/FallenBehindManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/ConsensusHashFinderTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/ConsensusHashFinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/ConsensusHashManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/ConsensusHashManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssHandlerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssMetricsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/RoundHashValidatorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/RoundHashValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/SignedStateComparisonTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/SignedStateComparisonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AccumulatedAverageTimeTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AccumulatedAverageTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AtomicAverageTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AtomicAverageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AtomicMaxTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AtomicMaxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AtomicSumAndCountTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/AtomicSumAndCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/CycleMetricsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stats/CycleMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stream/StreamSignTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/stream/StreamSignTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ConnectionFactory.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/EventEquality.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/EventEquality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/EventFactory.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/EventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/GenerationsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/GenerationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/HashGenerator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/HashGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/LocalConnection.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/LocalConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ShadowEventTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ShadowEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ShadowGraphTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ShadowGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncExceptionTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncFilteringTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncFilteringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncNode.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestExecutor.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestParams.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestUtilsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTestUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncValidator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/Synchronizer.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/Synchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/TestingSyncManager.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/TestingSyncManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/system/SystemUtilsTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/system/SystemUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/threading/PauseAndDoTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/threading/PauseAndDoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/AccountFactory.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/AccountFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/BenchmarkAccount.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/BenchmarkAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/BenchmarkKey.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/BenchmarkKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/MerkleMapBenchmarkMetadata.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/MerkleMapBenchmarkMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/MerkleMapBenchmarkUtils.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/MerkleMapBenchmarkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/RandomKeySet.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/RandomKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/CreateAccountOperation.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/CreateAccountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/DeleteAccountOperation.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/DeleteAccountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/ReadBalanceOperation.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/ReadBalanceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/TransferOperation.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/benchmark/operations/TransferOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/AccessibleMerkleMap.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/AccessibleMerkleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/DummyFCQueueElement.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/DummyFCQueueElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/FCMapComplexValue.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/FCMapComplexValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/FCQValue.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/FCQValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/SimpleValue.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/dummy/SimpleValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/EntityType.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/ExpectedValue.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/ExpectedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/LifecycleStatus.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/LifecycleStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/SaveExpectedMapHandler.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/SaveExpectedMapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/TransactionState.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/TransactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/TransactionType.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/lifecycle/TransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/MapKey.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/MapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/MapValue.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/MapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/MerkleMapKey.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/MerkleMapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/TransactionRecord.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/pta/TransactionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/serialization/MapKeyDeserializer.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/serialization/MapKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/AbstractPerformanceTest.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/AbstractPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/KeyValueProvider.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/KeyValueProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/MapMutatorSet.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/MapMutatorSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/MerkleMapTestUtil.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/main/java/com/swirlds/merkle/map/test/util/MerkleMapTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/KeyTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/KeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MMSerializeTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MMSerializeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapEntryKeyTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapEntryKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapEntryTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapEntryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapMemoryBenchmark.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapMemoryBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapMemoryTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapMemoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapPerformanceTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapPerformanceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/ValueTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/ValueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/benchmark/MerkleMapBenchmark.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/benchmark/MerkleMapBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/lifecycle/ExpectedValueTest.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/lifecycle/ExpectedValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/pta/MapValueTest.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/pta/MapValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleBinaryTreePerformanceTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleBinaryTreePerformanceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleBinaryTreeTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleBinaryTreeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleMapEntryTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleMapEntryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleTreeInternalNodeTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/MerkleTreeInternalNodeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/internal/BitUtilTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/tree/test/internal/BitUtilTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/build.gradle.kts
+++ b/platform-sdk/swirlds-virtualmap/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/jmh/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayBench.java
+++ b/platform-sdk/swirlds-virtualmap/src/jmh/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualKey.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualLongKey.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualLongKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMapMigration.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMapMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualValue.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSourceBuilder.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSourceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashRecord.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualKeySet.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualLeafRecord.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualLeafRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/ConcurrentNodeStatusTracker.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/ConcurrentNodeStatusTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/Path.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/Path.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/VirtualStateAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/VirtualStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/ArrayHashingQueue.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/ArrayHashingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/CompoundHashingQueue.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/CompoundHashingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/HashJob.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/HashJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/HashingQueue.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/HashingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/PeekIterator.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/PeekIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHashListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/AbstractHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/AbstractHashListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/FullLeafRehashHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/FullLeafRehashHashListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualInternalNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualInternalNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualLeafNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualLeafNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapState.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualStateAccessorImpl.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualStateAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/PipelineList.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/PipelineList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/PipelineListNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/PipelineListNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/BooleanBitSetQueue.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/BooleanBitSetQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBitSetQueue.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBitSetQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIterator.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectState.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualLearnerTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualLearnerTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTeacherTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTeacherTreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTreeViewBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTreeViewBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/TestKey.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/TestKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/TestValue.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/TestValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapHashingTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapHashingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapLifecycleTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapLifecycleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapRandomTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapRandomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapStatisticsTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTestUtils.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapValidator.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/config/VirtualMapConfigTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/config/VirtualMapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/InMemoryBuilder.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/InMemoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/InMemoryDataSource.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/InMemoryDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/InMemoryKeySet.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/InMemoryKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashRecordTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualLeafRecordTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualLeafRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/ConcurrentNodeStatusTrackerTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/ConcurrentNodeStatusTrackerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/PathTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/PathTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/MTModifyTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/MTModifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/ArrayHashingQueueTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/ArrayHashingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/CompoundHashingQueueTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/CompoundHashingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/HashingQueueTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/HashingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/PeekIteratorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/PeekIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherHugeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherHugeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/DummyVirtualStateAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/DummyVirtualStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImplTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualInternalNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualInternalNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualLeafNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualLeafNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualMerkleNavigationTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualMerkleNavigationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeHashingTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeHashingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/BooleanBitSetQueueTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/BooleanBitSetQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBitSetQueueTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBitSetQueueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIteratorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ConcurrentBlockingIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/RandomVirtualMapReconnectTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/RandomVirtualMapReconnectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectStateTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapLargeReconnectTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapLargeReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds/build.gradle.kts
+++ b/platform-sdk/swirlds/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update copyrights to 2024 on the repo to avoid unnecessary large diffs on PRs