### PR TITLE
fix: 10948: JRS failure SmartContractByteCodeMapValueSerializer.getSerializedSize

### DIFF
--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapKey.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapKey.java
@@ -55,7 +55,7 @@ public final class SmartContractByteCodeMapKey implements VirtualLongKey {
         this.contractId = contractId;
     }
 
-    public static int getSizeInBytes() {
+    static int getSizeInBytes() {
         return Long.BYTES;
     }
 

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValue.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValue.java
@@ -133,6 +133,10 @@ public final class SmartContractByteCodeMapValue implements VirtualValue {
         return new SmartContractByteCodeMapValue(this);
     }
 
+    int getSizeInBytes() {
+        return Integer.BYTES + byteCode.length;
+    }
+
     @Override
     public void serialize(final SerializableDataOutputStream out) throws IOException {
         out.writeByteArray(byteCode);

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValueSerializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/bytecode/SmartContractByteCodeMapValueSerializer.java
@@ -62,6 +62,11 @@ public final class SmartContractByteCodeMapValueSerializer implements ValueSeria
     }
 
     @Override
+    public int getSerializedSize(@NonNull final SmartContractByteCodeMapValue value) {
+        return value.getSizeInBytes();
+    }
+
+    @Override
     public void serialize(
             @NonNull final SmartContractByteCodeMapValue value, @NonNull final WritableSequentialData out) {
         value.serialize(out);

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapKey.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapKey.java
@@ -87,7 +87,7 @@ public final class SmartContractMapKey implements VirtualKey {
         return contractId == buffer.getLong() && keyValuePairIndex == buffer.getLong();
     }
 
-    public static int getSizeInBytes() {
+    static int getSizeInBytes() {
         return 2 * Long.BYTES;
     }
 

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapValue.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/map/smartcontracts/data/SmartContractMapValue.java
@@ -160,7 +160,7 @@ public final class SmartContractMapValue implements VirtualValue {
         return Arrays.hashCode(value);
     }
 
-    public static int getSizeInBytes() {
+    static int getSizeInBytes() {
         return 32;
     }
 


### PR DESCRIPTION
Fix summary: implemented `getSerializedSize(T)` method in SmartContractByteCodeMapValueSerializer.

Fixes: https://github.com/hashgraph/hedera-services/issues/10948
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
