### PR TITLE
build: Adjust time for release branch creation

### DIFF
--- a/.github/workflows/config/node-release.yaml
+++ b/.github/workflows/config/node-release.yaml
@@ -1,9 +1,9 @@
 release:
   branching:
     execution:
-      time: "20:00:00"
+      time: "00:00:00"
     schedule:
-      - on: "2023-02-27"
+      - on: "2024-02-28"
         name: release/0.48
         initial-tag:
           create: false


### PR DESCRIPTION
This will kick off create the release branch for release 0.48 at the specified time