### PR TITLE
fix: resolve Snyk Report workflow step failure

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -608,14 +608,29 @@ jobs:
             !cancelled()
           }}
         run: |
-          if [[ -f "snyk-test.json" ]]; then
+          if [[ -f "snyk-test.json" && -n "$(cat snyk-test.json | tr -d '[:space:]')" ]]; then
             snyk-to-html -i snyk-test.json -o snyk-test.html --summary
             html-to-markdown snyk-test.html -o snyk
             cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [[ -f "snyk-code.json" ]]; then
+          if [[ -f "snyk-code.json" && -n "$(cat snyk-code.json | tr -d '[:space:]')" ]]; then
             snyk-to-html -i snyk-code.json -o snyk-code.html --summary
             html-to-markdown snyk-code.html -o snyk
             cat snyk/snyk-code.html.md >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Check Snyk Files
+        if: ${{ always() }}
+        run: |
+          echo "::group::Snyk File List"
+            ls -lah snyk* || true
+          echo "::endgroup::"
+
+          echo "::group::Snyk Test Contents"
+            cat snyk-test.json || true
+          echo "::endgroup::"
+
+          echo "::group::Snyk Code Contents"
+            cat snyk-code.json || true
+          echo "::endgroup::"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Addresses a behavioral change in the latest `snyk` CLI version which causes a blank JSON file to be written if there are no detections.
   - Previously, the `snyk` CLI behavior was to not write a file at all if no detections were found.

### Related Issues

- Closes #11266  