### PR TITLE
chore: copy and release periodically in `TokenService` migration

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredWritableStates.java
@@ -71,4 +71,8 @@ public class FilteredWritableStates extends FilteredReadableStates implements Wr
 
         return delegate.getQueue(stateKey);
     }
+
+    public WritableStates getDelegate() {
+        return delegate;
+    }
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
@@ -83,4 +83,13 @@ public interface MigrationContext {
      * @return the next entity number
      */
     long newEntityNum();
+
+    /**
+     * Copies and releases the underlying on-disk state for the given key. If this is not called
+     * periodically during a large migration, the underlying {@code VirtualMap} will grow too large
+     * and apply extreme backpressure in during transaction handling post-migration.
+     *
+     * @param stateKey the key of the state to copy and release
+     */
+    void copyAndReleaseOnDiskState(String stateKey);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
@@ -46,7 +46,7 @@ public final class BlockInfoTranslator {
                 .lastBlockNumber(merkleNetworkContext.getAlignmentBlockNo())
                 .blockHashes(getBlockHashes(merkleNetworkContext.getBlockHashes()));
         if (merkleNetworkContext.firstConsTimeOfCurrentBlock().getEpochSecond() > 0) {
-            blockInfoBuilder.firstConsTimeOfLastBlock(Timestamp.newBuilder()
+            blockInfoBuilder.firstConsTimeOfCurrentBlock(Timestamp.newBuilder()
                     .seconds(merkleNetworkContext.firstConsTimeOfCurrentBlock().getEpochSecond())
                     .nanos(merkleNetworkContext.firstConsTimeOfCurrentBlock().getNano())
                     .build());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -110,10 +110,10 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      */
     private static final long DO_NOT_USE_IN_REAL_LIFE_CLASS_ID = 0x0000deadbeef0000L;
 
-    private static final long CLASS_ID = 0x2de3ead3caf06392L;
+//    private static final long CLASS_ID = 0x2de3ead3caf06392L;
     // Uncomment the following class ID to run a mono -> modular state migration
     // NOTE: also change class ID of ServicesState
-    // private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
+    private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
     private static final int VERSION_1 = 30;
     private static final int CURRENT_VERSION = VERSION_1;
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -649,6 +649,8 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
             final var md = stateMetadata.get(stateKey);
             final VirtualMap<?, ?> virtualMap = (VirtualMap<?, ?>) findNode(md);
             final var mutableCopy = virtualMap.copy();
+            System.out.println("Copying and releasing virtual map for " + stateKey
+                    + ", now has " + mutableCopy.size() + " entries");
             setChild(findNodeIndex(serviceName, stateKey), mutableCopy);
             kvInstances.put(stateKey, createReadableKVState(md, mutableCopy));
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -110,7 +110,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      */
     private static final long DO_NOT_USE_IN_REAL_LIFE_CLASS_ID = 0x0000deadbeef0000L;
 
-//    private static final long CLASS_ID = 0x2de3ead3caf06392L;
+    //    private static final long CLASS_ID = 0x2de3ead3caf06392L;
     // Uncomment the following class ID to run a mono -> modular state migration
     // NOTE: also change class ID of ServicesState
     private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
@@ -562,7 +562,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
          * @return The found node
          */
         @NonNull
-        private MerkleNode findNode(@NonNull final StateMetadata<?, ?> md) {
+        MerkleNode findNode(@NonNull final StateMetadata<?, ?> md) {
             final var index =
                     findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
             if (index == -1) {
@@ -637,6 +637,20 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
                 @NonNull final String serviceName, @NonNull final Map<String, StateMetadata<?, ?>> stateMetadata) {
             super(stateMetadata);
             this.serviceName = requireNonNull(serviceName);
+        }
+
+        /**
+         * Copies and releases the {@link VirtualMap} for the given state key. This ensures
+         * data is continually flushed to disk
+         *
+         * @param stateKey the state key
+         */
+        public void copyAndReleaseVirtualMap(@NonNull final String stateKey) {
+            final var md = stateMetadata.get(stateKey);
+            final VirtualMap<?, ?> virtualMap = (VirtualMap<?, ?>) findNode(md);
+            final var mutableCopy = virtualMap.copy();
+            setChild(findNodeIndex(serviceName, stateKey), mutableCopy);
+            kvInstances.put(stateKey, createReadableKVState(md, mutableCopy));
         }
 
         @NonNull

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -110,10 +110,10 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      */
     private static final long DO_NOT_USE_IN_REAL_LIFE_CLASS_ID = 0x0000deadbeef0000L;
 
-    //    private static final long CLASS_ID = 0x2de3ead3caf06392L;
+    private static final long CLASS_ID = 0x2de3ead3caf06392L;
     // Uncomment the following class ID to run a mono -> modular state migration
     // NOTE: also change class ID of ServicesState
-    private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
+    //    private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
     private static final int VERSION_1 = 30;
     private static final int CURRENT_VERSION = VERSION_1;
 
@@ -649,8 +649,6 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
             final var md = stateMetadata.get(stateKey);
             final VirtualMap<?, ?> virtualMap = (VirtualMap<?, ?>) findNode(md);
             final var mutableCopy = virtualMap.copy();
-            System.out.println("Copying and releasing virtual map for " + stateKey
-                    + ", now has " + mutableCopy.size() + " entries");
             setChild(findNodeIndex(serviceName, stateKey), mutableCopy);
             kvInstances.put(stateKey, createReadableKVState(md, mutableCopy));
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -550,6 +550,7 @@ public class HandleWorkflow {
                 }
             }
         } catch (final Exception e) {
+            e.printStackTrace();
             logger.error("Possibly CATASTROPHIC failure while handling a user transaction", e);
             // We should always rollback stack including gas charges when there is an unexpected exception
             rollback(true, ResponseCodeEnum.FAIL_INVALID, stack, recordListBuilder);

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -77,6 +77,11 @@ public class FakeSchemaRegistry implements SchemaRegistry {
             final var previousStates = new EmptyReadableStates();
             final var writableStates = new MapWritableStates(writables);
             schema.migrate(new MigrationContext() {
+                @Override
+                public void copyAndReleaseOnDiskState(String stateKey) {
+                    // No-op
+                }
+
                 @NonNull
                 @Override
                 public ReadableStates previousStates() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -115,7 +115,7 @@ public class ServicesState extends PartialNaryMerkleInternal
         implements MerkleInternal, SwirldState, StateChildrenProvider {
     private static final Logger log = LogManager.getLogger(ServicesState.class);
 
-    private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1aL;
+    private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1bL;
     // Uncomment the following class ID to run a mono -> modular state migration
     // NOTE: also change class ID of MerkleHederaState
     // private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1bL;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -115,7 +115,7 @@ public class ServicesState extends PartialNaryMerkleInternal
         implements MerkleInternal, SwirldState, StateChildrenProvider {
     private static final Logger log = LogManager.getLogger(ServicesState.class);
 
-    private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1bL;
+    private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1aL;
     // Uncomment the following class ID to run a mono -> modular state migration
     // NOTE: also change class ID of MerkleHederaState
     // private static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1bL;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVers.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/SerializableSemVers.java
@@ -35,7 +35,7 @@ public class SerializableSemVers implements SoftwareVersion {
     private static final Pattern ALPHA_PRE_PATTERN = Pattern.compile("alpha[.](\\d+)");
     private static boolean currentVersionHasPatchMigrationRecords = false;
     public static final int RELEASE_027_VERSION = 1;
-    public static final long CLASS_ID = 0x7f2b1bc2df8cbd0bL;
+    public static final long CLASS_ID = 0x6f2b1bc2df8cbd0bL;
 
     private int servicesPreAlphaNumber;
     private int protoPreAlphaNumber;

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
@@ -212,6 +212,7 @@ public class InitialModServiceTokenSchema extends Schema {
                                     nftsToState.get().put(toNftId, translated);
                                     if (numNftInsertions.incrementAndGet() % 10_000 == 0) {
                                         // Make sure we are flushing data to disk as we go
+                                        ((WritableKVStateBase) nftsToState.get()).commit();
                                         ctx.copyAndReleaseOnDiskState(NFTS_KEY);
                                         // And ensure we have the latest writable state
                                         nftsToState.set(ctx.newStates().get(NFTS_KEY));
@@ -256,6 +257,7 @@ public class InitialModServiceTokenSchema extends Schema {
                                     tokenRelsToState.get().put(newPair, translated);
                                     if (numTokenRelInsertions.incrementAndGet() % 10_000 == 0) {
                                         // Make sure we are flushing data to disk as we go
+                                        ((WritableKVStateBase) tokenRelsToState.get()).commit();
                                         ctx.copyAndReleaseOnDiskState(TOKEN_RELS_KEY);
                                         // And ensure we have the latest writable state
                                         tokenRelsToState.set(ctx.newStates().get(TOKEN_RELS_KEY));
@@ -292,6 +294,7 @@ public class InitialModServiceTokenSchema extends Schema {
                                                     toAcct);
                                     if (numAccountInsertions.incrementAndGet() % 10_000 == 0) {
                                         // Make sure we are flushing data to disk as we go
+                                        ((WritableKVStateBase) acctsToState.get()).commit();
                                         ctx.copyAndReleaseOnDiskState(ACCOUNTS_KEY);
                                         // And ensure we have the latest writable state
                                         acctsToState.set(ctx.newStates().get(ACCOUNTS_KEY));

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
@@ -184,9 +184,11 @@ public class InitialModServiceTokenSchema extends Schema {
 
         if (acctsFs != null) {
             log.info("BBM: migrating token service");
+            System.out.println("BBM: migrating token service");
 
             // ---------- NFTs
             log.info("BBM: doing nfts...");
+            System.out.println("BBM: doing nfts...");
             var nftsToState = ctx.newStates().<NftID, Nft>get(NFTS_KEY);
             try {
                 VirtualMapLike.from(nftsFs)
@@ -212,9 +214,11 @@ public class InitialModServiceTokenSchema extends Schema {
             }
             if (nftsToState.isModified()) ((WritableKVStateBase) nftsToState).commit();
             log.info("BBM: finished nfts");
+            System.out.println("BBM: finished nfts");
 
             // ---------- Token Rels/Associations
             log.info("BBM: doing token rels...");
+            System.out.println("BBM: doing token rels...");
             var tokenRelsToState = ctx.newStates().<EntityIDPair, TokenRelation>get(TOKEN_RELS_KEY);
             try {
                 VirtualMapLike.from(trFs)
@@ -246,9 +250,11 @@ public class InitialModServiceTokenSchema extends Schema {
             }
             if (tokenRelsToState.isModified()) ((WritableKVStateBase) tokenRelsToState).commit();
             log.info("BBM: finished token rels");
+            System.out.println("BBM: finished token rels");
 
             // ---------- Accounts
             log.info("BBM: doing accounts");
+            System.out.println("BBM: doing accounts");
             var acctsToState = ctx.newStates().<AccountID, Account>get(ACCOUNTS_KEY);
             try {
                 VirtualMapLike.from(acctsFs)
@@ -270,9 +276,11 @@ public class InitialModServiceTokenSchema extends Schema {
             }
             if (acctsToState.isModified()) ((WritableKVStateBase) acctsToState).commit();
             log.info("BBM: finished accts");
+            System.out.println("BBM: finished accts");
 
             // ---------- Tokens
             log.info("BBM: starting tokens (both fungible and non-fungible)");
+            System.out.println("BBM: starting tokens (both fungible and non-fungible)");
             var tokensToState = ctx.newStates().<TokenID, Token>get(TOKENS_KEY);
             MerkleMapLike.from(tFs).forEachNode((entityNum, merkleToken) -> {
                 var toToken = TokenStateTranslator.tokenFromMerkle(merkleToken);
@@ -281,9 +289,11 @@ public class InitialModServiceTokenSchema extends Schema {
             });
             if (tokensToState.isModified()) ((WritableKVStateBase) tokensToState).commit();
             log.info("BBM: finished tokens (fung and non-fung)");
+            System.out.println("BBM: finished tokens (fung and non-fung)");
 
             // ---------- Staking Info
             log.info("BBM: starting staking info");
+            System.out.println("BBM: starting staking info");
             var stakingToState = ctx.newStates().<EntityNumber, StakingNodeInfo>get(STAKING_INFO_KEY);
             stakingFs.forEach((entityNum, merkleStakingInfo) -> {
                 var toStakingInfo = StakingNodeInfoStateTranslator.stakingInfoFromMerkleStakingInfo(merkleStakingInfo);
@@ -295,14 +305,17 @@ public class InitialModServiceTokenSchema extends Schema {
             });
             if (stakingToState.isModified()) ((WritableKVStateBase) stakingToState).commit();
             log.info("BBM: finished staking info");
+            System.out.println("BBM: finished staking info");
 
             // ---------- Staking Rewards
             log.info("BBM: starting staking rewards");
+            System.out.println("BBM: starting staking rewards");
             final var srToState = ctx.newStates().<NetworkStakingRewards>getSingleton(STAKING_NETWORK_REWARDS_KEY);
             final var toSr = NetworkingStakingTranslator.networkStakingRewardsFromMerkleNetworkContext(mnc);
             srToState.put(toSr);
             if (srToState.isModified()) ((WritableSingletonStateBase) srToState).commit();
             log.info("BBM: finished staking rewards");
+            System.out.println("BBM: finished staking rewards");
         } else {
             log.warn("BBM: no token 'from' state found");
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
@@ -186,11 +186,9 @@ public class InitialModServiceTokenSchema extends Schema {
 
         if (acctsFs != null) {
             log.info("BBM: migrating token service");
-            System.out.println("BBM: migrating token service");
 
             // ---------- NFTs
             log.info("BBM: doing nfts...");
-            System.out.println("BBM: doing nfts...");
             final var nftsToState = new AtomicReference<>(ctx.newStates().<NftID, Nft>get(NFTS_KEY));
             final var numNftInsertions = new AtomicLong();
             try {
@@ -224,11 +222,9 @@ public class InitialModServiceTokenSchema extends Schema {
             }
             if (nftsToState.get().isModified()) ((WritableKVStateBase) nftsToState.get()).commit();
             log.info("BBM: finished nfts");
-            System.out.println("BBM: finished nfts");
 
             // ---------- Token Rels/Associations
             log.info("BBM: doing token rels...");
-            System.out.println("BBM: doing token rels...");
             final var numTokenRelInsertions = new AtomicLong();
             final var tokenRelsToState =
                     new AtomicReference<>(ctx.newStates().<EntityIDPair, TokenRelation>get(TOKEN_RELS_KEY));
@@ -269,11 +265,9 @@ public class InitialModServiceTokenSchema extends Schema {
             }
             if (tokenRelsToState.get().isModified()) ((WritableKVStateBase) tokenRelsToState.get()).commit();
             log.info("BBM: finished token rels");
-            System.out.println("BBM: finished token rels");
 
             // ---------- Accounts
             log.info("BBM: doing accounts");
-            System.out.println("BBM: doing accounts");
 
             final var numAccountInsertions = new AtomicLong();
             final var acctsToState = new AtomicReference<>(ctx.newStates().<AccountID, Account>get(ACCOUNTS_KEY));
@@ -306,11 +300,9 @@ public class InitialModServiceTokenSchema extends Schema {
             }
             if (acctsToState.get().isModified()) ((WritableKVStateBase) acctsToState.get()).commit();
             log.info("BBM: finished accts");
-            System.out.println("BBM: finished accts");
 
             // ---------- Tokens
             log.info("BBM: starting tokens (both fungible and non-fungible)");
-            System.out.println("BBM: starting tokens (both fungible and non-fungible)");
             var tokensToState = ctx.newStates().<TokenID, Token>get(TOKENS_KEY);
             MerkleMapLike.from(tFs).forEachNode((entityNum, merkleToken) -> {
                 var toToken = TokenStateTranslator.tokenFromMerkle(merkleToken);
@@ -319,11 +311,9 @@ public class InitialModServiceTokenSchema extends Schema {
             });
             if (tokensToState.isModified()) ((WritableKVStateBase) tokensToState).commit();
             log.info("BBM: finished tokens (fung and non-fung)");
-            System.out.println("BBM: finished tokens (fung and non-fung)");
 
             // ---------- Staking Info
             log.info("BBM: starting staking info");
-            System.out.println("BBM: starting staking info");
             var stakingToState = ctx.newStates().<EntityNumber, StakingNodeInfo>get(STAKING_INFO_KEY);
             stakingFs.forEach((entityNum, merkleStakingInfo) -> {
                 var toStakingInfo = StakingNodeInfoStateTranslator.stakingInfoFromMerkleStakingInfo(merkleStakingInfo);
@@ -335,17 +325,14 @@ public class InitialModServiceTokenSchema extends Schema {
             });
             if (stakingToState.isModified()) ((WritableKVStateBase) stakingToState).commit();
             log.info("BBM: finished staking info");
-            System.out.println("BBM: finished staking info");
 
             // ---------- Staking Rewards
             log.info("BBM: starting staking rewards");
-            System.out.println("BBM: starting staking rewards");
             final var srToState = ctx.newStates().<NetworkStakingRewards>getSingleton(STAKING_NETWORK_REWARDS_KEY);
             final var toSr = NetworkingStakingTranslator.networkStakingRewardsFromMerkleNetworkContext(mnc);
             srToState.put(toSr);
             if (srToState.isModified()) ((WritableSingletonStateBase) srToState).commit();
             log.info("BBM: finished staking rewards");
-            System.out.println("BBM: finished staking rewards");
         } else {
             log.warn("BBM: no token 'from' state found");
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
@@ -80,6 +80,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
 import org.apache.logging.log4j.LogManager;
@@ -189,7 +191,8 @@ public class InitialModServiceTokenSchema extends Schema {
             // ---------- NFTs
             log.info("BBM: doing nfts...");
             System.out.println("BBM: doing nfts...");
-            var nftsToState = ctx.newStates().<NftID, Nft>get(NFTS_KEY);
+            final var nftsToState = new AtomicReference<>(ctx.newStates().<NftID, Nft>get(NFTS_KEY));
+            final var numNftInsertions = new AtomicLong();
             try {
                 VirtualMapLike.from(nftsFs)
                         .extractVirtualMapData(
@@ -206,20 +209,28 @@ public class InitialModServiceTokenSchema extends Schema {
                                     var fromNft2 = new MerkleUniqueToken(
                                             fromNft.getOwner(), fromNft.getMetadata(), fromNft.getCreationTime());
                                     var translated = NftStateTranslator.nftFromMerkleUniqueToken(fromNft2);
-                                    nftsToState.put(toNftId, translated);
+                                    nftsToState.get().put(toNftId, translated);
+                                    if (numNftInsertions.incrementAndGet() % 10_000 == 0) {
+                                        // Make sure we are flushing data to disk as we go
+                                        ctx.copyAndReleaseOnDiskState(NFTS_KEY);
+                                        // And ensure we have the latest writable state
+                                        nftsToState.set(ctx.newStates().get(NFTS_KEY));
+                                    }
                                 },
                                 1);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            if (nftsToState.isModified()) ((WritableKVStateBase) nftsToState).commit();
+            if (nftsToState.get().isModified()) ((WritableKVStateBase) nftsToState.get()).commit();
             log.info("BBM: finished nfts");
             System.out.println("BBM: finished nfts");
 
             // ---------- Token Rels/Associations
             log.info("BBM: doing token rels...");
             System.out.println("BBM: doing token rels...");
-            var tokenRelsToState = ctx.newStates().<EntityIDPair, TokenRelation>get(TOKEN_RELS_KEY);
+            final var numTokenRelInsertions = new AtomicLong();
+            final var tokenRelsToState =
+                    new AtomicReference<>(ctx.newStates().<EntityIDPair, TokenRelation>get(TOKEN_RELS_KEY));
             try {
                 VirtualMapLike.from(trFs)
                         .extractVirtualMapData(
@@ -242,20 +253,28 @@ public class InitialModServiceTokenSchema extends Schema {
                                                     .tokenNum(key.getLowOrderAsLong())
                                                     .build())
                                             .build();
-                                    tokenRelsToState.put(newPair, translated);
+                                    tokenRelsToState.get().put(newPair, translated);
+                                    if (numTokenRelInsertions.incrementAndGet() % 10_000 == 0) {
+                                        // Make sure we are flushing data to disk as we go
+                                        ctx.copyAndReleaseOnDiskState(TOKEN_RELS_KEY);
+                                        // And ensure we have the latest writable state
+                                        tokenRelsToState.set(ctx.newStates().get(TOKEN_RELS_KEY));
+                                    }
                                 },
                                 1);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            if (tokenRelsToState.isModified()) ((WritableKVStateBase) tokenRelsToState).commit();
+            if (tokenRelsToState.get().isModified()) ((WritableKVStateBase) tokenRelsToState.get()).commit();
             log.info("BBM: finished token rels");
             System.out.println("BBM: finished token rels");
 
             // ---------- Accounts
             log.info("BBM: doing accounts");
             System.out.println("BBM: doing accounts");
-            var acctsToState = ctx.newStates().<AccountID, Account>get(ACCOUNTS_KEY);
+
+            final var numAccountInsertions = new AtomicLong();
+            final var acctsToState = new AtomicReference<>(ctx.newStates().<AccountID, Account>get(ACCOUNTS_KEY));
             try {
                 VirtualMapLike.from(acctsFs)
                         .extractVirtualMapData(
@@ -264,17 +283,25 @@ public class InitialModServiceTokenSchema extends Schema {
                                     var acctNum = entry.left().asEntityNum().longValue();
                                     var fromAcct = entry.right();
                                     var toAcct = AccountStateTranslator.accountFromOnDiskAccount(fromAcct);
-                                    acctsToState.put(
-                                            AccountID.newBuilder()
-                                                    .accountNum(acctNum)
-                                                    .build(),
-                                            toAcct);
+                                    acctsToState
+                                            .get()
+                                            .put(
+                                                    AccountID.newBuilder()
+                                                            .accountNum(acctNum)
+                                                            .build(),
+                                                    toAcct);
+                                    if (numAccountInsertions.incrementAndGet() % 10_000 == 0) {
+                                        // Make sure we are flushing data to disk as we go
+                                        ctx.copyAndReleaseOnDiskState(ACCOUNTS_KEY);
+                                        // And ensure we have the latest writable state
+                                        acctsToState.set(ctx.newStates().get(ACCOUNTS_KEY));
+                                    }
                                 },
                                 1);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            if (acctsToState.isModified()) ((WritableKVStateBase) acctsToState).commit();
+            if (acctsToState.get().isModified()) ((WritableKVStateBase) acctsToState.get()).commit();
             log.info("BBM: finished accts");
             System.out.println("BBM: finished accts");
 


### PR DESCRIPTION
**Description**:
 - Quick-and-dirty change to ensure target `VirtualMap`'s are being regularly flushed to disk throughout the `TokenService` migration.
 - Implementation details may need some refinement.