### PR TITLE
chore: bump HAPI proto version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -138,7 +138,7 @@ fun includeAllProjects(containingFolder: String) {
 }
 
 // The HAPI API version to use for Protobuf sources.
-val hapiProtoVersion = "0.44.0"
+val hapiProtoVersion = "0.46.0"
 
 dependencyResolutionManagement {
     // Protobuf tool versions


### PR DESCRIPTION
**Description**:
Sets `hapiProtoVersion` to `v0.46.0`.