### PR TITLE
fix: pbj-221: upgrade PBJ dependency to 0.7.22

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.20")
+    version("com.hedera.pbj.runtime", "0.7.22")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,6 +150,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.20")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.22")
     }
 }


### PR DESCRIPTION
**Description**:
PBJ has increased the `maxSize` limit when parsing models from 21K to 2M in PBJ v0.7.22.

As discovered at https://github.com/hashgraph/pbj/issues/221 , EVM bytecode can be larger than 21K. And it was suggested in an off-line conversation that the bytecode can be up to 1M in size. So we've increased the currently hard-coded `maxSize` limit in PBJ to 2M to be on the safe size.

**Related issue(s)**:

Fixes #https://github.com/hashgraph/pbj/issues/221

**Notes for reviewer**:
The PBJ v0.7.22 is released: https://central.sonatype.com/artifact/com.hedera.pbj/pbj-runtime/versions

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
