### PR TITLE
fix: fix ERC-20 log events and custom fee calculations

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
@@ -217,7 +217,7 @@ public class DecodingFacade {
             // otherwise default to false in order to preserve the existing behaviour.
             // The isApproval parameter only exists in the new form of cryptoTransfer
             final boolean isApproval = (transfer.size() > 2) && (boolean) transfer.get(2);
-            addSignedAdjustment(fungibleTransfers, tokenType, accountID, amount, isApproval);
+            addSignedAdjustment(fungibleTransfers, tokenType, accountID, amount, isApproval, false);
         }
         return fungibleTransfers;
     }
@@ -250,8 +250,9 @@ public class DecodingFacade {
             final TokenID tokenType,
             final AccountID accountID,
             final long amount,
-            final boolean isApproval) {
-        if (amount > 0) {
+            final boolean isApproval,
+            final boolean zeroAmountIsReceiver) {
+        if (amount > 0 || (amount == 0 && zeroAmountIsReceiver)) {
             fungibleTransfers.add(
                     new SyntheticTxnFactory.FungibleTokenTransfer(amount, isApproval, tokenType, null, accountID));
         } else {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -224,8 +224,8 @@ public class ERCTransferPrecompile extends TransferPrecompile {
         final var amount = (BigInteger) decodedArguments.get(1);
 
         final List<SyntheticTxnFactory.FungibleTokenTransfer> fungibleTransfers = new ArrayList<>();
-        addSignedAdjustment(fungibleTransfers, token, recipient, amount.longValueExact(), false);
-        addSignedAdjustment(fungibleTransfers, token, caller, -amount.longValueExact(), false);
+        addSignedAdjustment(fungibleTransfers, token, recipient, amount.longValueExact(), false, true);
+        addSignedAdjustment(fungibleTransfers, token, caller, -amount.longValueExact(), false, false);
 
         final var tokenTransferWrappers =
                 Collections.singletonList(new TokenTransferWrapper(NO_NFT_EXCHANGES, fungibleTransfers));
@@ -265,9 +265,9 @@ public class ERCTransferPrecompile extends TransferPrecompile {
             final List<SyntheticTxnFactory.FungibleTokenTransfer> fungibleTransfers = new ArrayList<>();
             final var amount = (BigInteger) decodedArguments.get(offset + 2);
 
-            addSignedAdjustment(fungibleTransfers, token, to, amount.longValueExact(), false);
+            addSignedAdjustment(fungibleTransfers, token, to, amount.longValueExact(), false, true);
 
-            addSignedAdjustment(fungibleTransfers, token, from, -amount.longValueExact(), true);
+            addSignedAdjustment(fungibleTransfers, token, from, -amount.longValueExact(), true, false);
 
             final var tokenTransferWrappers =
                     Collections.singletonList(new TokenTransferWrapper(NO_NFT_EXCHANGES, fungibleTransfers));
@@ -303,7 +303,6 @@ public class ERCTransferPrecompile extends TransferPrecompile {
                 amount = BigInteger.valueOf(fungibleTransfer.amount());
             }
         }
-
         return EncodingFacade.LogBuilder.logBuilder()
                 .forLogger(logger)
                 .forEventSignature(AbiConstants.TRANSFER_EVENT)

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -541,7 +541,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
                 accountID = generateAccountIDWithAliasCalculatedFrom(accountID);
             }
 
-            DecodingFacade.addSignedAdjustment(fungibleTransfers, tokenType, accountID, amount, false);
+            DecodingFacade.addSignedAdjustment(fungibleTransfers, tokenType, accountID, amount, false, false);
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/SpanMapManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/SpanMapManager.java
@@ -318,7 +318,7 @@ public class SpanMapManager {
         }
     }
 
-    private void expandImpliedTransfers(final TxnAccessor accessor) {
+    public void expandImpliedTransfers(final TxnAccessor accessor) {
         final var op = accessor.getTxn().getCryptoTransfer();
         final var impliedTransfers = impliedTransfersMarshal.unmarshalFromGrpc(op, accessor.getPayer());
         reCalculateXferMeta(accessor, impliedTransfers);
@@ -328,12 +328,16 @@ public class SpanMapManager {
     }
 
     public static void reCalculateXferMeta(final TxnAccessor accessor, final ImpliedTransfers impliedTransfers) {
+        final var maybeAssessedCustomFees = impliedTransfers.getAssessedCustomFeeWrappers();
+        if (maybeAssessedCustomFees.isEmpty()) {
+            return;
+        }
         final var xferMeta = accessor.availXferUsageMeta();
 
         var customFeeTokenTransfers = 0;
         var customFeeHbarTransfers = 0;
         final Set<EntityId> involvedTokens = new HashSet<>();
-        for (final var assessedFeeWrapper : impliedTransfers.getAssessedCustomFeeWrappers()) {
+        for (final var assessedFeeWrapper : maybeAssessedCustomFees) {
             if (assessedFeeWrapper.isForHbar()) {
                 customFeeHbarTransfers++;
             } else {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StandardProcessLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/StandardProcessLogicTest.java
@@ -40,6 +40,7 @@ import com.hedera.node.app.service.mono.state.expiry.ExpiryManager;
 import com.hedera.node.app.service.mono.stats.ExecutionTimeTracker;
 import com.hedera.node.app.service.mono.txns.schedule.ScheduleProcessing;
 import com.hedera.node.app.service.mono.txns.span.ExpandHandleSpan;
+import com.hedera.node.app.service.mono.txns.span.SpanMapManager;
 import com.hedera.node.app.service.mono.utils.accessors.PlatformTxnAccessor;
 import com.hedera.node.app.service.mono.utils.accessors.TxnAccessor;
 import com.hedera.test.extensions.LogCaptor;
@@ -70,6 +71,9 @@ class StandardProcessLogicTest {
 
     @Mock
     private ExpiryManager expiries;
+
+    @Mock
+    private SpanMapManager spanMapManager;
 
     @Mock
     private InvariantChecks invariantChecks;
@@ -140,7 +144,8 @@ class StandardProcessLogicTest {
                 recordStreaming,
                 workingView,
                 recordCache,
-                InitTrigger.GENESIS);
+                InitTrigger.GENESIS,
+                spanMapManager);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/SpanMapManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/span/SpanMapManagerTest.java
@@ -198,7 +198,6 @@ class SpanMapManagerTest {
         given(accessor.getTxn()).willReturn(pretendXferTxn);
         given(accessor.getSpanMap()).willReturn(span);
         given(accessor.getFunction()).willReturn(CryptoTransfer);
-        given(accessor.availXferUsageMeta()).willReturn(xferMeta);
         given(impliedTransfersMarshal.unmarshalFromGrpc(pretendXferTxn.getCryptoTransfer(), payer))
                 .willReturn(someImpliedXfers);
 
@@ -215,7 +214,6 @@ class SpanMapManagerTest {
         given(accessor.getTxn()).willReturn(pretendXferTxn);
         given(accessor.getSpanMap()).willReturn(span);
         given(accessor.getFunction()).willReturn(CryptoTransfer);
-        given(accessor.availXferUsageMeta()).willReturn(xferMeta);
         given(impliedTransfersMarshal.unmarshalFromGrpc(pretendXferTxn.getCryptoTransfer(), payer))
                 .willReturn(someValidImpliedXfers);
 
@@ -274,7 +272,6 @@ class SpanMapManagerTest {
         given(accessor.getTxn()).willReturn(pretendXferTxn);
         given(accessor.getSpanMap()).willReturn(span);
         given(accessor.getFunction()).willReturn(CryptoTransfer);
-        given(accessor.availXferUsageMeta()).willReturn(xferMeta);
         given(dynamicProperties.maxTransferListSize()).willReturn(maxHbarAdjusts);
         given(dynamicProperties.maxTokenTransferListSize()).willReturn(maxTokenAdjusts + 1);
         spanMapAccessor.setImpliedTransfers(accessor, someImpliedXfers);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleSystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleSystemContractOperations.java
@@ -76,7 +76,6 @@ public class HandleSystemContractOperations implements SystemContractOperations 
         requireNonNull(strategy);
         requireNonNull(syntheticPayerId);
         requireNonNull(recordBuilderClass);
-
         return context.dispatchChildTransaction(
                 syntheticBody, recordBuilderClass, activeSignatureTestWith(strategy), syntheticPayerId, CHILD);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -168,7 +168,7 @@ public class ClassicTransfersCall extends AbstractHtsCall {
      * @param systemContractGasCalculator the gas calculator to use
      * @param enhancement the enhancement to use
      * @param payerId the payer of the transaction
-     * @param selector
+     * @param selector the selector of the call
      * @return the gas requirement for the transaction to be dispatched
      */
     public static long transferGasRequirement(
@@ -263,17 +263,17 @@ public class ClassicTransfersCall extends AbstractHtsCall {
     private void maybeEmitErcLogsFor(
             @NonNull final CryptoTransferTransactionBody op, @NonNull final MessageFrame frame) {
         if (Arrays.equals(ClassicTransfersTranslator.TRANSFER_FROM.selector(), selector)) {
-            final var fungibleTransfers = op.tokenTransfersOrThrow().get(0);
+            final var fungibleTransfers = op.tokenTransfersOrThrow().getFirst();
             logSuccessfulFungibleTransfer(
                     fungibleTransfers.tokenOrThrow(),
                     fungibleTransfers.transfersOrThrow(),
                     readableAccountStore(),
                     frame);
         } else if (Arrays.equals(ClassicTransfersTranslator.TRANSFER_NFT_FROM.selector(), selector)) {
-            final var nftTransfers = op.tokenTransfersOrThrow().get(0);
+            final var nftTransfers = op.tokenTransfersOrThrow().getFirst();
             logSuccessfulNftTransfer(
                     nftTransfers.tokenOrThrow(),
-                    nftTransfers.nftTransfersOrThrow().get(0),
+                    nftTransfers.nftTransfersOrThrow().getFirst(),
                     readableAccountStore(),
                     frame);
         }


### PR DESCRIPTION
**Description**:
 - Closes #11630 
 - Fixes #11778
 - Fix two small mono-service issues that we have no reason to reproduce in mod-service:
    1. Use the correct resource prices for scheduled `CryptoTransfer`'s that trigger custom fee payments.
    2. Set the receiver log topic in an ERC-20 `TRANSFER_EVENT` even when the transferred amount is `0`.
 - Fix mod-service to only emit ERC-20 events on `SUCCESS`; and to still distinguish the logical sender and receiver when the amount is `0`.