### PR TITLE
fix: (mod-service)Use concurrent read cache

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVStateBase.java
@@ -68,7 +68,9 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
         Objects.requireNonNull(key);
         if (!hasBeenRead(key)) {
             final var value = readFromDataSource(key);
-            markRead(key, value);
+            if (value != null) {
+                markRead(key, value);
+            }
         }
         return readCache.get(key);
     }
@@ -121,7 +123,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @param key The key
      * @param value The value
      */
-    protected final void markRead(@NonNull K key, @Nullable V value) {
+    protected final void markRead(@NonNull K key, @NonNull V value) {
         readCache.put(key, value);
     }
 

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableKVStateBase.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.spi.state;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A base class for implementations of {@link ReadableKVState} and {@link WritableKVState}.
@@ -38,7 +39,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * changed before we got to handle transaction. If the value is "null", this means it was NOT
      * FOUND when we looked it up.
      */
-    private final Map<K, V> readCache = new HashMap<>();
+    private final Map<K, V> readCache = new ConcurrentHashMap<>();
 
     private final Set<K> unmodifiableReadKeys = Collections.unmodifiableSet(readCache.keySet());
 

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVStateBase.java
@@ -110,9 +110,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
         // We have not queried this key before, so let's look it up and store that we have
         // read this key. And then return the value.
         final var val = getForModifyFromDataSource(key);
-        if(val != null){
-            markRead(key, val);
-        }
+        markRead(key, val);
         return val;
     }
 

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableKVStateBase.java
@@ -110,7 +110,9 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
         // We have not queried this key before, so let's look it up and store that we have
         // read this key. And then return the value.
         final var val = getForModifyFromDataSource(key);
-        markRead(key, val);
+        if(val != null){
+            markRead(key, val);
+        }
         return val;
     }
 


### PR DESCRIPTION
Root cause is the [use of a ](http://java/com/hedera/node/app/spi/state/ReadableKVStateBase.java#L41)HashMap readCache[ in ](http://java/com/hedera/node/app/spi/state/ReadableKVStateBase.java#L41)ReadableKVStateBase results a race between (1) thread A that is trying to get an already-read key and (2) thread B that is trying to add a newly-read key and hence resizing the HashMap. This can lead to ISS. 

To solve the issue used `ConcurrentHashMap` or `SynchronizedMap` instead of `HashMap` for readCache. Since we want to store null values in readCache if the entity doesn't exist in state, and `ConcurrentHashMap` doesn't allow null values decided to use `SynchronizedMap`.


This will be changed to use a Marker object instead of null value in the future based on performance testing.