### PR TITLE
build: support running selected JMH tests

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.benchmark-conventions.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.benchmark-conventions.gradle.kts
@@ -21,6 +21,17 @@ plugins { id("me.champeau.jmh") }
 jmh {
     jmhVersion = "1.37"
     includeTests = false
+    // Filter JMH tests from command line via -PjmhTests=...
+    val commandLineIncludes = providers.gradleProperty("jmhTests")
+    if (commandLineIncludes.isPresent) {
+        includes.add(commandLineIncludes.get())
+    }
+}
+
+dependencies {
+    // Required for the JMH IDEA plugin:
+    // https://plugins.jetbrains.com/plugin/7529-jmh-java-microbenchmark-harness
+    jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:${jmh.jmhVersion.get()}")
 }
 
 tasks.jmh { outputs.upToDateWhen { false } }
@@ -41,6 +52,7 @@ configurations {
     val javaModule = Attribute.of("javaModule", Boolean::class.javaObjectType)
     jmhRuntimeClasspath { attributes { attribute(javaModule, false) } }
     jmhCompileClasspath { attributes { attribute(javaModule, false) } }
+    jmhAnnotationProcessor { attributes { attribute(javaModule, false) } }
 }
 
 tasks.assemble {


### PR DESCRIPTION
**Description**:
1) Allow running a single test from command line using `-PjmhTests`
2) Use the [JMH IntelliJ plugin](https://plugins.jetbrains.com/plugin/7529-jmh-java-microbenchmark-harness) to run from IntelliJ 

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/11863

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
