### PR TITLE
perf: Ensure TransactionStateLogger is not logging on info level

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/logging/TransactionStateLogger.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/logging/TransactionStateLogger.java
@@ -120,7 +120,7 @@ public final class TransactionStateLogger {
             @NonNull final ConsensusTransaction transaction,
             @Nullable final TransactionBody txBody,
             @NonNull final AccountID payer) {
-        logger.info(
+        logger.debug(
                 "    Starting user transaction {} at platform time {} from payer 0.0.{}",
                 txBody == null ? "null" : formatTransactionId(txBody.transactionID()),
                 transaction.getConsensusTimestamp(),


### PR DESCRIPTION
This PR changes the last logging statement on the info level to a debug statement. As the methods in `TransactionStateLogger` are called for each transaction, the info level is not appropriate.

Closes #11270 