### PR TITLE
fix: bug in future event buffer

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/FutureEventBuffer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/FutureEventBuffer.java
@@ -114,7 +114,7 @@ public class FutureEventBuffer {
 
         // We want to release all events with birth rounds less than or equal to the pending consensus round.
         // In order to do that, we tell the sequence map to shift its window to the oldest round that we want
-        // keep within the buffer.
+        // to keep within the buffer.
         final long oldestRoundToBuffer = eventWindow.getPendingConsensusRound() + 1;
 
         final List<GossipEvent> events = new ArrayList<>();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/FutureEventBuffer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/FutureEventBuffer.java
@@ -112,8 +112,13 @@ public class FutureEventBuffer {
     public List<GossipEvent> updateEventWindow(@NonNull final NonAncientEventWindow eventWindow) {
         this.eventWindow = Objects.requireNonNull(eventWindow);
 
+        // We want to release all events with birth rounds less than or equal to the pending consensus round.
+        // In order to do that, we tell the sequence map to shift its window to the oldest round that we want
+        // keep within the buffer.
+        final long oldestRoundToBuffer = eventWindow.getPendingConsensusRound() + 1;
+
         final List<GossipEvent> events = new ArrayList<>();
-        futureEvents.shiftWindow(eventWindow.getPendingConsensusRound(), (round, roundEvents) -> {
+        futureEvents.shiftWindow(oldestRoundToBuffer, (round, roundEvents) -> {
             for (final GossipEvent event : roundEvents) {
                 if (!eventWindow.isAncient(event)) {
                     events.add(event);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/FutureEventBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/FutureEventBufferTests.java
@@ -153,8 +153,8 @@ class FutureEventBufferTests {
     }
 
     /**
-     * It is plausible that we have a big jump in rounds due to a reconnect. Verify that we don't emit events
-     * if they become ancient while buffered.
+     * It is plausible that we have a big jump in rounds due to a reconnect. Verify that we don't emit events if they
+     * become ancient while buffered.
      */
     @Test
     void eventsGoAncientWhileBufferedTest() {
@@ -209,5 +209,60 @@ class FutureEventBufferTests {
 
         final List<GossipEvent> bufferedEvents = futureEventBuffer.updateEventWindow(newEventWindow);
         assertTrue(bufferedEvents.isEmpty());
+    }
+
+    /**
+     * Verify that an event that is buffered gets released at the exact moment we expect.
+     */
+    @Test
+    void eventInBufferIsReleasedOnTimeTest() {
+        final Random random = getRandomPrintSeed();
+
+        final Configuration configuration = new TestConfigBuilder()
+                .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, true)
+                .getOrCreateConfig();
+
+        final PlatformContext platformContext = TestPlatformContextBuilder.create()
+                .withConfiguration(configuration)
+                .build();
+
+        final FutureEventBuffer futureEventBuffer = new FutureEventBuffer(platformContext);
+
+        final long pendingConsensusRound = random.nextLong(100, 1_000);
+        final long nonAncientBirthRound = pendingConsensusRound / 2;
+
+        final NonAncientEventWindow eventWindow =
+                new NonAncientEventWindow(pendingConsensusRound - 1, nonAncientBirthRound, 1, BIRTH_ROUND_THRESHOLD);
+        futureEventBuffer.updateEventWindow(eventWindow);
+
+        final long roundsUntilRelease = random.nextLong(10, 20);
+        final long eventBirthRound = pendingConsensusRound + roundsUntilRelease;
+        final GossipEvent event = generateEvent(random, eventBirthRound);
+
+        // Event is from the future, we can't release it yet
+        assertNull(futureEventBuffer.addEvent(event));
+
+        // While the (newPendingConsensusRound-1) is less than the event's birth round, the event should be buffered
+        for (long currentConsensusRound = pendingConsensusRound - 1;
+                currentConsensusRound < eventBirthRound - 1;
+                currentConsensusRound++) {
+
+            final NonAncientEventWindow newEventWindow =
+                    new NonAncientEventWindow(currentConsensusRound, nonAncientBirthRound, 1, BIRTH_ROUND_THRESHOLD);
+            final List<GossipEvent> bufferedEvents = futureEventBuffer.updateEventWindow(newEventWindow);
+            assertTrue(bufferedEvents.isEmpty());
+        }
+
+        // When the pending consensus round is equal to the event's birth round, the event should be released
+        // Note: the pending consensus round is equal to the current consensus round + 1, but the argument
+        // for an event window takes the current consensus round, not the pending consensus round.
+        // To land with the pending consensus round at the exact value as the event's birth round, we need to
+        // set the current consensus round to the event's birth round - 1.
+
+        final NonAncientEventWindow newEventWindow =
+                new NonAncientEventWindow(eventBirthRound - 1, nonAncientBirthRound, 1, BIRTH_ROUND_THRESHOLD);
+        final List<GossipEvent> bufferedEvents = futureEventBuffer.updateEventWindow(newEventWindow);
+        assertEquals(1, bufferedEvents.size());
+        assertSame(event, bufferedEvents.getFirst());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/FutureEventBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/FutureEventBufferTests.java
@@ -131,8 +131,8 @@ class FutureEventBufferTests {
                 newPendingConsensusRound <= maxFutureRound;
                 newPendingConsensusRound++) {
 
-            final NonAncientEventWindow newEventWindow =
-                    new NonAncientEventWindow(newPendingConsensusRound, nonAncientBirthRound, 1, BIRTH_ROUND_THRESHOLD);
+            final NonAncientEventWindow newEventWindow = new NonAncientEventWindow(
+                    newPendingConsensusRound - 1, nonAncientBirthRound, 1, BIRTH_ROUND_THRESHOLD);
 
             final List<GossipEvent> bufferedEvents = futureEventBuffer.updateEventWindow(newEventWindow);
 


### PR DESCRIPTION
Related to #11872 
Needs to be back ported to `release/0.48`
