### PR TITLE
Limit maximum number of events sent during a sync.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncUtils.java
@@ -212,7 +212,7 @@ public final class SyncUtils {
 
     /**
      * Send the events the peer needs. The complementary function to
-     * {@link #readEventsINeed(Connection, Consumer, SyncMetrics, CountDownLatch, IntakeEventCounter, Duration)}.
+     * {@link #readEventsINeed(Connection, Consumer, int, SyncMetrics, CountDownLatch, IntakeEventCounter, Duration)}.
      *
      * @param connection          the connection to write to
      * @param events              the events to write
@@ -235,14 +235,6 @@ public final class SyncUtils {
                     connection.getDescription(),
                     events.size());
             for (final EventImpl event : events) {
-                if (event.isFromSignedState()) {
-                    // if we encounter an event from a signed state, we should not send that event because it will have
-                    // had its transactions removed. the receiver would get the wrong hash and the signature check
-                    // would fail
-                    connection.getDos().writeByte(ByteConstants.COMM_EVENT_ABORT);
-                    writeAborted.set(true);
-                    break;
-                }
                 connection.getDos().writeByte(ByteConstants.COMM_EVENT_NEXT);
                 connection.getDos().writeEventData(event);
             }
@@ -283,6 +275,7 @@ public final class SyncUtils {
      *
      * @param connection         the connection to read from
      * @param eventHandler       the consumer of received events
+     * @param maxEventCount      the maximum number of events to read, or 0 for no limit
      * @param syncMetrics        tracks event reading metrics
      * @param eventReadingDone   used to notify the writing thread that reading is done
      * @param intakeEventCounter keeps track of the number of events in the intake pipeline from each peer
@@ -293,6 +286,7 @@ public final class SyncUtils {
     public static Callable<Integer> readEventsINeed(
             final Connection connection,
             final Consumer<GossipEvent> eventHandler,
+            final int maxEventCount,
             final SyncMetrics syncMetrics,
             final CountDownLatch eventReadingDone,
             @NonNull final IntakeEventCounter intakeEventCounter,
@@ -303,6 +297,7 @@ public final class SyncUtils {
             int eventsRead = 0;
             try {
                 final long startTime = System.nanoTime();
+                int count = 0;
                 while (true) {
                     // readByte() will throw a timeout exception if the socket timeout is exceeded
                     final byte next = connection.getDis().readByte();
@@ -311,6 +306,13 @@ public final class SyncUtils {
                     checkEventExchangeTime(maxSyncTime, startTime);
                     switch (next) {
                         case ByteConstants.COMM_EVENT_NEXT -> {
+                            if (maxEventCount > 0) {
+                                count++;
+                                if (count > maxEventCount) {
+                                    throw new IOException("max event count " + maxEventCount + " exceeded");
+                                }
+                            }
+
                             final GossipEvent gossipEvent = connection.getDis().readEventData();
 
                             gossipEvent.setSenderId(connection.getOtherId());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
@@ -41,6 +41,7 @@ import java.time.Duration;
  *                                        during a sync
  * @param maxSyncTime                     the maximum amount of time to spend syncing with a peer, syncs that take
  *                                        longer than this will be aborted
+ * @param maxSyncEventCount               the maximum number of events to send in a sync, or 0 for no limit
  */
 @ConfigData("sync")
 public record SyncConfig(
@@ -52,4 +53,5 @@ public record SyncConfig(
         @ConfigProperty(defaultValue = "true") boolean filterLikelyDuplicates,
         @ConfigProperty(defaultValue = "3s") Duration nonAncestorFilterThreshold,
         @ConfigProperty(defaultValue = "500ms") Duration syncKeepalivePeriod,
-        @ConfigProperty(defaultValue = "1m") Duration maxSyncTime) {}
+        @ConfigProperty(defaultValue = "1m") Duration maxSyncTime,
+        @ConfigProperty(defaultValue = "100") int maxSyncEventCount) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/EventImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/EventImpl.java
@@ -92,11 +92,6 @@ public class EventImpl extends EventMetadata
     private RunningHash runningHash;
 
     /**
-     * Tracks if this event was read out of a signed state.
-     */
-    private boolean fromSignedState;
-
-    /**
      * An unmodifiable ordered set of system transaction indices in the array of all transactions, from lowest to
      * highest.
      */
@@ -586,22 +581,6 @@ public class EventImpl extends EventMetadata
      */
     public boolean isEmpty() {
         return getTransactions() == null || getTransactions().length == 0;
-    }
-
-    /**
-     * Check if this event was read from a signed state.
-     *
-     * @return true iff this event was loaded from a signed state
-     */
-    public boolean isFromSignedState() {
-        return fromSignedState;
-    }
-
-    /**
-     * Mark this as an event that was read from a signed state.
-     */
-    public void markAsSignedStateEvent() {
-        this.fromSignedState = true;
     }
 
     //

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformData.java
@@ -205,7 +205,6 @@ public class PlatformData extends PartialMerkleLeaf implements MerkleLeaf {
             for (int i = 0; i < eventNum; i++) {
                 events[i] = in.readSerializable(false, EventImpl::new);
                 events[i].getBaseEventHashedData().setHash(in.readSerializable(false, Hash::new));
-                events[i].markAsSignedStateEvent();
             }
             State.linkParents(events);
         }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncNode.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncNode.java
@@ -36,6 +36,7 @@ import com.swirlds.platform.gossip.IntakeEventCounter;
 import com.swirlds.platform.gossip.shadowgraph.Shadowgraph;
 import com.swirlds.platform.gossip.shadowgraph.ShadowgraphInsertionException;
 import com.swirlds.platform.gossip.shadowgraph.ShadowgraphSynchronizer;
+import com.swirlds.platform.gossip.sync.config.SyncConfig_;
 import com.swirlds.platform.metrics.SyncMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.system.address.AddressBook;
@@ -115,9 +116,10 @@ public class SyncNode {
         discardedEvents = new LinkedList<>();
         saveGeneratedEvents = false;
 
-        // The original sync tests are incompatible with event filtering.
+        // The original sync tests are incompatible with event filtering and reduced sync event counts.
         final Configuration configuration = new TestConfigBuilder()
-                .withValue("sync.filterLikelyDuplicates", false)
+                .withValue(SyncConfig_.FILTER_LIKELY_DUPLICATES, false)
+                .withValue(SyncConfig_.MAX_SYNC_EVENT_COUNT, 0)
                 .getOrCreateConfig();
 
         platformContext = TestPlatformContextBuilder.create()
@@ -222,9 +224,10 @@ public class SyncNode {
             receivedEventQueue.add(event);
         };
 
-        // The original sync tests are incompatible with event filtering.
+        // The original sync tests are incompatible with event filtering and reduced sync event counts.
         final Configuration configuration = new TestConfigBuilder()
-                .withValue("sync.filterLikelyDuplicates", false)
+                .withValue(SyncConfig_.FILTER_LIKELY_DUPLICATES, false)
+                .withValue(SyncConfig_.MAX_SYNC_EVENT_COUNT, 0)
                 .getOrCreateConfig();
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/Synchronizer.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/Synchronizer.java
@@ -22,7 +22,10 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.common.test.fixtures.threading.SyncPhaseParallelExecutor;
 import com.swirlds.common.threading.pool.ParallelExecutor;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.gossip.shadowgraph.ShadowgraphSynchronizer;
+import com.swirlds.platform.gossip.sync.config.SyncConfig_;
 import com.swirlds.platform.network.Connection;
 
 /**
@@ -48,8 +51,15 @@ public class Synchronizer {
      */
     public void synchronize(final SyncNode caller, final SyncNode listener) throws Exception {
 
-        final PlatformContext platformContext =
-                TestPlatformContextBuilder.create().build();
+        // The original sync tests are incompatible with event filtering and reduced sync event counts.
+        final Configuration configuration = new TestConfigBuilder()
+                .withValue(SyncConfig_.FILTER_LIKELY_DUPLICATES, false)
+                .withValue(SyncConfig_.MAX_SYNC_EVENT_COUNT, 0)
+                .getOrCreateConfig();
+
+        final PlatformContext platformContext = TestPlatformContextBuilder.create()
+                .withConfiguration(configuration)
+                .build();
 
         parallelExecutor.doParallel(
                 () -> {


### PR DESCRIPTION
Cherry pick of https://github.com/hashgraph/hedera-services/pull/11608

Note: we have not yet decided if we are going to merge this into release 0.47.