### PR TITLE
chore: use metadata-derived class id for `QueueNode` when available

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateMetadata.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateMetadata.java
@@ -41,6 +41,7 @@ public final class StateMetadata<K, V> {
     private static final String ON_DISK_VALUE_SERIALIZER_CLASS_ID_SUFFIX = "OnDiskValueSerializer";
     private static final String IN_MEMORY_VALUE_CLASS_ID_SUFFIX = "InMemoryValue";
     private static final String SINGLETON_CLASS_ID_SUFFIX = "SingletonLeaf";
+    private static final String QUEUE_NODE_CLASS_ID_SUFFIX = "QueueNode";
 
     private final String serviceName;
     private final Schema schema;
@@ -51,6 +52,7 @@ public final class StateMetadata<K, V> {
     private final long onDiskValueSerializerClassId;
     private final long inMemoryValueClassId;
     private final long singletonClassId;
+    private final long queueNodeClassId;
 
     /**
      * Create an instance.
@@ -77,6 +79,7 @@ public final class StateMetadata<K, V> {
         this.inMemoryValueClassId =
                 StateUtils.computeClassId(serviceName, stateKey, version, IN_MEMORY_VALUE_CLASS_ID_SUFFIX);
         this.singletonClassId = StateUtils.computeClassId(serviceName, stateKey, version, SINGLETON_CLASS_ID_SUFFIX);
+        this.queueNodeClassId = StateUtils.computeClassId(serviceName, stateKey, version, QUEUE_NODE_CLASS_ID_SUFFIX);
     }
 
     public String serviceName() {
@@ -113,5 +116,9 @@ public final class StateMetadata<K, V> {
 
     public long singletonClassId() {
         return singletonClassId;
+    }
+
+    public long queueNodeClassId() {
+        return queueNodeClassId;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/QueueNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/queue/QueueNode.java
@@ -80,7 +80,7 @@ public class QueueNode<E> extends PartialBinaryMerkleInternal implements Labeled
 
     @Override
     public long getClassId() {
-        return CLASS_ID;
+        return md == null ? CLASS_ID : md.queueNodeClassId();
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/queue/QueueNodeTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/queue/QueueNodeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state.merkle.queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.hedera.node.app.spi.fixtures.state.TestSchema;
+import com.hedera.node.app.spi.state.StateDefinition;
+import com.hedera.node.app.state.merkle.MerkleTestBase;
+import com.hedera.node.app.state.merkle.StateMetadata;
+import org.junit.jupiter.api.Test;
+
+class QueueNodeTest extends MerkleTestBase {
+    @Test
+    void usesQueueNodeIdFromMetadataIfAvailable() {
+        final var metadata = new StateMetadata<>(
+                FIRST_SERVICE, new TestSchema(1), StateDefinition.queue(FRUIT_STATE_KEY, STRING_CODEC));
+        final var node = new QueueNode<>(metadata);
+        assertNotEquals(0x990FF87AD2691DCL, node.getClassId());
+    }
+
+    @Test
+    void usesDefaultClassIdWithoutMetadata() {
+        final var node = new QueueNode();
+        assertEquals(0x990FF87AD2691DCL, node.getClassId());
+    }
+}


### PR DESCRIPTION
**Description**:
 - When a `QueueNode` is serialized, write the class id for its `StateMetadata` instead of the deprecated fixed `CLASS_ID`.