### PR TITLE
fix: change EnityNumber to Contract ID in state defintion

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/EntityUtilizationMultiplierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/EntityUtilizationMultiplierTest.java
@@ -157,7 +157,7 @@ class EntityUtilizationMultiplierTest {
                         Map.of(
                                 InitialModServiceContractSchema.STORAGE_KEY,
                                 new HashMap<>(),
-                                InitialModServiceContractSchema.BYTECODE_KEY,
+                                InitialModServiceContractSchema.CONTRACT_ID_KEY,
                                 Map.of(
                                         new EntityNumber(4L), Bytecode.DEFAULT,
                                         new EntityNumber(5L), Bytecode.DEFAULT)));
@@ -185,7 +185,7 @@ class EntityUtilizationMultiplierTest {
                         Map.of(
                                 InitialModServiceContractSchema.STORAGE_KEY,
                                 new HashMap<>(),
-                                InitialModServiceContractSchema.BYTECODE_KEY,
+                                InitialModServiceContractSchema.CONTRACT_ID_KEY,
                                 Map.of(
                                         new EntityNumber(4L), Bytecode.DEFAULT,
                                         new EntityNumber(5L), Bytecode.DEFAULT)));

--- a/hedera-node/hedera-app/src/xtest/java/common/AbstractXTest.java
+++ b/hedera-node/hedera-app/src/xtest/java/common/AbstractXTest.java
@@ -347,7 +347,7 @@ public abstract class AbstractXTest {
         return component()
                 .hederaState()
                 .getReadableStates(ContractServiceImpl.NAME)
-                .get(InitialModServiceContractSchema.BYTECODE_KEY);
+                .get(InitialModServiceContractSchema.CONTRACT_ID_KEY);
     }
 
     protected ReadableKVState<AccountID, Account> finalAccounts() {
@@ -426,7 +426,7 @@ public abstract class AbstractXTest {
         fakeHederaState.addService(
                 ContractServiceImpl.NAME,
                 Map.of(
-                        InitialModServiceContractSchema.BYTECODE_KEY,
+                        InitialModServiceContractSchema.CONTRACT_ID_KEY,
                         initialBytecodes(),
                         InitialModServiceContractSchema.STORAGE_KEY,
                         new HashMap<SlotKey, SlotValue>()));

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/InitialModServiceContractSchema.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/InitialModServiceContractSchema.java
@@ -16,8 +16,8 @@
 
 package com.hedera.node.app.service.contract.impl.state;
 
+import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.contract.Bytecode;
 import com.hedera.hapi.node.state.contract.SlotKey;
 import com.hedera.hapi.node.state.contract.SlotValue;
@@ -35,7 +35,7 @@ import java.util.Set;
  */
 public class InitialModServiceContractSchema extends Schema {
     public static final String STORAGE_KEY = "STORAGE";
-    public static final String BYTECODE_KEY = "BYTECODE";
+    public static final String CONTRACT_ID_KEY = "CONTRACT_ID";
     private static final int MAX_BYTECODES = 50_000_000;
     private static final int MAX_STORAGE_ENTRIES = 500_000_000;
 
@@ -59,7 +59,7 @@ public class InitialModServiceContractSchema extends Schema {
         return StateDefinition.onDisk(STORAGE_KEY, SlotKey.PROTOBUF, SlotValue.PROTOBUF, MAX_STORAGE_ENTRIES);
     }
 
-    private @NonNull StateDefinition<EntityNumber, Bytecode> bytecodeDef() {
-        return StateDefinition.onDisk(BYTECODE_KEY, EntityNumber.PROTOBUF, Bytecode.PROTOBUF, MAX_BYTECODES);
+    private @NonNull StateDefinition<ContractID, Bytecode> bytecodeDef() {
+        return StateDefinition.onDisk(CONTRACT_ID_KEY, ContractID.PROTOBUF, Bytecode.PROTOBUF, MAX_BYTECODES);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ReadableContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ReadableContractStateStore.java
@@ -42,7 +42,7 @@ public class ReadableContractStateStore implements ContractStateStore {
     public ReadableContractStateStore(@NonNull final ReadableStates states) {
         requireNonNull(states);
         this.storage = states.get(InitialModServiceContractSchema.STORAGE_KEY);
-        this.bytecode = states.get(InitialModServiceContractSchema.BYTECODE_KEY);
+        this.bytecode = states.get(InitialModServiceContractSchema.CONTRACT_ID_KEY);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/WritableContractStateStore.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/WritableContractStateStore.java
@@ -38,7 +38,7 @@ public class WritableContractStateStore implements ContractStateStore {
     public WritableContractStateStore(@NonNull final WritableStates states) {
         requireNonNull(states);
         this.storage = states.get(InitialModServiceContractSchema.STORAGE_KEY);
-        this.bytecode = states.get(InitialModServiceContractSchema.BYTECODE_KEY);
+        this.bytecode = states.get(InitialModServiceContractSchema.CONTRACT_ID_KEY);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ReadableContractStateStoreTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ReadableContractStateStoreTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.contract.impl.test.state;
 
-import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.BYTECODE_KEY;
+import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.CONTRACT_ID_KEY;
 import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.STORAGE_KEY;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.BYTECODE;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ENTITY_NUMBER;
@@ -59,7 +59,7 @@ class ReadableContractStateStoreTest {
     @BeforeEach
     void setUp() {
         given(states.<SlotKey, SlotValue>get(STORAGE_KEY)).willReturn(storage);
-        given(states.<EntityNumber, Bytecode>get(BYTECODE_KEY)).willReturn(bytecode);
+        given(states.<EntityNumber, Bytecode>get(CONTRACT_ID_KEY)).willReturn(bytecode);
 
         subject = new ReadableContractStateStore(states);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/WritableContractStateStoreTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/WritableContractStateStoreTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.contract.impl.test.state;
 
-import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.BYTECODE_KEY;
+import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.CONTRACT_ID_KEY;
 import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.STORAGE_KEY;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.BYTECODE;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ENTITY_NUMBER;
@@ -58,7 +58,7 @@ class WritableContractStateStoreTest {
     @BeforeEach
     void setUp() {
         given(states.<SlotKey, SlotValue>get(STORAGE_KEY)).willReturn(storage);
-        given(states.<EntityNumber, Bytecode>get(BYTECODE_KEY)).willReturn(bytecode);
+        given(states.<EntityNumber, Bytecode>get(CONTRACT_ID_KEY)).willReturn(bytecode);
 
         subject = new WritableContractStateStore(states);
     }


### PR DESCRIPTION
change EnityNumber to Contract ID in state defintion

**Related issue(s)**:

Fixes #10747 

