### PR TITLE
perf: improve VirtualHasher performance

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/tasks/AbstractTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/tasks/AbstractTask.java
@@ -67,7 +67,7 @@ public abstract class AbstractTask extends ForkJoinTask<Void> {
      * If the task has no dependencies then execute it. If the task has dependencies, decrement the dependency count and
      * execute it if the resulting number of dependencies is zero.
      */
-    protected void send() {
+    public void send() {
         if (dependencyCount == null || dependencyCount.decrementAndGet() == 0) {
             if ((Thread.currentThread() instanceof ForkJoinWorkerThread t) && (t.getPool() == pool)) {
                 fork();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -89,7 +89,7 @@ public record VirtualMapConfig(
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "50.0")
                 double percentHashThreads, // FUTURE WORK: We need to add min/max support for double values
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numHashThreads,
-        @Min(1) @Max(64) @ConfigProperty(defaultValue = "6") int virtualHasherChunkHeight,
+        @Min(1) @Max(64) @ConfigProperty(defaultValue = "3") int virtualHasherChunkHeight,
         @Min(0) @ConfigProperty(defaultValue = "500000") int reconnectFlushInterval,
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "25.0")
                 double percentCleanerThreads, // FUTURE WORK: We need to add min/max support for double values

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,6 +94,16 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
     private VirtualHashListener<K, V> listener;
 
     /**
+     * A task holding the resulting hash. Used to synchronize all parallel computations.
+     */
+    private HashHoldingTask resultTask;
+
+    /**
+     * This atomic reference is used to serialize (non-deterministically) all notification tasks.
+     */
+    private final AtomicReference<NotificationTask> nextTaskPlaceHolder = new AtomicReference<>();
+
+    /**
      * An instance of {@link Cryptography} used to hash leaves. This should be a static final
      * field, but it doesn't work very well as platform configs aren't loaded at the time when
      * this class is initialized. It would result in a cryptography instance with default (and
@@ -145,51 +156,86 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         return hash(hashReader, sortedDirtyLeaves, firstLeafPath, lastLeafPath, null);
     }
 
-    class ChunkHashTask extends AbstractTask {
+    class NotificationTask extends AbstractTask {
+        long path;
+        VirtualLeafRecord<K, V> leaf;
+        Hash hash;
+        AbstractTask nextTask;
+
+        NotificationTask(final ForkJoinPool pool, final int dependencies) {
+            super(pool, dependencies);
+        }
+
+        void setData(VirtualLeafRecord<K, V> leaf, long path, Hash hash, AbstractTask nextTask) {
+            this.leaf = leaf;
+            this.path = path;
+            this.hash = hash;
+            this.nextTask = nextTask;
+            send();
+        }
+
+        @Override
+        protected boolean exec() {
+            if (leaf != null) {
+                listener.onLeafHashed(leaf);
+            }
+            listener.onNodeHashed(path, hash);
+            nextTask.send();
+            return true;
+        }
+    }
+
+    class HashHoldingTask extends AbstractTask {
+
+        // Input hashes. Some hashes may be null, which indicates they should be loaded from disk
+        protected final Hash[] ins;
+
+        HashHoldingTask(final ForkJoinPool pool, final int dependencies, final int numHashes) {
+            super(pool, dependencies);
+            ins = numHashes > 0 ? new Hash[numHashes] : null;
+        }
+
+        @Override
+        protected boolean exec() {
+            return true;
+        }
+
+        void setHash(int index, Hash hash) {
+            ins[index] = hash;
+            send();
+        }
+    }
+
+    class ChunkHashTask extends HashHoldingTask {
 
         private final long path;
 
         private final int height; // 1 for 3-node chunk, 2 for 7-node chunk, and so on
 
-        private ChunkHashTask out;
-
-        // Input hashes. Some hashes may be null, which indicates they should be loaded from disk
-        private final Hash[] ins;
+        private HashHoldingTask out;
 
         // If not null, the task hashes the leaf. If null, the task processes the input hashes
         private VirtualLeafRecord<K, V> leaf;
 
         ChunkHashTask(final ForkJoinPool pool, final long path, final int height) {
-            super(pool, 1 + (1 << height));
+            super(pool, 1 + (1 << height), height > 0 ? 1 << height : 0);
             this.height = height;
             this.path = path;
-            this.ins = new Hash[1 << height];
         }
 
-        void setOut(final ChunkHashTask out) {
+        void setOut(final HashHoldingTask out) {
             this.out = out;
-            assert path == 0 || Path.getRank(path) - out.height == Path.getRank(out.path)
-                    : "setOut " + path + " " + height + " " + out.path;
             send();
         }
 
-        void setData(final VirtualLeafRecord<K, V> leaf) {
-            assert leaf == null || path == leaf.getPath();
-            assert leaf == null || height == 1;
-            assert leaf != null || out != null;
-            if (leaf == null) {
-                out.setHash(getIndexInOut(), null);
-            } else {
-                this.leaf = leaf;
-                send(); // left hash dependency
-                send(); // right hash dependency
-            }
+        void setLeaf(final VirtualLeafRecord<K, V> leaf) {
+            assert leaf != null && path == leaf.getPath() && height == 0;
+            this.leaf = leaf;
+            send();
         }
 
-        void setHash(final int index, final Hash hash) {
-            assert index >= 0 && index < (1 << height);
-            ins[index] = hash;
-            send();
+        void complete() {
+            out.send();
         }
 
         @Override
@@ -200,20 +246,29 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
             super.completeExceptionally(ex);
         }
 
+        void scheduleNotificationTask(VirtualLeafRecord<K, V> leaf, long path, Hash hash) {
+            NotificationTask currentTask = nextTaskPlaceHolder.get();
+            if (path == ROOT_PATH) {
+                currentTask.setData(leaf, path, hash, resultTask);
+            } else {
+                final NotificationTask nextTask = new NotificationTask(HASHING_POOL, 2);
+                while (!nextTaskPlaceHolder.compareAndSet(currentTask, nextTask)) {
+                    currentTask = nextTaskPlaceHolder.get();
+                }
+                currentTask.setData(leaf, path, hash, nextTask);
+            }
+        }
+
         @Override
         protected boolean exec() {
             try {
                 final Hash hash;
                 if (leaf != null) {
                     hash = cryptography.digestSync(leaf);
-                    listener.onLeafHashed(leaf);
-                    listener.onNodeHashed(path, hash);
+                    scheduleNotificationTask(leaf, path, hash);
                 } else {
                     int len = 1 << height;
-                    long rankPath = path;
-                    for (int i = 0; i < height; i++) {
-                        rankPath = Path.getLeftChildPath(rankPath);
-                    }
+                    long rankPath = Path.getLeftGrandChildPath(path, height);
                     while (len > 1) {
                         for (int i = 0; i < len / 2; i++) {
                             final long hashedPath = Path.getParentPath(rankPath + i * 2);
@@ -229,7 +284,7 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
                                     right = hashReader.apply(rankPath + i * 2 + 1);
                                 }
                                 ins[i] = hash(hashedPath, left, right);
-                                listener.onNodeHashed(hashedPath, ins[i]);
+                                scheduleNotificationTask(null, hashedPath, ins[i]);
                             }
                         }
                         rankPath = Path.getParentPath(rankPath);
@@ -260,11 +315,12 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         }
 
         private int getIndexInOut() {
-            if (path == 0) {
+            if (out instanceof ChunkHashTask t) {
+                final long firstInPathInOut = Path.getLeftGrandChildPath(t.path, t.height);
+                return (int) (path - firstInPathInOut);
+            } else {
                 return 0;
             }
-            final long firstInPathInOut = Path.getLeftGrandChildPath(out.path, out.height);
-            return (int) (path - firstInPathInOut);
         }
     }
 
@@ -309,7 +365,7 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         // Each chunk is processed in a separate task. Tasks have dependencies. Once all task
         // dependencies are met, the task is scheduled for execution in the pool. Each task
         // has N input dependencies, where N is the number of nodes at the lowest chunk rank,
-        // i.e. 2^height. Every input depenency is either set to a hash from another task,
+        // i.e. 2^height. Every input dependency is either set to a hash from another task,
         // or a null value, which indicates that the input hash needs not to be recalculated,
         // but loaded from disk. A special case of a task is leaf tasks, they are all of
         // height 1, both input dependencies are null, but they are given a leaf instead. For
@@ -328,13 +384,17 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         // Let the listener know we have started hashing.
         listener.onHashingStarted();
 
+        // Initialize the notification task series
+        NotificationTask notificationTask = new NotificationTask(HASHING_POOL, 1);
+        nextTaskPlaceHolder.set(notificationTask);
+
         // This map contains all tasks created, but not scheduled for execution yet
         final HashMap<Long, ChunkHashTask> map = new HashMap<>();
-        // The result task. It is never executed, but used as an output dependency for
-        // the root task below. When the root task is done executing, that is it produced
+        // The result task. When the root task is done executing, that is it produced
         // a root hash, this hash is set as an input dependency for this result task, where
-        // it's read and returned in the end of this method
-        ChunkHashTask resultTask = new ChunkHashTask(HASHING_POOL, INVALID_PATH, 1);
+        // it's read and returned in the end of this method. The other dependency is the
+        // root notification task.
+        resultTask = new HashHoldingTask(HASHING_POOL, 2, 1);
         int rootTaskHeight = Math.min(firstLeafRank, chunkHeight);
         ChunkHashTask rootTask = new ChunkHashTask(HASHING_POOL, ROOT_PATH, rootTaskHeight);
         rootTask.setOut(resultTask);
@@ -347,7 +407,7 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         // Tasks may have different heights. The root task has a default height. If the whole
         // virtual tree has fewer ranks than the default height, the root task will cover all
         // the tree (almost all, see comments below about leaf task heights)
-        final int[] parentRankHeights = new int[256]; // assuming there may be no more than 256 ranks in the tree
+        final int[] parentRankHeights = new int[lastLeafRank + 1];
         parentRankHeights[0] = 1;
         for (int i = 1; i <= firstLeafRank; i++) {
             parentRankHeights[i] = Math.min((i - 1) % chunkHeight + 1, i);
@@ -374,9 +434,9 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
             long curPath = leaf.getPath();
             ChunkHashTask curTask = map.remove(curPath);
             if (curTask == null) {
-                curTask = new ChunkHashTask(HASHING_POOL, curPath, 1);
+                curTask = new ChunkHashTask(HASHING_POOL, curPath, 0);
             }
-            curTask.setData(leaf);
+            curTask.setLeaf(leaf);
 
             // The next step is to iterate over parent tasks, until an already created task
             // is met (e.g. the root task). For every parent task, check all already created
@@ -400,7 +460,7 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
                     while (curStackPath < Math.min(curPath, lastPathInCurStackChunk)) {
                         final ChunkHashTask t = map.remove(curStackPath);
                         assert t != null;
-                        t.setData(null);
+                        t.complete();
                         curStackPath++;
                     }
                     stack[curRank] = INVALID_PATH;
@@ -436,28 +496,29 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
                         continue;
                     }
                     if (siblingPath > lastLeafPath) {
+                        assert siblingPath == 2;
                         parentTask.setHash((int) (siblingPath - firstSiblingPath), NULL_HASH);
-                        continue;
-                    }
-                    // Get or create the sibling task
-                    ChunkHashTask siblingTask = map.remove(siblingPath);
-                    if (siblingTask == null) {
-                        siblingTask = new ChunkHashTask(HASHING_POOL, siblingPath, curTask.height);
-                    }
-                    // Set sibling task output to the same parent
-                    siblingTask.setOut(parentTask);
-                    // Mark the sibling as clean if: it's to the left AND this is not the very first leaf
-                    if ((siblingPath < curPath) && !firstLeaf) {
-                        siblingTask.setData(null);
+                    } else if ((siblingPath < curPath) && !firstLeaf) {
+                        curTask.complete();
                     } else {
-                        map.put(siblingPath, siblingTask);
+                        // Get or create a sibling task
+                        final int siblingHeight;
+                        if (curTask.height == 0) {
+                            siblingHeight = siblingPath < firstLeafPath ? 1 : 0;
+                        } else {
+                            siblingHeight = curTask.height;
+                        }
+                        ChunkHashTask siblingTask = map.computeIfAbsent(
+                                siblingPath, path -> new ChunkHashTask(HASHING_POOL, path, siblingHeight));
+                        // Set sibling task output to the same parent
+                        siblingTask.setOut(parentTask);
                     }
-                    // Now update the stack to the first sibling to the right. When the next node
-                    // at the same rank is processed, all tasks starting from this sibling are
-                    // guaranteed to be clean
-                    if ((curPath != lastSiblingPath) && !firstLeaf) {
-                        stack[curRank] = curPath + 1;
-                    }
+                }
+                // Now update the stack to the first sibling to the right. When the next node
+                // at the same rank is processed, all tasks starting from this sibling are
+                // guaranteed to be clean
+                if ((curPath != lastSiblingPath) && !firstLeaf) {
+                    stack[curRank] = curPath + 1;
                 }
 
                 curPath = parentPath;
@@ -472,11 +533,11 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         // created during walking from the last leaf on the last leaf rank to the root; sibling
         // tasks to the left of the very first route to the root. There are no more dirty leaves,
         // all these tasks may be marked as clean now
-        map.forEach((path, task) -> task.setData(null));
+        map.forEach((path, task) -> task.complete());
         map.clear();
 
         try {
-            rootTask.join();
+            resultTask.join();
         } catch (final Exception e) {
             if (shutdown.get()) {
                 return null;


### PR DESCRIPTION
**Description**:
* reduce object allocation
* remove synchronization around notification and make it task-based
* tune virtualHasherChunkHeight

**Related issue(s)**:

Fixes #11636

**Notes for reviewer**:
```
Benchmark                             (keySize)   (maxKey)  (numFiles)  (numRecords)  (numThreads)  (recordSize)  Mode  Cnt      Score   Error  Units
CryptoBenchMerkleDb.transferPrefetch         24  500000000        6000        100000            32          1024  avgt       16815.734           s/op
```
Previous best score - 18268 (the lower the better).

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
