### PR TITLE
chore: cherry-pick static call with selfdestruct to system account between 0.0.751  and 0.0.999 results in FAIL_INVALID

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationV046.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaSelfDestructOperationV046.java
@@ -74,6 +74,9 @@ public class HederaSelfDestructOperationV046 extends SelfDestructOperation {
         final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
         final var beneficiaryAddress = Words.toAddress(frame.getStackItem(0));
         final var toBeDeleted = frame.getRecipientAddress();
+        if (frame.isStatic()) {
+            return reversionWith(null, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+        }
         if (systemAccountDetector.test(beneficiaryAddress) || !addressValidator.test(beneficiaryAddress, frame)) {
             return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
         }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSelfDestructOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSelfDestructOperation.java
@@ -71,11 +71,13 @@ public class CustomSelfDestructOperation extends AbstractOperation {
 
             final var tbdAddress = frame.getRecipientAddress();
             final var proxyWorldUpdater = (ProxyWorldUpdater) frame.getWorldUpdater();
-            // Enforce Hedera-specific restrictions on account deletion
-            final var maybeHaltReason =
-                    proxyWorldUpdater.tryTrackingSelfDestructBeneficiary(tbdAddress, beneficiaryAddress, frame);
-            if (maybeHaltReason.isPresent()) {
-                return haltFor(null, 0, maybeHaltReason.get());
+            // Enforce Hedera-specific restrictions on account deletion for non-static frames
+            if (!frame.isStatic()) {
+                final var maybeHaltReason =
+                        proxyWorldUpdater.tryTrackingSelfDestructBeneficiary(tbdAddress, beneficiaryAddress, frame);
+                if (maybeHaltReason.isPresent()) {
+                    return haltFor(null, 0, maybeHaltReason.get());
+                }
             }
 
             // Now proceed with the self-destruct

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSelfDestructOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSelfDestructOperationTest.java
@@ -158,8 +158,6 @@ class CustomSelfDestructOperationTest {
         given(frame.getRecipientAddress()).willReturn(TBD);
         given(addressChecks.isPresent(BENEFICIARY, frame)).willReturn(true);
         given(frame.getWorldUpdater()).willReturn(proxyWorldUpdater);
-        given(proxyWorldUpdater.tryTrackingSelfDestructBeneficiary(TBD, BENEFICIARY, frame))
-                .willReturn(Optional.empty());
         given(proxyWorldUpdater.get(TBD)).willReturn(account);
         given(account.getBalance()).willReturn(INHERITANCE);
     }


### PR DESCRIPTION
Cherry pick #11243 static call with selfdestruct to system account between 0.0.751  and 0.0.999 results in FAIL_INVALID (#11243)

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
