### PR TITLE
feat: unique tokens modular signed state dumper

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -304,12 +304,30 @@ public class DumpStateCommand extends AbstractCommand {
             @Option(
                             names = {"-s", "--summary"},
                             description = "Emit a summary information")
-                    final boolean emitSummary) {
+                    final boolean emitSummary,
+            @Option(
+                            names = {"-k", "--slots"},
+                            description = "Emit the slot/value pairs for each contract's store")
+                    final boolean withSlots,
+            @Option(
+                            names = {"--migrate"},
+                            description =
+                                    "migrate from mono-service representation to modular-service representation (before dump)")
+                    final boolean withMigration,
+            @Option(
+                            names = {"--validate-migration"},
+                            description = "validate the migrated contract store")
+                    final boolean withValidationOfMigration) {
         Objects.requireNonNull(uniquesPath);
         init();
         System.out.println("=== unique NFTs ===");
         DumpUniqueTokensSubcommand.doit(
-                parent.signedState, uniquesPath, emitSummary ? EmitSummary.YES : EmitSummary.NO, parent.verbosity);
+                parent.signedState,
+                uniquesPath,
+                emitSummary ? EmitSummary.YES : EmitSummary.NO,
+                withMigration ? WithMigration.YES : WithMigration.NO,
+                withValidationOfMigration ? WithValidation.YES : WithValidation.NO,
+                parent.verbosity);
         finish();
     }
 

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpStateCommand.java
@@ -306,10 +306,6 @@ public class DumpStateCommand extends AbstractCommand {
                             description = "Emit a summary information")
                     final boolean emitSummary,
             @Option(
-                            names = {"-k", "--slots"},
-                            description = "Emit the slot/value pairs for each contract's store")
-                    final boolean withSlots,
-            @Option(
                             names = {"--migrate"},
                             description =
                                     "migrate from mono-service representation to modular-service representation (before dump)")

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpUniqueTokensSubcommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/DumpUniqueTokensSubcommand.java
@@ -320,7 +320,7 @@ public class DumpUniqueTokensSubcommand {
             try {
                 uniquesStore
                         .virtualMap()
-                        .extractVirtualMapDataC(
+                        .extractVirtualMapData(
                                 getStaticThreadManager(),
                                 p -> {
                                     keys.add(UniqueNFTId.from(p.left()));
@@ -350,7 +350,6 @@ public class DumpUniqueTokensSubcommand {
         final var uniquesStore = getMigratedUniques();
         final var r = new HashMap<UniqueNFTId, UniqueNFT>();
 
-        System.out.println("MIGRATING!!!");
         uniquesStore.keys().forEachRemaining(key -> {
             final var id = UniqueNFTId.from(key);
             final var nft = UniqueNFT.from(uniquesStore.get(key));

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokensMigrator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/UniqueTokensMigrator.java
@@ -83,6 +83,9 @@ public class UniqueTokensMigrator {
         LOG.info("Migrated {} unique tokens", count.get());
     }
 
+    /**
+     * Do the transform from mono-service's unique tokens to modular-service's unique tokens
+     */
     public static void migrateFromUniqueTokenVirtualMap(
             @NonNull VirtualMapLike<UniqueTokenKey, UniqueTokenValue> fromState,
             @NonNull WritableKVState<NftID, Nft> toState) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/module-info.java
@@ -44,5 +44,6 @@ module com.hedera.node.app.service.token.impl {
             com.hedera.node.app;
     exports com.hedera.node.app.service.token.impl.schemas to
             com.hedera.node.app,
-            com.hedera.node.app.service.token.impl.api.test;
+            com.hedera.node.app.service.token.impl.api.test,
+            com.hedera.node.services.cli;
 }


### PR DESCRIPTION
**Description**:
Dumps all `uniqueTokens` entities from `modular-services` in deterministic way

**Related issue(s)**:

Fixes #10917 

**Notes for reviewer**:
- Change to using `.virtualMap().extractVirtualMapData()` instead of `.virtualMap().extractVirtualMapDataC()` because the latter was non-deterministic. My tests shows no performance impact. With an average of 3 runs both implementations took ~42 seconds to execute the state dump.
- Currently we pass 5 null parameters to `InitialModServiceTokenSchema`'s constructor in `getMigratedUniques()`. Didn't think of a better way for now
- The `withValidation` option only changes the summary for now
- Do we need to implement the migration if the `state.getUniqueNFTTokens()` is not virtual?

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
