### PR TITLE
chore: Extend Mixed operation submitted for Restart and Reconnect tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOperations.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOperations.java
@@ -54,6 +54,7 @@ public class MixedOperations {
     static final String SUBMIT_KEY = "submitKey";
     static final String ADMIN_KEY = "adminKey";
     static final String TOKEN = "token";
+    static final String NFT = "nft";
     static final String SENDER = "sender";
     static final String RECEIVER = "receiver";
     static final String TOPIC = "topic";
@@ -69,6 +70,7 @@ public class MixedOperations {
 
     Supplier<HapiSpecOperation[]> mixedOps(
             final AtomicInteger tokenId,
+            final AtomicInteger nftId,
             final AtomicInteger scheduleId,
             final AtomicInteger contractId,
             final Random r) {
@@ -97,7 +99,7 @@ public class MixedOperations {
                     .toArray(HapiSpecOperation[]::new)),
             sleepFor(10000),
             inParallel(IntStream.range(0, numSubmissions)
-                    .mapToObj(ignore -> tokenCreate(TOKEN + tokenId.getAndIncrement())
+                    .mapToObj(ignore -> tokenCreate(NFT + nftId.getAndIncrement())
                             .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
                             .treasury(TREASURY)
                             .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
@@ -145,7 +147,7 @@ public class MixedOperations {
                     .mapToObj(ignore -> contractCreate(CONTRACT_NAME_PREFIX + contractId.getAndIncrement())
                             .bytecode(SOME_BYTE_CODE)
                             .logging())
-                    .toArray(HapiSpecOperation[]::new)),
+                    .toArray(HapiSpecOperation[]::new))
         };
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.shutDownNode;
@@ -33,6 +34,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForNodeToShutDo
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.scheduleOpsEnablement;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.ADMIN_KEY;
+import static com.hedera.services.bdd.suites.regression.system.MixedOperations.NFT;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.PAYER;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.RECEIVER;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.SENDER;
@@ -42,6 +44,7 @@ import static com.hedera.services.bdd.suites.regression.system.MixedOperations.T
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.TREASURY;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.SUPPLY_KEY;
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -52,6 +55,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
@@ -87,9 +91,10 @@ public class MixedOpsNodeDeathReconnectTest extends HapiSuite {
         final AtomicInteger tokenId = new AtomicInteger(0);
         final AtomicInteger scheduleId = new AtomicInteger(0);
         final AtomicInteger contractId = new AtomicInteger(0);
+        AtomicInteger nftId = new AtomicInteger(0);
         Random r = new Random(38582L);
         Supplier<HapiSpecOperation[]> mixedOpsBurst =
-                new MixedOperations(NUM_SUBMISSIONS).mixedOps(tokenId, scheduleId, contractId, r);
+                new MixedOperations(NUM_SUBMISSIONS).mixedOps(tokenId, nftId, scheduleId, contractId, r);
         return defaultHapiSpec("RestartMixedOps")
                 .given(
                         newKeyNamed(SUBMIT_KEY),
@@ -116,6 +121,13 @@ public class MixedOpsNodeDeathReconnectTest extends HapiSuite {
                 .when(
                         // Submit operations when node 2 is down
                         inParallel(mixedOpsBurst.get()),
+                        sleepFor(10000),
+                        inParallel(IntStream.range(0, NUM_SUBMISSIONS)
+                                .mapToObj(ignore -> mintToken(
+                                                NFT + nftId.getAndDecrement(),
+                                                List.of(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("b")))
+                                        .logging())
+                                .toArray(HapiSpecOperation[]::new)),
                         // start all nodes
                         startNode("Carol").logged(),
                         // wait for node 2 to go BEHIND

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -20,6 +20,7 @@ import static com.hedera.services.bdd.junit.TestTags.ND_RECONNECT;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.shutDownNode;
@@ -35,6 +36,7 @@ import static com.hedera.services.bdd.suites.regression.system.MixedOperations.A
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.PAYER;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.RECEIVER;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.SENDER;
+import static com.hedera.services.bdd.suites.regression.system.MixedOperations.SOME_BYTE_CODE;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.SUBMIT_KEY;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.TOPIC;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.TREASURY;
@@ -44,6 +46,7 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.suites.HapiSuite;
 import java.util.List;
 import java.util.Random;
@@ -81,11 +84,12 @@ public class MixedOpsNodeDeathReconnectTest extends HapiSuite {
 
     @HapiTest
     private HapiSpec reconnectMixedOps() {
-        AtomicInteger tokenId = new AtomicInteger(0);
-        AtomicInteger scheduleId = new AtomicInteger(0);
+        final AtomicInteger tokenId = new AtomicInteger(0);
+        final AtomicInteger scheduleId = new AtomicInteger(0);
+        final AtomicInteger contractId = new AtomicInteger(0);
         Random r = new Random(38582L);
         Supplier<HapiSpecOperation[]> mixedOpsBurst =
-                new MixedOperations(NUM_SUBMISSIONS).mixedOps(tokenId, scheduleId, r);
+                new MixedOperations(NUM_SUBMISSIONS).mixedOps(tokenId, scheduleId, contractId, r);
         return defaultHapiSpec("RestartMixedOps")
                 .given(
                         newKeyNamed(SUBMIT_KEY),
@@ -98,6 +102,8 @@ public class MixedOpsNodeDeathReconnectTest extends HapiSuite {
                         cryptoCreate(SENDER).balance(ONE_MILLION_HBARS).payingWith(PAYER),
                         cryptoCreate(RECEIVER).balance(ONE_MILLION_HBARS).payingWith(PAYER),
                         createTopic(TOPIC).submitKeyName(SUBMIT_KEY).payingWith(PAYER),
+                        fileCreate(SOME_BYTE_CODE)
+                                .path(HapiSpecSetup.getDefaultInstance().defaultContractPath()),
                         // Kill node 2
                         shutDownNode("Carol").logged(),
                         // Wait for it to shut down
@@ -125,6 +131,8 @@ public class MixedOpsNodeDeathReconnectTest extends HapiSuite {
                         cryptoCreate(SENDER).balance(ONE_MILLION_HBARS).payingWith(PAYER),
                         cryptoCreate(RECEIVER).balance(ONE_MILLION_HBARS).payingWith(PAYER),
                         createTopic(TOPIC).submitKeyName(SUBMIT_KEY).payingWith(PAYER),
+                        fileCreate(SOME_BYTE_CODE)
+                                .path(HapiSpecSetup.getDefaultInstance().defaultContractPath()),
                         inParallel(mixedOpsBurst.get()));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsStateCreation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsStateCreation.java
@@ -16,20 +16,22 @@
 
 package com.hedera.services.bdd.suites.regression.system;
 
-import static com.hedera.services.bdd.junit.TestTags.RESTART;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.shutDownAllNodes;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.startAllNodes;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForNodesToBecomeActive;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForNodesToFreeze;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForNodesToShutDown;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.scheduleOpsEnablement;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.ADMIN_KEY;
@@ -43,33 +45,30 @@ import static com.hedera.services.bdd.suites.regression.system.MixedOperations.T
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.SUPPLY_KEY;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.suites.HapiSuite;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Tag;
 
-/**
- * This test is to verify restart functionality. It submits a burst of mixed operations, then
- * freezes all nodes, shuts them down, restarts them, and submits the same burst of mixed operations
- * again.
- */
-@HapiTestSuite
-@Tag(RESTART)
-public class MixedOpsRestartTest extends HapiSuite {
-    private static final Logger log = LogManager.getLogger(MixedOpsRestartTest.class);
+public class MixedOpsStateCreation extends HapiSuite {
+    private static final Logger log = LogManager.getLogger(MixedOpsStateCreation.class);
 
     private static final int NUM_SUBMISSIONS = 20;
+    private static final String KV_CONTRACT = "Create2MultipleCreates";
+    private static final String CONTRACT_ADMIN_KEY = "Create2MultipleCreates";
+    public static final String GET_BYTECODE = "getBytecode";
+    public static final String DEPLOY = "deploy";
 
     public static void main(String... args) {
-        new MixedOpsRestartTest().runSuiteSync();
+        new MixedOpsStateCreation().runSuiteSync();
     }
 
     @Override
@@ -79,19 +78,22 @@ public class MixedOpsRestartTest extends HapiSuite {
 
     @Override
     public List<HapiSpec> getSpecsInSuite() {
-        return List.of(restartMixedOps());
+        return List.of(createState());
     }
 
     @HapiTest
-    final HapiSpec restartMixedOps() {
+    final HapiSpec createState() {
         AtomicInteger tokenId = new AtomicInteger(0);
         AtomicInteger scheduleId = new AtomicInteger(0);
         AtomicInteger contractId = new AtomicInteger(0);
+        final AtomicReference<String> factoryEvmAddress = new AtomicReference<>();
+        final AtomicReference<byte[]> testContractInitcode = new AtomicReference<>();
         Random r = new Random(38582L);
         Supplier<HapiSpecOperation[]> mixedOpsBurst =
                 new MixedOperations(NUM_SUBMISSIONS).mixedOps(tokenId, scheduleId, contractId, r);
         return defaultHapiSpec("RestartMixedOps")
                 .given(
+                        newKeyNamed(CONTRACT_ADMIN_KEY),
                         newKeyNamed(SUBMIT_KEY),
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(ADMIN_KEY),
@@ -104,34 +106,37 @@ public class MixedOpsRestartTest extends HapiSuite {
                         createTopic(TOPIC).submitKeyName(SUBMIT_KEY).payingWith(PAYER),
                         fileCreate(SOME_BYTE_CODE)
                                 .path(HapiSpecSetup.getDefaultInstance().defaultContractPath()),
+                        // Create a contract with some KV Pairs
+                        uploadInitCode(KV_CONTRACT),
+                        contractCreate(KV_CONTRACT)
+                                .payingWith(GENESIS)
+                                .adminKey(CONTRACT_ADMIN_KEY)
+                                .entityMemo("Test contract")
+                                .gas(10_000_000L)
+                                .exposingNumTo(num -> factoryEvmAddress.set(asHexedSolidityAddress(0, 0, num))),
+                        sourcing(() -> contractCallLocal(
+                                        KV_CONTRACT,
+                                        GET_BYTECODE,
+                                        asHeadlongAddress(factoryEvmAddress.get()),
+                                        BigInteger.valueOf(42))
+                                .exposingTypedResultsTo(results -> {
+                                    final var tcInitcode = (byte[]) results[0];
+                                    testContractInitcode.set(tcInitcode);
+                                })
+                                .payingWith(GENESIS)
+                                .nodePayment(ONE_HBAR)),
+                        sourcing(() -> contractCall(
+                                        KV_CONTRACT, DEPLOY, testContractInitcode.get(), BigInteger.valueOf(42))
+                                .payingWith(GENESIS)
+                                .gas(10_000_000L)
+                                .sending(1_234L)),
                         inParallel(mixedOpsBurst.get()))
                 .when(
+                        sleepFor(60000),
                         // freeze nodes
                         freezeOnly().startingIn(10).payingWith(GENESIS),
                         // wait for all nodes to be in FREEZE status
-                        waitForNodesToFreeze(75).logged(),
-                        // shut down all nodes, since the platform doesn't automatically go back to ACTIVE status
-                        shutDownAllNodes().logged(),
-                        // wait for all nodes to be shut down
-                        waitForNodesToShutDown(60).logged(),
-                        // This sleep is needed, since the ports of shutdown nodes may still be in time_wait status,
-                        // which will cause an error that address is already in use when restarting nodes.
-                        // Sleep long enough (120s or 180 secs for TIME_WAIT status to be finished based on
-                        // kernel settings), so restarting nodes succeeds.
-                        sleepFor(180_000L).logged(),
-                        // start all nodes
-                        startAllNodes().logged(),
-                        // wait for all nodes to be ACTIVE
-                        waitForNodesToBecomeActive(100).logged())
-                .then(
-                        // Once nodes come back ACTIVE, submit some operations again
-                        cryptoCreate(PAYER).balance(100 * ONE_MILLION_HBARS),
-                        cryptoCreate(TREASURY).balance(ONE_MILLION_HBARS).payingWith(PAYER),
-                        cryptoCreate(SENDER).balance(ONE_MILLION_HBARS).payingWith(PAYER),
-                        cryptoCreate(RECEIVER).balance(ONE_MILLION_HBARS).payingWith(PAYER),
-                        createTopic(TOPIC).submitKeyName(SUBMIT_KEY).payingWith(PAYER),
-                        fileCreate(SOME_BYTE_CODE)
-                                .path(HapiSpecSetup.getDefaultInstance().defaultContractPath()),
-                        inParallel(mixedOpsBurst.get()));
+                        waitForNodesToFreeze(75).logged())
+                .then();
     }
 }


### PR DESCRIPTION
Fixes #11006 

- Extends the operations done during Restart and Reconnect tests in CI
- Adds a new suite `MixedOpsStateCreation` to create a local state that contains all entity types

The state created has 
```
2024-01-16 23:28:46.436 INFO  392  ServicesState - Platform state includes freeze time=2024-01-17T05:25:53.198681Z and last frozen=2024-01-17T05:25:53.198681Z
2024-01-16 23:28:46.445 INFO  177  ServicesState -   (@ 0) # NFTs               = 38
2024-01-16 23:28:46.446 INFO  181  ServicesState -   (@ 1) # token associations = 40
2024-01-16 23:28:46.446 INFO  185  ServicesState -   (@ 2) # topics             = 21
2024-01-16 23:28:46.446 INFO  186  ServicesState -   (@ 3) # blobs              = 132
2024-01-16 23:28:46.446 INFO  190  ServicesState -   (@ 4) # accounts/contracts = 812
2024-01-16 23:28:46.446 INFO  194  ServicesState -   (@ 5) # tokens             = 40
2024-01-16 23:28:46.446 INFO  195  ServicesState -   (@ 8) # scheduled txns     = 100
2024-01-16 23:28:46.446 INFO  199  ServicesState -   (@ 11) # contract K/V pairs = 5