### PR TITLE
build: add back '-XX:ActiveProcessorCount=6' to 'eet'

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -215,6 +215,7 @@ testing {
                 testTask {
                     shouldRunAfter(tasks.test)
                     maxHeapSize = "8g"
+                    jvmArgs("-XX:ActiveProcessorCount=6")
                 }
             }
         }


### PR DESCRIPTION
**Description**:
To chek if this decreases the likelihood of these test environment errors to appear:
https://scans.gradle.com/s/siwhcv3vmntkw/tests/overview?outcome=FAILED

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
