### PR TITLE
chore: don't externalize zero staking rewards

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.token.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.node.app.service.token.impl.comparator.TokenComparators.TOKEN_TRANSFER_LIST_COMPARATOR;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.asAccountAmounts;
+import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.requiresExternalization;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Collections.emptyList;
 
@@ -79,7 +80,7 @@ public class FinalizeParentRecordHandler extends RecordFinalizerBase implements 
             // Calculate staking rewards and add them also to hbarChanges here, before assessing
             // net changes for transaction record
             final var rewardsPaid = stakingRewardsHandler.applyStakingRewards(context);
-            if (!rewardsPaid.isEmpty()) {
+            if (requiresExternalization(rewardsPaid)) {
                 recordBuilder.paidStakingRewards(asAccountAmounts(rewardsPaid));
             }
         }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHelperTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHelperTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token.impl.test.handlers.staking;
+
+import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.requiresExternalization;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StakingRewardsHelperTest {
+    @Test
+    void onlyNonZeroRewardsIncludedInAccountAmounts() {
+        final var zeroRewardId = AccountID.newBuilder().accountNum(1234L).build();
+        final var nonZeroRewardId = AccountID.newBuilder().accountNum(4321L).build();
+        final var someRewards = Map.of(zeroRewardId, 0L, nonZeroRewardId, 1L);
+        final var paidStakingRewards = StakingRewardsHelper.asAccountAmounts(someRewards);
+        assertThat(paidStakingRewards)
+                .containsExactly(AccountAmount.newBuilder()
+                        .accountID(nonZeroRewardId)
+                        .amount(1L)
+                        .build());
+    }
+
+    @Test
+    void emptyRewardsPaidDoesNotNeedExternalizing() {
+        assertThat(requiresExternalization(Map.of())).isFalse();
+    }
+
+    @Test
+    void onlyZeroRewardPaidDoesNotNeedExternalizing() {
+        final var zeroRewardId = AccountID.newBuilder().accountNum(1234L).build();
+        assertThat(requiresExternalization(Map.of(zeroRewardId, 0L))).isFalse();
+    }
+
+    @Test
+    void nonZeroRewardsPaidNeedsExternalizing() {
+        final var zeroRewardId = AccountID.newBuilder().accountNum(1234L).build();
+        final var nonZeroRewardId = AccountID.newBuilder().accountNum(4321L).build();
+        final var someRewards = Map.of(zeroRewardId, 0L, nonZeroRewardId, 1L);
+        assertThat(requiresExternalization(someRewards)).isTrue();
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -1800,7 +1800,10 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final AtomicReference<ByteString> expectedChildAddress = new AtomicReference<>();
         final AtomicReference<ByteString> expectedParentAddress = new AtomicReference<>();
 
-        return defaultHapiSpec("PropagatesNestedCreations", NONDETERMINISTIC_TRANSACTION_FEES, NONDETERMINISTIC_NONCE)
+        // Fully non-deterministic for fuzzy matching because mod-service externalizes
+        // nested contract creations in the order they are ATTEMPTED; while mono-service
+        // externalizes them in the order they are COMPLETED
+        return defaultHapiSpec("PropagatesNestedCreations", FULLY_NONDETERMINISTIC)
                 .given(
                         newKeyNamed(adminKey),
                         uploadInitCode(contract),


### PR DESCRIPTION
**Description**:
- Updates to only set the `paid_staking_rewards` field in a record if there are non-zero rewards paid; and only include non-zero rewards in the list (c.f. mono-service behavior [here](https://github.com/hashgraph/hedera-services/blob/develop/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/SideEffectsTracker.java#L295)).
- Mark `propagatesNestedCreations()` as `FULLY_NONDETERMINISTIC` because we are (currently, at least) accepting that mod-service externalizes internal `CONTRACT_CREATION`s in the order they are _attempted_; while mono-service externalizes them in the order they _succeed_.