### PR TITLE
fix: reduce sync permit count (#11545)

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
@@ -46,7 +46,7 @@ import java.time.Duration;
 public record SyncConfig(
         @ConfigProperty(defaultValue = "25") int syncSleepAfterFailedNegotiation,
         @ConfigProperty(defaultValue = "17") int syncProtocolPermitCount,
-        @ConfigProperty(defaultValue = "true") boolean onePermitPerPeer,
+        @ConfigProperty(defaultValue = "false") boolean onePermitPerPeer,
         @ConfigProperty(defaultValue = "1000") int syncProtocolHeartbeatPeriod,
         @ConfigProperty(defaultValue = "true") boolean waitForEventsInIntake,
         @ConfigProperty(defaultValue = "true") boolean filterLikelyDuplicates,


### PR DESCRIPTION
closes #11544 

Observed test flake related to not enough signatures being collected, known issue.