### PR TITLE
test: Fix fuzzy match flakiness

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -39,6 +39,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
@@ -118,7 +119,7 @@ public class ContractCallLocalSuite extends HapiSuite {
         final AtomicReference<com.esaulpaugh.headlong.abi.Address> nftOwnerAddress = new AtomicReference<>();
         final AtomicReference<com.esaulpaugh.headlong.abi.Address> senderAddress = new AtomicReference<>();
 
-        return defaultHapiSpec("htsOwnershipCheckWorksWithAliasAddress")
+        return defaultHapiSpec("htsOwnershipCheckWorksWithAliasAddress", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(TOKEN_TREASURY),
                         newKeyNamed(SUPPLY_KEY),
@@ -256,7 +257,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     final HapiSpec lowBalanceFails() {
         final long adequateQueryPayment = 500_000_000L;
 
-        return defaultHapiSpec("lowBalanceFails")
+        return defaultHapiSpec("lowBalanceFails", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate("payer"),
                         cryptoCreate("payer").balance(adequateQueryPayment),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -187,7 +187,7 @@ public class ContractCallLocalSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec vanillaSuccess() {
-        return defaultHapiSpec("vanillaSuccess")
+        return defaultHapiSpec("vanillaSuccess", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
                 .when(contractCall(CONTRACT, "create").gas(785_000))
                 .then(
@@ -201,7 +201,7 @@ public class ContractCallLocalSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec impureCallFails() {
-        return defaultHapiSpec("impureCallFails")
+        return defaultHapiSpec("impureCallFails", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
                 .when()
                 .then(
@@ -213,7 +213,7 @@ public class ContractCallLocalSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec invalidDeletedContract() {
-        return defaultHapiSpec("invalidDeletedContract")
+        return defaultHapiSpec("invalidDeletedContract", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when(contractDelete(CONTRACT))
                 .then(contractCallLocal(CONTRACT, "create")
@@ -225,7 +225,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     final HapiSpec invalidContractID() {
         final var invalidContract = HapiSpecSetup.getDefaultInstance().invalidContractName();
         final var functionAbi = getABIFor(FUNCTION, "getIndirect", "CreateTrivial");
-        return defaultHapiSpec("InvalidContractID")
+        return defaultHapiSpec("InvalidContractID", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given()
                 .when()
                 .then(
@@ -241,7 +241,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     final HapiSpec insufficientFeeFails() {
         final long adequateQueryPayment = 500_000L;
 
-        return defaultHapiSpec("insufficientFeeFails")
+        return defaultHapiSpec("insufficientFeeFails", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(cryptoCreate("payer"), uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when(contractCall(CONTRACT, "create").gas(785_000))
                 .then(
@@ -282,7 +282,7 @@ public class ContractCallLocalSuite extends HapiSuite {
                 + "\"outputs\": [{\"name\": \"\",\"type\": \"uint8\"}],\"payable\": false,"
                 + "\"type\": \"function\"}";
 
-        return defaultHapiSpec("erc20Query")
+        return defaultHapiSpec("erc20Query", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(tokenCreate(TOKEN).decimals(DECIMALS).symbol(SYMBOL).asCallableContract())
                 .when()
                 .then(contractCallLocalWithFunctionAbi(TOKEN, decimalsABI)
@@ -292,7 +292,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     // https://github.com/hashgraph/hedera-services/pull/5485
     @HapiTest
     final HapiSpec callLocalDoesNotCheckSignaturesNorPayer() {
-        return defaultHapiSpec("callLocalDoesNotCheckSignaturesNorPayer")
+        return defaultHapiSpec("callLocalDoesNotCheckSignaturesNorPayer", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
                 .when(contractCall(CONTRACT, "create").gas(785_000))
                 .then(withOpContext((spec, opLog) -> IntStream.range(0, 2000).forEach(i -> {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -689,7 +689,8 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec(
                         "cannotUseMirrorAddressOfAliasedContractInPrecompileMethod",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate("Treasury"),
                         sourcing(() -> createLargeFile(DEFAULT_PAYER, ASSOCIATOR, literalInitcodeFor("Associator"))),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -2162,7 +2162,8 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec(
                         "sendHbarsFromDifferentAddressessToAddress",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS)
+                        NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(10_000L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -577,7 +577,7 @@ public class ContractCallSuite extends HapiSuite {
                         "NestedContractCannotOverSendValue",
                         NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS,
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_TRANSACTION_FEES)
+                        HIGHLY_NON_DETERMINISTIC_FEES)
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS),
                         cryptoCreate(RECEIVER).balance(10_000L),
@@ -881,7 +881,8 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec(
                         "erc721TokenUriAndHtsNftInfoTreatNonUtf8BytesDifferently",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         uploadInitCode(contractAlternatives),
                         contractCreate(contractAlternatives),
@@ -1471,7 +1472,7 @@ public class ContractCallSuite extends HapiSuite {
     @HapiTest
     HapiSpec depositDeleteSuccess() {
         final var initBalance = 7890L;
-        return defaultHapiSpec("DepositDeleteSuccess", NONDETERMINISTIC_TRANSACTION_FEES)
+        return defaultHapiSpec("DepositDeleteSuccess", HIGHLY_NON_DETERMINISTIC_FEES)
                 .given(
                         cryptoCreate(BENEFICIARY).balance(initBalance),
                         uploadInitCode(PAY_RECEIVABLE_CONTRACT),
@@ -2118,7 +2119,7 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec(
                         "sendHbarsToDifferentAddresses",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_TRANSACTION_FEES)
+                        HIGHLY_NON_DETERMINISTIC_FEES)
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER_1).balance(10_000L),
@@ -2208,7 +2209,8 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec(
                         "sendHbarsToOuterContractFromDifferentAddresses",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS)
+                        NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         uploadInitCode(NESTED_TRANSFERRING_CONTRACT, NESTED_TRANSFER_CONTRACT),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -368,7 +368,7 @@ public class ContractCallSuite extends HapiSuite {
         final var failedResult = Bytes32.repeat((byte) 0);
         final ContractCallResult unsuccessfulResult = () -> failedResult;
         final ContractCallResult successfulResult = () -> failedResult.or(Bytes.of(1));
-        return defaultHapiSpec("callsToSystemEntityNumsAreTreatedAsPrecompileCalls")
+        return defaultHapiSpec("callsToSystemEntityNumsAreTreatedAsPrecompileCalls", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         uploadInitCode(TEST_CONTRACT),
                         contractCreate(
@@ -559,7 +559,7 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec depositMoreThanBalanceFailsGracefully() {
-        return defaultHapiSpec("depositMoreThanBalanceFailsGracefully")
+        return defaultHapiSpec("depositMoreThanBalanceFailsGracefully", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         uploadInitCode(PAY_RECEIVABLE_CONTRACT),
                         cryptoCreate(ACCOUNT).balance(ONE_HBAR - 1))
@@ -632,7 +632,10 @@ public class ContractCallSuite extends HapiSuite {
         final AtomicReference<String> childMirror = new AtomicReference<>();
         final AtomicReference<String> childEip1014 = new AtomicReference<>();
 
-        return defaultHapiSpec("whitelistingAliasedContract", NONDETERMINISTIC_FUNCTION_PARAMETERS)
+        return defaultHapiSpec(
+                        "whitelistingAliasedContract",
+                        NONDETERMINISTIC_FUNCTION_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         sourcing(() -> createLargeFile(DEFAULT_PAYER, WHITELISTER, literalInitcodeFor("Whitelister"))),
                         sourcing(() -> createLargeFile(DEFAULT_PAYER, CREATOR, literalInitcodeFor("Creator"))),
@@ -823,7 +826,7 @@ public class ContractCallSuite extends HapiSuite {
         final var minPriceToAccessGatedMethod = 666L;
         final var minValueToAccessGatedMethodAtCurrentRate = new AtomicLong();
 
-        return defaultHapiSpec("ExchangeRatePrecompileWorks")
+        return defaultHapiSpec("ExchangeRatePrecompileWorks", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         uploadInitCode(rateAware),
                         contractCreate(rateAware, BigInteger.valueOf(minPriceToAccessGatedMethod)),
@@ -1136,7 +1139,8 @@ public class ContractCallSuite extends HapiSuite {
                         "ocToken",
                         HIGHLY_NON_DETERMINISTIC_FEES,
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(TOKEN_ISSUER).balance(1_000_000_000_000L),
                         cryptoCreate(ALICE).balance(10_000_000_000L).payingWith(TOKEN_ISSUER),
@@ -1436,7 +1440,7 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     HapiSpec depositSuccess() {
-        return defaultHapiSpec("DepositSuccess")
+        return defaultHapiSpec("DepositSuccess", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         uploadInitCode(PAY_RECEIVABLE_CONTRACT),
                         contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD))
@@ -1553,7 +1557,7 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     HapiSpec insufficientGas() {
-        return defaultHapiSpec("InsufficientGas", NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+        return defaultHapiSpec("InsufficientGas", NONDETERMINISTIC_CONTRACT_CALL_RESULTS, HIGHLY_NON_DETERMINISTIC_FEES)
                 .given(
                         uploadInitCode(SIMPLE_STORAGE_CONTRACT),
                         contractCreate(SIMPLE_STORAGE_CONTRACT).adminKey(THRESHOLD),
@@ -1569,7 +1573,7 @@ public class ContractCallSuite extends HapiSuite {
     HapiSpec insufficientFee() {
         final var contract = CREATE_TRIVIAL;
 
-        return defaultHapiSpec("InsufficientFee")
+        return defaultHapiSpec("InsufficientFee", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(cryptoCreate("accountToPay"), uploadInitCode(contract), contractCreate(contract))
                 .when()
                 .then(contractCall(contract, "create")
@@ -1582,7 +1586,7 @@ public class ContractCallSuite extends HapiSuite {
     HapiSpec nonPayable() {
         final var contract = CREATE_TRIVIAL;
 
-        return defaultHapiSpec("NonPayable")
+        return defaultHapiSpec("NonPayable", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(contract), contractCreate(contract))
                 .when(contractCall(contract, "create")
                         .via("callTxn")
@@ -1822,7 +1826,10 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec contractTransferToSigReqAccountWithoutKeyFails() {
-        return defaultHapiSpec("ContractTransferToSigReqAccountWithoutKeyFails", NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+        return defaultHapiSpec(
+                        "ContractTransferToSigReqAccountWithoutKeyFails",
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(RECEIVABLE_SIG_REQ_ACCOUNT)
                                 .balance(1_000_000_000_000L)
@@ -1847,7 +1854,7 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec minChargeIsTXGasUsedByContractCall() {
-        return defaultHapiSpec("MinChargeIsTXGasUsedByContractCall")
+        return defaultHapiSpec("MinChargeIsTXGasUsedByContractCall", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(SIMPLE_UPDATE_CONTRACT))
                 .when(
                         contractCreate(SIMPLE_UPDATE_CONTRACT).gas(300_000L),
@@ -1868,7 +1875,10 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec hscsEvm006ContractHBarTransferToAccount() {
-        return defaultHapiSpec("hscsEvm006ContractHBarTransferToAccount", NONDETERMINISTIC_FUNCTION_PARAMETERS)
+        return defaultHapiSpec(
+                        "hscsEvm006ContractHBarTransferToAccount",
+                        NONDETERMINISTIC_FUNCTION_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(10_000L),
@@ -1901,7 +1911,8 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec(
                         "hscsEvm005TransfersWithSubLevelCallsBetweenContracts",
                         HIGHLY_NON_DETERMINISTIC_FEES,
-                        NONDETERMINISTIC_FUNCTION_PARAMETERS)
+                        NONDETERMINISTIC_FUNCTION_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         uploadInitCode(topLevelContract, subLevelContract))
@@ -2035,7 +2046,10 @@ public class ContractCallSuite extends HapiSuite {
         final var PAYER_KEY = "pkey";
         final var OTHER_KEY = "okey";
         final var KEY_LIST = "klist";
-        return defaultHapiSpec("hscsEvm010MultiSignatureAccounts", NONDETERMINISTIC_FUNCTION_PARAMETERS)
+        return defaultHapiSpec(
+                        "hscsEvm010MultiSignatureAccounts",
+                        NONDETERMINISTIC_FUNCTION_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         newKeyNamed(PAYER_KEY),
                         newKeyNamed(OTHER_KEY),
@@ -2248,7 +2262,10 @@ public class ContractCallSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec sendHbarsToCallerFromDifferentAddresses() {
-        return defaultHapiSpec("sendHbarsToCallerFromDifferentAddresses", NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS)
+        return defaultHapiSpec(
+                        "sendHbarsToCallerFromDifferentAddresses",
+                        NONDETERMINISTIC_CONSTRUCTOR_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(withOpContext((spec, log) -> {
                     final var keyCreation = newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE);
                     if (!spec.isUsingEthCalls()) {
@@ -2476,7 +2493,9 @@ public class ContractCallSuite extends HapiSuite {
         final var failingCall = "FailingCall";
         final AtomicReference<Timestamp> parentConsTime = new AtomicReference<>();
         return defaultHapiSpec(
-                        "ConsTimeManagementWorksWithRevertedInternalCreations", NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+                        "ConsTimeManagementWorksWithRevertedInternalCreations",
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(contract), contractCreate(contract))
                 .when(contractCall(
                                 contract,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
@@ -24,6 +24,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withTargetLedgerId;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
@@ -63,7 +64,7 @@ public class ContractGetInfoSuite extends HapiSuite {
     final HapiSpec getInfoWorks() {
         final var contract = "Multipurpose";
         final var MEMO = "This is a test.";
-        return defaultHapiSpec("GetInfoWorks")
+        return defaultHapiSpec("GetInfoWorks", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         newKeyNamed("adminKey"),
                         uploadInitCode(contract),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -257,7 +257,7 @@ public class ContractUpdateSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec updateAutoRenewWorks() {
-        return defaultHapiSpec("UpdateAutoRenewWorks")
+        return defaultHapiSpec("UpdateAutoRenewWorks", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         newKeyNamed(ADMIN_KEY),
                         uploadInitCode(CONTRACT),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -169,7 +169,10 @@ public class ContractUpdateSuite extends HapiSuite {
         final AtomicReference<String> childMirror = new AtomicReference<>();
         final AtomicReference<String> childEip1014 = new AtomicReference<>();
 
-        return defaultHapiSpec("Eip1014AddressAlwaysHasPriority", NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+        return defaultHapiSpec(
+                        "Eip1014AddressAlwaysHasPriority",
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(contract), contractCreate(contract).via(creationTxn))
                 .when(captureChildCreate2MetaFor(2, 0, "setup", creationTxn, childMirror, childEip1014))
                 .then(
@@ -221,7 +224,7 @@ public class ContractUpdateSuite extends HapiSuite {
         final var secondMemo = "Second";
         final var thirdMemo = "Third";
 
-        return defaultHapiSpec("UpdateWithBothMemoSettersWorks")
+        return defaultHapiSpec("UpdateWithBothMemoSettersWorks", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         newKeyNamed(ADMIN_KEY),
                         uploadInitCode(CONTRACT),
@@ -238,7 +241,7 @@ public class ContractUpdateSuite extends HapiSuite {
     @HapiTest
     final HapiSpec updatingExpiryWorks() {
         final var newExpiry = Instant.now().getEpochSecond() + 5 * ONE_MONTH;
-        return defaultHapiSpec("UpdatingExpiryWorks")
+        return defaultHapiSpec("UpdatingExpiryWorks", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when(contractUpdate(CONTRACT).newExpirySecs(newExpiry))
                 .then(getContractInfo(CONTRACT).has(contractWith().expiry(newExpiry)));
@@ -249,7 +252,7 @@ public class ContractUpdateSuite extends HapiSuite {
         final var smallBuffer = 12_345L;
         final var excessiveExpiry = defaultMaxLifetime + Instant.now().getEpochSecond() + smallBuffer;
 
-        return defaultHapiSpec("RejectsExpiryTooFarInTheFuture")
+        return defaultHapiSpec("RejectsExpiryTooFarInTheFuture", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when()
                 .then(contractUpdate(CONTRACT).newExpirySecs(excessiveExpiry).hasKnownStatus(INVALID_EXPIRATION_TIME));
@@ -311,7 +314,7 @@ public class ContractUpdateSuite extends HapiSuite {
     // https://github.com/hashgraph/hedera-services/issues/3037
     @HapiTest
     final HapiSpec immutableContractKeyFormIsStandard() {
-        return defaultHapiSpec("ImmutableContractKeyFormIsStandard")
+        return defaultHapiSpec("ImmutableContractKeyFormIsStandard", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).immutable())
                 .when()
                 .then(getContractInfo(CONTRACT).has(contractWith().immutableContractKey(CONTRACT)));
@@ -319,7 +322,7 @@ public class ContractUpdateSuite extends HapiSuite {
 
     @HapiTest
     final HapiSpec canMakeContractImmutableWithEmptyKeyList() {
-        return defaultHapiSpec("CanMakeContractImmutableWithEmptyKeyList")
+        return defaultHapiSpec("CanMakeContractImmutableWithEmptyKeyList", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         newKeyNamed(ADMIN_KEY),
                         newKeyNamed(NEW_ADMIN_KEY),
@@ -334,7 +337,7 @@ public class ContractUpdateSuite extends HapiSuite {
     @HapiTest
     final HapiSpec givenAdminKeyMustBeValid() {
         final var contract = "BalanceLookup";
-        return defaultHapiSpec("GivenAdminKeyMustBeValid")
+        return defaultHapiSpec("GivenAdminKeyMustBeValid", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(contract), contractCreate(contract))
                 .when(getContractInfo(contract).logged())
                 .then(contractUpdate(contract)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/BalanceOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/BalanceOperationSuite.java
@@ -32,6 +32,7 @@ import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_FUNCTION_PARAMETERS;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
@@ -77,7 +78,10 @@ public class BalanceOperationSuite extends HapiSuite {
         final var ACCOUNT = "test";
         final var INVALID_ADDRESS = "0x0000000000000000000000000000000000123456";
 
-        return defaultHapiSpec("VerifiesExistenceOfAccountsAndContracts", NONDETERMINISTIC_FUNCTION_PARAMETERS)
+        return defaultHapiSpec(
+                        "VerifiesExistenceOfAccountsAndContracts",
+                        NONDETERMINISTIC_FUNCTION_PARAMETERS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(cryptoCreate("test").balance(BALANCE), uploadInitCode(contract), contractCreate(contract))
                 .when()
                 .then(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeHashOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeHashOperationSuite.java
@@ -28,10 +28,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.snapshotMode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_FUNCTION_PARAMETERS;
-import static com.hedera.services.bdd.spec.utilops.records.SnapshotMode.FUZZY_MATCH_AGAINST_HAPI_TEST_STREAMS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 
 import com.google.protobuf.ByteString;
@@ -47,7 +45,7 @@ import org.hyperledger.besu.crypto.Hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestSuite
+@HapiTestSuite(fuzzyMatch = true)
 @Tag(SMART_CONTRACT)
 public class ExtCodeHashOperationSuite extends HapiSuite {
 
@@ -77,12 +75,8 @@ public class ExtCodeHashOperationSuite extends HapiSuite {
         final var hashOf = "hashOf";
 
         final String account = "account";
-        return defaultHapiSpec("VerifiesExistence")
-                .given(
-                        snapshotMode(FUZZY_MATCH_AGAINST_HAPI_TEST_STREAMS, NONDETERMINISTIC_FUNCTION_PARAMETERS),
-                        uploadInitCode(contract),
-                        contractCreate(contract),
-                        cryptoCreate(account))
+        return defaultHapiSpec("VerifiesExistence", NONDETERMINISTIC_FUNCTION_PARAMETERS)
+                .given(uploadInitCode(contract), contractCreate(contract), cryptoCreate(account))
                 .when()
                 .then(
                         contractCall(contract, hashOf, asHeadlongAddress(invalidAddress))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PushZeroOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/PushZeroOperationSuite.java
@@ -29,6 +29,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
@@ -79,7 +80,7 @@ public class PushZeroOperationSuite extends HapiSuite {
     final HapiSpec pushZeroHappyPathWorks() {
         final var pushZeroContract = CONTRACT;
         final var pushResult = "pushResult";
-        return defaultHapiSpec("prngPrecompileHappyPathWorks")
+        return defaultHapiSpec("prngPrecompileHappyPathWorks", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
                         overriding(CONTRACTS_DYNAMIC_EVM_VERSION, TRUE_VALUE),
                         overriding(CONTRACTS_EVM_VERSION, EVM_VERSION_0_38),
@@ -105,7 +106,7 @@ public class PushZeroOperationSuite extends HapiSuite {
     final HapiSpec pushZeroDisabledInV034() {
         final var pushZeroContract = CONTRACT;
         final var pushResult = "pushResult";
-        return propertyPreservingHapiSpec("pushZeroDisabledInV034")
+        return propertyPreservingHapiSpec("pushZeroDisabledInV034", NONDETERMINISTIC_TRANSACTION_FEES)
                 .preserving(CONTRACTS_DYNAMIC_EVM_VERSION, CONTRACTS_EVM_VERSION)
                 .given(
                         overriding(CONTRACTS_DYNAMIC_EVM_VERSION, TRUE_VALUE),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
@@ -26,6 +26,7 @@ import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -73,7 +74,7 @@ public class ERC721ContractInteractions extends HapiSuite {
         final var APPROVE_TX = "approve";
         final var TRANSFER_FROM_TX = "transferFrom";
 
-        return defaultHapiSpec("CallsERC721ContractInteractions")
+        return defaultHapiSpec("CallsERC721ContractInteractions", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(QueryVerbs.getAccountBalance(DEFAULT_CONTRACT_SENDER).logged(), uploadInitCode(CONTRACT))
                 .when(
                         QueryVerbs.getAccountBalance(DEFAULT_CONTRACT_SENDER).logged(),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsSuite.java
@@ -26,6 +26,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.*;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_CONTRACT_CALL_RESULTS;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_FUNCTION_PARAMETERS;
+import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.*;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE;
@@ -87,7 +88,8 @@ public class SigningReqsSuite extends HapiSuite {
         return propertyPreservingHapiSpec(
                         "AutoRenewAccountCanUseLegacySigActivationIfConfigured",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
-                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS)
+                        NONDETERMINISTIC_CONTRACT_CALL_RESULTS,
+                        NONDETERMINISTIC_TRANSACTION_FEES)
                 .preserving(LEGACY_ACTIVATIONS_PROP)
                 .given(
                         cryptoCreate(CIVILIAN).balance(10L * ONE_HUNDRED_HBARS),


### PR DESCRIPTION
**Description**:
I have three PRs that I'm trying to merge but there is a lot of flakyness. Here is the results I got:

**PR**: https://github.com/hashgraph/hedera-services/pull/10839

```
Attempt #1
ExtCodeHashOperationSuite » verifiesExistenceFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)
PushZeroOperationSuite » pushZeroHappyPathWorksFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)
ContractCallSuite » depositDeleteSuccessFAILED(Transaction fees '1101898159' and '1102102981' varied by more than 50000 tinybar)
ContractGetInfoSuite » getInfoWorksFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)

Attempt #2
SigningReqsSuite » autoRenewAccountCanUseLegacySigActivationIfConfiguredFAILED(Transaction fees '131770614' and '131770612' varied by more than 1 tinybar)
ContractCallSuite » callsToSystemEntityNumsAreTreatedAsPrecompileCallsFAILED(Instead of 17 items, 15 were generated)
ContractCallLocalSuite » htsOwnershipCheckWorksWithAliasAddressFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)
ContractCallSuite » erc721TokenUriAndHtsNftInfoTreatNonUtf8BytesDifferentlyFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)

Attempt #3
SigningReqsSuite » autoRenewAccountCanUseLegacySigActivationIfConfiguredFAILED(Transaction fees '131770616' and '131770614' varied by more than 1 tinybar)
ContractCallLocalSuite » lowBalanceFailsFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)
ContractCallSuite » erc721TokenUriAndHtsNftInfoTreatNonUtf8BytesDifferentlyFAILED(Transaction fees '131770616' and '131770614' varied by more than 1 tinybar)
PushZeroOperationSuite » pushZeroHappyPathWorksFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)
ContractCallSuite » sendHbarsToDifferentAddressesFAILED(Transaction fees '598457750' and '598662572' varied by more than 50000 tinybar)
ContractUpdateSuite » updatingExpiryWorksFAILED(Instead of 4 items, 2 were generated)
```


**PR**: https://github.com/hashgraph/hedera-services/pull/10850
```
Attempt #1
SigningReqsSuite » autoRenewAccountCanUseLegacySigActivationIfConfiguredFAILED(Transaction fees '131770616' and '131770614' varied by more than 1 tinybar)
ContractCallSuite » nestedContractCannotOverSendValueFAILED(Transaction fees '605012053' and '605216876' varied by more than 50000 tinybar)
ContractCallSuite » sendHbarsToOuterContractFromDifferentAddressesFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybarg)
LogsSuite » log1WorksFAILED(Instead of 4 items, 1 were generated)


Attempt #2
BalanceOperationSuite » verifiesExistenceOfAccountsAndContractsFAILED(Transaction fees '93545982' and '93562549' varied by more than 1 tinybar)
```

Most of the problems come from nondeterministic Transaction fees. I add to all of them `NONDETERMINISTIC_TRANSACTION_FEES` and hopefully we will have a more stable CI.

If I added `NONDETERMINISTIC_TRANSACTION_FEES` to a test that it shouldn't have please let me know.
For sure there will be more flaky tests but I'm fixing the once I see.


**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/10853