### PR TITLE
fix: state unchanged on restart without upgrade

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
@@ -200,19 +200,25 @@ public class AddressBookInitializer {
                     "Overriding the address book in the state with the address book from config.txt");
             candidateAddressBook = configAddressBook;
             previousAddressBook = stateAddressBook;
+            // change indicator is true to indicate that the address books need to be updated in the state.
+            addressBookChange = true;
         } else if (initialState.isGenesisState()) {
-            // If this is a genesis state, the state's address book and previous address book will be null.
+            // If this is a genesis state, the state's address book and previous address book may be null.
             // Adopt the config.txt address book.
             logger.info(STARTUP.getMarker(), "Starting from genesis: using the config address book.");
             candidateAddressBook = configAddressBook;
             checkCandidateAddressBookValidity(candidateAddressBook);
             previousAddressBook = null;
+            // change indicator is true to indicate that the address books need to be updated in the state.
+            addressBookChange = true;
         } else if (!softwareUpgrade) {
             // Loaded State From Disk, Non-Genesis, No Software Upgrade
             logger.info(STARTUP.getMarker(), "Using the loaded state's address book and weight values.");
             candidateAddressBook = stateAddressBook;
             // since state address book was checked for validity prior to adoption, no check needed here.
             previousAddressBook = null;
+            // change indicator is false to keep the current and previous address books the same.
+            addressBookChange = false;
         } else {
             // Loaded State from Disk, Non-Genesis, There is a software version upgrade
             logger.info(
@@ -224,19 +230,11 @@ public class AddressBookInitializer {
                     .copy();
             candidateAddressBook = checkCandidateAddressBookValidity(candidateAddressBook);
             previousAddressBook = stateAddressBook;
+            // change indicator is true to indicate that the address books need to be updated in the state.
+            addressBookChange = true;
         }
-        // This flag indicates the state needs to be updated with the changes to the address books.
-        addressBookChange = hasAddressBookChanged(initialState, candidateAddressBook, previousAddressBook);
         recordAddressBooks(candidateAddressBook);
         return new InitializedAddressBooks(candidateAddressBook, previousAddressBook);
-    }
-
-    private boolean hasAddressBookChanged(
-            @NonNull final SignedState state,
-            @Nullable final AddressBook currentAddressBook,
-            @Nullable final AddressBook previousAddressBook) {
-        return !Objects.equals(state.getState().getPlatformState().getAddressBook(), currentAddressBook)
-                || !Objects.equals(state.getState().getPlatformState().getPreviousAddressBook(), previousAddressBook);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -143,7 +143,9 @@ class AddressBookInitializerTest {
         assertNull(initializer.getPreviousAddressBook(), "The previous address book should be null.");
         assertAddressBookFileContent(
                 initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
-        assertFalse(initializer.hasAddressBookChanged());
+        // Even when the genesis state has the correct address book, we always adopt the config.txt address book and
+        // indicate an address book change.
+        assertTrue(initializer.hasAddressBookChanged());
     }
 
     @Test
@@ -152,7 +154,7 @@ class AddressBookInitializerTest {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
         // initial state has currentAddressBook set to configAddressBook
-        final SignedState signedState = getMockSignedState(7, configAddressBook, null, true);
+        final SignedState signedState = getMockSignedState(7, null, null, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 new NodeId(0),
                 getMockSoftwareVersion(2),
@@ -169,7 +171,7 @@ class AddressBookInitializerTest {
         assertNull(initializer.getPreviousAddressBook(), "The previous address book should be null.");
         assertAddressBookFileContent(
                 initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
-        assertFalse(initializer.hasAddressBookChanged());
+        assertTrue(initializer.hasAddressBookChanged());
     }
 
     @Test
@@ -198,8 +200,8 @@ class AddressBookInitializerTest {
                 "When there is no upgrade, the address book should not change");
         assertAddressBookFileContent(
                 initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
-        // Initializer nullifies the previous address book when there is no software upgrade.
-        assertTrue(initializer.hasAddressBookChanged());
+        // The addressBooks remain unchanged when there is no software upgrade.
+        assertFalse(initializer.hasAddressBookChanged());
     }
 
     @Test


### PR DESCRIPTION
**Description**:

A previous PR made a change to the AddressBookInitializer that caused the address books in the state to be upgrade when there was not a software upgrade taking place.  This caused the nodes to ISS when restarted without a software upgrade.   

This PR fixes that problem.  

**Related issue(s)**:

Fixes #11041

**Notes for reviewer**:

I adjusted unit tests to match the correct behavior. 
I manually verified that the state is no longer modified on restart using the state that lead to the ISS. 