### PR TITLE
chore: Update local-node Docker images to Java 21 (cherry pick #10834)

### DIFF
--- a/hedera-node/infrastructure/docker/containers/local-node/network-node-base/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/local-node/network-node-base/Dockerfile
@@ -24,7 +24,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install basic OS utilities for building
 RUN apt-get update && \
-	apt-get install --yes tar gzip gnupg2 curl
+  apt-get install --yes tar gzip gnupg2 curl
 
 ##########################
 ####    Java Setup    ####
@@ -33,41 +33,33 @@ RUN apt-get update && \
 RUN set -eux; \
         ARCH="$(dpkg --print-architecture)"; \
         case "${ARCH}" in \
-           aarch64|arm64) \
-             ESUM='0084272404b89442871e0a1f112779844090532978ad4d4191b8d03fc6adfade'; \
-             BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.7_7.tar.gz'; \
-             ;; \
-           armhf|arm) \
-             ESUM='e7a84c3e59704588510d7e6cce1f732f397b54a3b558c521912a18a1b4d0abdc'; \
-             BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.7_7.tar.gz'; \
-             ;; \
-           ppc64el|powerpc:common64) \
-             ESUM='8f4366ff1eddb548b1744cd82a1a56ceee60abebbcbad446bfb3ead7ac0f0f85'; \
-             BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.7_7.tar.gz'; \
-             ;; \
-           s390x|s390:64-bit) \
-             ESUM='2d75540ae922d0c4162729267a8c741e2414881a468fd2ce4140b4069ba47ca9'; \
-             BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.7_7.tar.gz'; \
-             ;; \
-           amd64|i386:x86-64) \
-             ESUM='e9458b38e97358850902c2936a1bb5f35f6cffc59da9fcd28c63eab8dbbfbc3b'; \
-             BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.7_7.tar.gz'; \
-             ;; \
-           *) \
-             echo "Unsupported arch: ${ARCH}"; \
-             exit 1; \
-             ;; \
-        esac; \
-    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-    mkdir -p /usr/local/java; \
-    tar --extract \
-    	      --file /tmp/openjdk.tar.gz \
-    	      --directory "/usr/local/java" \
-    	      --strip-components 1 \
-    	      --no-same-owner \
-    	  ; \
-    rm -f /tmp/openjdk.tar.gz /usr/local/java/lib/src.zip;
+            aarch64|arm64) \
+                ESUM='e184dc29a6712c1f78754ab36fb48866583665fa345324f1a79e569c064f95e9'; \
+                BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz'; \
+              ;; \
+            amd64|i386:x86-64) \
+              ESUM='1a6fa8abda4c5caed915cfbeeb176e7fbd12eb6b222f26e290ee45808b529aa1'; \
+              BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz'; \
+              ;; \
+            ppc64el|powerpc:common64) \
+              ESUM='9574828ef3d735a25404ced82e09bf20e1614f7d6403956002de9cfbfcb8638f'; \
+              BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.1_12.tar.gz'; \
+              ;; \
+            *) \
+              echo "Unsupported arch: ${ARCH}"; \
+              exit 1; \
+              ;; \
+          esac; \
+  curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+  mkdir -p /usr/local/java; \
+  tar --extract \
+  --file /tmp/openjdk.tar.gz \
+  --directory "/usr/local/java" \
+  --strip-components 1 \
+  --no-same-owner \
+  ; \
+  rm -f /tmp/openjdk.tar.gz /usr/local/java/lib/src.zip;
 
 
 ########################################################################################################################
@@ -80,7 +72,7 @@ FROM ubuntu:${UBUNTU_TAG} AS openjdk-base
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
-ENV JAVA_VERSION="jdk-17.0.7+7"
+ENV JAVA_VERSION="jdk-21.0.1+12"
 ENV JAVA_HOME="/usr/local/java/"
 
 # Fetch Validated Java Binaries
@@ -88,49 +80,49 @@ COPY --from=openjdk-builder /usr/local/java/ /usr/local/java/
 
 # Install Basic OS Requirements
 RUN apt-get update && \
-	apt-get install --yes --no-install-recommends tar gzip openssl zlib1g libsodium23 sudo && \
-	apt-get install --yes --no-install-recommends libnetty-tcnative-jni && \
-	apt-get autoremove --yes && \
-	apt-get autoclean --yes && \
-	apt-get clean all --yes && \
-    rm -rf /var/lib/{apt,dpkg,cache,log}/
+  apt-get install --yes --no-install-recommends tar gzip openssl zlib1g libsodium23 sudo && \
+  apt-get install --yes --no-install-recommends libnetty-tcnative-jni && \
+  apt-get autoremove --yes && \
+  apt-get autoclean --yes && \
+  apt-get clean all --yes && \
+  rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Install Java Alternatives
 RUN update-alternatives --install "/usr/bin/java" "java" "${JAVA_HOME}/bin/java" 1500 && \
-    update-alternatives --install "/usr/bin/javac" "javac" "${JAVA_HOME}/bin/javac" 1500 && \
-    update-alternatives --install "/usr/bin/javadoc" "javadoc" "${JAVA_HOME}/bin/javadoc" 1500 && \
-    update-alternatives --install "/usr/bin/jshell" "jshell" "${JAVA_HOME}/bin/jshell" 1500 && \
-    update-alternatives --install "/usr/bin/jstack" "jstack" "${JAVA_HOME}/bin/jstack" 1500 && \
-    update-alternatives --install "/usr/bin/jps" "jps" "${JAVA_HOME}/bin/jps" 1500 && \
-    update-alternatives --install "/usr/bin/jmap" "jmap" "${JAVA_HOME}/bin/jmap" 1500
+  update-alternatives --install "/usr/bin/javac" "javac" "${JAVA_HOME}/bin/javac" 1500 && \
+  update-alternatives --install "/usr/bin/javadoc" "javadoc" "${JAVA_HOME}/bin/javadoc" 1500 && \
+  update-alternatives --install "/usr/bin/jshell" "jshell" "${JAVA_HOME}/bin/jshell" 1500 && \
+  update-alternatives --install "/usr/bin/jstack" "jstack" "${JAVA_HOME}/bin/jstack" 1500 && \
+  update-alternatives --install "/usr/bin/jps" "jps" "${JAVA_HOME}/bin/jps" 1500 && \
+  update-alternatives --install "/usr/bin/jmap" "jmap" "${JAVA_HOME}/bin/jmap" 1500
 
 # Create Application Folders
 RUN mkdir -p "/opt/hgcapp" && \
-    mkdir -p "/opt/hgcapp/accountBalances" && \
-    mkdir -p "/opt/hgcapp/eventsStreams" && \
-    mkdir -p "/opt/hgcapp/recordStreams" && \
-    mkdir -p "/opt/hgcapp/services-hedera" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/apps" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/backup" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/config" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/lib" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/onboard" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/stats" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/saved" && \
-    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"
+  mkdir -p "/opt/hgcapp/accountBalances" && \
+  mkdir -p "/opt/hgcapp/eventsStreams" && \
+  mkdir -p "/opt/hgcapp/recordStreams" && \
+  mkdir -p "/opt/hgcapp/services-hedera" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/apps" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/backup" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/config" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/lib" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/onboard" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/stats" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/saved" && \
+  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"
 
 # Configure the standard user account
 RUN groupadd --gid 2000 hedera && \
-    useradd --no-user-group --create-home --uid 2000 --gid 2000 --shell /bin/bash hedera && \
-    chown -R hedera:hedera /opt/hgcapp
+  useradd --no-user-group --create-home --uid 2000 --gid 2000 --shell /bin/bash hedera && \
+  chown -R hedera:hedera /opt/hgcapp
 
 # Configure SUDO support
 RUN echo >> /etc/sudoers && \
-    echo "%hedera ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+  echo "%hedera ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 
 # Define Volume Bindpoints

--- a/hedera-node/infrastructure/docker/containers/local-node/network-node-base/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/local-node/network-node-base/Dockerfile
@@ -24,7 +24,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install basic OS utilities for building
 RUN apt-get update && \
-  apt-get install --yes tar gzip gnupg2 curl
+	apt-get install --yes tar gzip gnupg2 curl
 
 ##########################
 ####    Java Setup    ####
@@ -33,33 +33,33 @@ RUN apt-get update && \
 RUN set -eux; \
         ARCH="$(dpkg --print-architecture)"; \
         case "${ARCH}" in \
-            aarch64|arm64) \
-                ESUM='e184dc29a6712c1f78754ab36fb48866583665fa345324f1a79e569c064f95e9'; \
-                BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz'; \
-              ;; \
-            amd64|i386:x86-64) \
-              ESUM='1a6fa8abda4c5caed915cfbeeb176e7fbd12eb6b222f26e290ee45808b529aa1'; \
-              BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz'; \
-              ;; \
-            ppc64el|powerpc:common64) \
-              ESUM='9574828ef3d735a25404ced82e09bf20e1614f7d6403956002de9cfbfcb8638f'; \
-              BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.1_12.tar.gz'; \
-              ;; \
-            *) \
-              echo "Unsupported arch: ${ARCH}"; \
-              exit 1; \
-              ;; \
-          esac; \
-  curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-  mkdir -p /usr/local/java; \
-  tar --extract \
-  --file /tmp/openjdk.tar.gz \
-  --directory "/usr/local/java" \
-  --strip-components 1 \
-  --no-same-owner \
-  ; \
-  rm -f /tmp/openjdk.tar.gz /usr/local/java/lib/src.zip;
+           aarch64|arm64) \
+             ESUM='e184dc29a6712c1f78754ab36fb48866583665fa345324f1a79e569c064f95e9'; \
+             BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz'; \
+             ;; \
+           amd64|i386:x86-64) \
+             ESUM='1a6fa8abda4c5caed915cfbeeb176e7fbd12eb6b222f26e290ee45808b529aa1'; \
+             BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz'; \
+             ;; \
+           ppc64el|powerpc:common64) \
+             ESUM='9574828ef3d735a25404ced82e09bf20e1614f7d6403956002de9cfbfcb8638f'; \
+             BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.1_12.tar.gz'; \
+             ;; \
+           *) \
+             echo "Unsupported arch: ${ARCH}"; \
+             exit 1; \
+             ;; \
+        esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /usr/local/java; \
+    tar --extract \
+    	      --file /tmp/openjdk.tar.gz \
+    	      --directory "/usr/local/java" \
+    	      --strip-components 1 \
+    	      --no-same-owner \
+    	  ; \
+    rm -f /tmp/openjdk.tar.gz /usr/local/java/lib/src.zip;
 
 
 ########################################################################################################################
@@ -80,49 +80,49 @@ COPY --from=openjdk-builder /usr/local/java/ /usr/local/java/
 
 # Install Basic OS Requirements
 RUN apt-get update && \
-  apt-get install --yes --no-install-recommends tar gzip openssl zlib1g libsodium23 sudo && \
-  apt-get install --yes --no-install-recommends libnetty-tcnative-jni && \
-  apt-get autoremove --yes && \
-  apt-get autoclean --yes && \
-  apt-get clean all --yes && \
-  rm -rf /var/lib/{apt,dpkg,cache,log}/
+	apt-get install --yes --no-install-recommends tar gzip openssl zlib1g libsodium23 sudo && \
+	apt-get install --yes --no-install-recommends libnetty-tcnative-jni && \
+	apt-get autoremove --yes && \
+	apt-get autoclean --yes && \
+	apt-get clean all --yes && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Install Java Alternatives
 RUN update-alternatives --install "/usr/bin/java" "java" "${JAVA_HOME}/bin/java" 1500 && \
-  update-alternatives --install "/usr/bin/javac" "javac" "${JAVA_HOME}/bin/javac" 1500 && \
-  update-alternatives --install "/usr/bin/javadoc" "javadoc" "${JAVA_HOME}/bin/javadoc" 1500 && \
-  update-alternatives --install "/usr/bin/jshell" "jshell" "${JAVA_HOME}/bin/jshell" 1500 && \
-  update-alternatives --install "/usr/bin/jstack" "jstack" "${JAVA_HOME}/bin/jstack" 1500 && \
-  update-alternatives --install "/usr/bin/jps" "jps" "${JAVA_HOME}/bin/jps" 1500 && \
-  update-alternatives --install "/usr/bin/jmap" "jmap" "${JAVA_HOME}/bin/jmap" 1500
+    update-alternatives --install "/usr/bin/javac" "javac" "${JAVA_HOME}/bin/javac" 1500 && \
+    update-alternatives --install "/usr/bin/javadoc" "javadoc" "${JAVA_HOME}/bin/javadoc" 1500 && \
+    update-alternatives --install "/usr/bin/jshell" "jshell" "${JAVA_HOME}/bin/jshell" 1500 && \
+    update-alternatives --install "/usr/bin/jstack" "jstack" "${JAVA_HOME}/bin/jstack" 1500 && \
+    update-alternatives --install "/usr/bin/jps" "jps" "${JAVA_HOME}/bin/jps" 1500 && \
+    update-alternatives --install "/usr/bin/jmap" "jmap" "${JAVA_HOME}/bin/jmap" 1500
 
 # Create Application Folders
 RUN mkdir -p "/opt/hgcapp" && \
-  mkdir -p "/opt/hgcapp/accountBalances" && \
-  mkdir -p "/opt/hgcapp/eventsStreams" && \
-  mkdir -p "/opt/hgcapp/recordStreams" && \
-  mkdir -p "/opt/hgcapp/services-hedera" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/apps" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/backup" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/config" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/lib" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/onboard" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/stats" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/saved" && \
-  mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"
+    mkdir -p "/opt/hgcapp/accountBalances" && \
+    mkdir -p "/opt/hgcapp/eventsStreams" && \
+    mkdir -p "/opt/hgcapp/recordStreams" && \
+    mkdir -p "/opt/hgcapp/services-hedera" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/apps" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/backup" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/config" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/lib" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/onboard" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/stats" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/saved" && \
+    mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"
 
 # Configure the standard user account
 RUN groupadd --gid 2000 hedera && \
-  useradd --no-user-group --create-home --uid 2000 --gid 2000 --shell /bin/bash hedera && \
-  chown -R hedera:hedera /opt/hgcapp
+    useradd --no-user-group --create-home --uid 2000 --gid 2000 --shell /bin/bash hedera && \
+    chown -R hedera:hedera /opt/hgcapp
 
 # Configure SUDO support
 RUN echo >> /etc/sudoers && \
-  echo "%hedera ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    echo "%hedera ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 
 # Define Volume Bindpoints


### PR DESCRIPTION
**Description**:
This PR cherry picks an update to `Dockerfile` definitions for `local-node` images of `hedera-services` to facilitate the migration to Java 21 and fix broken local node images for the 0.46 release.

Cherry pick #10834 

**Related issue(s)**:

Fixes #10833

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
