### PR TITLE
fix: (mod-service)Fix block number closing issue on restart

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -585,8 +585,6 @@ public final class Hedera implements SwirldMain {
             // server when we fall behind or ISS.
             final var notifications = platform.getNotificationEngine();
             notifications.register(PlatformStatusChangeListener.class, notification -> {
-                final var wasActive = platformStatus == PlatformStatus.ACTIVE;
-                final var wasFreeze = platformStatus == PlatformStatus.FREEZING;
                 platformStatus = notification.getNewStatus();
                 switch (platformStatus) {
                     case ACTIVE -> {
@@ -604,14 +602,12 @@ public final class Hedera implements SwirldMain {
 
                     case CATASTROPHIC_FAILURE -> {
                         logger.info("Hederanode#{} is {}", nodeId, platformStatus.name());
-                        if (wasActive) shutdownGrpcServer();
+                        shutdownGrpcServer();
                     }
                     case FREEZE_COMPLETE -> {
                         logger.info("Hederanode#{} is {}", nodeId, platformStatus.name());
                         closeRecordStreams();
-                        if (wasActive || wasFreeze) {
-                            shutdownGrpcServer();
-                        }
+                        shutdownGrpcServer();
                     }
                 }
             });


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/11083


Like mono-service [closes](https://github.com/hashgraph/hedera-services/blob/develop/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/logic/StatusChangeListener.java#L65) `multiStreams` when platform status changes to `FREEZE_COMPLETE`. Added similar logic in `Hedera` to close record streams.


Tested with restart test and the `BlockNumberValidator` added in https://github.com/hashgraph/hedera-services/pull/10944