### PR TITLE
ci: turning off release 0.45 regression

### DIFF
--- a/.github/workflows/node-zxcron-release-fsts-regression.yaml
+++ b/.github/workflows/node-zxcron-release-fsts-regression.yaml
@@ -51,7 +51,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 45 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 46 ]]; then
               continue
             fi
 

--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -51,7 +51,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 45 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 46 ]]; then
               continue
             fi
 


### PR DESCRIPTION
**Description**:

Turning off release 0.45 regression tests

**Related issue(s)**:

Closes #11039 

