### PR TITLE
feat: pcli state validateAddressBook command

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -60,7 +60,7 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
     }
 
     /**
-     * The path to state to edit
+     * The path to the output directory
      */
     @CommandLine.Parameters(description = "The path to the output directory", index = "1")
     private void setOutputDir(final Path outputDir) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
@@ -59,7 +59,7 @@ public class ValidateAddressBookStateCommand extends AbstractCommand {
     }
 
     /**
-     * The path to state to edit
+     * The path to the address book to validate
      */
     @CommandLine.Parameters(description = "The path to the address book to validate as a successor", index = "1")
     private void setAddressBookPath(final Path addressBookPath) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package com.swirlds.platform.cli;
 
-import static com.swirlds.platform.state.signed.SavedStateMetadata.NO_NODE_ID;
-import static com.swirlds.platform.state.signed.SignedStateFileWriter.writeSignedStateFilesToDirectory;
-
 import com.swirlds.base.time.Time;
 import com.swirlds.cli.commands.StateCommand;
 import com.swirlds.cli.utility.AbstractCommand;
@@ -26,35 +23,37 @@ import com.swirlds.cli.utility.SubcommandOf;
 import com.swirlds.common.context.DefaultPlatformContext;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.CryptographyHolder;
-import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.config.DefaultConfiguration;
-import com.swirlds.platform.consensus.SyntheticSnapshot;
-import com.swirlds.platform.state.PlatformData;
 import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.state.signed.DeserializedSignedState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedStateFileReader;
+import com.swirlds.platform.system.address.AddressBook;
+import com.swirlds.platform.system.address.AddressBookUtils;
+import com.swirlds.platform.system.address.AddressBookValidator;
 import com.swirlds.platform.util.BootstrapUtils;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.util.concurrent.ExecutionException;
 import picocli.CommandLine;
 
 @CommandLine.Command(
-        name = "genesis",
+        name = "validateAddressBook",
         mixinStandardHelpOptions = true,
-        description = "Edit an existing state by replacing the platform state with a new genesis state.")
+        description = "Validates the given address book as a successor to the address book in the given state.")
 @SubcommandOf(StateCommand.class)
-public class GenesisPlatformStateCommand extends AbstractCommand {
+public class ValidateAddressBookStateCommand extends AbstractCommand {
     private Path statePath;
-    private Path outputDir;
+    private Path addressBookPath;
 
     /**
      * The path to state to edit
      */
-    @CommandLine.Parameters(description = "The path to the state to edit", index = "0")
+    @CommandLine.Parameters(description = "The path to the state", index = "0")
     private void setStatePath(final Path statePath) {
         this.statePath = pathMustExist(statePath.toAbsolutePath());
     }
@@ -62,39 +61,40 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
     /**
      * The path to state to edit
      */
-    @CommandLine.Parameters(description = "The path to the output directory", index = "1")
-    private void setOutputDir(final Path outputDir) {
-        this.outputDir = dirMustExist(outputDir.toAbsolutePath());
+    @CommandLine.Parameters(description = "The path to the address book to validate as a successor", index = "1")
+    private void setAddressBookPath(final Path addressBookPath) {
+        this.addressBookPath = pathMustExist(addressBookPath.toAbsolutePath());
     }
 
     @Override
-    public Integer call() throws IOException, ExecutionException, InterruptedException {
+    public Integer call() throws IOException, ExecutionException, InterruptedException, ParseException {
         final Configuration configuration = DefaultConfiguration.buildBasicConfiguration();
         BootstrapUtils.setupConstructableRegistry();
 
         final PlatformContext platformContext = new DefaultPlatformContext(
                 configuration, new NoOpMetrics(), CryptographyHolder.get(), Time.getCurrent());
 
-        System.out.printf("Reading from %s %n", statePath.toAbsolutePath());
+        System.out.printf("Reading state from %s %n", statePath.toAbsolutePath());
         final DeserializedSignedState deserializedSignedState =
                 SignedStateFileReader.readStateFile(platformContext, statePath);
+
+        System.out.printf("Reading address book from %s %n", addressBookPath.toAbsolutePath());
+        final String addressBookString = Files.readString(addressBookPath);
+        final AddressBook addressBook = AddressBookUtils.parseAddressBookText(addressBookString);
+
+        final AddressBook stateAddressBook;
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             final PlatformState platformState =
                     reservedSignedState.get().getState().getPlatformState();
-            System.out.printf("Replacing platform data %n");
-            platformState.setRound(PlatformData.GENESIS_ROUND);
-            platformState.setSnapshot(SyntheticSnapshot.getGenesisSnapshot());
-            System.out.printf("Nullifying Address Books %n");
-            platformState.setAddressBook(null);
-            platformState.setPreviousAddressBook(null);
-            System.out.printf("Hashing state %n");
-            MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(reservedSignedState.get().getState())
-                    .get();
-            System.out.printf("Writing modified state to %s %n", outputDir.toAbsolutePath());
-            writeSignedStateFilesToDirectory(platformContext, NO_NODE_ID, outputDir, reservedSignedState.get());
+            System.out.printf("Extracting the state address book for comparison %n");
+            stateAddressBook = platformState.getAddressBook();
         }
 
+        System.out.printf("Validating address book %n");
+        // if the address book is not valid an exception will be thrown which will propagate up to the CLI
+        AddressBookValidator.validateNewAddressBook(stateAddressBook, addressBook);
+
+        System.out.printf("PASS: The address book is valid as a successor to the state's address book %n");
         return 0;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookValidator.java
@@ -110,7 +110,8 @@ public final class AddressBookValidator {
      * @param newAddressBook the new address book
      * @throws IllegalStateException if the nextNodeId in the new address book is less than or equal to the nextNodeId
      *                               in the old address book, or if there are any new nodes in the new address book that
-     *                               are less than the old nextNodeId or greater than or equal to the new nextNodeId.
+     *                               are less than the old nextNodeId or greater than or equal to the new nextNodeId, or
+     *                               if the new address book is empty.
      */
     public static void validateNewAddressBook(
             @NonNull final AddressBook oldAddressBook, @NonNull final AddressBook newAddressBook) {
@@ -126,6 +127,10 @@ public final class AddressBookValidator {
 
         final int oldSize = oldAddressBook.getSize();
         final int newSize = newAddressBook.getSize();
+
+        if (newSize == 0) {
+            throw new IllegalStateException("The new address book's size must be greater than 0");
+        }
 
         // Verify that the old next node id is greater than the highest node id in the old address book.
         final NodeId oldLastNodeId = (oldSize == 0 ? null : oldAddressBook.getNodeId(oldSize - 1));


### PR DESCRIPTION
**Description**:

This PR does the following: 
* adds a new pcli command: `pcli state validateAddressBook`
* adds a check for empty address book to the validation process. 
* fixes a description of a parameter in the `pcli state genesis` command. 

The intended use for  `pcli state validateAddressBook` is to check that a given config.txt will not generate errors during a software upgrade with the given state without needing to spin up a network to find that out.   Great for checking hand-crafted config.txt to make sure there are no problems. 

**Related issue(s)**:

Fixes #11251 

**Notes for reviewer**:

If there is a better name for this tool, please suggest it. 

Manual testing performed.  

Example Commandline: 
```
pcli state validateAddressBook \
--load /Users/user/IdeaProjects/hedera-services/platform-sdk/sdk/data/apps/HashgraphDemo.jar \
/Users/user/IdeaProjects/hedera-services/platform-sdk/sdk/data/saved/com.swirlds.demo.hashgraph.HashgraphDemoMain/0/123/233/SignedState.swh \
/Users/user/IdeaProjects/hedera-services/platform-sdk/sdk/config.txt 
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
