### PR TITLE
fix: 10904 Log catastrophic failures during ingest 

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -140,7 +140,7 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
             callsHandledSpeedometer.cycle();
         } catch (final Exception e) {
             // Track the number of times we failed to handle a call
-            logger.error("Failed to handle call! Unexpected exception", e);
+            logger.error("Possibly CATASTROPHIC failure while handling a call and running the ingest workflow", e);
             callsFailedCounter.increment();
             responseObserver.onError(e);
         }


### PR DESCRIPTION
**Description**:

Change the catch-clause in MethodBase.invoke() so that it logs a message that triggers an alert in production with:
"Possibly CATASTROPHIC failure while handling a call and running the ingest workflow."

**Related issue(s)**:

Fixes #10904 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
