### PR TITLE
fix: 11298: VirtualMapReconnectTest fails intermittently with path not in range log message

### DIFF
--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -225,6 +225,9 @@ public class VirtualMapReconnectTestBase {
                     final VirtualRoot root = learnerMap.getRight();
                     assertTrue(root.isHashed(), "Learner root node must be hashed");
                 } catch (Exception e) {
+                    if (!failureExpected) {
+                        e.printStackTrace(System.err);
+                    }
                     assertTrue(failureExpected, "We did not expect an exception on this reconnect attempt! " + e);
                 }
 


### PR DESCRIPTION
Fix summary: added a statement to print reconnect exceptions (if not expected) full stack traces during tests. It doesn't fix the problem, but helps debug it in the future.

Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
