### PR TITLE
fix: Fix service names for metrics

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -167,7 +167,7 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
             @NonNull final Metrics metrics,
             @NonNull final String nameTemplate,
             @NonNull final String descriptionTemplate) {
-        final var baseName = serviceName + ":" + methodName;
+        final var baseName = serviceName.replace('.', ':') + ":" + methodName;
         final var name = String.format(nameTemplate, baseName);
         final var desc = String.format(descriptionTemplate, baseName);
         return metrics.getOrCreate(new Counter.Config("app", name).withDescription(desc));
@@ -185,7 +185,7 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
             @NonNull final Metrics metrics,
             @NonNull final String nameTemplate,
             @NonNull final String descriptionTemplate) {
-        final var baseName = serviceName + ":" + methodName;
+        final var baseName = serviceName.replace('.', ':') + ":" + methodName;
         final var name = String.format(nameTemplate, baseName);
         final var desc = String.format(descriptionTemplate, baseName);
         return metrics.getOrCreate(new SpeedometerMetric.Config("app", name).withDescription(desc));


### PR DESCRIPTION
Service names are prepended with "proto.". This PR replaces the '.' as it is not accepted in metric names.