### PR TITLE
chore: skip unwanted parts of init during mono event stream recovery

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/StateModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/StateModule.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.state;
 
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.BOOTSTRAP_GENESIS_PUBLIC_KEY;
+import static com.swirlds.platform.system.InitTrigger.EVENT_STREAM_RECOVERY;
 
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
@@ -167,7 +168,7 @@ public interface StateModule {
             @NonNull final RecordStreamManager recordStreamManager,
             @NonNull final BalancesExporter balancesExporter,
             @NonNull final NodeId nodeId) {
-        if (initTrigger == InitTrigger.EVENT_STREAM_RECOVERY) {
+        if (initTrigger == EVENT_STREAM_RECOVERY) {
             return Optional.of(new ExportingRecoveredStateListener(recordStreamManager, balancesExporter, nodeId));
         } else {
             return Optional.empty();
@@ -224,10 +225,15 @@ public interface StateModule {
 
     @Provides
     @Singleton
-    static Optional<PrintStream> providePrintStream(final ConsoleCreator consoleCreator, final Platform platform) {
-        return Optional.ofNullable(consoleCreator.createConsole(
-                        platform, (int) platform.getSelfId().id(), true))
-                .map(c -> c.out);
+    static Optional<PrintStream> providePrintStream(
+            @NonNull final ConsoleCreator consoleCreator,
+            @NonNull final InitTrigger initTrigger,
+            @NonNull final Platform platform) {
+        return initTrigger == EVENT_STREAM_RECOVERY
+                ? Optional.empty()
+                : Optional.ofNullable(consoleCreator.createConsole(
+                                platform, (int) platform.getSelfId().id(), true))
+                        .map(c -> c.out);
     }
 
     @Provides

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/GrpcStarterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/GrpcStarterTest.java
@@ -32,6 +32,7 @@ import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
 import com.hedera.test.extensions.LoggingTarget;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import java.io.PrintStream;
@@ -73,7 +74,27 @@ class GrpcStarterTest {
     @BeforeEach
     void setUp() {
         subject = new GrpcStarter(
-                nodeId, grpcServerManager, nodeLocalProperties, () -> addressBook, Optional.of(console));
+                nodeId,
+                InitTrigger.GENESIS,
+                grpcServerManager,
+                nodeLocalProperties,
+                () -> addressBook,
+                Optional.of(console));
+    }
+
+    @Test
+    void doesNothingDuringEventStreamRecovery() {
+        subject = new GrpcStarter(
+                nodeId,
+                InitTrigger.EVENT_STREAM_RECOVERY,
+                grpcServerManager,
+                nodeLocalProperties,
+                () -> addressBook,
+                Optional.of(console));
+
+        subject.startIfAppropriate();
+
+        verifyNoInteractions(grpcServerManager, nodeLocalProperties, addressBook, console);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/StateModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/StateModuleTest.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.state;
 
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.BOOTSTRAP_GENESIS_PUBLIC_KEY;
+import static com.hedera.node.app.service.mono.state.StateModule.providePrintStream;
 import static com.hedera.node.app.service.mono.state.StateModule.provideStateViews;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -60,7 +61,13 @@ class StateModuleTest {
     private NetworkInfo networkInfo;
 
     @Mock
+    private Platform platform;
+
+    @Mock
     private RecordStreamManager recordStreamManager;
+
+    @Mock
+    private StateModule.ConsoleCreator consoleCreator;
 
     @Mock
     private BalancesExporter balancesExporter;
@@ -72,6 +79,12 @@ class StateModuleTest {
         // expect:
         assertEquals(
                 Charset.defaultCharset(), StateModule.provideNativeCharset().get());
+    }
+
+    @Test
+    void providesEmptyConsolePrintStreamDuringEventRecovery() {
+        final var maybePrintStream = providePrintStream(consoleCreator, InitTrigger.EVENT_STREAM_RECOVERY, platform);
+        assertTrue(maybePrintStream.isEmpty());
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -133,13 +133,8 @@ public final class EventRecoveryWorkflow {
                 .getConfigData(PathsConfig.class);
 
         // parameters if the app needs them
-        System.out.println("Loading configuration from " + configurationFiles);
-        final ApplicationDefinition appDefinition = ApplicationDefinitionLoader.loadDefault(
-                defaultPathsConfig,
-                getAbsolutePath(
-                        configurationFiles.isEmpty()
-                                ? DEFAULT_CONFIG_FILE_NAME
-                                : configurationFiles.get(0).toString()));
+        final ApplicationDefinition appDefinition =
+                ApplicationDefinitionLoader.loadDefault(defaultPathsConfig, getAbsolutePath(DEFAULT_CONFIG_FILE_NAME));
         ParameterProvider.getInstance().setParameters(appDefinition.getAppParameters());
 
         final SwirldMain appMain = loadAppMain(mainClassName);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -133,8 +133,13 @@ public final class EventRecoveryWorkflow {
                 .getConfigData(PathsConfig.class);
 
         // parameters if the app needs them
-        final ApplicationDefinition appDefinition =
-                ApplicationDefinitionLoader.loadDefault(defaultPathsConfig, getAbsolutePath(DEFAULT_CONFIG_FILE_NAME));
+        System.out.println("Loading configuration from " + configurationFiles);
+        final ApplicationDefinition appDefinition = ApplicationDefinitionLoader.loadDefault(
+                defaultPathsConfig,
+                getAbsolutePath(
+                        configurationFiles.isEmpty()
+                                ? DEFAULT_CONFIG_FILE_NAME
+                                : configurationFiles.get(0).toString()));
         ParameterProvider.getInstance().setParameters(appDefinition.getAppParameters());
 
         final SwirldMain appMain = loadAppMain(mainClassName);


### PR DESCRIPTION
**Description**:
 - Reduces friction in running mono-service `EVENT_STREAM_RECOVERY` by not trying to create a GUI console or start Netty.