### PR TITLE
build: add new Gradle modules for the block node

### DIFF
--- a/block-node/blocknode-core-spi/build.gradle.kts
+++ b/block-node/blocknode-core-spi/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-core-spi/src/main/java/com/hedera/node/blocknode/core/spi/DummyCoreSpi.java
+++ b/block-node/blocknode-core-spi/src/main/java/com/hedera/node/blocknode/core/spi/DummyCoreSpi.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.core.spi;
+
+public interface DummyCoreSpi {
+    void doSomething();
+}

--- a/block-node/blocknode-core-spi/src/main/java/module-info.java
+++ b/block-node/blocknode-core-spi/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module com.hedera.node.blocknode.core.spi {
+    // Export packages with public interfaces to the world as needed.
+    exports com.hedera.node.blocknode.core.spi;
+}

--- a/block-node/blocknode-core-spi/src/test/java/com/hedera/node/blocknode/core/spi/test/DummyCoreSpiTest.java
+++ b/block-node/blocknode-core-spi/src/test/java/com/hedera/node/blocknode/core/spi/test/DummyCoreSpiTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.core.spi.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.blocknode.core.spi.DummyCoreSpi;
+import org.junit.jupiter.api.Test;
+
+class DummyCoreSpiTest {
+
+    @Test
+    void dummySpiNullCheck() {
+        final DummyCoreSpi dummyCoreSpi = null;
+        assertNull(dummyCoreSpi);
+    }
+
+    @Test
+    void dummySpiDoSomethingCheck() {
+        final DummyCoreSpi dummyCoreSpi = new DummyCoreSpi() {
+            @Override
+            public void doSomething() {
+                // Do nothing.
+            }
+        };
+
+        assertDoesNotThrow(dummyCoreSpi::doSomething);
+    }
+}

--- a/block-node/blocknode-core-spi/src/test/java/module-info.java
+++ b/block-node/blocknode-core-spi/src/test/java/module-info.java
@@ -1,0 +1,9 @@
+module com.hedera.node.blocknode.core.spi.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.core.spi.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.core.spi;
+    requires org.junit.jupiter.api;
+}

--- a/block-node/blocknode-core/build.gradle.kts
+++ b/block-node/blocknode-core/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-core/src/main/java/com/hedera/node/blocknode/core/Example.java
+++ b/block-node/blocknode-core/src/main/java/com/hedera/node/blocknode/core/Example.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.core;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.blocknode.core.spi.DummyCoreSpi;
+import com.hedera.node.blocknode.filesystem.api.DummyFileSystemApi;
+import com.hedera.node.blocknode.filesystem.local.LocalFileSystem;
+import com.hedera.node.blocknode.filesystem.s3.S3FileSystem;
+import com.hedera.node.blocknode.grpc.api.DummyGrpcApi;
+import com.hedera.node.blocknode.state.BlockNodeState;
+
+public interface Example {
+
+    AccountID accountIdFrom(byte[] bytes);
+
+    DummyCoreSpi spi();
+
+    DummyGrpcApi grpcApi();
+
+    DummyFileSystemApi fileSystemApi();
+
+    default BlockNodeState newState() {
+        return new BlockNodeState();
+    }
+
+    default DummyFileSystemApi s3FileSystem() {
+        return new S3FileSystem();
+    }
+
+    default DummyFileSystemApi localFileSystem() {
+        return new LocalFileSystem();
+    }
+}

--- a/block-node/blocknode-core/src/main/java/module-info.java
+++ b/block-node/blocknode-core/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+module com.hedera.node.blocknode.core {
+    // Selectively export non-public packages to the test module.
+    exports com.hedera.node.blocknode.core to
+            com.hedera.node.blocknode.core.test;
+
+    // Require the modules needed for compilation.
+    requires com.hedera.node.blocknode.filesystem.local;
+    requires com.hedera.node.blocknode.filesystem.s3;
+
+    // Require modules which are needed for compilation and should be available to all modules that depend on this
+    // module (including tests and other source sets).
+    requires transitive com.hedera.node.blocknode.core.spi;
+    requires transitive com.hedera.node.blocknode.filesystem.api;
+    requires transitive com.hedera.node.blocknode.grpc.api;
+    requires transitive com.hedera.node.blocknode.state;
+    requires transitive com.hedera.node.hapi;
+}

--- a/block-node/blocknode-core/src/test/java/com/hedera/node/blocknode/core/test/ExampleTest.java
+++ b/block-node/blocknode-core/src/test/java/com/hedera/node/blocknode/core/test/ExampleTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.core.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.blocknode.core.Example;
+import com.hedera.node.blocknode.core.spi.DummyCoreSpi;
+import com.hedera.node.blocknode.filesystem.api.DummyFileSystemApi;
+import com.hedera.node.blocknode.grpc.api.DummyGrpcApi;
+import org.junit.jupiter.api.Test;
+
+class ExampleTest {
+
+    @Test
+    void exampleNullCheck() {
+        final Example example = null;
+        assertNull(example);
+    }
+
+    @Test
+    void exampleSpiNullCheck() {
+        final Example example = new Example() {
+            @Override
+            public AccountID accountIdFrom(byte[] bytes) {
+                return null;
+            }
+
+            @Override
+            public DummyCoreSpi spi() {
+                return null;
+            }
+
+            @Override
+            public DummyGrpcApi grpcApi() {
+                return null;
+            }
+
+            @Override
+            public DummyFileSystemApi fileSystemApi() {
+                return localFileSystem();
+            }
+        };
+
+        assertNotNull(example);
+        assertNull(example.spi());
+        assertNull(example.grpcApi());
+        assertNotNull(example.fileSystemApi());
+        assertNotNull(example.localFileSystem());
+        assertNotNull(example.s3FileSystem());
+        assertNotNull(example.newState());
+
+        assertNull(example.newState().applicationState());
+        assertDoesNotThrow(example.fileSystemApi()::doSomething);
+        assertDoesNotThrow(example.s3FileSystem()::doSomething);
+        assertDoesNotThrow(example.localFileSystem()::doSomething);
+    }
+}

--- a/block-node/blocknode-core/src/test/java/module-info.java
+++ b/block-node/blocknode-core/src/test/java/module-info.java
@@ -1,0 +1,10 @@
+module com.hedera.node.blocknode.core.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.core.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.core;
+    requires com.swirlds.platform.core;
+    requires org.junit.jupiter.api;
+}

--- a/block-node/blocknode-filesystem-api/build.gradle.kts
+++ b/block-node/blocknode-filesystem-api/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-filesystem-api/src/main/java/com/hedera/node/blocknode/filesystem/api/DummyFileSystemApi.java
+++ b/block-node/blocknode-filesystem-api/src/main/java/com/hedera/node/blocknode/filesystem/api/DummyFileSystemApi.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.filesystem.api;
+
+public interface DummyFileSystemApi {
+    void doSomething();
+}

--- a/block-node/blocknode-filesystem-api/src/main/java/module-info.java
+++ b/block-node/blocknode-filesystem-api/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module com.hedera.node.blocknode.filesystem.api {
+    // Export packages with public interfaces to the world as needed.
+    exports com.hedera.node.blocknode.filesystem.api;
+}

--- a/block-node/blocknode-filesystem-api/src/test/java/com/hedera/node/blocknode/filesystem/api/test/DummyFileSystemApiTest.java
+++ b/block-node/blocknode-filesystem-api/src/test/java/com/hedera/node/blocknode/filesystem/api/test/DummyFileSystemApiTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.filesystem.api.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.blocknode.filesystem.api.DummyFileSystemApi;
+import org.junit.jupiter.api.Test;
+
+class DummyFileSystemApiTest {
+
+    @Test
+    void dummySpiNullCheck() {
+        final DummyFileSystemApi dummyFileSystemApi = null;
+        assertNull(dummyFileSystemApi);
+    }
+
+    @Test
+    void dummySpiDoSomethingCheck() {
+        final DummyFileSystemApi dummyFileSystemApi = new DummyFileSystemApi() {
+            @Override
+            public void doSomething() {
+                // Do nothing.
+            }
+        };
+
+        assertDoesNotThrow(dummyFileSystemApi::doSomething);
+    }
+}

--- a/block-node/blocknode-filesystem-api/src/test/java/module-info.java
+++ b/block-node/blocknode-filesystem-api/src/test/java/module-info.java
@@ -1,0 +1,9 @@
+module com.hedera.node.blocknode.filesystem.api.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.filesystem.api.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.filesystem.api;
+    requires org.junit.jupiter.api;
+}

--- a/block-node/blocknode-filesystem-local/build.gradle.kts
+++ b/block-node/blocknode-filesystem-local/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-filesystem-local/src/main/java/com/hedera/node/blocknode/filesystem/local/LocalFileSystem.java
+++ b/block-node/blocknode-filesystem-local/src/main/java/com/hedera/node/blocknode/filesystem/local/LocalFileSystem.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.filesystem.local;
+
+import com.hedera.node.blocknode.core.spi.DummyCoreSpi;
+import com.hedera.node.blocknode.filesystem.api.DummyFileSystemApi;
+
+public class LocalFileSystem implements DummyFileSystemApi {
+    @Override
+    public void doSomething() {
+        final DummyCoreSpi dummyCoreSpi = () -> {
+            // Do nothing.
+        };
+
+        dummyCoreSpi.doSomething();
+    }
+}

--- a/block-node/blocknode-filesystem-local/src/main/java/module-info.java
+++ b/block-node/blocknode-filesystem-local/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module com.hedera.node.blocknode.filesystem.local {
+    // Selectively export non-public packages to the test module.
+    exports com.hedera.node.blocknode.filesystem.local to
+            com.hedera.node.blocknode.filesystem.local.test,
+            com.hedera.node.blocknode.core;
+
+    // Require the modules needed for compilation.
+    requires com.hedera.node.blocknode.core.spi;
+
+    // Require modules which are needed for compilation and should be available to all modules that depend on this
+    // module (including tests and other source sets).
+    requires transitive com.hedera.node.blocknode.filesystem.api;
+}

--- a/block-node/blocknode-filesystem-local/src/test/java/com/hedera/node/blocknode/filesystem/local/test/LocalFileSystemTest.java
+++ b/block-node/blocknode-filesystem-local/src/test/java/com/hedera/node/blocknode/filesystem/local/test/LocalFileSystemTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.filesystem.local.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.blocknode.filesystem.local.LocalFileSystem;
+import org.junit.jupiter.api.Test;
+
+class LocalFileSystemTest {
+
+    @Test
+    void localFileSystemNullCheck() {
+        final LocalFileSystem localFileSystem = null;
+        assertNull(localFileSystem);
+    }
+
+    @Test
+    void localFileSystemDoSomethingCheck() {
+        final LocalFileSystem localFileSystem = new LocalFileSystem();
+        assertNotNull(localFileSystem);
+        assertDoesNotThrow(localFileSystem::doSomething);
+    }
+}

--- a/block-node/blocknode-filesystem-local/src/test/java/module-info.java
+++ b/block-node/blocknode-filesystem-local/src/test/java/module-info.java
@@ -1,0 +1,9 @@
+module com.hedera.node.blocknode.filesystem.local.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.filesystem.local.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.filesystem.local;
+    requires org.junit.jupiter.api;
+}

--- a/block-node/blocknode-filesystem-s3/build.gradle.kts
+++ b/block-node/blocknode-filesystem-s3/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-filesystem-s3/src/main/java/com/hedera/node/blocknode/filesystem/s3/S3FileSystem.java
+++ b/block-node/blocknode-filesystem-s3/src/main/java/com/hedera/node/blocknode/filesystem/s3/S3FileSystem.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.filesystem.s3;
+
+import com.hedera.node.blocknode.core.spi.DummyCoreSpi;
+import com.hedera.node.blocknode.filesystem.api.DummyFileSystemApi;
+
+public class S3FileSystem implements DummyFileSystemApi {
+    @Override
+    public void doSomething() {
+        final DummyCoreSpi dummyCoreSpi = () -> {
+            // Do nothing.
+        };
+
+        dummyCoreSpi.doSomething();
+    }
+}

--- a/block-node/blocknode-filesystem-s3/src/main/java/module-info.java
+++ b/block-node/blocknode-filesystem-s3/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module com.hedera.node.blocknode.filesystem.s3 {
+    // Selectively export non-public packages to the test module.
+    exports com.hedera.node.blocknode.filesystem.s3 to
+            com.hedera.node.blocknode.filesystem.s3.test,
+            com.hedera.node.blocknode.core;
+
+    // Require the modules needed for compilation.
+    requires com.hedera.node.blocknode.core.spi;
+
+    // Require modules which are needed for compilation and should be available to all modules that depend on this
+    // module (including tests and other source sets).
+    requires transitive com.hedera.node.blocknode.filesystem.api;
+}

--- a/block-node/blocknode-filesystem-s3/src/test/java/com/hedera/node/blocknode/filesystem/s3/test/S3FileSystemTest.java
+++ b/block-node/blocknode-filesystem-s3/src/test/java/com/hedera/node/blocknode/filesystem/s3/test/S3FileSystemTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.filesystem.s3.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.blocknode.filesystem.s3.S3FileSystem;
+import org.junit.jupiter.api.Test;
+
+class S3FileSystemTest {
+
+    @Test
+    void localFileSystemNullCheck() {
+        final S3FileSystem s3FileSystem = null;
+        assertNull(s3FileSystem);
+    }
+
+    @Test
+    void localFileSystemDoSomethingCheck() {
+        final S3FileSystem s3FileSystem = new S3FileSystem();
+        assertNotNull(s3FileSystem);
+        assertDoesNotThrow(s3FileSystem::doSomething);
+    }
+}

--- a/block-node/blocknode-filesystem-s3/src/test/java/module-info.java
+++ b/block-node/blocknode-filesystem-s3/src/test/java/module-info.java
@@ -1,0 +1,9 @@
+module com.hedera.node.blocknode.filesystem.s3.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.filesystem.s3.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.filesystem.s3;
+    requires org.junit.jupiter.api;
+}

--- a/block-node/blocknode-grpc-api/build.gradle.kts
+++ b/block-node/blocknode-grpc-api/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-grpc-api/src/main/java/com/hedera/node/blocknode/grpc/api/DummyGrpcApi.java
+++ b/block-node/blocknode-grpc-api/src/main/java/com/hedera/node/blocknode/grpc/api/DummyGrpcApi.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.grpc.api;
+
+public interface DummyGrpcApi {
+    void doSomething();
+}

--- a/block-node/blocknode-grpc-api/src/main/java/module-info.java
+++ b/block-node/blocknode-grpc-api/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module com.hedera.node.blocknode.grpc.api {
+    // Export packages with public interfaces to the world as needed.
+    exports com.hedera.node.blocknode.grpc.api;
+}

--- a/block-node/blocknode-grpc-api/src/test/java/com/hedera/node/blocknode/core/grpc/api/test/DummyGrpcApiTest.java
+++ b/block-node/blocknode-grpc-api/src/test/java/com/hedera/node/blocknode/core/grpc/api/test/DummyGrpcApiTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.core.grpc.api.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.blocknode.grpc.api.DummyGrpcApi;
+import org.junit.jupiter.api.Test;
+
+class DummyGrpcApiTest {
+
+    @Test
+    void dummyApiNullCheck() {
+        final DummyGrpcApi dummyGrpcApi = null;
+        assertNull(dummyGrpcApi);
+    }
+
+    @Test
+    void dummyApiDoSomethingCheck() {
+        final DummyGrpcApi dummyGrpcApi = new DummyGrpcApi() {
+            @Override
+            public void doSomething() {
+                // Do nothing.
+            }
+        };
+
+        assertDoesNotThrow(dummyGrpcApi::doSomething);
+    }
+}

--- a/block-node/blocknode-grpc-api/src/test/java/module-info.java
+++ b/block-node/blocknode-grpc-api/src/test/java/module-info.java
@@ -1,0 +1,9 @@
+module com.hedera.node.blocknode.grpc.api.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.core.grpc.api.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.grpc.api;
+    requires org.junit.jupiter.api;
+}

--- a/block-node/blocknode-state/build.gradle.kts
+++ b/block-node/blocknode-state/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.hashgraph.blocknode.conventions") }

--- a/block-node/blocknode-state/src/main/java/com/hedera/node/blocknode/state/BlockNodeState.java
+++ b/block-node/blocknode-state/src/main/java/com/hedera/node/blocknode/state/BlockNodeState.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.state;
+
+import com.hedera.node.blocknode.core.spi.DummyCoreSpi;
+import com.swirlds.platform.state.State;
+
+public class BlockNodeState {
+    public State applicationState() {
+        final DummyCoreSpi dummyCoreSpi = () -> {
+            // Do nothing.
+        };
+        dummyCoreSpi.doSomething();
+
+        return null;
+    }
+}

--- a/block-node/blocknode-state/src/main/java/module-info.java
+++ b/block-node/blocknode-state/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module com.hedera.node.blocknode.state {
+    // Export the packages that should be available to other modules.
+    exports com.hedera.node.blocknode.state;
+
+    // Require the modules needed for compilation.
+    requires com.hedera.node.blocknode.core.spi;
+
+    // Require modules which are needed for compilation and should be available to all modules that depend on this
+    // module (including tests and other source sets
+    requires transitive com.swirlds.platform.core;
+}

--- a/block-node/blocknode-state/src/test/java/com/hedera/node/blocknode/state/test/BlockNodeStateTest.java
+++ b/block-node/blocknode-state/src/test/java/com/hedera/node/blocknode/state/test/BlockNodeStateTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.blocknode.state.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.blocknode.state.BlockNodeState;
+import org.junit.jupiter.api.Test;
+
+class BlockNodeStateTest {
+
+    @Test
+    void blockNodeStateTest() {
+        final BlockNodeState blockNodeState = new BlockNodeState();
+        assertNotNull(blockNodeState);
+        assertNull(blockNodeState.applicationState());
+    }
+}

--- a/block-node/blocknode-state/src/test/java/module-info.java
+++ b/block-node/blocknode-state/src/test/java/module-info.java
@@ -1,0 +1,9 @@
+module com.hedera.node.blocknode.state.test {
+    // Open test packages to JUnit 5 and Mockito as required.
+    opens com.hedera.node.blocknode.state.test to
+            org.junit.platform.commons;
+
+    // Require other modules needed for the unit tests to compile.
+    requires com.hedera.node.blocknode.state;
+    requires org.junit.jupiter.api;
+}

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.blocknode.conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.blocknode.conventions.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("java-library")
+    id("com.hedera.hashgraph.java")
+}
+
+group = "com.hedera.storage"
+
+tasks.checkModuleInfo { moduleNamePrefix = "com.hedera.storage" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -116,6 +116,15 @@ includeAllProjects("platform-sdk/platform-apps/demos")
 
 includeAllProjects("platform-sdk/platform-apps/tests")
 
+// Block Node Projects
+include(":blocknode-core", "block-node/blocknode-core")
+include(":blocknode-core-spi", "block-node/blocknode-core-spi")
+include(":blocknode-filesystem-api", "block-node/blocknode-filesystem-api")
+include(":blocknode-filesystem-local", "block-node/blocknode-filesystem-local")
+include(":blocknode-filesystem-s3", "block-node/blocknode-filesystem-s3")
+include(":blocknode-grpc-api", "block-node/blocknode-grpc-api")
+include(":blocknode-state", "block-node/blocknode-state")
+
 fun include(name: String, path: String) {
     include(name)
     project(name).projectDir = File(rootDir, path)


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds a new set of Gradle projects/modules for the Block Node initiative.
- Adds `module-info.java` definitions for both `main` and `test` source sets.
- Adds a new Gradle conventions plugin for the Block Node projects.
- Adds example/dummy code used to verify the Gradle build is functional. 

### Related Issues

- Closes #11236 