### PR TITLE
fix: wait longer for freeze transaction to be handled

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -59,7 +59,7 @@ public class SimpleFreezeOnly extends HapiSuite {
     final HapiSpec simpleFreezeWithTimestamp() {
         return defaultHapiSpec("SimpleFreezeWithTimeStamp")
                 .given(freezeOnly().payingWith(GENESIS).startingAt(Instant.now().plusSeconds(10)))
-                .when(sleepFor(4000))
+                .when(sleepFor(40000))
                 .then(cryptoCreate("not_going_to_happen").hasPrecheck(ResponseCodeEnum.PLATFORM_NOT_ACTIVE));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -59,7 +59,7 @@ public class SimpleFreezeOnly extends HapiSuite {
     final HapiSpec simpleFreezeWithTimestamp() {
         return defaultHapiSpec("SimpleFreezeWithTimeStamp")
                 .given(freezeOnly().payingWith(GENESIS).startingAt(Instant.now().plusSeconds(10)))
-                .when(sleepFor(11000))
+                .when(sleepFor(4000))
                 .then(cryptoCreate("not_going_to_happen").hasPrecheck(ResponseCodeEnum.PLATFORM_NOT_ACTIVE));
     }
 }


### PR DESCRIPTION
**Description**:

Sometimes it takes longer for service app to handle freeze transaction and put platform enter sleep mode

**Related issue(s)**:

Fixes #11788 


Test result

https://swirldslabs.slack.com/archives/C03G7CBJJ06/p1709097277261679
https://swirldslabs.slack.com/archives/C03G7CBJJ06/p1709099820470689
