### PR TITLE
fix: 11750 Fixed synchronization in   `BreakableDataSource.saveRecords`

### DIFF
--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
@@ -54,14 +54,12 @@ public final class BreakableDataSource implements VirtualDataSource<TestKey, Tes
         if (builder.numTimesBroken < builder.numTimesToBreak) {
             // Syncronization block is not required here, as this code is never called in parallel
             // (though from different threads). `volatile` modifier is sufficient to ensure visibility.
-            if (builder.numTimesBroken < builder.numTimesToBreak) {
-                builder.numCalls += leaves.size();
-                if (builder.numCalls > builder.numCallsBeforeThrow) {
-                    builder.numCalls = 0;
-                    builder.numTimesBroken++;
-                    delegate.close();
-                    throw new IOException("Something bad on the DB!");
-                }
+            builder.numCalls += leaves.size();
+            if (builder.numCalls > builder.numCallsBeforeThrow) {
+                builder.numCalls = 0;
+                builder.numTimesBroken++;
+                delegate.close();
+                throw new IOException("Something bad on the DB!");
             }
         }
 

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
@@ -31,8 +31,8 @@ public final class BrokenBuilder implements VirtualDataSourceBuilder<TestKey, Te
 
     VirtualDataSourceBuilder<TestKey, TestValue> delegate;
 
-    int numCallsBeforeThrow = Integer.MAX_VALUE;
-    int numTimesToBreak = 0;
+    volatile int numCallsBeforeThrow = Integer.MAX_VALUE;
+    volatile int numTimesToBreak = 0;
 
     // the following fields are volatile to ensure visibility,
     // as BreakableDataSource.saveRecords called from multiple threads.

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
@@ -32,9 +32,12 @@ public final class BrokenBuilder implements VirtualDataSourceBuilder<TestKey, Te
     VirtualDataSourceBuilder<TestKey, TestValue> delegate;
 
     int numCallsBeforeThrow = Integer.MAX_VALUE;
-    int numCalls = 0;
     int numTimesToBreak = 0;
-    int numTimesBroken = 0;
+
+    // the following fields are volatile to ensure visibility,
+    // as BreakableDataSource.saveRecords called from multiple threads.
+    volatile int numCalls = 0;
+    volatile int numTimesBroken = 0;
 
     public BrokenBuilder() {}
 


### PR DESCRIPTION
**Description**:

This PR fixed synchronization issues stemming from the fact that `saveRecords` method is no longer called from a single thread. 

**Related issue(s)**:

Fixes #11750 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
