### PR TITLE
fix: 11328 Optimized `DataFileReaderPbj.leaseFileChannel` method 

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -107,7 +107,9 @@ public record MerkleDbConfig(
         @ConfigProperty(defaultValue = "-1") int numHalfDiskHashMapFlushThreads,
         @ConfigProperty(defaultValue = "262144") int reservedBufferLengthForLeafList,
         @ConfigProperty(defaultValue = "1048576") int leafRecordCacheSize,
-        @ConfigProperty(defaultValue = "true") boolean usePbj) {
+        @ConfigProperty(defaultValue = "true") boolean usePbj,
+        @Min(1) @ConfigProperty(defaultValue = "8") int maxFileChannelsPerFileReader,
+        @Min(1) @ConfigProperty(defaultValue = "8") int maxThreadsPerFileChannel) {
 
     static double UNIT_FRACTION_PERCENT = 100.0;
 

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -86,6 +86,10 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
  *      If the value is zero, leaf records cache isn't used.
  * @param usePbj
  *      If true, use PBJ format for new (flushed) and compacted data files, otherwise use JDB.
+ * @param maxFileChannelsPerFileReader
+ *     Maximum number of file channels per file reader.
+ * @param maxThreadsPerFileChannel
+ *    Maximum number of threads per file channel.
  */
 @ConfigData("merkleDb")
 public record MerkleDbConfig(

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderJdb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderJdb.java
@@ -146,7 +146,7 @@ public class DataFileReaderJdb<D> extends DataFileReaderPbj<D> {
                 // and retry
                 reopenFileChannel(fcIndex, fileChannel);
             } finally {
-                releaseFileChannel();
+                releaseFileChannel(fcIndex);
             }
         }
         throw new IOException("Failed to read from file, file channels keep getting closed");

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderJdb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderJdb.java
@@ -146,7 +146,7 @@ public class DataFileReaderJdb<D> extends DataFileReaderPbj<D> {
                 // and retry
                 reopenFileChannel(fcIndex, fileChannel);
             } finally {
-                releaseFileChannel(fcIndex);
+                releaseFileChannel();
             }
         }
         throw new IOException("Failed to read from file, file channels keep getting closed");

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderPbj.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderPbj.java
@@ -22,6 +22,8 @@ import static com.swirlds.merkledb.files.DataFileCommon.FIELD_DATAFILE_ITEMS;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoWriterTools;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.swirlds.common.config.singleton.ConfigurationHolder;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.serialize.DataItemSerializer;
 import com.swirlds.merkledb.utilities.MerkleDbFileUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -37,6 +39,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -75,11 +78,13 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 // https://github.com/hashgraph/hedera-services/issues/8344
 public class DataFileReaderPbj<D> implements DataFileReader<D> {
 
+    private static final MerkleDbConfig CONFIG = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
+
     private static final ThreadLocal<ByteBuffer> BUFFER_CACHE = new ThreadLocal<>();
     private static final ThreadLocal<BufferedData> BUFFEREDDATA_CACHE = new ThreadLocal<>();
 
     /** Max number of file channels to use for reading */
-    protected static final int MAX_FILE_CHANNELS = 8;
+    protected static final int MAX_FILE_CHANNELS = CONFIG.maxFileChannelsPerFileReader();
     /**
      * When a data file reader is created, a single file channel is open to read data from the
      * file. This channel is used by all threads. Number of threads currently reading data is
@@ -87,7 +92,7 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
      * exceeds this threshold, a new file channel is open, unless there are {@link #MAX_FILE_CHANNELS}
      * channels are already opened.
      */
-    protected static final int THREADS_PER_FILECHANNEL = 8;
+    protected static final int THREADS_PER_FILECHANNEL = CONFIG.maxThreadsPerFileChannel();
     /**
      * A single data file reader may use multiple file channels. Previously, a single file channel
      * was used, and it resulted in unnecessary locking in FileChannelImpl.readInternal(), when
@@ -100,6 +105,7 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
     protected final AtomicInteger fileChannelsCount = new AtomicInteger(0);
     /** Number of file channels currently in use by all threads working with this data file reader */
     protected final AtomicInteger fileChannelsInUse = new AtomicInteger(0);
+    protected final AtomicIntegerArray fileChannelsLeases = new AtomicIntegerArray(MAX_FILE_CHANNELS);
 
     /** Indicates whether this file reader is open */
     private final AtomicBoolean open = new AtomicBoolean(true);
@@ -324,7 +330,8 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
     /**
      * Returns an index of an opened file channel to read data and increments the lease count.
      * Opens a new file channel, if possible, when the lease count per channel is greater than
-     * {@link #THREADS_PER_FILECHANNEL}.
+     * {@link #THREADS_PER_FILECHANNEL}. This method returns an index of a file channel that is least
+     * used at the moment.
      *
      * @return An index of a file channel to read data
      * @throws IOException
@@ -336,17 +343,38 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
         // Although openNewFileChannel() is thread safe, it makes sense to check the count here.
         // Since the channels are never closed (other than when the data file reader is closed),
         // it's safe to check count against MAX_FILE_CHANNELS
-        if ((inUse / count > THREADS_PER_FILECHANNEL) && (count < MAX_FILE_CHANNELS)) {
+        if (((float) inUse / count > THREADS_PER_FILECHANNEL) && (count < MAX_FILE_CHANNELS)) {
             openNewFileChannel(count);
             count = fileChannelsCount.get();
+            int lease = count - 1;
+            fileChannelsLeases.incrementAndGet(lease);
+            return lease;
         }
-        return inUse % count;
+        // find a channel with the least number of leases
+        // it's an estimate, as the number of leases may change while we're iterating, but it's good enough
+        int minCount = Integer.MAX_VALUE;
+        int lease = 0;
+        for (int i = 0; i < count; i++) {
+            int currentLeaseCount = fileChannelsLeases.get(i);
+            if(currentLeaseCount == 0) {
+                lease = i;
+                break;
+            }
+            if(minCount > currentLeaseCount) {
+                minCount = currentLeaseCount;
+                lease = i;
+            }
+        }
+        fileChannelsLeases.incrementAndGet(lease);
+        return lease;
     }
 
     /**
      * Decreases the number of opened file channels in use by one.
+     * @param fcIndex Index of the file channel to release
      */
-    protected void releaseFileChannel() {
+    protected void releaseFileChannel(int fcIndex) {
+        fileChannelsLeases.decrementAndGet(fcIndex);
         fileChannelsInUse.decrementAndGet();
     }
 
@@ -428,7 +456,7 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
                 // and retry
                 reopenFileChannel(fcIndex, fileChannel);
             } finally {
-                releaseFileChannel();
+                releaseFileChannel(fcIndex);
             }
         }
         throw new IOException("Failed to read from file, file channel keeps getting closed");

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderPbj.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileReaderPbj.java
@@ -105,6 +105,7 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
     protected final AtomicInteger fileChannelsCount = new AtomicInteger(0);
     /** Number of file channels currently in use by all threads working with this data file reader */
     protected final AtomicInteger fileChannelsInUse = new AtomicInteger(0);
+
     protected final AtomicIntegerArray fileChannelLeases = new AtomicIntegerArray(MAX_FILE_CHANNELS);
 
     /** Indicates whether this file reader is open */
@@ -356,11 +357,11 @@ public class DataFileReaderPbj<D> implements DataFileReader<D> {
         int channelLease = 0;
         for (int i = 0; i < count; i++) {
             final int currentLeaseCount = fileChannelLeases.get(i);
-            if(currentLeaseCount == 0) {
+            if (currentLeaseCount == 0) {
                 channelLease = i;
                 break;
             }
-            if(minCount > currentLeaseCount) {
+            if (minCount > currentLeaseCount) {
                 minCount = currentLeaseCount;
                 channelLease = i;
             }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderPbjTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderPbjTest.java
@@ -1,0 +1,91 @@
+package com.swirlds.merkledb.files;
+
+import static com.swirlds.merkledb.files.DataFileReaderPbj.MAX_FILE_CHANNELS;
+import static com.swirlds.merkledb.files.DataFileReaderPbj.THREADS_PER_FILECHANNEL;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.swirlds.merkledb.test.fixtures.ExampleFixedSizeDataSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+class DataFileReaderPbjTest {
+
+    @Mock
+    private DataFileMetadata dataFileMetadata;
+    private File file;
+    private DataFileReaderPbj dataFileReaderPbj;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        openMocks(this);
+        file = File.createTempFile( "file-reader", "test");
+        dataFileReaderPbj = new DataFileReaderPbj(file.toPath(), new ExampleFixedSizeDataSerializer(), dataFileMetadata);
+    }
+
+    @Test
+    void testLeaseFileChannel() throws IOException {
+        for (int i = 0; i < THREADS_PER_FILECHANNEL; i++) {
+            int lease = dataFileReaderPbj.leaseFileChannel();
+            assertEquals(0, lease);
+        }
+
+        assertEquals(1, dataFileReaderPbj.leaseFileChannel());
+
+        for (int i = 0; i < THREADS_PER_FILECHANNEL - 1; i++) {
+            int lease = dataFileReaderPbj.leaseFileChannel();
+            assertEquals(1, lease);
+        }
+
+        assertEquals(2, dataFileReaderPbj.leaseFileChannel());
+    }
+
+    @Test
+    void testLeaseFileChannel_maxFileChannels() throws IOException {
+        for (int i = 0; i < THREADS_PER_FILECHANNEL * MAX_FILE_CHANNELS; i++) {
+            dataFileReaderPbj.leaseFileChannel();
+        }
+
+        // verifying that all channels were created
+        assertEquals(MAX_FILE_CHANNELS, dataFileReaderPbj.fileChannelsCount.get(), "File channel count is unexpected");
+
+        // verifying even distribution
+        for (int i = 0; i < MAX_FILE_CHANNELS; i++) {
+            assertEquals(8, dataFileReaderPbj.fileChannelsLeases.get(i));
+        }
+
+        assertEquals(0, dataFileReaderPbj.leaseFileChannel());
+        assertEquals(1, dataFileReaderPbj.leaseFileChannel());
+
+        // verifying that no additional channels were created
+        assertEquals(MAX_FILE_CHANNELS, dataFileReaderPbj.fileChannelsCount.get(), "File channel count is unexpected");
+    }
+
+    @Test
+    void testLeaseFileChannel_leaseLeastUsed () throws IOException {
+        for (int i = 0; i < THREADS_PER_FILECHANNEL * MAX_FILE_CHANNELS; i++) {
+            dataFileReaderPbj.leaseFileChannel();
+        }
+
+        dataFileReaderPbj.releaseFileChannel(5);
+        dataFileReaderPbj.releaseFileChannel(5);
+
+        dataFileReaderPbj.releaseFileChannel(4);
+
+        assertEquals(5, dataFileReaderPbj.leaseFileChannel());
+        assertEquals(4, dataFileReaderPbj.leaseFileChannel());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        file.deleteOnExit();
+    }
+}

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderPbjTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderPbjTest.java
@@ -9,13 +9,10 @@ import com.swirlds.merkledb.test.fixtures.ExampleFixedSizeDataSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
 class DataFileReaderPbjTest {
 
@@ -59,7 +56,7 @@ class DataFileReaderPbjTest {
 
         // verifying even distribution
         for (int i = 0; i < MAX_FILE_CHANNELS; i++) {
-            assertEquals(8, dataFileReaderPbj.fileChannelsLeases.get(i));
+            assertEquals(8, dataFileReaderPbj.fileChannelLeases.get(i));
         }
 
         assertEquals(0, dataFileReaderPbj.leaseFileChannel());

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderPbjTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderPbjTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.swirlds.merkledb.files;
 
 import static com.swirlds.merkledb.files.DataFileReaderPbj.MAX_FILE_CHANNELS;
@@ -6,26 +22,27 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.swirlds.merkledb.test.fixtures.ExampleFixedSizeDataSerializer;
+import java.io.File;
+import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import java.io.File;
-import java.io.IOException;
-
 class DataFileReaderPbjTest {
 
     @Mock
     private DataFileMetadata dataFileMetadata;
+
     private File file;
     private DataFileReaderPbj dataFileReaderPbj;
 
     @BeforeEach
     void setUp() throws IOException {
         openMocks(this);
-        file = File.createTempFile( "file-reader", "test");
-        dataFileReaderPbj = new DataFileReaderPbj(file.toPath(), new ExampleFixedSizeDataSerializer(), dataFileMetadata);
+        file = File.createTempFile("file-reader", "test");
+        dataFileReaderPbj =
+                new DataFileReaderPbj(file.toPath(), new ExampleFixedSizeDataSerializer(), dataFileMetadata);
     }
 
     @Test
@@ -67,7 +84,7 @@ class DataFileReaderPbjTest {
     }
 
     @Test
-    void testLeaseFileChannel_leaseLeastUsed () throws IOException {
+    void testLeaseFileChannel_leaseLeastUsed() throws IOException {
         for (int i = 0; i < THREADS_PER_FILECHANNEL * MAX_FILE_CHANNELS; i++) {
             dataFileReaderPbj.leaseFileChannel();
         }


### PR DESCRIPTION
**Description**:

Optimized `DataFileReaderPbj.leaseFileChannel` method  to make sure that it returns an index of the least used file channel at the moment

**Related issue(s)**:

Fixes #11328 


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
