### PR TITLE
fix: transaction fee in record for mono code

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerCharging.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerCharging.java
@@ -205,6 +205,7 @@ public class NarratedLedgerCharging implements NarratedCharging {
         long chargeableNetworkFee = Math.min(networkFee, effPayerStartingBalance);
         ledger.adjustBalance(grpcNodeId, -chargeableNetworkFee);
         feeDistribution.distributeChargedFee(+chargeableNetworkFee, ledger.getAccountsLedger());
+        totalCharged = chargeableNetworkFee;
     }
 
     private void initEffPayerBalance(EntityNum effPayerId) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerChargingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/charging/NarratedLedgerChargingTest.java
@@ -217,7 +217,7 @@ class NarratedLedgerChargingTest {
         verify(ledger).adjustBalance(grpcNodeId, -networkFee + 1);
         verify(feeDistribution).distributeChargedFee(networkFee - 1, accountsLedger);
 
-        assertEquals(0, subject.totalFeesChargedToPayer());
+        assertEquals(399, subject.totalFeesChargedToPayer());
     }
 
     @Test


### PR DESCRIPTION
fix the issue of Mismatched field counts (found but did not expect [transactionFee]) between expected receipt {

Transaction fee weren't appearing for duplicate transactions as part of the consensus transaction.

**Related issue(s)**:

Fixes #11402 

