### PR TITLE
Mark count up latch tests as timing sensitive.

### DIFF
--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/CountUpLatchTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/CountUpLatchTests.java
@@ -17,6 +17,7 @@
 package com.swirlds.common.threading;
 
 import static com.swirlds.common.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags.TIMING_SENSITIVE;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -41,6 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("CountUpLatch Tests")
+@Tag(TIMING_SENSITIVE)
 class CountUpLatchTests {
 
     @Test


### PR DESCRIPTION
closes #11653 
