### PR TITLE
fix: 11496 Temporary disabled `VirtualPipelineTests.flushThrottle` 

### DIFF
--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/map/MapTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/map/MapTest.java
@@ -31,6 +31,7 @@ import com.swirlds.virtual.merkle.TestValue;
 import com.swirlds.virtual.merkle.TestValueSerializer;
 import com.swirlds.virtualmap.VirtualMap;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -55,6 +56,8 @@ final class MapTest {
     @Tag(TIME_CONSUMING)
     @Tags({@Tag("VirtualMerkle"), @Tag("VMAP-019")})
     @DisplayName("Insert one million elements with same key but different value")
+    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11498
+    @Disabled
     void insertRemoveAndModifyOneMillion() throws InterruptedException {
         final int changesPerBatch = 15_432; // Some unexpected size just to be crazy
         final int max = 1_000_000;

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -84,6 +84,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -1047,6 +1048,8 @@ class VirtualMapTests extends VirtualTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("VMAP-019")})
     @DisplayName("Insert one million elements with same key but different value")
     @Tag(TestQualifierTags.TIME_CONSUMING)
+    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11498
+    @Disabled
     void insertRemoveAndModifyOneMillion() throws InterruptedException {
         final int changesPerBatch = 15_432; // Some unexpected size just to be crazy
         final int max = 1_000_000;

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -62,6 +62,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -835,6 +836,7 @@ class VirtualPipelineTests {
     @Test
     @Tag(TestQualifierTags.TIME_CONSUMING)
     @DisplayName("Flush Throttle")
+    @Disabled
     void flushThrottle() throws InterruptedException {
 
         final int preferredQueueSize = 2;

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -836,6 +836,7 @@ class VirtualPipelineTests {
     @Test
     @Tag(TestQualifierTags.TIME_CONSUMING)
     @DisplayName("Flush Throttle")
+    // FUTURE WORK: https://github.com/hashgraph/hedera-services/pull/11497
     @Disabled
     void flushThrottle() throws InterruptedException {
 


### PR DESCRIPTION
**Description**:

Temporary disabled `VirtualPipelineTests.flushThrottle` stabilize test pipeline

**Related issue(s)**:

Relates to #11496 
