### PR TITLE
fix: 11363: Backport the fix for 11348 to release 0.47

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/Bucket.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/Bucket.java
@@ -228,7 +228,7 @@ public sealed class Bucket<K extends VirtualKey> implements Closeable permits Pa
      * @param value the entry value, this can also be special
      *     HalfDiskHashMap.INVALID_VALUE to mean delete
      */
-    public void putValue(final K key, final long value) {
+    public final void putValue(final K key, final long value) {
         putValue(key, INVALID_VALUE, value);
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketTest.java
@@ -277,6 +277,14 @@ class BucketTest {
         assertEquals(0, outBucket.getBucketIndex());
     }
 
+    @ParameterizedTest
+    @EnumSource(KeyType.class)
+    void parsedBucketPutIfEqual(final KeyType keyType) throws IOException {
+        final VirtualLongKey key1 = keyType.keyConstructor.apply(1L);
+        final Bucket<VirtualLongKey> bucket = new ParsedBucket<>(keyType.keySerializer, null);
+        assertDoesNotThrow(() -> bucket.putValue(key1, INVALID_VALUE, 1));
+    }
+
     private void checkKey(Bucket<VirtualLongKey> bucket, VirtualLongKey key) {
         var findResult =
                 assertDoesNotThrow(() -> bucket.findValue(key.hashCode(), key, -1), "No exception should be thrown");


### PR DESCRIPTION
Fix summary: direct backport of https://github.com/hashgraph/hedera-services/pull/11349 to `release/0.47` branch.

Fixes: https://github.com/hashgraph/hedera-services/issues/11363
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
