### PR TITLE
perf: Warm tokens as they are also on-disk now

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableTokenStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableTokenStoreImpl.java
@@ -112,7 +112,13 @@ public class ReadableTokenStoreImpl implements ReadableTokenStore {
      * Returns the number of tokens in the state.
      * @return the number of tokens in the state.
      */
+    @Override
     public long sizeOfState() {
         return tokenState.size();
+    }
+
+    @Override
+    public void warm(@NonNull final TokenID tokenId) {
+        tokenState.warm(tokenId);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -137,6 +137,7 @@ public class CryptoTransferHandler implements TransactionHandler {
         requireNonNull(context);
 
         final ReadableAccountStore accountStore = context.createStore(ReadableAccountStore.class);
+        final ReadableTokenStore tokenStore = context.createStore(ReadableTokenStore.class);
         final ReadableNftStore nftStore = context.createStore(ReadableNftStore.class);
         final ReadableTokenRelationStore tokenRelationStore = context.createStore(ReadableTokenRelationStore.class);
         final CryptoTransferTransactionBody op = context.body().cryptoTransferOrThrow();
@@ -155,6 +156,7 @@ public class CryptoTransferHandler implements TransactionHandler {
                 .filter(TokenTransferList::hasNftTransfers)
                 .forEach(tokenTransferList -> {
                     final TokenID tokenID = tokenTransferList.tokenOrThrow();
+                    tokenStore.warm(tokenID);
                     final List<NftTransfer> nftTransfers = tokenTransferList.nftTransfersOrThrow();
                     for (final NftTransfer nftTransfer : nftTransfers) {
                         warmNftTransfer(accountStore, nftStore, tokenRelationStore, tokenID, nftTransfer);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableTokenStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableTokenStoreImplTest.java
@@ -22,9 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.node.app.service.mono.pbj.PbjConverter;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.FcCustomFee;
@@ -121,5 +124,11 @@ class ReadableTokenStoreImplTest extends TokenHandlerTestBase {
     void returnSizeOfState() {
         final var store = new ReadableTokenStoreImpl(readableStates);
         assertEquals(readableStates.get(TOKENS).size(), store.sizeOfState());
+    }
+
+    @Test
+    void warmWarmsUnderlyingState(@Mock ReadableKVState<EntityIDPair, TokenRelation> tokenRelations) {
+        subject.warm(tokenId);
+        verify(tokens).warm(tokenId);
     }
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableTokenStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableTokenStore.java
@@ -92,5 +92,14 @@ public interface ReadableTokenStore {
      * Returns the number of tokens in the state.
      * @return the number of tokens in the state.
      */
-    public long sizeOfState();
+    long sizeOfState();
+
+    /**
+     * Warms the system by preloading a token into memory
+     *
+     * <p>The default implementation is empty because preloading data into memory is only used for some implementations.
+     *
+     * @param tokenId the token id
+     */
+    default void warm(@NonNull TokenID tokenId) {}
 }


### PR DESCRIPTION
This PR adds the warming of tokens to `CryptoTransfer` as tokens are also on-disk now.

Closes #11410 