### PR TITLE
chore: ensure validation runners use the same docker & containerd versions

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -58,6 +58,7 @@ env:
   DOCKER_REGISTRY: localhost:5000
   DOCKER_IMAGE_NAME: main-network-node
   DOCKER_CONTEXT_PATH: hedera-node/infrastructure/docker/containers/production-next/main-network-node
+  SKOPEO_VERSION: v1.14.0
 
 jobs:
   generate-baseline:
@@ -75,17 +76,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ inputs.ref }}
-
-      - name: Setup Java
-        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
-        with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          cache-disabled: true
 
       - name: Authenticate to Google Cloud
         id: google-auth
@@ -121,16 +111,74 @@ jobs:
           echo "name=${BASELINE_NAME}" >> "${GITHUB_OUTPUT}"
           echo "file=${BASELINE_FILE}" >> "${GITHUB_OUTPUT}"
 
+      - name: Setup Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        with:
+          cache-disabled: true
+
       - name: Install Skopeo and JQ
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends skopeo jq
 
-      - name: Build Gradle Artifacts
-        id: gradle-build
+      - name: Install KillAll
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        run: ./gradlew assemble --scan
+        run: sudo apt-get install --yes --no-install-recommends psmisc
+
+      - name: Create Docker Working Directory
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        run: |
+          USER="$(id -un)"
+          GROUP="$(id -gn)"
+          sudo mkdir -p /x
+          sudo chown -vR ${USER}:${GROUP} /x
+          sudo ls -lah /x
+
+      - name: Remove Docker from Self Hosted Runners
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        run: |
+          set -x
+          sudo killall dockerd || true
+          sudo killall containerd || true
+          sudo rm -rvf /usr/bin/*containerd* || true
+          sudo rm -rvf /usr/bin/docker* || true
+          sudo rm -rvf /usr/local/bin/docker* || true
+          sudo rm -rvf /usr/local/bin/*lima* || true
+
+      - name: Setup Containerd Support
+        uses: crazy-max/ghaction-setup-containerd@60acbf31e6572da7b83a4ed6b428ed92a35ff4d7 # v3.0.0
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        with:
+          containerd-version: v1.7.2
+
+      - name: Setup Docker Support
+        uses: crazy-max/ghaction-setup-docker@d9be6cade441568ba10037bce5221b8f564981f1 # v3.0.0
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        env:
+          HOME: /x
+        with:
+          version: v24.0.7
+
+      - name: Configure Default Docker Context
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        run: |
+          set -x
+          if grep setup-docker-action < <(docker context ls --format '{{ .Name }}') >/dev/null; then
+            docker context rm -f setup-docker-action
+          fi
+          
+          DOCKER_CONTEXT_PATH="$(sudo find /x -name docker.sock | tr -d '[:space:]')"
+          docker context create setup-docker-action --docker "host=unix://${DOCKER_CONTEXT_PATH}"
+          docker context use setup-docker-action
 
       - name: Setup QEmu Support
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
@@ -148,10 +196,16 @@ jobs:
         run: docker run -d -p 5000:5000 --restart=always --name registry registry:latest
 
       - name: Show Docker Version
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: docker version
 
       - name: Show Docker Info
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: docker info
+
+      - name: Build Gradle Artifacts
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
+        run: ./gradlew assemble --scan
 
       - name: Prepare for Docker Build
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -185,7 +239,7 @@ jobs:
         env:
           MANIFEST_PATH: ${{ env.DOCKER_MANIFEST_PATH }}
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        run: ${{ env.DOCKER_MANIFEST_GENERATOR }}
+        run: GITHUB_SHA="${{ needs.generate-baseline.outputs.sha-abbrev }}" ${{ env.DOCKER_MANIFEST_GENERATOR }}
 
       - name: Amend Manifest with Gradle Artifacts
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -208,22 +262,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows is disabled due to GitHub not supporting Docker Desktop/Podman Desktop and Docker CE on Windows not
-        # supporting BuildKit and the Buildx plugin.
-        # The GitHub hosted ubuntu-22.04 runners are disabled temporarily due to the Azure VM causing docker container
-        # builds to be non-deterministic. Self-hosted runners using Ubuntu 22.04 are unaffected.
-        # The Self Hosted Large instance is temporarily disabled because it is running no longer supported version of
-        # Ubuntu 18.04. The Large instance will be upgraded to Ubuntu 22.04 in the near future.
-        # Disabled macos-11 runner to minimize the number of concurrent macOS builds due to concurrency issues.
+        # Windows is not supported due to GitHub not supporting Docker Desktop/Podman Desktop and Docker CE on Windows
+        # not supporting BuildKit and the Buildx plugin.
+        # GitHub hosted MacOS and Ubuntu runners are temporarily disabled.
         os:
           #- ubuntu-22.04
-          - ubuntu-20.04
-          - macos-12
+          #- ubuntu-20.04
+          #- macos-12
           #- macos-11
-          #- windows-2022
-          #- windows-2019
           - [self-hosted, Linux, medium, ephemeral]
-          #- [self-hosted, Linux, large, ephemeral]
+          - [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Standardize Git Line Endings
         run: |
@@ -240,21 +288,27 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install Skopeo and JQ (Linux)
+      - name: Install JQ (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends skopeo jq
+          sudo apt-get install --yes --no-install-recommends jq
+
+      - name: Install Skopeo (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          source /etc/os-release
+          if [[ "${VERSION_ID}" != "20.04" ]]; then
+            sudo apt-get install --yes --no-install-recommends skopeo
+          fi
+
+      - name: Install KillAll (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo apt-get install --yes --no-install-recommends psmisc
 
       - name: Install Skopeo and JQ (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: brew install skopeo jq
-
-      - name: Install Skopeo and JQ (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          curl -L -o /usr/bin/jq.exe https://github.com/stedolan/jq/releases/latest/download/jq-win64.exe
-          curl -L -o /usr/bin/skopeo.exe https://github.com/passcod/winskopeo/releases/latest/download/skopeo.exe
 
       - name: Setup CoreUtils (macOS)
         if: ${{ runner.os == 'macOS' }}
@@ -282,19 +336,67 @@ jobs:
           tar -xzf "${{ needs.generate-baseline.outputs.name }}"
           mv "sdk" "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}/"
 
-      - name: Set up Docker
+      - name: Create Docker Working Directory
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          USER="$(id -un)"
+          GROUP="$(id -gn)"
+          sudo mkdir -p /x
+          sudo chown -vR ${USER}:${GROUP} /x
+          sudo ls -lah /x
+
+      - name: Remove Preinstalled Docker
+        if: ${{ contains(matrix.os, 'self-hosted') || runner.os == 'macOS' }}
+        run: |
+          set -x
+          sudo killall dockerd || true
+          sudo killall containerd || true
+          sudo rm -rvf /usr/bin/*containerd* || true
+          sudo rm -rvf /usr/bin/docker* || true
+          sudo rm -rvf /usr/local/bin/docker* || true
+          sudo rm -rvf /usr/local/bin/*lima* || true
+
+      - name: Install Lima (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          VERSION="v0.20.0"
+          curl -fsSL "https://github.com/lima-vm/lima/releases/download/${VERSION}/lima-${VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | sudo tar Cxzvm /usr/local
+
+      - name: Determine Home Directory
+        id: home
+        run: echo "directory=$(tr -d '[:space:]' < <(cd ~ && pwd))" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Containerd Support
+        uses: crazy-max/ghaction-setup-containerd@60acbf31e6572da7b83a4ed6b428ed92a35ff4d7 # v3.0.0
+        if: ${{ runner.os == 'Linux' }}
+        with:
+          containerd-version: v1.7.2
+
+      - name: Setup Docker Support
         uses: crazy-max/ghaction-setup-docker@d9be6cade441568ba10037bce5221b8f564981f1 # v3.0.0
-        if: ${{ !contains(matrix.os, 'self-hosted') }}
+        env:
+          HOME: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
         with:
           version: v24.0.7
 
+      - name: Configure Default Docker Context
+        env:
+          SEARCH_PATH: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
+        run: |
+          set -x
+          if grep setup-docker-action < <(docker context ls --format '{{ .Name }}') >/dev/null; then
+            docker context rm -f setup-docker-action
+          fi
+          
+          DOCKER_CONTEXT_PATH="$(sudo find "${SEARCH_PATH}" -name docker.sock | tr -d '[:space:]')"
+          docker context create setup-docker-action --docker "host=unix://${DOCKER_CONTEXT_PATH}"
+          docker context use setup-docker-action
+
       - name: Setup QEmu Support
-        if: ${{ runner.os != 'Windows' }}
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
       - name: Setup Docker Buildx Support
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        if: ${{ runner.os != 'Windows' }}
         with:
           version: v0.12.0
           driver-opts: network=host
@@ -325,7 +427,7 @@ jobs:
         id: regen-manifest
         env:
           MANIFEST_PATH: ${{ env.DOCKER_MANIFEST_PATH }}/regenerated
-        run: ${{ env.DOCKER_MANIFEST_GENERATOR }}
+        run: GITHUB_SHA="${{ needs.generate-baseline.outputs.sha-abbrev }}" ${{ env.DOCKER_MANIFEST_GENERATOR }}
 
       - name: Validate Layers (linux/amd64)
         run: |

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -175,7 +175,7 @@ jobs:
           if grep setup-docker-action < <(docker context ls --format '{{ .Name }}') >/dev/null; then
             docker context rm -f setup-docker-action
           fi
-          
+
           DOCKER_CONTEXT_PATH="$(sudo find /x -name docker.sock | tr -d '[:space:]')"
           docker context create setup-docker-action --docker "host=unix://${DOCKER_CONTEXT_PATH}"
           docker context use setup-docker-action
@@ -387,7 +387,7 @@ jobs:
           if grep setup-docker-action < <(docker context ls --format '{{ .Name }}') >/dev/null; then
             docker context rm -f setup-docker-action
           fi
-          
+
           DOCKER_CONTEXT_PATH="$(sudo find "${SEARCH_PATH}" -name docker.sock | tr -d '[:space:]')"
           docker context create setup-docker-action --docker "host=unix://${DOCKER_CONTEXT_PATH}"
           docker context use setup-docker-action


### PR DESCRIPTION
## Description

This pull request changes the following:

- Addresses the determinism failure which occurred due to a change in the GitHub hosted runners.
- Temporarily removes usage of the GitHub hosted runners and introduces an additional version of the self-hosted runners.
- Updates the CI pipeline to ensure the same version of `dockerd` and `containerd` is used across all runners.
