### PR TITLE
feat: pbj-208: upgrade PBJ dependency to 0.7.20

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.19")
+    version("com.hedera.pbj.runtime", "0.7.20")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,6 +150,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.19")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.20")
     }
 }


### PR DESCRIPTION
**Description**:
Upgrading PBJ dependency to 0.7.20 in order to incorporate https://github.com/hashgraph/pbj/issues/208 fixed at https://github.com/hashgraph/pbj/pull/210

The fix introduces a maximum size for repeated/length-encoded fields that PBJ parses successfully. The parsing now errors out if PBJ encounters a field larger than the defined maximum size.

The PBJ 0.7.20 is already published to Maven: https://central.sonatype.com/artifact/com.hedera.pbj/pbj-runtime/versions

**Related issue(s)**:

Fixes #https://github.com/hashgraph/pbj/issues/208

**Notes for reviewer**:
Unit tests in hedera-services pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
