### PR TITLE
fix: 11715 Properly handle closed `PairedStreams` object

### DIFF
--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
@@ -984,7 +984,8 @@ public final class MerkleTestUtils {
             final int latencyMilliseconds,
             final ReconnectConfig reconnectConfig)
             throws Exception {
-        try (PairedStreams streams = new PairedStreams()) {
+        final PairedStreams streams = new PairedStreams();
+        try {
 
             final LearningSynchronizer learner;
             final TeachingSynchronizer teacher;
@@ -1083,6 +1084,13 @@ public final class MerkleTestUtils {
             assertReconnectValidity(startingTree, desiredTree, generatedTree);
 
             return (T) generatedTree;
+        } finally {
+            try {
+                streams.close();
+            } catch (IOException e) {
+                // test code, no danger. The stream could have been closed previously.
+                e.printStackTrace();
+            }
         }
     }
 

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
@@ -984,8 +984,7 @@ public final class MerkleTestUtils {
             final int latencyMilliseconds,
             final ReconnectConfig reconnectConfig)
             throws Exception {
-        final PairedStreams streams = new PairedStreams();
-        try {
+        try (PairedStreams streams = new PairedStreams()) {
 
             final LearningSynchronizer learner;
             final TeachingSynchronizer teacher;
@@ -996,14 +995,7 @@ public final class MerkleTestUtils {
                         streams.getLearnerInput(),
                         streams.getLearnerOutput(),
                         startingTree,
-                        () -> {
-                            try {
-                                streams.disconnect();
-                            } catch (final IOException e) {
-                                // test code, no danger
-                                e.printStackTrace();
-                            }
-                        },
+                        streams::disconnect,
                         reconnectConfig);
                 final PlatformContext platformContext =
                         TestPlatformContextBuilder.create().build();
@@ -1014,14 +1006,7 @@ public final class MerkleTestUtils {
                         streams.getTeacherInput(),
                         streams.getTeacherOutput(),
                         desiredTree,
-                        () -> {
-                            try {
-                                streams.disconnect();
-                            } catch (final IOException e) {
-                                // test code, no danger
-                                e.printStackTrace();
-                            }
-                        },
+                        streams::disconnect,
                         reconnectConfig);
             } else {
                 learner = new LaggingLearningSynchronizer(
@@ -1029,14 +1014,7 @@ public final class MerkleTestUtils {
                         streams.getLearnerOutput(),
                         startingTree,
                         latencyMilliseconds,
-                        () -> {
-                            try {
-                                streams.disconnect();
-                            } catch (final IOException e) {
-                                // test code, no danger
-                                e.printStackTrace();
-                            }
-                        },
+                        streams::disconnect,
                         reconnectConfig);
                 final PlatformContext platformContext =
                         TestPlatformContextBuilder.create().build();
@@ -1046,14 +1024,7 @@ public final class MerkleTestUtils {
                         streams.getTeacherOutput(),
                         desiredTree,
                         latencyMilliseconds,
-                        () -> {
-                            try {
-                                streams.disconnect();
-                            } catch (IOException e) {
-                                // test code, no danger
-                                e.printStackTrace();
-                            }
-                        },
+                        streams::disconnect,
                         reconnectConfig);
             }
 
@@ -1084,13 +1055,6 @@ public final class MerkleTestUtils {
             assertReconnectValidity(startingTree, desiredTree, generatedTree);
 
             return (T) generatedTree;
-        } finally {
-            try {
-                streams.close();
-            } catch (IOException e) {
-                // test code, no danger. The stream could have been closed previously.
-                e.printStackTrace();
-            }
         }
     }
 

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/PairedStreams.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/PairedStreams.java
@@ -80,29 +80,39 @@ public class PairedStreams implements AutoCloseable {
     }
 
     @Override
-    public void close() throws IOException {
-        teacherOutput.close();
-        teacherInput.close();
-        learnerOutput.close();
-        learnerInput.close();
+    public void close() {
+        try {
+            teacherOutput.close();
+            teacherInput.close();
+            learnerOutput.close();
+            learnerInput.close();
 
-        teacherOutputBuffer.close();
-        teacherInputBuffer.close();
-        learnerOutputBuffer.close();
-        learnerInputBuffer.close();
+            teacherOutputBuffer.close();
+            teacherInputBuffer.close();
+            learnerOutputBuffer.close();
+            learnerInputBuffer.close();
 
-        server.close();
-        teacherSocket.close();
-        learnerSocket.close();
+            server.close();
+            teacherSocket.close();
+            learnerSocket.close();
+        } catch (IOException e) {
+            // this is the test code, and we don't want the test to fail because of a close error
+            e.printStackTrace();
+        }
     }
 
     /**
      * Do an emergency shutdown of the sockets. Intentionally pulls the rug out from
      * underneath all streams reading/writing the sockets.
      */
-    public void disconnect() throws IOException {
-        server.close();
-        teacherSocket.close();
-        learnerSocket.close();
+    public void disconnect() {
+        try {
+            server.close();
+            teacherSocket.close();
+            learnerSocket.close();
+        } catch (IOException e) {
+            // this is the test code, and we don't want the test to fail because of a close error
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
**Description**:

This PR prevents possible failures in attempt of closing `PairedStreams` object which was previously closed. If `close` method throws an expection in this case the test shouldn't fail.


**Related issue(s)**:

Fixes #11715 
