### PR TITLE
chore: only override Netty defaults on non-`DEV` profile; other fixes

### DIFF
--- a/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
@@ -30,6 +30,7 @@ import com.hedera.node.app.workflows.ingest.IngestWorkflow;
 import com.hedera.node.app.workflows.query.QueryWorkflow;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.data.GrpcConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.NettyConfig;
 import com.hedera.pbj.runtime.RpcMethodDefinition;
 import com.hedera.pbj.runtime.RpcServiceDefinition;
@@ -231,6 +232,7 @@ abstract class GrpcTestBase extends TestBase {
                 .withConfigDataType(MetricsConfig.class)
                 .withConfigDataType(GrpcConfig.class)
                 .withConfigDataType(NettyConfig.class)
+                .withConfigDataType(HederaConfig.class)
                 .withSource(testConfig)
                 .build();
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/netty/NettyGrpcServerManager.java
@@ -26,7 +26,9 @@ import com.hedera.node.app.workflows.ingest.IngestWorkflow;
 import com.hedera.node.app.workflows.query.QueryWorkflow;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.GrpcConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.NettyConfig;
+import com.hedera.node.config.types.Profile;
 import com.swirlds.common.metrics.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -60,21 +62,35 @@ import org.apache.logging.log4j.Logger;
  */
 @Singleton
 public final class NettyGrpcServerManager implements GrpcServerManager {
-    /** The logger instance for this class. */
+    /**
+     * The logger instance for this class.
+     */
     private static final Logger logger = LogManager.getLogger(NettyGrpcServerManager.class);
-    /** The supported ciphers for TLS */
+    /**
+     * The supported ciphers for TLS
+     */
     private static final List<String> SUPPORTED_CIPHERS = List.of(
             "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_AES_256_GCM_SHA384");
-    /** The supported protocols for TLS */
+    /**
+     * The supported protocols for TLS
+     */
     private static final List<String> SUPPORTED_PROTOCOLS = List.of("TLSv1.2", "TLSv1.3");
 
-    /** The set of {@link ServiceDescriptor}s for services that the gRPC server will expose */
+    /**
+     * The set of {@link ServiceDescriptor}s for services that the gRPC server will expose
+     */
     private final Set<ServerServiceDefinition> services;
-    /** The configuration provider, so we can figure out ports and other information. */
+    /**
+     * The configuration provider, so we can figure out ports and other information.
+     */
     private final ConfigProvider configProvider;
-    /** The gRPC server listening on the plain (non-tls) port */
+    /**
+     * The gRPC server listening on the plain (non-tls) port
+     */
     private Server plainServer;
-    /** The gRPC server listening on the plain TLS port */
+    /**
+     * The gRPC server listening on the plain TLS port
+     */
     private Server tlsServer;
 
     /**
@@ -144,10 +160,14 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
         final var startRetryIntervalMs = nettyConfig.startRetryIntervalMs();
         final var grpcConfig = configProvider.getConfiguration().getConfigData(GrpcConfig.class);
         final var port = grpcConfig.port();
+        final var profile = configProvider
+                .getConfiguration()
+                .getConfigData(HederaConfig.class)
+                .activeProfile();
 
         // Start the plain-port server
         logger.info("Starting gRPC server on port {}", port);
-        var nettyBuilder = builderFor(port, nettyConfig);
+        var nettyBuilder = builderFor(port, nettyConfig, profile);
         plainServer = startServerWithRetry(nettyBuilder, startRetries, startRetryIntervalMs);
         logger.info("gRPC server listening on port {}", plainServer.getPort());
 
@@ -158,7 +178,7 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
         try {
             final var tlsPort = grpcConfig.tlsPort();
             logger.info("Starting TLS gRPC server on port {}", tlsPort);
-            nettyBuilder = builderFor(tlsPort, nettyConfig);
+            nettyBuilder = builderFor(tlsPort, nettyConfig, profile);
             configureTls(nettyBuilder, nettyConfig);
             tlsServer = startServerWithRetry(nettyBuilder, startRetries, startRetryIntervalMs);
             logger.info("TLS gRPC server listening on port {}", tlsServer.getPort());
@@ -255,20 +275,14 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
         }
     }
 
-    /** Utility for setting up various shared configuration settings between both servers */
-    private NettyServerBuilder builderFor(final int port, NettyConfig config) {
+    /**
+     * Utility for setting up various shared configuration settings between both servers
+     */
+    private NettyServerBuilder builderFor(
+            final int port, @NonNull final NettyConfig config, @NonNull final Profile activeProfile) {
         NettyServerBuilder builder = null;
         try {
-            builder = NettyServerBuilder.forPort(port)
-                    .keepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
-                    .permitKeepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
-                    .keepAliveTimeout(config.prodKeepAliveTimeout(), TimeUnit.SECONDS)
-                    .maxConnectionAge(config.prodMaxConnectionAge(), TimeUnit.SECONDS)
-                    .maxConnectionAgeGrace(config.prodMaxConnectionAgeGrace(), TimeUnit.SECONDS)
-                    .maxConnectionIdle(config.prodMaxConnectionIdle(), TimeUnit.SECONDS)
-                    .maxConcurrentCallsPerConnection(config.prodMaxConcurrentCalls())
-                    .flowControlWindow(config.prodFlowControlWindow())
-                    .directExecutor()
+            builder = withConfigForActiveProfile(NettyServerBuilder.forPort(port), config, activeProfile)
                     .channelType(EpollServerSocketChannel.class)
                     .bossEventLoopGroup(new EpollEventLoopGroup())
                     .workerEventLoopGroup(new EpollEventLoopGroup());
@@ -276,23 +290,33 @@ public final class NettyGrpcServerManager implements GrpcServerManager {
         } catch (final UnsatisfiedLinkError | NoClassDefFoundError ignored) {
             // If we can't use Epoll, then just use NIO
             logger.info("Epoll not available, using NIO");
-            builder = NettyServerBuilder.forPort(port)
-                    .keepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
-                    .permitKeepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
-                    .keepAliveTimeout(config.prodKeepAliveTimeout(), TimeUnit.SECONDS)
-                    .maxConnectionAge(config.prodMaxConnectionAge(), TimeUnit.SECONDS)
-                    .maxConnectionAgeGrace(config.prodMaxConnectionAgeGrace(), TimeUnit.SECONDS)
-                    .maxConnectionIdle(config.prodMaxConnectionIdle(), TimeUnit.SECONDS)
-                    .maxConcurrentCallsPerConnection(config.prodMaxConcurrentCalls())
-                    .flowControlWindow(config.prodFlowControlWindow())
-                    .directExecutor();
+            builder = withConfigForActiveProfile(NettyServerBuilder.forPort(port), config, activeProfile);
         } catch (final Exception unexpected) {
             logger.info("Unexpected exception initializing Netty", unexpected);
         }
         return builder;
     }
 
-    /** Utility for setting up TLS configuration */
+    private NettyServerBuilder withConfigForActiveProfile(
+            @NonNull final NettyServerBuilder builder,
+            @NonNull final NettyConfig config,
+            @NonNull final Profile activeProfile) {
+        if (activeProfile != Profile.DEV) {
+            builder.keepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
+                    .permitKeepAliveTime(config.prodKeepAliveTime(), TimeUnit.SECONDS)
+                    .keepAliveTimeout(config.prodKeepAliveTimeout(), TimeUnit.SECONDS)
+                    .maxConnectionAge(config.prodMaxConnectionAge(), TimeUnit.SECONDS)
+                    .maxConnectionAgeGrace(config.prodMaxConnectionAgeGrace(), TimeUnit.SECONDS)
+                    .maxConnectionIdle(config.prodMaxConnectionIdle(), TimeUnit.SECONDS)
+                    .maxConcurrentCallsPerConnection(config.prodMaxConcurrentCalls())
+                    .flowControlWindow(config.prodFlowControlWindow());
+        }
+        return builder.directExecutor();
+    }
+
+    /**
+     * Utility for setting up TLS configuration
+     */
     private void configureTls(final NettyServerBuilder builder, NettyConfig config)
             throws SSLException, FileNotFoundException {
         final var tlsCrtPath = config.tlsCrtPath();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulator.java
@@ -36,6 +36,9 @@ public class SynchronizedThrottleAccumulator {
 
     private final ThrottleAccumulator frontendThrottle;
 
+    @NonNull
+    private Instant lastDecisionTime = Instant.EPOCH;
+
     @Inject
     public SynchronizedThrottleAccumulator(ThrottleAccumulator frontendThrottle) {
         this.frontendThrottle = requireNonNull(frontendThrottle, "frontendThrottle must not be null");
@@ -50,7 +53,8 @@ public class SynchronizedThrottleAccumulator {
      * @return whether the transaction should be throttled
      */
     public synchronized boolean shouldThrottle(@NonNull TransactionInfo txnInfo, HederaState state) {
-        return frontendThrottle.shouldThrottle(txnInfo, Instant.now(), state);
+        setDecisionTime();
+        return frontendThrottle.shouldThrottle(txnInfo, lastDecisionTime, state);
     }
 
     /*
@@ -63,6 +67,12 @@ public class SynchronizedThrottleAccumulator {
      * @return whether the query should be throttled
      */
     public synchronized boolean shouldThrottle(HederaFunctionality queryFunction, Query query, AccountID queryPayerId) {
-        return frontendThrottle.shouldThrottle(queryFunction, Instant.now(), query, queryPayerId);
+        setDecisionTime();
+        return frontendThrottle.shouldThrottle(queryFunction, lastDecisionTime, query, queryPayerId);
+    }
+
+    private void setDecisionTime() {
+        final var now = Instant.now();
+        lastDecisionTime = now.isBefore(lastDecisionTime) ? lastDecisionTime : now;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -277,6 +277,7 @@ public class HapiApiClients {
         if (channelPools.isEmpty()) {
             return;
         }
+        shutdownChannels();
         channelPools.clear();
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotModeOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotModeOp.java
@@ -72,7 +72,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -780,19 +779,12 @@ public class SnapshotModeOp extends UtilOp implements SnapshotOp {
 
     private Set<SnapshotMatchMode> computeMatchModesIncluding(@NonNull final SnapshotMatchMode... specialMatchModes) {
         final Set<SnapshotMatchMode> modes = new HashSet<>(Arrays.asList(specialMatchModes));
-        if (isProbablyNonLocalEnv()) {
+        if (System.getenv("CI") != null) {
             // In CI the presence of end-of-staking-period records makes all
             // nonces non-deterministic (as any transaction may or may not
             // trigger an end-of-period record, which consumes a nonce)
             modes.add(NONDETERMINISTIC_NONCE);
         }
         return modes.isEmpty() ? EnumSet.noneOf(SnapshotMatchMode.class) : EnumSet.copyOf(modes);
-    }
-
-    private boolean isProbablyNonLocalEnv() {
-        final var osName = Optional.ofNullable(System.getProperty("os.name"))
-                .map(String::toLowerCase)
-                .orElse("");
-        return Stream.of("nix", "nux", "aix").anyMatch(osName::contains);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeCopyOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeCopyOperationSuite.java
@@ -28,10 +28,9 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.snapshotMode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_FUNCTION_PARAMETERS;
-import static com.hedera.services.bdd.spec.utilops.records.SnapshotMode.FUZZY_MATCH_AGAINST_HAPI_TEST_STREAMS;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 
 import com.google.protobuf.ByteString;
@@ -45,7 +44,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestSuite
+@HapiTestSuite(fuzzyMatch = true)
 @Tag(SMART_CONTRACT)
 public class ExtCodeCopyOperationSuite extends HapiSuite {
 
@@ -74,12 +73,9 @@ public class ExtCodeCopyOperationSuite extends HapiSuite {
         final var codeCopyOf = "codeCopyOf";
         final var account = "account";
 
-        return defaultHapiSpec("VerifiesExistence")
-                .given(
-                        snapshotMode(FUZZY_MATCH_AGAINST_HAPI_TEST_STREAMS, NONDETERMINISTIC_FUNCTION_PARAMETERS),
-                        cryptoCreate(account),
-                        uploadInitCode(contract),
-                        contractCreate(contract))
+        return defaultHapiSpec(
+                        "VerifiesExistence", NONDETERMINISTIC_TRANSACTION_FEES, NONDETERMINISTIC_FUNCTION_PARAMETERS)
+                .given(cryptoCreate(account), uploadInitCode(contract), contractCreate(contract))
                 .when()
                 .then(
                         contractCall(contract, codeCopyOf, asHeadlongAddress(invalidAddress))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NftTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NftTransferSuite.java
@@ -31,6 +31,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
@@ -53,7 +54,10 @@ public class NftTransferSuite extends HapiSuite {
     private static final String USER_ACCOUNT_PREFIX = "party-";
     private static final String FEE_COLLECTOR = "feeCollector";
     private static final int NUM_ACCOUNTS = 10;
-    private static final int NUM_TOKEN_TYPES = 100;
+    // If this is set too high then prod Netty settings create a high
+    // risk of server sending GOAWAY; and in practice it seems quite
+    // hard to stabilize HapiSpec behavior in this event
+    private static final int NUM_TOKEN_TYPES = 10;
     private static final int NUM_ROUNDS = 100;
 
     private static void runTestTask() {
@@ -191,6 +195,7 @@ public class NftTransferSuite extends HapiSuite {
         return blockingOrder(createBasicAccounts(), createAccountsAndNfts());
     }
 
+    @HapiTest
     final HapiSpec transferNfts() {
         return defaultHapiSpec("TransferNfts")
                 .given(setupNftTest(), transferInitial())

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/SteadyStateThrottlingCheck.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/SteadyStateThrottlingCheck.java
@@ -49,6 +49,7 @@ import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountBalance;
+import com.hedera.services.bdd.suites.BddMethodIsNotATest;
 import com.hedera.services.bdd.suites.HapiSuite;
 import java.util.Collections;
 import java.util.List;
@@ -80,11 +81,9 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
             HapiSpecSetup.getDefaultNodeProps().get(TOKENS_NFTS_MINT_THROTTLE_SCALE_FACTOR);
 
     private static final int REGRESSION_NETWORK_SIZE = 4;
-    private static final int PREVIEWNET_NETWORK_SIZE = 7;
 
     private static final double THROUGHPUT_LIMITS_XFER_NETWORK_TPS = 100.0;
     private static final double THROUGHPUT_LIMITS_FUNGIBLE_MINT_NETWORK_TPS = 30.0;
-    private static final double PREVIEWNET_THROUGHPUT_LIMITS_NON_FUNGIBLE_MINT_NETWORK_TPS = 50.0;
 
     private static final double PRIORITY_RESERVATIONS_CONTRACT_CALL_NETWORK_TPS = 2.0;
     private static final double CREATION_LIMITS_CRYPTO_CREATE_NETWORK_TPS = 1.0;
@@ -94,16 +93,11 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
 
     private static final double EXPECTED_XFER_TPS = THROUGHPUT_LIMITS_XFER_NETWORK_TPS / NETWORK_SIZE;
     private static final double EXPECTED_FUNGIBLE_MINT_TPS = THROUGHPUT_LIMITS_FUNGIBLE_MINT_NETWORK_TPS / NETWORK_SIZE;
-
-    @SuppressWarnings("java:S1068")
-    private static final double EXPECTED_PREVIEWNET_NON_FUNGIBLE_MINT_TPS =
-            PREVIEWNET_THROUGHPUT_LIMITS_NON_FUNGIBLE_MINT_NETWORK_TPS / PREVIEWNET_NETWORK_SIZE;
-
     private static final double EXPECTED_CONTRACT_CALL_TPS =
             PRIORITY_RESERVATIONS_CONTRACT_CALL_NETWORK_TPS / NETWORK_SIZE;
     private static final double EXPECTED_CRYPTO_CREATE_TPS = CREATION_LIMITS_CRYPTO_CREATE_NETWORK_TPS / NETWORK_SIZE;
     private static final double EXPECTED_GET_BALANCE_QPS = FREE_QUERY_LIMITS_GET_BALANCE_NETWORK_QPS / NETWORK_SIZE;
-    private static final double TOLERATED_PERCENT_DEVIATION = 5;
+    private static final double TOLERATED_PERCENT_DEVIATION = 7;
     private static final String SUPPLY = "supply";
     private static final String TOKEN = "token";
     private static final String CIVILIAN = "civilian";
@@ -153,22 +147,22 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
         return checkTps("FungibleMints", EXPECTED_FUNGIBLE_MINT_TPS, fungibleMintOps());
     }
 
-    //    @HapiTest - This test fails
+    @HapiTest
     @Order(4)
     final HapiSpec checkContractCallsTps() {
         return checkTps("ContractCalls", EXPECTED_CONTRACT_CALL_TPS, scCallOps());
     }
 
-    //    @HapiTest - This test fails
+    @HapiTest
     @Order(5)
     final HapiSpec checkCryptoCreatesTps() {
         return checkTps("CryptoCreates", EXPECTED_CRYPTO_CREATE_TPS, cryptoCreateOps());
     }
 
-    //    @HapiTest - This test hangs
+    @HapiTest
     @Order(6)
     final HapiSpec checkBalanceQps() {
-        return checkBalanceQps(1000, EXPECTED_GET_BALANCE_QPS);
+        return checkBalanceQps(50, EXPECTED_GET_BALANCE_QPS);
     }
 
     @HapiTest
@@ -187,7 +181,7 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
                                 .payingWith(ADDRESS_BOOK_CONTROL));
     }
 
-    @HapiTest
+    @BddMethodIsNotATest
     final HapiSpec checkTps(String txn, double expectedTps, Function<HapiSpec, OpProvider> provider) {
         return checkCustomNetworkTps(txn, expectedTps, provider, Collections.emptyMap());
     }
@@ -205,7 +199,7 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
      *     "default.payer.pemKeyPassphrase", "[SUPERUSER_PEM_PASSPHRASE]")));
      * }</pre>
      */
-    @HapiTest
+    @BddMethodIsNotATest
     @SuppressWarnings("java:S5960")
     final HapiSpec checkCustomNetworkTps(
             String txn, double expectedTps, Function<HapiSpec, OpProvider> provider, Map<String, String> custom) {
@@ -231,7 +225,7 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
                 }));
     }
 
-    @HapiTest
+    @BddMethodIsNotATest
     final HapiSpec checkBalanceQps(int burstSize, double expectedQps) {
         return defaultHapiSpec("CheckBalanceQps")
                 .given(cryptoCreate("curious").payingWith(GENESIS))
@@ -346,7 +340,7 @@ public class SteadyStateThrottlingCheck extends HapiSuite {
 
             @Override
             public Optional<HapiSpecOperation> get() {
-                var op = contractCall("scMulti")
+                var op = contractCall(contract)
                         .noLogging()
                         .deferStatusResolution()
                         .payingWith(CIVILIAN)


### PR DESCRIPTION
**Description**:
 - Closes #10637
 - As per mod-service, only override Netty server defaults if active profile is not `DEV`.
    * This lets us enable `SteadyStateThrottleCheck` and get stable success with a max allowed deviation of 7% from nominal TPS over the 3-minute test period.
 - Avoids a possible unhandled exception in `SynchronizedThrottleAccumulator` in which thread scheduling effects could make `Instant.now()` appear to go backward in time.
 - Restores an accidentally removed call to `shutdownChannels()` in `HapiApiClients`.
 - Makes `NONDETERMINISTIC_NONCE` a default `SnapshotMatchMode` when running in a Linux environment (mostly accurate approximation for "when running in CI").
 - Adds `NONDETERMINISTIC_TRANSACTION_FEES` to `ExtCodeCopyOperationSuite.verifiesExistence()`.
 - Stabilizes `NftTransferSuite` by submitting fewer concurrent operations (maybe not needed with `DEV` profile change above, but the test doesn't offer any more functional test coverage either way).