### PR TITLE
chore: Add `orderedSolderTo` method to OutputWire

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/OutputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/OutputWire.java
@@ -25,6 +25,7 @@ import com.swirlds.common.wiring.transformers.internal.AdvancedWireTransformer;
 import com.swirlds.common.wiring.wires.SolderType;
 import com.swirlds.common.wiring.wires.input.InputWire;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -88,6 +89,25 @@ public abstract class OutputWire<OUT> {
      */
     public void solderTo(@NonNull final InputWire<OUT> inputWire) {
         solderTo(inputWire, SolderType.PUT);
+    }
+
+    /**
+     * A convenience method that should be used iff the order in which the {@code inputWires} are soldered is important.
+     * Using this method reduces the chance of inadvertent reordering when code is modified or reorganized. All
+     * invocations of this method should carefully document why the provided ordering is important.
+     * <p>
+     * Since this method is specifically for input wires that require a certain order, at least two input wires must be
+     * provided.
+     *
+     * @param inputWires – an ordered list of the input wire to forward output data to
+     * @throws IllegalArgumentException is the size of {@code inputWires} is less than 2
+     * @see #solderTo(InputWire)
+     */
+    public void orderedSolderTo(@NonNull final List<InputWire<OUT>> inputWires) {
+        if (inputWires.size() < 2) {
+            throw new IllegalArgumentException("List must contain at least 2 input wires.");
+        }
+        inputWires.forEach(this::solderTo);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/OutputWire.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/wires/output/OutputWire.java
@@ -100,7 +100,7 @@ public abstract class OutputWire<OUT> {
      * provided.
      *
      * @param inputWires – an ordered list of the input wire to forward output data to
-     * @throws IllegalArgumentException is the size of {@code inputWires} is less than 2
+     * @throws IllegalArgumentException if the size of {@code inputWires} is less than 2
      * @see #solderTo(InputWire)
      */
     public void orderedSolderTo(@NonNull final List<InputWire<OUT>> inputWires) {

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/wires/OutputWireTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/wires/OutputWireTests.java
@@ -64,28 +64,28 @@ public class OutputWireTests {
                 .build()
                 .cast();
 
-        BindableInputWire<Integer, Integer> intInput = intForwarder.buildInputWire("intInput");
-        BindableInputWire<Integer, Void> firstComponentInput = firstComponent.buildInputWire("ints");
-        BindableInputWire<Integer, Void> secondComponentInput = secondComponent.buildInputWire("ints");
+        final BindableInputWire<Integer, Integer> intInput = intForwarder.buildInputWire("intInput");
+        final BindableInputWire<Integer, Void> firstComponentInput = firstComponent.buildInputWire("ints");
+        final BindableInputWire<Integer, Void> secondComponentInput = secondComponent.buildInputWire("ints");
 
         // Send integers to the first component before the second component
-        List<InputWire<Integer>> inputList = List.of(firstComponentInput, secondComponentInput);
+        final List<InputWire<Integer>> inputList = List.of(firstComponentInput, secondComponentInput);
         intForwarder.getOutputWire().orderedSolderTo(inputList);
 
         intInput.bind((i -> i));
 
-        AtomicInteger firstCompRecNum = new AtomicInteger();
-        AtomicInteger secondsCompRecNum = new AtomicInteger();
-        AtomicInteger firstCompErrorCount = new AtomicInteger();
-        AtomicInteger secondCompErrorCount = new AtomicInteger();
+        final AtomicInteger firstCompRecNum = new AtomicInteger();
+        final AtomicInteger secondCompRecNum = new AtomicInteger();
+        final AtomicInteger firstCompErrorCount = new AtomicInteger();
+        final AtomicInteger secondCompErrorCount = new AtomicInteger();
 
         firstComponentInput.bind(i -> {
-            if (firstCompRecNum.incrementAndGet() <= secondsCompRecNum.get()) {
+            if (firstCompRecNum.incrementAndGet() <= secondCompRecNum.get()) {
                 firstCompErrorCount.incrementAndGet();
             }
         });
         secondComponentInput.bind(i -> {
-            if (firstCompRecNum.get() != secondsCompRecNum.incrementAndGet()) {
+            if (firstCompRecNum.get() != secondCompRecNum.incrementAndGet()) {
                 secondCompErrorCount.incrementAndGet();
             }
         });

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/wires/OutputWireTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/wires/OutputWireTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.wiring.wires;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.swirlds.base.time.Time;
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.common.wiring.model.WiringModel;
+import com.swirlds.common.wiring.schedulers.TaskScheduler;
+import com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType;
+import com.swirlds.common.wiring.wires.input.BindableInputWire;
+import com.swirlds.common.wiring.wires.input.InputWire;
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests the functionality of output wires
+ */
+public class OutputWireTests {
+
+    /**
+     * Test that the ordered solder to method forwards data in the proper order.
+     *
+     * @param count the number of data to send through the wires
+     */
+    @ParameterizedTest()
+    @ValueSource(ints = {10_000})
+    void orderedSolderToTest(final int count) {
+        final PlatformContext platformContext =
+                TestPlatformContextBuilder.create().build();
+        final WiringModel model = WiringModel.create(platformContext, Time.getCurrent(), ForkJoinPool.commonPool());
+
+        final TaskScheduler<Integer> intForwarder = model.schedulerBuilder("intForwarder")
+                .withType(TaskSchedulerType.DIRECT)
+                .build()
+                .cast();
+        final TaskScheduler<Void> firstComponent = model.schedulerBuilder("firstComponent")
+                .withType(TaskSchedulerType.DIRECT)
+                .build()
+                .cast();
+        final TaskScheduler<Void> secondComponent = model.schedulerBuilder("secondComponent")
+                .withType(TaskSchedulerType.DIRECT)
+                .build()
+                .cast();
+
+        BindableInputWire<Integer, Integer> intInput = intForwarder.buildInputWire("intInput");
+        BindableInputWire<Integer, Void> firstComponentInput = firstComponent.buildInputWire("ints");
+        BindableInputWire<Integer, Void> secondComponentInput = secondComponent.buildInputWire("ints");
+
+        // Send integers to the first component before the second component
+        List<InputWire<Integer>> inputList = List.of(firstComponentInput, secondComponentInput);
+        intForwarder.getOutputWire().orderedSolderTo(inputList);
+
+        intInput.bind((i -> i));
+
+        AtomicInteger firstCompRecNum = new AtomicInteger();
+        AtomicInteger secondsCompRecNum = new AtomicInteger();
+        AtomicInteger firstCompErrorCount = new AtomicInteger();
+        AtomicInteger secondCompErrorCount = new AtomicInteger();
+
+        firstComponentInput.bind(i -> {
+            if (firstCompRecNum.incrementAndGet() <= secondsCompRecNum.get()) {
+                firstCompErrorCount.incrementAndGet();
+            }
+        });
+        secondComponentInput.bind(i -> {
+            if (firstCompRecNum.get() != secondsCompRecNum.incrementAndGet()) {
+                secondCompErrorCount.incrementAndGet();
+            }
+        });
+
+        for (int i = 0; i < count; i++) {
+            intInput.put(i);
+        }
+
+        assertEquals(0, firstCompErrorCount.get(), "The first component should always receive data first");
+        assertEquals(0, secondCompErrorCount.get(), "The second component should always receive data second");
+    }
+
+    /**
+     * Test that the expected exceptions are thrown
+     */
+    @Test
+    void orderedSolderToThrows() {
+        final PlatformContext platformContext =
+                TestPlatformContextBuilder.create().build();
+        final WiringModel model = WiringModel.create(platformContext, Time.getCurrent(), ForkJoinPool.commonPool());
+
+        final TaskScheduler<Integer> schedulerA = model.schedulerBuilder("schedulerA")
+                .withType(TaskSchedulerType.DIRECT)
+                .build()
+                .cast();
+        final TaskScheduler<Integer> schedulerB = model.schedulerBuilder("schedulerB")
+                .withType(TaskSchedulerType.DIRECT)
+                .build()
+                .cast();
+
+        InputWire<Integer> inputWire = schedulerB.buildInputWire("inputWire");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> schedulerA.getOutputWire().orderedSolderTo(List.of(inputWire)),
+                "Method should throw when provided less than two input wires.");
+    }
+}


### PR DESCRIPTION
**Description**:
Adds an `orderedSolderTo()` method to `OutputWire`.

**Related issue(s)**:

Fixes #11307

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
