### PR TITLE
chore: account for staking records in various specs

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4263,7 +4263,9 @@ public class TraceabilitySuite extends HapiSuite {
                                     hapiGetContractBytecode);
                             expectContractBytecode(
                                     specName,
-                                    topLevelCallTxnRecord.getChildRecord(0).getConsensusTimestamp(),
+                                    topLevelCallTxnRecord
+                                            .getFirstNonStakingChildRecord()
+                                            .getConsensusTimestamp(),
                                     asContract(mirrorLiteralId.get()),
                                     ByteStringUtils.wrapUnsafely(testContractInitcode.get()),
                                     ByteStringUtils.wrapUnsafely(bytecodeFromMirror.get()));
@@ -5110,7 +5112,9 @@ public class TraceabilitySuite extends HapiSuite {
                                     hapiGetContractBytecode);
                             expectContractBytecode(
                                     specName,
-                                    topLevelCallTxnRecord.getChildRecord(0).getConsensusTimestamp(),
+                                    topLevelCallTxnRecord
+                                            .getFirstNonStakingChildRecord()
+                                            .getConsensusTimestamp(),
                                     asContract(mergedContractIdAsString),
                                     ByteStringUtils.wrapUnsafely(testContractInitcode.get()),
                                     ByteStringUtils.wrapUnsafely(mergedContractBytecode.get()));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -183,8 +183,10 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
 
                     allRunFor(spec, cryptoTransferWithLazyCreate, getHollowAccountInfoAfterCreation, hapiGetTxnRecord);
 
-                    final AccountID newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final AccountID newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
 
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
                 }))
@@ -637,8 +639,10 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                             getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                     allRunFor(spec, op, hapiGetTxnRecord);
 
-                    final AccountID newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final AccountID newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
 
                     final var secondECDSAKey = spec.registry()
@@ -655,7 +659,7 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                     allRunFor(spec, op2, secondHapiGetTxnRecord);
 
                     final AccountID anotherNewAccountID = secondHapiGetTxnRecord
-                            .getChildRecord(0)
+                            .getFirstNonStakingChildRecord()
                             .getReceipt()
                             .getAccountID();
                     spec.registry().saveAccountId(ANOTHER_SECP_256K1_SOURCE_KEY, anotherNewAccountID);
@@ -725,8 +729,10 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                     final var hapiGetTxnRecord =
                             getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                     allRunFor(spec, op1, op2, hapiGetTxnRecord);
-                    final var newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final var newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
                 }))
                 .then(withOpContext((spec, opLog) -> {
@@ -793,8 +799,10 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                     final var hapiGetTxnRecord =
                             getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                     allRunFor(spec, op1, op2, hapiGetTxnRecord);
-                    final var newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final var newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
                 }))
                 .then(withOpContext((spec, opLog) -> {
@@ -909,8 +917,10 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                     final var hapiGetTxnRecord =
                             getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                     allRunFor(spec, op, hapiGetTxnRecord);
-                    final var hollowAccountId =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final var hollowAccountId = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     // try sending from hollow through transfer precompile and with appropriate sig
                     // this should fail, since the sig is not a required sig for the ContractCall
                     final var token = spec.registry().getTokenID(ft);
@@ -996,8 +1006,10 @@ public class HollowAccountFinalizationSuite extends HapiSuite {
                         getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                 allRunFor(spec, op, op2, hapiGetTxnRecord);
 
-                final AccountID newAccountID =
-                        hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                final AccountID newAccountID = hapiGetTxnRecord
+                        .getFirstNonStakingChildRecord()
+                        .getReceipt()
+                        .getAccountID();
                 spec.registry().saveAccountId(key, newAccountID);
             })
         };

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -149,7 +149,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                     .andAllChildRecords()
                                     .logged();
                             allRunFor(spec, lookup);
-                            final var childCreation = lookup.getChildRecord(0);
+                            final var childCreation = lookup.getFirstNonStakingChildRecord();
                             maliciousEOAId.set(
                                     asAccountString(childCreation.getReceipt().getAccountID()));
                         }),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -1984,8 +1984,10 @@ public class LeakyContractTestsSuite extends HapiSuite {
                     final var getTxnRecord =
                             getTxnRecord(payTxn).andAllChildRecords().logged();
                     allRunFor(spec, getTxnRecord);
-                    final var lazyAccountId =
-                            getTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final var lazyAccountId = getTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     final var name = "lazy";
                     spec.registry().saveAccountId(name, lazyAccountId);
                     allRunFor(spec, getAccountBalance(name).hasTinyBars(depositAmount));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
@@ -761,8 +761,10 @@ public class LeakyCryptoTestsSuite extends HapiSuite {
                             getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                     allRunFor(spec, op, op2, hapiGetTxnRecord);
 
-                    final AccountID newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final AccountID newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
                 }))
                 .then(overriding(LAZY_CREATION_ENABLED, FALSE), withOpContext((spec, opLog) -> {
@@ -872,8 +874,10 @@ public class LeakyCryptoTestsSuite extends HapiSuite {
                             getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
                     allRunFor(spec, op, hapiGetTxnRecord);
 
-                    final AccountID newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final AccountID newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
 
                     final var op2 = ethereumContractCreate(CONTRACT)
@@ -1102,8 +1106,10 @@ public class LeakyCryptoTestsSuite extends HapiSuite {
 
                     allRunFor(spec, op, hapiGetTxnRecord);
 
-                    final AccountID newAccountID =
-                            hapiGetTxnRecord.getChildRecord(0).getReceipt().getAccountID();
+                    final AccountID newAccountID = hapiGetTxnRecord
+                            .getFirstNonStakingChildRecord()
+                            .getReceipt()
+                            .getAccountID();
                     spec.registry().saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
                 }))
                 .then(withOpContext((spec, opLog) -> {


### PR DESCRIPTION
**Description**:
Replaces multiple hard-coded `getChildRecord(0)` with `getFirstNonStakingRecord()`.