### PR TITLE
fix: only compare child time created against self parent time created…

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/InOrderLinker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/InOrderLinker.java
@@ -239,11 +239,15 @@ public class InOrderLinker {
                 candidateParent.getBaseEvent().getHashedData().getTimeCreated();
         final Instant childTimeCreated = child.getHashedData().getTimeCreated();
 
-        if (parentTimeCreated.compareTo(childTimeCreated) >= 0) {
+        // only do this check for self parent, since the event creator doesn't consider other parent creation time
+        // when deciding on the event creation time
+        if (parentDescriptor.getCreator().equals(child.getDescriptor().getCreator())
+                && parentTimeCreated.compareTo(childTimeCreated) >= 0) {
+
             timeCreatedMismatchAccumulator.update(1);
-            timeCreatedMismatchLogger.warn(
+            timeCreatedMismatchLogger.error(
                     EXCEPTION.getMarker(),
-                    "Child time created isn't strictly after parent time created. "
+                    "Child time created isn't strictly after self parent time created. "
                             + "Child: {}, parent: {}, child time created: {}, parent time created: {}",
                     EventStrings.toMediumString(child),
                     EventStrings.toMediumString(candidateParent),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
@@ -539,7 +539,7 @@ class InOrderLinkerTests {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    @DisplayName("Other parent with mismatched time created should not be linked")
+    @DisplayName("Other parent with mismatched time created should be linked")
     void otherParentTimeCreatedMismatch(final boolean useBirthRoundForAncient) {
         final AncientMode ancientMode =
                 useBirthRoundForAncient ? AncientMode.BIRTH_ROUND_THRESHOLD : AncientMode.GENERATION_THRESHOLD;
@@ -547,7 +547,7 @@ class InOrderLinkerTests {
         final Hash lateParentHash = randomHash(random);
         final long lateParentGeneration = 1;
         final GossipEvent lateParent = generateMockEvent(
-                selfId,
+                otherId,
                 lateParentHash,
                 lateParentGeneration,
                 1,
@@ -568,7 +568,7 @@ class InOrderLinkerTests {
         final EventImpl linkedEvent = inOrderLinker.linkEvent(child);
         assertNotEquals(null, linkedEvent);
         assertNotEquals(null, linkedEvent.getSelfParent(), "Self parent should not be null");
-        assertNull(linkedEvent.getOtherParent(), "Other parent has mismatched time created, and should be null");
+        assertNotEquals(null, linkedEvent.getOtherParent(), "Other parent should not be null");
         assertEquals(0, exitedIntakePipelineCount.get());
     }
 }


### PR DESCRIPTION
- part of #11666 (but that issue shouldn't be closed yet)

This PR is a cherry pick of https://github.com/hashgraph/hedera-services/pull/11668