### PR TITLE
fix: 11507 Temporary disabled a test 

### DIFF
--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTest.java
@@ -323,6 +323,8 @@ class VirtualMapReconnectTest extends VirtualMapReconnectTestBase {
     @MethodSource("provideSmallTreePermutations")
     @DisplayName("Learner Aborts Reconnect Half Way Through")
     @Tag(TIMING_SENSITIVE)
+    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11507
+    @Disabled
     void learnerAbortsReconnectHalfWayThrough(final TreePermutation treePermutation) {
         configureReconnectToFailQuickly();
 


### PR DESCRIPTION
**Description**:

Temporary disabled a test `VirtualMapReconnectTest.learnerAbortsReconnectHalfWayThrough` to stabilize the test pipeline

**Related issue(s)**:

Relates to #11507 

**Notes for reviewer**:

These tests will be fixed later



**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
