### PR TITLE
fix: 11561 Added `isReconnectContext` flag to handle node removal properly in the reconnect context.

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/hammer/java/com/swirlds/merkledb/files/CloseFlushTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/hammer/java/com/swirlds/merkledb/files/CloseFlushTest.java
@@ -156,14 +156,16 @@ public class CloseFlushTest {
                         final long lastLeafPath,
                         final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
                         final Stream<VirtualLeafRecord<K, V>> leafRecordsToAddOrUpdate,
-                        final Stream<VirtualLeafRecord<K, V>> leafRecordsToDelete) {
+                        final Stream<VirtualLeafRecord<K, V>> leafRecordsToDelete,
+                        final boolean isReconnectContext) {
                     try {
                         delegate.saveRecords(
                                 firstLeafPath,
                                 lastLeafPath,
                                 pathHashRecordsToUpdate,
                                 leafRecordsToAddOrUpdate,
-                                leafRecordsToDelete);
+                                leafRecordsToDelete,
+                                isReconnectContext);
                     } catch (final Exception e) {
                         exceptionSink.set(e);
                     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/DataSourceValidatorTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/DataSourceValidatorTest.java
@@ -17,19 +17,15 @@
 package com.swirlds.merkledb;
 
 import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyEquals;
-import static com.swirlds.merkledb.MerkleDbDataSourceTest.createDataSource;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
 import com.swirlds.merkledb.test.fixtures.TestType;
-import com.swirlds.virtualmap.VirtualLongKey;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -39,62 +35,62 @@ class DataSourceValidatorTest {
     @TempDir
     private Path tempDir;
 
-    private MerkleDbDataSource<VirtualLongKey, ExampleByteArrayVirtualValue> dataSource;
     private int count;
-    private DataSourceValidator<VirtualLongKey, ExampleByteArrayVirtualValue> validator;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    public void setUp() {
         count = 10_000;
         // check db count
         assertEventuallyEquals(
                 0L, MerkleDbDataSource::getCountOfOpenDatabases, Duration.ofSeconds(1), "Expected no open dbs");
-        // create db
-
-        dataSource = createDataSource(tempDir, "createAndCheckInternalNodeHashes", TestType.fixed_fixed, count, 0);
-        validator = new DataSourceValidator<>(dataSource);
-
-        // check db count
-        assertEventuallyEquals(
-                1L, MerkleDbDataSource::getCountOfOpenDatabases, Duration.ofSeconds(1), "Expected only 1 db");
     }
 
     @Test
     void testValidateValidDataSource() throws IOException {
-        // create some node hashes
-        dataSource.saveRecords(
-                count,
-                count * 2L,
-                IntStream.range(0, count).mapToObj(MerkleDbDataSourceTest::createVirtualInternalRecord),
-                IntStream.range(count, count * 2 + 1)
-                        .mapToObj(i -> TestType.fixed_fixed.dataType().createVirtualLeafRecord(i)),
-                Stream.empty());
+        MerkleDbDataSourceTest.createAndApplyDataSource(
+                tempDir, "createAndCheckInternalNodeHashes", TestType.fixed_fixed, count, 0, dataSource -> {
+                    // check db count
+                    assertEventuallyEquals(
+                            1L,
+                            MerkleDbDataSource::getCountOfOpenDatabases,
+                            Duration.ofSeconds(1),
+                            "Expected only 1 db");
 
-        assertTrue(validator.validate());
+                    final var validator = new DataSourceValidator<>(dataSource);
+                    // create some node hashes
+                    dataSource.saveRecords(
+                            count,
+                            count * 2L,
+                            IntStream.range(0, count).mapToObj(MerkleDbDataSourceTest::createVirtualInternalRecord),
+                            IntStream.range(count, count * 2 + 1)
+                                    .mapToObj(
+                                            i -> TestType.fixed_fixed.dataType().createVirtualLeafRecord(i)),
+                            Stream.empty());
+
+                    assertTrue(validator.validate());
+                });
     }
 
     @Test
     void testValidateInvalidDataSource() throws IOException {
-        // check db count
-        // create some node hashes
-        dataSource.saveRecords(
-                count,
-                count * 2L,
-                IntStream.range(0, count).mapToObj(MerkleDbDataSourceTest::createVirtualInternalRecord),
-                // leaves are missing
-                Stream.empty(),
-                Stream.empty());
-
-        assertFalse(validator.validate());
-    }
-
-    @AfterEach
-    public void cleanup() throws IOException {
-        if (dataSource != null) {
-            dataSource.close();
-            // check db count
-            assertEventuallyEquals(
-                    0L, MerkleDbDataSource::getCountOfOpenDatabases, Duration.ofSeconds(1), "Expected no open dbs");
-        }
+        MerkleDbDataSourceTest.createAndApplyDataSource(
+                tempDir, "createAndCheckInternalNodeHashes", TestType.fixed_fixed, count, 0, dataSource -> {
+                    // check db count
+                    assertEventuallyEquals(
+                            1L,
+                            MerkleDbDataSource::getCountOfOpenDatabases,
+                            Duration.ofSeconds(1),
+                            "Expected only 1 db");
+                    final var validator = new DataSourceValidator<>(dataSource);
+                    // create some node hashes
+                    dataSource.saveRecords(
+                            count,
+                            count * 2L,
+                            IntStream.range(0, count).mapToObj(MerkleDbDataSourceTest::createVirtualInternalRecord),
+                            // leaves are missing
+                            Stream.empty(),
+                            Stream.empty());
+                    assertFalse(validator.validate());
+                });
     }
 }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
@@ -16,8 +16,8 @@
 
 package com.swirlds.merkledb;
 
+import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyEquals;
 import static com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags.TIMING_SENSITIVE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.swirlds.common.constructable.ConstructableRegistry;
@@ -33,6 +33,7 @@ import com.swirlds.merkledb.test.fixtures.ExampleLongKeyFixedSize;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -55,7 +56,8 @@ public class MerkleDbTest {
     @AfterEach
     public void shutdownTest() {
         // check db count
-        assertEquals(0, MerkleDbDataSource.getCountOfOpenDatabases(), "Expected no open dbs");
+        assertEventuallyEquals(
+                0L, MerkleDbDataSource::getCountOfOpenDatabases, Duration.ofSeconds(2), "Expected no open dbs");
     }
 
     private static MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> fixedConfig() {

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
@@ -46,9 +46,9 @@ public final class BreakableDataSource implements VirtualDataSource<TestKey, Tes
             final long lastLeafPath,
             final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
             final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
-            final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete)
+            final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete,
+            final boolean isReconnectContext)
             throws IOException {
-
         final List<VirtualLeafRecord<TestKey, TestValue>> leaves = leafRecordsToAddOrUpdate.toList();
 
         if (builder.numTimesBroken < builder.numTimesToBreak) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
@@ -251,9 +251,9 @@ public abstract class VirtualMapReconnectTestBase {
                 final long lastLeafPath,
                 final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
                 final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
-                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete)
+                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete,
+                final boolean isReconnectContext)
                 throws IOException {
-
             final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
                     leafRecordsToAddOrUpdate.collect(Collectors.toList());
 

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/AbstractHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/AbstractHashListener.java
@@ -178,7 +178,8 @@ public abstract class AbstractHashListener<K extends VirtualKey, V extends Virtu
                         lastLeafPath,
                         hashesToFlush.stream(),
                         leavesToFlush.stream(),
-                        findLeavesToRemove());
+                        findLeavesToRemove(),
+                        true);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImplTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorImplTest.java
@@ -334,14 +334,16 @@ public class RecordAccessorImplTest {
                 final long lastLeafPath,
                 final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
                 final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
-                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete)
+                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete,
+                final boolean isReconnectContext)
                 throws IOException {
             delegate.saveRecords(
                     firstLeafPath,
                     lastLeafPath,
                     pathHashRecordsToUpdate,
                     leafRecordsToAddOrUpdate,
-                    leafRecordsToDelete);
+                    leafRecordsToDelete,
+                    isReconnectContext);
         }
 
         @Override

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
@@ -170,14 +170,33 @@ class ReconnectHashListenerTest {
                 final long lastLeafPath,
                 final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
                 final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
-                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete)
+                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete,
+                final boolean isReconnectContext)
                 throws IOException {
-
             final var ir = pathHashRecordsToUpdate.toList();
             this.internalRecords.add(ir);
             final var lr = leafRecordsToAddOrUpdate.toList();
             this.leafRecords.add(lr);
-            delegate.saveRecords(firstLeafPath, lastLeafPath, ir.stream(), lr.stream(), leafRecordsToDelete);
+            delegate.saveRecords(
+                    firstLeafPath, lastLeafPath, ir.stream(), lr.stream(), leafRecordsToDelete, isReconnectContext);
+        }
+
+        @Override
+        public void saveRecords(
+                final long firstLeafPath,
+                final long lastLeafPath,
+                final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
+                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
+                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete)
+                throws IOException {
+
+            saveRecords(
+                    firstLeafPath,
+                    lastLeafPath,
+                    pathHashRecordsToUpdate,
+                    leafRecordsToAddOrUpdate,
+                    leafRecordsToDelete,
+                    true);
         }
 
         @Override

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
@@ -248,13 +248,13 @@ public abstract class VirtualMapReconnectTestBase {
 
         @Override
         public void saveRecords(
-                final long firstLeafPath,
-                final long lastLeafPath,
-                final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
-                final Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete)
+                long firstLeafPath,
+                long lastLeafPath,
+                Stream<VirtualHashRecord> pathHashRecordsToUpdate,
+                Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToAddOrUpdate,
+                Stream<VirtualLeafRecord<TestKey, TestValue>> leafRecordsToDelete,
+                boolean isReconnectContext)
                 throws IOException {
-
             final List<VirtualLeafRecord<TestKey, TestValue>> leaves =
                     leafRecordsToAddOrUpdate.collect(Collectors.toList());
 


### PR DESCRIPTION
**Description**:

Added `isReconnectContext` flag to handle node removal properly in the reconnect context.

Misc:
- Added `@Tag(TIMING_SENSITIVE)` to `dirtyDeletedLeavesBetweenFlushes` and `snapshotRestoreIndex`.
- Added `isReconnectContext` parameter to InMemoryDataSource.
- Added eventual assert for `MerkleDbTest.shutdownTest`.
- Refactored tests to automatically close the datasource.

**Related issue(s)**:

Fixes #11561 , relates to #11498 

**Notes for reviewer**:

This PR has the same changes as https://github.com/hashgraph/hedera-services/pull/11500

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
