### PR TITLE
fix: (mod) fix alias management

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
@@ -28,7 +28,6 @@ import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExcep
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.SELF_DESTRUCT_TO_SELF;
 import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.MISSING_ENTITY_NUMBER;
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.EVM_ADDRESS_LENGTH_AS_LONG;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asLongZeroAddress;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.isLongZero;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.maybeMissingNumberOf;
@@ -506,10 +505,9 @@ public class DispatchingEvmFrameState implements EvmFrameState {
 
     private boolean isNotPriority(
             final Address address, final @NonNull com.hedera.hapi.node.state.token.Account account) {
-        final var alias = requireNonNull(account).alias();
-        return alias != null
-                && alias.length() == EVM_ADDRESS_LENGTH_AS_LONG
-                && !address.equals(pbjToBesuAddress(alias));
+        requireNonNull(account);
+        final var maybeEvmAddress = extractEvmAddress(account.alias());
+        return maybeEvmAddress != null && !address.equals(pbjToBesuAddress(maybeEvmAddress));
     }
 
     private com.hedera.hapi.node.state.token.Account validatedAccount(final AccountID accountID) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
@@ -62,6 +62,7 @@ import com.hedera.node.app.service.mono.state.virtual.UniqueTokenValue;
 import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskAccount;
 import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskTokenRel;
 import com.hedera.node.app.service.mono.utils.EntityNum;
+import com.hedera.node.app.service.token.AliasUtils;
 import com.hedera.node.app.service.token.impl.TokenServiceImpl;
 import com.hedera.node.app.service.token.impl.codec.NetworkingStakingTranslator;
 import com.hedera.node.app.spi.state.MigrationContext;
@@ -341,6 +342,12 @@ public class InitialModServiceTokenSchema extends Schema {
                                         aliasesState
                                                 .get()
                                                 .put(new ProtoBytes(toAcct.alias()), toAcct.accountIdOrThrow());
+                                        if (toAcct.alias().toByteArray().length > 20) {
+                                            final var result = AliasUtils.extractEvmAddress(toAcct.alias());
+                                            if (result != null) {
+                                                aliasesState.get().put(new ProtoBytes(result), toAcct.accountId());
+                                            }
+                                        }
                                         if (numAliasesInsertions.incrementAndGet() % 10_000 == 0) {
                                             // Make sure we are flushing data to disk as we go
                                             ((WritableKVStateBase) aliasesState.get()).commit();


### PR DESCRIPTION
**Description**:
 - During BBM, add `alias-to-id` mappings for _both_ the in-state alias (which could be a "key alias") and any implied EVM address.
 - When checking if an EVM address is the "priority" address for an account, also detect the case the account's key alias maps to the given EVM address.