### PR TITLE
feat: 11436: Provide a way to have different reconnect teacher/learner threads implementations

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -260,12 +260,12 @@ public class LearningSynchronizer implements ReconnectNodeCount {
             view = (LearnerTreeView<T>) new LearnerPushReceiveMerkleTreeView(reconnectConfig, root);
         } else {
             assert root instanceof CustomReconnectRoot;
-            view = ((CustomReconnectRoot<?, T>) root).buildLearnerView();
+            view = ((CustomReconnectRoot<?, T>) root).buildLearnerView(reconnectConfig);
         }
 
         final AtomicReference<T> reconstructedRoot = new AtomicReference<>();
 
-        view.startLearnerThread(workGroup, inputStream, outputStream, rootsToReceive, reconstructedRoot, this);
+        view.startLearnerThreads(workGroup, inputStream, outputStream, rootsToReceive, reconstructedRoot, this);
         InterruptedException interruptException = null;
         try {
             workGroup.waitForTermination();

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -22,20 +22,14 @@ import static com.swirlds.logging.legacy.LogMarker.RECONNECT;
 
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
-import com.swirlds.common.merkle.synchronization.internal.LearnerThread;
-import com.swirlds.common.merkle.synchronization.internal.Lesson;
-import com.swirlds.common.merkle.synchronization.internal.QueryResponse;
 import com.swirlds.common.merkle.synchronization.internal.ReconnectNodeCount;
-import com.swirlds.common.merkle.synchronization.streams.AsyncInputStream;
-import com.swirlds.common.merkle.synchronization.streams.AsyncOutputStream;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
 import com.swirlds.common.merkle.synchronization.views.CustomReconnectRoot;
+import com.swirlds.common.merkle.synchronization.views.LearnerPushReceiveMerkleTreeView;
 import com.swirlds.common.merkle.synchronization.views.LearnerTreeView;
-import com.swirlds.common.merkle.synchronization.views.StandardLearnerTreeView;
 import com.swirlds.common.merkle.utility.MerkleTreeVisualizer;
 import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.common.threading.pool.StandardWorkGroup;
@@ -263,22 +257,15 @@ public class LearningSynchronizer implements ReconnectNodeCount {
 
         final LearnerTreeView<T> view;
         if (root == null || !root.hasCustomReconnectView()) {
-            view = (LearnerTreeView<T>) new StandardLearnerTreeView(root);
+            view = (LearnerTreeView<T>) new LearnerPushReceiveMerkleTreeView(reconnectConfig, root);
         } else {
             assert root instanceof CustomReconnectRoot;
             view = ((CustomReconnectRoot<?, T>) root).buildLearnerView();
         }
 
-        final AsyncInputStream<Lesson<T>> in =
-                new AsyncInputStream<>(inputStream, workGroup, () -> new Lesson<>(view), reconnectConfig);
-        final AsyncOutputStream<QueryResponse> out = buildOutputStream(workGroup, outputStream);
-
-        in.start();
-        out.start();
-
         final AtomicReference<T> reconstructedRoot = new AtomicReference<>();
 
-        new LearnerThread<>(workGroup, threadManager, in, out, rootsToReceive, reconstructedRoot, view, this).start();
+        view.startLearnerThread(workGroup, inputStream, outputStream, rootsToReceive, reconstructedRoot, this);
         InterruptedException interruptException = null;
         try {
             workGroup.waitForTermination();
@@ -291,7 +278,7 @@ public class LearningSynchronizer implements ReconnectNodeCount {
 
             // Depending on where the failure occurred, there may be deserialized objects still sitting in
             // the async input stream's queue that haven't been attached to any tree.
-            in.abort();
+            view.abort();
 
             final MerkleNode merkleRoot = view.getMerkleRoot(reconstructedRoot.get());
             if (merkleRoot != null && merkleRoot.getReservationCount() == 0) {
@@ -310,14 +297,6 @@ public class LearningSynchronizer implements ReconnectNodeCount {
         viewsToInitialize.addFirst(view);
 
         return view.getMerkleRoot(reconstructedRoot.get());
-    }
-
-    /**
-     * Build the output stream. Exposed to allow unit tests to override implementation to simulate latency.
-     */
-    protected AsyncOutputStream<QueryResponse> buildOutputStream(
-            final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
-        return new AsyncOutputStream<>(out, workGroup, reconnectConfig);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerPushReceiveThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerPushReceiveThread.java
@@ -119,7 +119,7 @@ public class LearnerPushReceiveThread<T> {
         }
 
         if (originalNode != null && view.getClassId(originalNode) == lesson.getCustomViewClassId()) {
-            customRoot.setupWithOriginalNode(view.getReconnectConfig(), view.getMerkleRoot(originalNode));
+            customRoot.setupWithOriginalNode(view.getMerkleRoot(originalNode));
         } else {
             customRoot.setupWithNoData();
         }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerPushReceiveThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerPushReceiveThread.java
@@ -28,7 +28,6 @@ import com.swirlds.common.merkle.synchronization.streams.AsyncOutputStream;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
 import com.swirlds.common.merkle.synchronization.views.CustomReconnectRoot;
 import com.swirlds.common.merkle.synchronization.views.LearnerTreeView;
-import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.common.threading.pool.StandardWorkGroup;
 import com.swirlds.common.utility.ThresholdLimitingHandler;
 import java.util.List;
@@ -43,9 +42,9 @@ import org.apache.logging.log4j.Logger;
  * @param <T>
  * 		the type of data used by the view to represent a node
  */
-public class LearnerThread<T> {
+public class LearnerPushReceiveThread<T> {
 
-    private static final Logger logger = LogManager.getLogger(LearnerThread.class);
+    private static final Logger logger = LogManager.getLogger(LearnerPushReceiveThread.class);
 
     private static final String NAME = "send-and-receive";
 
@@ -61,17 +60,10 @@ public class LearnerThread<T> {
     private final ThresholdLimitingHandler<Throwable> exceptionRateLimiter = new ThresholdLimitingHandler<>(1);
 
     /**
-     * Responsible for creating and managing threads used by this object.
-     */
-    private final ThreadManager threadManager;
-
-    /**
      * Create a new thread for the learner.
      *
      * @param workGroup
      * 		the work group that will manage the thread
-     * @param threadManager
-     * 		manages the creation of threads
      * @param in
      * 		the input stream, this object is responsible for closing the stream when finished
      * @param out
@@ -85,9 +77,8 @@ public class LearnerThread<T> {
      * @param nodeCount
      * 		an object used to keep track of the number of nodes sent during the reconnect
      */
-    public LearnerThread(
+    public LearnerPushReceiveThread(
             final StandardWorkGroup workGroup,
-            final ThreadManager threadManager,
             final AsyncInputStream<Lesson<T>> in,
             final AsyncOutputStream<QueryResponse> out,
             final Queue<MerkleNode> rootsToReceive,
@@ -95,7 +86,6 @@ public class LearnerThread<T> {
             final LearnerTreeView<T> view,
             final ReconnectNodeCount nodeCount) {
         this.workGroup = workGroup;
-        this.threadManager = threadManager;
         this.in = in;
         this.out = out;
         this.rootsToReceive = rootsToReceive;
@@ -129,7 +119,7 @@ public class LearnerThread<T> {
         }
 
         if (originalNode != null && view.getClassId(originalNode) == lesson.getCustomViewClassId()) {
-            customRoot.setupWithOriginalNode(view.getMerkleRoot(originalNode));
+            customRoot.setupWithOriginalNode(view.getReconnectConfig(), view.getMerkleRoot(originalNode));
         } else {
             customRoot.setupWithNoData();
         }
@@ -243,8 +233,6 @@ public class LearnerThread<T> {
         try (in;
                 out;
                 view) {
-
-            view.startThreads(threadManager, workGroup);
 
             view.expectLessonFor(null, 0, view.getOriginalRoot(), false);
             in.anticipateMessage();

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSendingThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSendingThread.java
@@ -129,7 +129,7 @@ public class TeacherSendingThread<T> {
         final Lesson<T> lesson = new Lesson<>(CUSTOM_VIEW_ROOT, new CustomViewRootLesson(view.getClassId(node)));
         final CustomReconnectRoot<?, ?> subtreeRoot = (CustomReconnectRoot<?, ?>) view.getMerkleRoot(node);
 
-        subtrees.add(new TeacherSubtree(subtreeRoot, subtreeRoot.buildTeacherView()));
+        subtrees.add(new TeacherSubtree(subtreeRoot, subtreeRoot.buildTeacherView(view.getReconnectConfig())));
 
         return lesson;
     }
@@ -213,6 +213,7 @@ public class TeacherSendingThread<T> {
             throw new MerkleSynchronizationException("exception in the teacher's receiving thread", ex);
         } finally {
             senderIsFinished.set(true);
+            System.err.println("TeacherSendingThread.run finished");
         }
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSubtree.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/TeacherSubtree.java
@@ -17,7 +17,7 @@
 package com.swirlds.common.merkle.synchronization.internal;
 
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.common.merkle.synchronization.views.StandardTeacherTreeView;
+import com.swirlds.common.merkle.synchronization.views.TeacherPushReceiveMerkleTreeView;
 import com.swirlds.common.merkle.synchronization.views.TeacherTreeView;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -31,13 +31,13 @@ public final class TeacherSubtree implements AutoCloseable {
     private final TeacherTreeView<?> view;
 
     /**
-     * Create a subtree with {@link StandardTeacherTreeView}.
+     * Create a subtree with {@link TeacherPushReceiveMerkleTreeView}.
      *
      * @param configuration the configuration
      * @param root          the root of the subtree
      */
     public TeacherSubtree(@NonNull final Configuration configuration, final MerkleNode root) {
-        this(root, new StandardTeacherTreeView(configuration, root));
+        this(root, new TeacherPushReceiveMerkleTreeView(configuration, root));
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/CustomReconnectRoot.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/CustomReconnectRoot.java
@@ -17,6 +17,7 @@
 package com.swirlds.common.merkle.synchronization.views;
 
 import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 
 /**
  * Nodes that are want to use a custom view for reconnect must extend this interface and
@@ -60,7 +61,7 @@ public interface CustomReconnectRoot<T, L> extends MerkleNode {
      * @param originalNode
      * 		the original node in the learner's tree in the root position of this subtree
      */
-    void setupWithOriginalNode(final MerkleNode originalNode);
+    void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode);
 
     /**
      * Called on a node if there is no data to be copied.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/CustomReconnectRoot.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/CustomReconnectRoot.java
@@ -44,14 +44,14 @@ public interface CustomReconnectRoot<T, L> extends MerkleNode {
      *
      * @return a view representing this subtree
      */
-    TeacherTreeView<T> buildTeacherView();
+    TeacherTreeView<T> buildTeacherView(final ReconnectConfig reconnectConfig);
 
     /**
      * Build a view of this subtree to be used for reconnect by the learner.
      *
      * @return a view representing this subtree
      */
-    LearnerTreeView<L> buildLearnerView();
+    LearnerTreeView<L> buildLearnerView(final ReconnectConfig reconnectConfig);
 
     /**
      * If the original node in this position is of the correct type then the learner's node is initialized via
@@ -61,7 +61,7 @@ public interface CustomReconnectRoot<T, L> extends MerkleNode {
      * @param originalNode
      * 		the original node in the learner's tree in the root position of this subtree
      */
-    void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode);
+    void setupWithOriginalNode(final MerkleNode originalNode);
 
     /**
      * Called on a node if there is no data to be copied.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerPushReceiveMerkleTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerPushReceiveMerkleTreeView.java
@@ -71,7 +71,7 @@ public class LearnerPushReceiveMerkleTreeView implements LearnerTreeView<MerkleN
     }
 
     @Override
-    public void startLearnerThread(
+    public void startLearnerThreads(
             final StandardWorkGroup workGroup,
             final MerkleDataInputStream inputStream,
             final MerkleDataOutputStream outputStream,

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerPushReceiveMerkleTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerPushReceiveMerkleTreeView.java
@@ -21,22 +21,38 @@ import static com.swirlds.common.constructable.ClassIdFormatter.classIdString;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.MerkleDataInputStream;
+import com.swirlds.common.io.streams.MerkleDataOutputStream;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.merkle.synchronization.internal.ExpectedLesson;
+import com.swirlds.common.merkle.synchronization.internal.LearnerPushReceiveThread;
+import com.swirlds.common.merkle.synchronization.internal.Lesson;
+import com.swirlds.common.merkle.synchronization.internal.QueryResponse;
+import com.swirlds.common.merkle.synchronization.internal.ReconnectNodeCount;
+import com.swirlds.common.merkle.synchronization.streams.AsyncInputStream;
+import com.swirlds.common.merkle.synchronization.streams.AsyncOutputStream;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
+import com.swirlds.common.threading.pool.StandardWorkGroup;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Implementation for a view of a standard in memory merkle tree.
  */
-public class StandardLearnerTreeView implements LearnerTreeView<MerkleNode> {
+public class LearnerPushReceiveMerkleTreeView implements LearnerTreeView<MerkleNode> {
+
+    private final ReconnectConfig reconnectConfig;
 
     private final MerkleNode originalRoot;
+
+    private AsyncInputStream<Lesson<MerkleNode>> in;
+    private AsyncOutputStream<QueryResponse> out;
 
     private final Queue<ExpectedLesson<MerkleNode>> expectedLessons;
     private final LinkedList<MerkleInternal> nodesToInitialize;
@@ -47,10 +63,40 @@ public class StandardLearnerTreeView implements LearnerTreeView<MerkleNode> {
      * @param root
      * 		the root of the tree (or subtree)
      */
-    public StandardLearnerTreeView(final MerkleNode root) {
+    public LearnerPushReceiveMerkleTreeView(final ReconnectConfig reconnectConfig, final MerkleNode root) {
+        this.reconnectConfig = reconnectConfig;
         this.originalRoot = root;
         expectedLessons = new LinkedList<>();
         nodesToInitialize = new LinkedList<>();
+    }
+
+    @Override
+    public void startLearnerThread(
+            final StandardWorkGroup workGroup,
+            final MerkleDataInputStream inputStream,
+            final MerkleDataOutputStream outputStream,
+            final Queue<MerkleNode> rootsToReceive,
+            final AtomicReference<MerkleNode> reconstructedRoot,
+            final ReconnectNodeCount nodeCount) {
+        in = new AsyncInputStream<>(inputStream, workGroup, () -> new Lesson<>(this), reconnectConfig);
+        out = new AsyncOutputStream<>(outputStream, workGroup, reconnectConfig);
+
+        in.start();
+        out.start();
+
+        final LearnerPushReceiveThread<MerkleNode> learnerThread =
+                new LearnerPushReceiveThread<>(workGroup, in, out, rootsToReceive, reconstructedRoot, this, nodeCount);
+        learnerThread.start();
+    }
+
+    @Override
+    public void abort() {
+        in.abort();
+    }
+
+    @Override
+    public ReconnectConfig getReconnectConfig() {
+        return reconnectConfig;
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerTreeView.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public interface LearnerTreeView<T> extends LearnerExpectedLessonQueue<T>, LearnerInitializer<T>, TreeView<T> {
 
-    void startLearnerThread(
+    void startLearnerThreads(
             final StandardWorkGroup workGroup,
             final MerkleDataInputStream inputStream,
             final MerkleDataOutputStream outputStream,

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/LearnerTreeView.java
@@ -18,13 +18,18 @@ package com.swirlds.common.merkle.synchronization.views;
 
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.streams.MerkleDataInputStream;
+import com.swirlds.common.io.streams.MerkleDataOutputStream;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
+import com.swirlds.common.merkle.synchronization.internal.ReconnectNodeCount;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
-import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.common.threading.pool.StandardWorkGroup;
 import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A "view" into a merkle tree (or subtree) used to perform a reconnect operation. This view is used to access
@@ -35,15 +40,17 @@ import java.io.IOException;
  */
 public interface LearnerTreeView<T> extends LearnerExpectedLessonQueue<T>, LearnerInitializer<T>, TreeView<T> {
 
-    /**
-     * Start any required background threads. Threads should be created on the provided work group.
-     *
-     * @param threadManager
-     * 		responsible for creating new threads
-     * @param workGroup
-     * 		a work group responsible for managing threads
-     */
-    default void startThreads(final ThreadManager threadManager, final StandardWorkGroup workGroup) {}
+    void startLearnerThread(
+            final StandardWorkGroup workGroup,
+            final MerkleDataInputStream inputStream,
+            final MerkleDataOutputStream outputStream,
+            final Queue<MerkleNode> rootsToReceive,
+            final AtomicReference<T> reconstructedRoot,
+            final ReconnectNodeCount nodeCount);
+
+    default void abort() {}
+
+    ReconnectConfig getReconnectConfig();
 
     /**
      * Check if this view represents the root of the state.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/views/TeacherTreeView.java
@@ -16,9 +16,16 @@
 
 package com.swirlds.common.merkle.synchronization.views;
 
+import com.swirlds.base.time.Time;
+import com.swirlds.common.io.streams.MerkleDataInputStream;
+import com.swirlds.common.io.streams.MerkleDataOutputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
+import com.swirlds.common.merkle.synchronization.internal.TeacherSubtree;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
+import com.swirlds.common.threading.pool.StandardWorkGroup;
 import java.io.IOException;
+import java.util.Queue;
 
 /**
  * A "view" into a merkle tree (or subtree) used to perform a reconnect operation. This view is used to access
@@ -29,6 +36,15 @@ import java.io.IOException;
  */
 public interface TeacherTreeView<T>
         extends TeacherHandleQueue<T>, TeacherResponseQueue<T>, TeacherResponseTracker<T>, TreeView<T> {
+
+    void startTeacherThreads(
+            final Time time,
+            final StandardWorkGroup workGroup,
+            final MerkleDataInputStream inputStream,
+            final MerkleDataOutputStream outputStream,
+            final Queue<TeacherSubtree> subtrees);
+
+    ReconnectConfig getReconnectConfig();
 
     /**
      * Get the root of the tree.

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyCustomReconnectRoot.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyCustomReconnectRoot.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.merkle.synchronization.internal.NodeToSend;
 import com.swirlds.common.merkle.synchronization.views.CustomReconnectRoot;
 import com.swirlds.common.merkle.synchronization.views.LearnerTreeView;
@@ -36,6 +37,7 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
 
     private static final long CLASS_ID = 0x3d03994ec6d42dccL;
 
+    private ReconnectConfig reconnectConfig;
     private final List<DummyTeacherTreeView> views;
 
     public DummyCustomReconnectRoot() {
@@ -91,7 +93,9 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
      * {@inheritDoc}
      */
     @Override
-    public void setupWithOriginalNode(final MerkleNode originalNode) {}
+    public void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode) {
+        this.reconnectConfig = reconnectConfig;
+    }
 
     /**
      * {@inheritDoc}
@@ -104,7 +108,7 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
      */
     @Override
     public LearnerTreeView<MerkleNode> buildLearnerView() {
-        return new DummyLearnerTreeView(this);
+        return new DummyLearnerPushReceiveMerkleTreeView(reconnectConfig, this);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyCustomReconnectRoot.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyCustomReconnectRoot.java
@@ -37,8 +37,7 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
 
     private static final long CLASS_ID = 0x3d03994ec6d42dccL;
 
-    private ReconnectConfig reconnectConfig;
-    private final List<DummyTeacherTreeView> views;
+    private final List<DummyTeacherPushReceiveMerkleTreeView> views;
 
     public DummyCustomReconnectRoot() {
         views = new LinkedList<>();
@@ -72,10 +71,11 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
      * {@inheritDoc}
      */
     @Override
-    public TeacherTreeView<NodeToSend> buildTeacherView() {
+    public TeacherTreeView<NodeToSend> buildTeacherView(final ReconnectConfig reconnectConfig) {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
-        final DummyTeacherTreeView view = new DummyTeacherTreeView(platformContext.getConfiguration(), this);
+        final DummyTeacherPushReceiveMerkleTreeView view =
+                new DummyTeacherPushReceiveMerkleTreeView(platformContext.getConfiguration(), this);
         views.add(view);
         return view;
     }
@@ -84,7 +84,7 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
      * Throw an exception if all views have not yet been closed.
      */
     public void assertViewsAreClosed() {
-        for (final DummyTeacherTreeView view : views) {
+        for (final DummyTeacherPushReceiveMerkleTreeView view : views) {
             assertTrue(view.isClosed(), "view should have been closed");
         }
     }
@@ -93,9 +93,7 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
      * {@inheritDoc}
      */
     @Override
-    public void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode) {
-        this.reconnectConfig = reconnectConfig;
-    }
+    public void setupWithOriginalNode(final MerkleNode originalNode) {}
 
     /**
      * {@inheritDoc}
@@ -107,7 +105,7 @@ public class DummyCustomReconnectRoot extends DummyMerkleInternal
      * {@inheritDoc}
      */
     @Override
-    public LearnerTreeView<MerkleNode> buildLearnerView() {
+    public LearnerTreeView<MerkleNode> buildLearnerView(final ReconnectConfig reconnectConfig) {
         return new DummyLearnerPushReceiveMerkleTreeView(reconnectConfig, this);
     }
 

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyLearnerPushReceiveMerkleTreeView.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyLearnerPushReceiveMerkleTreeView.java
@@ -17,9 +17,10 @@
 package com.swirlds.common.test.fixtures.merkle.dummy;
 
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.common.merkle.synchronization.views.StandardLearnerTreeView;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
+import com.swirlds.common.merkle.synchronization.views.LearnerPushReceiveMerkleTreeView;
 
-public class DummyLearnerTreeView extends StandardLearnerTreeView {
+public class DummyLearnerPushReceiveMerkleTreeView extends LearnerPushReceiveMerkleTreeView {
 
     /**
      * Create a new standard tree view out of an in-memory merkle tree (or subtree).
@@ -27,8 +28,8 @@ public class DummyLearnerTreeView extends StandardLearnerTreeView {
      * @param root
      * 		the root of the tree (or subtree)
      */
-    public DummyLearnerTreeView(final MerkleNode root) {
-        super(root);
+    public DummyLearnerPushReceiveMerkleTreeView(final ReconnectConfig reconnectConfig, final MerkleNode root) {
+        super(reconnectConfig, root);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyTeacherPushReceiveMerkleTreeView.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyTeacherPushReceiveMerkleTreeView.java
@@ -19,7 +19,7 @@ package com.swirlds.common.test.fixtures.merkle.dummy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.common.merkle.synchronization.views.StandardTeacherTreeView;
+import com.swirlds.common.merkle.synchronization.views.TeacherPushReceiveMerkleTreeView;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * View for testing.
  */
-public class DummyTeacherTreeView extends StandardTeacherTreeView {
+public class DummyTeacherPushReceiveMerkleTreeView extends TeacherPushReceiveMerkleTreeView {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -37,7 +37,7 @@ public class DummyTeacherTreeView extends StandardTeacherTreeView {
      * @param configuration the configuration
      * @param root          the root of the tree
      */
-    public DummyTeacherTreeView(@NonNull final Configuration configuration, final MerkleNode root) {
+    public DummyTeacherPushReceiveMerkleTreeView(@NonNull final Configuration configuration, final MerkleNode root) {
         super(configuration, root);
     }
 

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/LaggingLearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/LaggingLearningSynchronizer.java
@@ -20,13 +20,9 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.synchronization.LearningSynchronizer;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
-import com.swirlds.common.merkle.synchronization.internal.QueryResponse;
-import com.swirlds.common.merkle.synchronization.streams.AsyncOutputStream;
-import com.swirlds.common.threading.pool.StandardWorkGroup;
 
 /**
  * A {@link LearningSynchronizer} with simulated latency.
@@ -53,9 +49,9 @@ public class LaggingLearningSynchronizer extends LearningSynchronizer {
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected AsyncOutputStream<QueryResponse> buildOutputStream(
-            final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
-        return new LaggingAsyncOutputStream<>(out, workGroup, latencyMilliseconds, reconnectConfig);
-    }
+    //    @Override
+    //    protected AsyncOutputStream<QueryResponse> buildOutputStream(
+    //            final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
+    //        return new LaggingAsyncOutputStream<>(out, workGroup, latencyMilliseconds, reconnectConfig);
+    //    }
 }

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/LaggingTeachingSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/LaggingTeachingSynchronizer.java
@@ -22,13 +22,9 @@ import com.swirlds.base.time.Time;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.synchronization.TeachingSynchronizer;
 import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
-import com.swirlds.common.merkle.synchronization.internal.Lesson;
-import com.swirlds.common.merkle.synchronization.streams.AsyncOutputStream;
-import com.swirlds.common.threading.pool.StandardWorkGroup;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -64,9 +60,9 @@ public class LaggingTeachingSynchronizer extends TeachingSynchronizer {
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected <T> AsyncOutputStream<Lesson<T>> buildOutputStream(
-            final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
-        return new LaggingAsyncOutputStream<>(out, workGroup, latencyMilliseconds, reconnectConfig);
-    }
+    //    @Override
+    //    protected <T> AsyncOutputStream<Lesson<T>> buildOutputStream(
+    //            final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
+    //        return new LaggingAsyncOutputStream<>(out, workGroup, latencyMilliseconds, reconnectConfig);
+    //    }
 }

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenVirtualMapTeacherView.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenVirtualMapTeacherView.java
@@ -16,10 +16,17 @@
 
 package com.swirlds.virtual.merkle.reconnect;
 
+import com.swirlds.base.time.Time;
+import com.swirlds.common.io.streams.MerkleDataInputStream;
+import com.swirlds.common.io.streams.MerkleDataOutputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
+import com.swirlds.common.merkle.synchronization.internal.TeacherSubtree;
 import com.swirlds.common.merkle.synchronization.views.TeacherTreeView;
+import com.swirlds.common.threading.pool.StandardWorkGroup;
 import java.io.IOException;
+import java.util.Queue;
 
 /**
  * An intentionally broken teacher tree view. Throws an IO exception after a certain number of nodes have been
@@ -50,6 +57,21 @@ public class BrokenVirtualMapTeacherView implements TeacherTreeView<Long> {
         this.baseView = baseView;
         this.permittedInternals = permittedInternals;
         this.permittedLeaves = permittedLeaves;
+    }
+
+    @Override
+    public void startTeacherThreads(
+            final Time time,
+            final StandardWorkGroup workGroup,
+            final MerkleDataInputStream inputStream,
+            final MerkleDataOutputStream outputStream,
+            final Queue<TeacherSubtree> subtrees) {
+        baseView.startTeacherThreads(time, workGroup, inputStream, outputStream, subtrees);
+    }
+
+    @Override
+    public ReconnectConfig getReconnectConfig() {
+        return baseView.getReconnectConfig();
     }
 
     @Override

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualRootNode.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualRootNode.java
@@ -62,17 +62,17 @@ public class FakeVirtualRootNode extends PartialBinaryMerkleInternal
     }
 
     @Override
-    public TeacherTreeView<Long> buildTeacherView() {
+    public TeacherTreeView<Long> buildTeacherView(final ReconnectConfig reconnectConfig) {
         return teacherTreeView;
     }
 
     @Override
-    public LearnerTreeView<Long> buildLearnerView() {
+    public LearnerTreeView<Long> buildLearnerView(final ReconnectConfig reconnectConfig) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode) {
+    public void setupWithOriginalNode(final MerkleNode originalNode) {
         throw new UnsupportedOperationException();
     }
 

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualRootNode.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/FakeVirtualRootNode.java
@@ -20,6 +20,7 @@ import com.swirlds.common.constructable.ConstructableIgnored;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialBinaryMerkleInternal;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.merkle.synchronization.views.CustomReconnectRoot;
 import com.swirlds.common.merkle.synchronization.views.LearnerTreeView;
 import com.swirlds.common.merkle.synchronization.views.TeacherTreeView;
@@ -71,7 +72,7 @@ public class FakeVirtualRootNode extends PartialBinaryMerkleInternal
     }
 
     @Override
-    public void setupWithOriginalNode(final MerkleNode originalNode) {
+    public void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode) {
         throw new UnsupportedOperationException();
     }
 

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTest.java
@@ -355,7 +355,8 @@ class VirtualMapReconnectTest extends VirtualMapReconnectTestBase {
 
             imitationMap.setChild(0, map.getChild(0).copy());
 
-            final TeacherTreeView<Long> view = ((VirtualRootNode<?, ?>) map.getChild(1)).buildTeacherView();
+            final TeacherTreeView<Long> view =
+                    ((VirtualRootNode<?, ?>) map.getChild(1)).buildTeacherView(reconnectConfig);
             final TeacherTreeView<Long> badView =
                     new BrokenVirtualMapTeacherView(view, permittedInternals, permittedLeaves);
             final MerkleNode imitationRoot = new FakeVirtualRootNode(badView);

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -77,7 +77,7 @@ import com.swirlds.virtualmap.internal.reconnect.ConcurrentBlockingIterator;
 import com.swirlds.virtualmap.internal.reconnect.LearnerPushReceiveVirtualTreeView;
 import com.swirlds.virtualmap.internal.reconnect.ReconnectHashListener;
 import com.swirlds.virtualmap.internal.reconnect.ReconnectState;
-import com.swirlds.virtualmap.internal.reconnect.VirtualTeacherTreeView;
+import com.swirlds.virtualmap.internal.reconnect.TeacherPushReceiveVirtualTreeView;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -304,6 +304,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
      */
     private AtomicBoolean reconnectHashingStarted;
 
+    private VirtualStateAccessor reconnectState;
     /**
      * The {@link RecordAccessor} for the state, cache, and data source needed during reconnect.
      */
@@ -394,7 +395,8 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
     @SuppressWarnings("ClassEscapesDefinedScope")
     public void postInit(final VirtualStateAccessor state) {
         // We're reconnecting, state doesn't match cache or dataSource, gotta bail.
-        if (learnerTreeView != null) {
+        //        if (learnerTreeView != null) {
+        if (originalMap != null) {
             fullyReconnectedState = state;
             return;
         }
@@ -634,7 +636,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
     public <T extends MerkleNode> T getChild(final int index) {
         if (isDestroyed()
                 || dataSource == null
-                || learnerTreeView != null
+                || originalMap != null
                 || state.getFirstLeafPath() == INVALID_PATH
                 || index > 1) {
             return null;
@@ -1365,16 +1367,19 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
      * {@inheritDoc}
      */
     @Override
-    public TeacherTreeView<Long> buildTeacherView() {
-        return new VirtualTeacherTreeView<>(getStaticThreadManager(), this, state, pipeline);
+    public TeacherTreeView<Long> buildTeacherView(final ReconnectConfig reconnectConfig) {
+        return new TeacherPushReceiveVirtualTreeView<>(
+                getStaticThreadManager(), reconnectConfig, this, state, pipeline);
     }
+
+    private VirtualRootNode<K, V> originalMap;
 
     /**
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
     @Override
-    public void setupWithOriginalNode(final ReconnectConfig reconnectConfig, final MerkleNode originalNode) {
+    public void setupWithOriginalNode(final MerkleNode originalNode) {
         assert originalNode instanceof VirtualRootNode : "The original node was not a VirtualRootNode!";
 
         // NOTE: If we're reconnecting, then the old tree is toast. We hold onto the originalMap to
@@ -1382,7 +1387,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
         // the old map again. We need the data source builder from the old map so, we can create
         // new data sources in this new map with all the right settings.
         //noinspection unchecked
-        final VirtualRootNode<K, V> originalMap = (VirtualRootNode<K, V>) originalNode;
+        originalMap = (VirtualRootNode<K, V>) originalNode;
         this.dataSourceBuilder = originalMap.dataSourceBuilder;
 
         // shutdown background compaction on original data source as it is no longer needed to be running as all data
@@ -1406,12 +1411,8 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
         reconnectHashingFuture = new CompletableFuture<>();
         reconnectHashingStarted = new AtomicBoolean(false);
 
-        final VirtualStateAccessor reconnectState = new ReconnectState(-1, -1);
+        reconnectState = new ReconnectState(-1, -1);
         reconnectRecords = new RecordAccessorImpl<>(reconnectState, snapshotCache, dataSource);
-
-        // During reconnect we want to look up state from the original records
-        learnerTreeView = new LearnerPushReceiveVirtualTreeView<>(
-                reconnectConfig, this, originalMap.records, originalMap.getState(), reconnectState);
 
         // Current statistics can only be registered when the node boots, requiring statistics
         // objects to be passed from version to version of the state.
@@ -1431,7 +1432,12 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
      * {@inheritDoc}
      */
     @Override
-    public LearnerTreeView<Long> buildLearnerView() {
+    public LearnerTreeView<Long> buildLearnerView(final ReconnectConfig reconnectConfig) {
+        assert originalMap != null;
+
+        // During reconnect we want to look up state from the original records
+        learnerTreeView = new LearnerPushReceiveVirtualTreeView<>(
+                reconnectConfig, this, originalMap.records, originalMap.getState(), reconnectState);
         return learnerTreeView;
     }
 
@@ -1507,6 +1513,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
                 logger.warn(RECONNECT.getMarker(), "virtual map hashing thread was never started");
             }
             learnerTreeView = null;
+            originalMap = null;
             postInit(fullyReconnectedState);
             // Start up data source compaction now
             dataSource.enableBackgroundCompaction();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPushReceiveVirtualTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPushReceiveVirtualTreeView.java
@@ -143,7 +143,7 @@ public final class LearnerPushReceiveVirtualTreeView<K extends VirtualKey, V ext
     }
 
     @Override
-    public void startLearnerThread(
+    public void startLearnerThreads(
             final StandardWorkGroup workGroup,
             final MerkleDataInputStream inputStream,
             final MerkleDataOutputStream outputStream,

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
@@ -30,6 +30,7 @@ import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
 import com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags;
 import com.swirlds.config.api.Configuration;
@@ -512,7 +513,9 @@ class VirtualRootNodeTest extends VirtualTestBase {
         VirtualRootNode<TestKey, TestValue> root = createRoot();
         VirtualRootNode<TestKey, TestValue> anotherRoot = createRoot();
         anotherRoot.computeHash();
-        root.setupWithOriginalNode(anotherRoot);
+        final ReconnectConfig config =
+                new TestConfigBuilder().getOrCreateConfig().getConfigData(ReconnectConfig.class);
+        root.setupWithOriginalNode(config, anotherRoot);
         assertDoesNotThrow(() -> root.postInit(null));
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
@@ -30,7 +30,6 @@ import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
-import com.swirlds.common.merkle.synchronization.config.ReconnectConfig;
 import com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException;
 import com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags;
 import com.swirlds.config.api.Configuration;
@@ -513,9 +512,7 @@ class VirtualRootNodeTest extends VirtualTestBase {
         VirtualRootNode<TestKey, TestValue> root = createRoot();
         VirtualRootNode<TestKey, TestValue> anotherRoot = createRoot();
         anotherRoot.computeHash();
-        final ReconnectConfig config =
-                new TestConfigBuilder().getOrCreateConfig().getConfigData(ReconnectConfig.class);
-        root.setupWithOriginalNode(config, anotherRoot);
+        root.setupWithOriginalNode(anotherRoot);
         assertDoesNotThrow(() -> root.postInit(null));
     }
 }


### PR DESCRIPTION
The first PR to address https://github.com/hashgraph/hedera-services/issues/11403, more to come. In this PR:

* Added a new method to `LearnerTreeView` to start learner threads in a given work group
* A similar method is added to `TeacherTreeView`
* Both `StandardTeacherTreeView` (renamed to `TeacherPushReceiveMerkleTreeView`) and `VirtualTeacherTreeView` (renamed to `TeacherPushReceiveVirtualTreeView`) create a pair of teacher threads in this method, same as what was done previously. In the future a different thread will be created here
* Similarly, learner views (also renamed) create a single learner thread (renamed to `LearnerPushReceiveThread`), unchanged from the current implementation
* `LearningSynchronizer` and `TeachingSynchronizer` are now pretty straightforward: create a work group, create a view, ask the view to run its threads (actually, tasks) in the work group, wait for the work group to complete (successfully, or with exceptions). Whatever tasks are run on the teacher / learner side is totally opaque to the synchronizers
* Minor cleanup: dropped `LearnerTreeView.startThreads()` method as it is no longer needed
* Changed `VirtualRootNode` to create its learner tree view in `buildLearnerTreeView()` method rather than in `setupWithOriginalNode()`

Fixes https://github.com/hashgraph/hedera-services/issues/11436
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
