### PR TITLE
chore: remove check which performs receiver signature check 

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogic.java
@@ -146,7 +146,7 @@ public class ContractCallTransitionLogic implements PreFetchableTransition {
         final var sender = accountStore.loadAccount(senderId);
         final var target = targetOf(op);
 
-        Account receiver = extractAndValidateReceiver(op, target, relayerId != null);
+        Account receiver = extractAndValidateReceiver(op, target, relayerId != null, true);
 
         final var callData = !op.getFunctionParameters().isEmpty()
                 ? Bytes.wrap(op.getFunctionParameters().toByteArray())
@@ -225,7 +225,7 @@ public class ContractCallTransitionLogic implements PreFetchableTransition {
         }
 
         try {
-            extractAndValidateReceiver(op, targetOf(op), false);
+            extractAndValidateReceiver(op, targetOf(op), false, false);
         } catch (InvalidTransactionException e) {
             return e.getResponseCode();
         }
@@ -242,7 +242,7 @@ public class ContractCallTransitionLogic implements PreFetchableTransition {
         }
 
         try {
-            extractAndValidateReceiver(op, targetOf(op), true);
+            extractAndValidateReceiver(op, targetOf(op), true, false);
         } catch (InvalidTransactionException e) {
             return e.getResponseCode();
         }
@@ -319,7 +319,10 @@ public class ContractCallTransitionLogic implements PreFetchableTransition {
     }
 
     private Account extractAndValidateReceiver(
-            ContractCallTransactionBody op, final EntityNum unaliasedTargetNum, final boolean isEthTx) {
+            ContractCallTransactionBody op,
+            final EntityNum unaliasedTargetNum,
+            final boolean isEthTx,
+            final boolean isHandle) {
 
         final var unaliasedTargetId = unaliasedTargetNum.toId();
         final var targetAliasIsMissing = unaliasedTargetNum.equals(EntityNum.MISSING_NUM);
@@ -336,15 +339,17 @@ public class ContractCallTransitionLogic implements PreFetchableTransition {
         if (!targetAliasIsMissing) {
 
             if (op.getAmount() > 0) {
-                // Since contracts cannot have receiverSigRequired=true, this can only
-                // restrict us from sending value to an EOA
-                final var sigReqIsMet = sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
-                        false,
-                        unaliasedTargetNum.toEvmAddress(),
-                        NEVER_ACTIVE_CONTRACT_ADDRESS,
-                        worldLedgers,
-                        ContractCall);
-                validateTrue(sigReqIsMet, INVALID_SIGNATURE);
+                if (isHandle) {
+                    // Since contracts cannot have receiverSigRequired=true, this can only
+                    // restrict us from sending value to an EOA
+                    final var sigReqIsMet = sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                            false,
+                            unaliasedTargetNum.toEvmAddress(),
+                            NEVER_ACTIVE_CONTRACT_ADDRESS,
+                            worldLedgers,
+                            ContractCall);
+                    validateTrue(sigReqIsMet, INVALID_SIGNATURE);
+                }
                 validateTrue(!isSystemAccount, INVALID_FEE_SUBMITTED);
                 validateTrue(
                         entityAccess.isExtant(unaliasedTargetNum.toEvmAddress())

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
@@ -789,8 +789,6 @@ class ContractCallTransitionLogicTest {
         given(properties.maxGasPerSec()).willReturn(gas + 1);
         given(properties.callsToNonExistingEntitiesEnabled(any())).willReturn(true);
         contractAccount.setSmartContract(true);
-        given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(anyBoolean(), any(), any(), any(), any()))
-                .willReturn(true);
         given(entityAccess.isExtant(any())).willReturn(true);
 
         // expect:
@@ -802,8 +800,6 @@ class ContractCallTransitionLogicTest {
         givenValidTxnCtx();
         given(properties.callsToNonExistingEntitiesEnabled(any())).willReturn(true);
         given(properties.maxGasPerSec()).willReturn(gas + 1);
-        given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(anyBoolean(), any(), any(), any(), any()))
-                .willReturn(true);
         given(entityAccess.isExtant(any())).willReturn(true);
         // expect:
         assertEquals(OK, subject.semanticCheck().apply(contractCallTxn));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
**Description**:
Remove a check which performs receiver signature checks during the precheck phase of `ContractCall` transactions. 
