### PR TITLE
chore: allow starting from genesis state with null address book.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/PlatformBuilder.java
@@ -263,6 +263,11 @@ public final class PlatformBuilder {
                                                 .copy());
             }
 
+            // At this point the initial state must have the current address book set.  If not, something is wrong.
+            if (initialState.get().getState().getPlatformState().getAddressBook() == null) {
+                throw new IllegalStateException("The current address book of the initial state is null.");
+            }
+
             final SwirldsPlatform platform = new SwirldsPlatform(
                     platformContext,
                     keysAndCerts.get(selfId),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -32,6 +32,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.config.DefaultConfiguration;
 import com.swirlds.platform.consensus.SyntheticSnapshot;
 import com.swirlds.platform.state.PlatformData;
+import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.state.signed.DeserializedSignedState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedStateFileReader;
@@ -78,9 +79,14 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
         final DeserializedSignedState deserializedSignedState =
                 SignedStateFileReader.readStateFile(platformContext, statePath);
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
+            final PlatformState platformState =
+                    reservedSignedState.get().getState().getPlatformState();
             System.out.printf("Replacing platform data %n");
-            reservedSignedState.get().getState().getPlatformState().setRound(PlatformData.GENESIS_ROUND);
-            reservedSignedState.get().getState().getPlatformState().setSnapshot(SyntheticSnapshot.getGenesisSnapshot());
+            platformState.setRound(PlatformData.GENESIS_ROUND);
+            platformState.setSnapshot(SyntheticSnapshot.getGenesisSnapshot());
+            System.out.printf("Nullifying Address Books %n");
+            platformState.setAddressBook(null);
+            platformState.setPreviousAddressBook(null);
             System.out.printf("Hashing state %n");
             MerkleCryptoFactory.getInstance()
                     .digestTreeAsync(reservedSignedState.get().getState())

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
@@ -129,7 +129,7 @@ public class PlatformState extends PartialMerkleLeaf implements MerkleLeaf {
      */
     private PlatformState(final PlatformState that) {
         super(that);
-        this.addressBook = that.addressBook.copy();
+        this.addressBook = that.addressBook == null ? null : that.addressBook.copy();
         this.previousAddressBook = that.previousAddressBook == null ? null : that.previousAddressBook.copy();
         this.round = that.round;
         this.runningEventHash = that.runningEventHash;
@@ -254,8 +254,8 @@ public class PlatformState extends PartialMerkleLeaf implements MerkleLeaf {
      *
      * @param addressBook an address book
      */
-    public void setAddressBook(@NonNull final AddressBook addressBook) {
-        this.addressBook = Objects.requireNonNull(addressBook);
+    public void setAddressBook(@Nullable final AddressBook addressBook) {
+        this.addressBook = addressBook;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SavedStateMetadata.java
@@ -194,7 +194,9 @@ public record SavedStateMetadata(
                 selfId,
                 signingNodes,
                 signedState.getSigningWeight(),
-                platformState.getAddressBook().getTotalWeight(),
+                platformState.getAddressBook() == null
+                        ? 0
+                        : platformState.getAddressBook().getTotalWeight(),
                 epochHash,
                 epochHash == null ? "null" : epochHash.toMnemonic());
     }
@@ -313,6 +315,7 @@ public record SavedStateMetadata(
     }
 
     // This unused method is intentionally not deleted, in case we ever decide to add a new long to this file.
+
     /**
      * Attempt to parse a long from the data map.
      *
@@ -408,6 +411,7 @@ public record SavedStateMetadata(
     }
 
     // This unused method is intentionally not deleted, in case we ever decide to add a new instant to this file.
+
     /**
      * Attempt to parse an instant from the data map.
      *

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -243,10 +243,13 @@ public class SignedState implements SignedStateInfo {
     public void setSigSet(@NonNull final SigSet sigSet) {
         this.sigSet = Objects.requireNonNull(sigSet);
         signingWeight = 0;
-        final AddressBook addressBook = getAddressBook();
-        for (final NodeId signingNode : sigSet) {
-            if (addressBook.contains(signingNode)) {
-                signingWeight += addressBook.getAddress(signingNode).getWeight();
+        if (!isGenesisState()) {
+            // Only non-genesis states will have signing weight
+            final AddressBook addressBook = getAddressBook();
+            for (final NodeId signingNode : sigSet) {
+                if (addressBook.contains(signingNode)) {
+                    signingWeight += addressBook.getAddress(signingNode).getWeight();
+                }
             }
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
@@ -155,7 +155,10 @@ public final class SignedStateFileWriter {
         writeHashInfoFile(directory, signedState.getState());
         writeMetadataFile(selfId, directory, signedState);
         writeEmergencyRecoveryFile(directory, signedState);
-        writeStateAddressBookFile(directory, signedState.getAddressBook());
+        if (!signedState.isGenesisState()) {
+            // Genesis states do not have address books.
+            writeStateAddressBookFile(directory, signedState.getAddressBook());
+        }
         writeSettingsUsed(directory, platformContext.getConfiguration());
 
         if (selfId != null) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -97,7 +97,10 @@ public class AddressBookUtils {
         boolean nextNodeIdParsed = false;
         for (final String line : addressBookText.split("\\r?\\n")) {
             final String trimmedLine = line.trim();
-            if (trimmedLine.isEmpty() || trimmedLine.startsWith("#")) {
+            if (trimmedLine.isEmpty()
+                    || trimmedLine.startsWith("#")
+                    || trimmedLine.startsWith("swirld")
+                    || trimmedLine.startsWith("app")) {
                 continue;
             }
             if (trimmedLine.startsWith(ADDRESS_KEYWORD)) {
@@ -112,7 +115,10 @@ public class AddressBookUtils {
             } else {
                 throw new ParseException(
                         "The line [%s] does not start with `%s` or `%s`."
-                                .formatted(line.substring(0, 30), ADDRESS_KEYWORD, NEXT_NODE_ID_KEYWORD),
+                                .formatted(
+                                        line.substring(0, Math.min(line.length(), 30)),
+                                        ADDRESS_KEYWORD,
+                                        NEXT_NODE_ID_KEYWORD),
                         0);
             }
         }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -19,6 +19,7 @@ package com.swirlds.platform;
 import static com.swirlds.platform.state.address.AddressBookInitializer.CONFIG_ADDRESS_BOOK_HEADER;
 import static com.swirlds.platform.state.address.AddressBookInitializer.CONFIG_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_HEADER;
+import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_NULL;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -337,7 +338,11 @@ class AddressBookInitializerTest {
         final SignedState signedState = mock(SignedState.class);
         final SoftwareVersion softwareVersion = getMockSoftwareVersion(2);
         final SwirldState swirldState = getMockSwirldStateSupplier(weightValue).get();
-        when(signedState.getAddressBook()).thenReturn(stateAddressBook);
+        if (fromGenesis) {
+            when(signedState.getAddressBook()).thenReturn(null);
+        } else {
+            when(signedState.getAddressBook()).thenReturn(stateAddressBook);
+        }
         when(signedState.getSwirldState()).thenReturn(swirldState);
         final PlatformState platformState = mock(PlatformState.class);
         when(platformState.getCreationSoftwareVersion()).thenReturn(softwareVersion);
@@ -469,7 +474,10 @@ class AddressBookInitializerTest {
                 "The configAddressBook content is not:\n" + configText + "\n\n debugFileContent:\n" + debugFileContent);
 
         // check stateAddressBook content
-        final String stateText = STATE_ADDRESS_BOOK_HEADER + "\n" + stateAddressBook.toConfigText();
+        final String stateAddressBookText =
+                (stateAddressBook == null ? STATE_ADDRESS_BOOK_NULL : stateAddressBook.toConfigText());
+        final String stateText = STATE_ADDRESS_BOOK_HEADER + "\n" + stateAddressBookText;
+
         assertTrue(
                 debugFileContent.contains(stateText),
                 "The stateAddressBook content is not:\n" + stateText + "\n\n debugFileContent:\n" + debugFileContent);


### PR DESCRIPTION
**Description**:

Please review carefully.  The following changes have been made. 
* the `pcli state genesis` command now sets the current and previous address book to null. 
* code paths which threw exception during testing due to null address book in the state have been modified to check for genesis or tolerate the presence of null. 
   * NEEDS Attentive Review
     * the signing weight of the genesis state is set to 0
* The startup sequence will adopt the config.txt when given a genesis state. 
* A bug was fixed in the AddressBookUtils class and parsing an address book can now tolerate config.txt. 
* a boolean flag is set to indicate if the address book was changed and the initial state needs to be updated with the new address book. 
* NOTE: after the AddressBookInitializer runs, the initialState should no longer have a null address book. 

**Related issue(s)**:

Fixes #10448 

**Notes for reviewer**:

**This Manual Testing Was Performed:** 
1. run HashgraphDemo with default settings. 
2. Stop after a saved state has been generated. 
3. generate a genesis state from the saved state using `pcli state genesis <source.swh> <outputDir> <--load path/HashgraphDemo.jar>`
4. copy genesis state to round 0 directory for each node. 
5. delete preconsensus event stream files. 
6. delete other node states. 
7. modify config.txt to have added (or removed) nodes. 
8. Verify that the application starts from genesis. 
 
