### PR TITLE
chore: use INFO level for state changes log

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -238,7 +238,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -238,7 +238,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -238,7 +238,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -238,7 +238,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -238,7 +238,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -238,7 +238,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/log4j2.xml
+++ b/hedera-node/log4j2.xml
@@ -198,7 +198,7 @@
     </Logger>
 
     <!-- Send transaction state logs to their own appender   -->
-    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+    <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
 

--- a/hedera-node/test-clients/src/main/resource/log4j2.xml
+++ b/hedera-node/test-clients/src/main/resource/log4j2.xml
@@ -29,7 +29,7 @@
 	<Loggers>
 
 		<!-- Send transaction state logs to their own appender   -->
-		<Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="trace" additivity="false">
+		<Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
 			<AppenderRef ref="TransactionStateLogs"/>
 		</Logger>
 


### PR DESCRIPTION
**Description**:
 - `TransactionStateLogger` is prohibitively expensive at `TRACE` level.