### PR TITLE
fix: 11540-ConcurrentTestSupportTest

### DIFF
--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/test/internal/fixtures/ConcurrentTestSupportTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/test/internal/fixtures/ConcurrentTestSupportTest.java
@@ -63,7 +63,7 @@ class ConcurrentTestSupportTest {
     @Test
     void testATaskThatRunsTooLong() {
         // given
-        try (ConcurrentTestSupport concurrentTestSupport = new ConcurrentTestSupport(Duration.ofSeconds(1))) {
+        try (ConcurrentTestSupport concurrentTestSupport = new ConcurrentTestSupport(Duration.ofMillis(500))) {
             final Runnable runnable = () -> sleep(1_010);
 
             // then
@@ -76,7 +76,7 @@ class ConcurrentTestSupportTest {
     void testMultipleTasksThatRunsTooLong() {
         // given
         try (ConcurrentTestSupport concurrentTestSupport = new ConcurrentTestSupport(Duration.ofSeconds(1)); ) {
-            final List<Runnable> runnables = IntStream.range(0, 50)
+            final List<Runnable> runnables = IntStream.range(0, 10)
                     .mapToObj(i -> (Runnable) () -> sleep(2000))
                     .toList();
 


### PR DESCRIPTION
Reduce the number of threads consumed by the test and check more spaced timeouts.

Fixes #11540