### PR TITLE
fix: only compare child time created against self parent time created…

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/InOrderLinker.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/linking/InOrderLinker.java
@@ -195,11 +195,19 @@ public class InOrderLinker {
                 candidateParent.getBaseEvent().getHashedData().getTimeCreated();
         final Instant childTimeCreated = child.getHashedData().getTimeCreated();
 
-        if (parentTimeCreated.compareTo(childTimeCreated) >= 0) {
+        // only do this check for self parent, since the event creator doesn't consider other parent creation time
+        // when deciding on the event creation time
+        if (candidateParent
+                        .getBaseEvent()
+                        .getHashedData()
+                        .getCreatorId()
+                        .equals(child.getDescriptor().getCreator())
+                && parentTimeCreated.compareTo(childTimeCreated) >= 0) {
+
             timeCreatedMismatchAccumulator.update(1);
-            timeCreatedMismatchLogger.warn(
+            timeCreatedMismatchLogger.error(
                     EXCEPTION.getMarker(),
-                    "Child time created isn't strictly after parent time created. "
+                    "Child time created isn't strictly after self parent time created. "
                             + "Child: {}, parent: {}, child time created: {}, parent time created: {}",
                     EventStrings.toMediumString(child),
                     EventStrings.toMediumString(candidateParent),


### PR DESCRIPTION
- part of #11666 

Cherry pick of https://github.com/hashgraph/hedera-services/pull/11668. There were conflicts which had to be resolved during the cherry pick.