### PR TITLE
fix: fee charge token create tx and also transaction hashing

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -246,8 +246,9 @@ public class SingleTransactionRecordBuilderImpl
      * @return the transaction record
      */
     public SingleTransactionRecord build() {
-        if (customizer != null) {
+        if (customizer != NOOP_EXTERNALIZED_RECORD_CUSTOMIZER) {
             transaction = customizer.apply(transaction);
+            transactionBytes = transaction.signedTransactionBytes();
         }
         final var builder = transactionReceiptBuilder.serialNumbers(serialNumbers);
         // FUTURE : In mono-service exchange rate is not set in preceding child records.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCall.java
@@ -52,6 +52,11 @@ public interface HtsCall {
             return new PricedResult(result, 0L, responseCode, isViewCall);
         }
 
+        public static PricedResult gasPlus(
+                FullResult result, ResponseCodeEnum responseCode, boolean isViewCall, long nonGasCost) {
+            return new PricedResult(result, nonGasCost, responseCode, isViewCall);
+        }
+
         public ContractFunctionResult asResultOfCall(
                 @NonNull final AccountID senderId,
                 @NonNull final ContractID contractId,
@@ -59,6 +64,7 @@ public interface HtsCall {
                 final long remainingGas) {
             return ContractFunctionResult.newBuilder()
                     .contractID(contractId)
+                    .amount(nonGasCost)
                     .contractCallResult(tuweniToPbjBytes(fullResult.output()))
                     .errorMessage(responseCode == SUCCESS ? null : responseCode.protoName())
                     .gasUsed(fullResult().gasRequirement())

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/ClassicCreatesCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/ClassicCreatesCallTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.lenient;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.token.TokenCreateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
@@ -50,6 +51,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -65,6 +67,9 @@ public class ClassicCreatesCallTest extends HtsCallTestBase {
 
     @Mock
     private ContractCallRecordBuilder recordBuilder;
+
+    @Mock
+    private BlockValues blockValues;
 
     private static final TransactionBody PRETEND_CREATE_TOKEN = TransactionBody.newBuilder()
             .tokenCreation(TokenCreateTransactionBody.newBuilder()
@@ -326,7 +331,8 @@ public class ClassicCreatesCallTest extends HtsCallTestBase {
                             eq(ContractCallRecordBuilder.class)))
                     .willReturn(recordBuilder);
         }
-
+        given(frame.getBlockValues()).willReturn(blockValues);
+        given(blockValues.getTimestamp()).willReturn(Timestamp.DEFAULT.seconds());
         subject = new ClassicCreatesCall(
                 gasCalculator,
                 mockEnhancement(),

--- a/hedera-node/test-clients/src/rcdiff/java/com/hedera/services/rcdiff/RcDiff.java
+++ b/hedera-node/test-clients/src/rcdiff/java/com/hedera/services/rcdiff/RcDiff.java
@@ -23,7 +23,11 @@ import static com.hedera.node.app.hapi.utils.forensics.DifferingEntries.FirstEnc
 import static com.hedera.node.app.hapi.utils.forensics.DifferingEntries.FirstEncounteredDifference.TRANSACTION_RECORD_MISMATCH;
 import static com.hedera.node.app.hapi.utils.forensics.OrderedComparison.findDifferencesBetweenV6;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotModeOp.exactMatch;
-import static picocli.CommandLine.*;
+import static picocli.CommandLine.Command;
+import static picocli.CommandLine.Model;
+import static picocli.CommandLine.Option;
+import static picocli.CommandLine.ParameterException;
+import static picocli.CommandLine.Spec;
 
 import com.hedera.node.app.hapi.utils.forensics.DifferingEntries;
 import com.hedera.node.app.hapi.utils.forensics.OrderedComparison;
@@ -182,20 +186,17 @@ public class RcDiff implements Callable<Integer> {
         if (firstEncounteredDifference == CONSENSUS_TIME_MISMATCH) {
             sb.append("➡️  Expected ")
                     .append(Objects.requireNonNull(diff.firstEntry()).consensusTime())
-                    .append(" but was ")
+                    .append("\n\n")
+                    .append("➡️ but was ")
                     .append(Objects.requireNonNull(diff.secondEntry()).consensusTime());
         } else if (firstEncounteredDifference == TRANSACTION_RECORD_MISMATCH
                 || firstEncounteredDifference == TRANSACTION_MISMATCH) {
             sb.append("\nFor body,\n")
                     .append(Objects.requireNonNull(diff.firstEntry()).body());
-            sb.append("➡️  Expected Receipt ")
-                    .append(Objects.requireNonNull(diff.firstEntry())
-                            .transactionRecord()
-                            .getReceipt())
+            sb.append("➡️  Expected Record ")
+                    .append(Objects.requireNonNull(diff.firstEntry()).transactionRecord())
                     .append(" but was ")
-                    .append(Objects.requireNonNull(diff.secondEntry())
-                            .transactionRecord()
-                            .getReceipt());
+                    .append(Objects.requireNonNull(diff.secondEntry()).transactionRecord());
         }
         return sb.toString();
     }


### PR DESCRIPTION
Fix both issues
Mismatched field counts (expected but not find [amount]) between expected contractID {

Mismatched values, expected '<ByteString@64e92d61 size=48 contents="\301M\020\254\fA\277\354\r\360m\200\375\204\220,tRy\201\363G\r\3764>:\210\373\261\177a\032\357\206\323\032\350%\343Z\002\363\301\344\343\215*">', got '<ByteString@7882c44a size=48 contents="\370*\355e\224j=-c\275&L\362\016\200\324\2761;\313\001\366\312\235\004 Ru>#\311N\270Ng:\2759\353\372u\361d\255\250dYq">' - Matching field 'transactionHash' ==> expected: <<ByteString@64e92d61 size=48 contents="\301M\020\254\fA\277\354\r\360m\200\375\204\220,tRy\201\363G\r\3764>:\210\373\261\177a\032\357\206\323\032\350%\343Z\002\363\301\344\343\215*">> but was: <<ByteString@7882c44a size=48 contents="\370*\355e\224j=-c\275&L\362\016\200\324\2761;\313\001\366\312\235\004 Ru>#\311N\270Ng:\2759\353\372u\361d\255\250dYq">>
**Related issue(s)**:

Fixes #11526 

