### PR TITLE
fix: pbj-220: upgrade PBJ dependency to 0.7.23

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.22")
+    version("com.hedera.pbj.runtime", "0.7.23")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
@@ -116,7 +116,8 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
                 throw new IllegalStateException("initRunningHash() can only be called once");
             }
 
-            if (runningHashes.runningHash() == null || runningHashes.runningHash().equals(Bytes.EMPTY)) {
+            if (runningHashes.runningHash() == null
+                    || runningHashes.runningHash().equals(Bytes.EMPTY)) {
                 throw new IllegalArgumentException("The initial running hash cannot be null or empty");
             }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
@@ -116,8 +116,8 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
                 throw new IllegalStateException("initRunningHash() can only be called once");
             }
 
-            if (runningHashes.runningHash() == null) {
-                throw new IllegalArgumentException("The initial running hash cannot be null");
+            if (runningHashes.runningHash() == null || runningHashes.runningHash().equals(Bytes.EMPTY)) {
+                throw new IllegalArgumentException("The initial running hash cannot be null or empty");
             }
 
             lastRecordHashingResult = completedFuture(runningHashes.runningHash());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
@@ -124,8 +124,8 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
             throw new IllegalStateException("initRunningHash() must only be called once");
         }
 
-        if (runningHashes.runningHash() == null) {
-            throw new IllegalArgumentException("The initial running hash cannot be null");
+        if (runningHashes.runningHash() == null || runningHashes.runningHash().equals(Bytes.EMPTY)) {
+            throw new IllegalArgumentException("The initial running hash cannot be null or empty");
         }
 
         runningHash = runningHashes.runningHash();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -301,7 +301,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                         } else {
                             // check nulls as well
                             assertThat(blockRecordManager.getNMinus3RunningHash())
-                                    .isNull();
+                                    .isEqualTo(Bytes.EMPTY);
                         }
                     }
                     j += batchSize;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
@@ -108,7 +108,7 @@ abstract class StreamFileProducerTest extends AppTestBase {
             final var runningHashes = new RunningHashes(randomBytes(32), null, null, null);
             subject.initRunningHash(runningHashes);
             assertThat(subject.getRunningHash()).isEqualTo(runningHashes.runningHash());
-            assertThat(subject.getNMinus3RunningHash()).isNull();
+            assertThat(subject.getNMinus3RunningHash()).isEqualTo(Bytes.EMPTY);
         }
     }
 
@@ -247,7 +247,7 @@ abstract class StreamFileProducerTest extends AppTestBase {
 
             // Submitting a batch of records only moves the running hash forward once, because it moves forward once
             // PER USER TRANSACTION, not per record.
-            assertThat(subject.getNMinus3RunningHash()).isNull();
+            assertThat(subject.getNMinus3RunningHash()).isEqualTo(Bytes.EMPTY);
 
             final var finalRunningHash = subject.getRunningHash();
             subject.close();

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
@@ -76,8 +76,7 @@ class FileServiceStateTranslatorTest extends FileTestBase {
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoKeysAndMemo);
 
         assertArrayEquals(
-                getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys().data(),
-                convertedFile.data());
+                getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys().data(), convertedFile.data());
         assertEquals(
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
@@ -105,9 +104,7 @@ class FileServiceStateTranslatorTest extends FileTestBase {
 
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoContent);
 
-        assertArrayEquals(
-                getExpectedMonoFileMetaAndContentEmptyContent().data(),
-                convertedFile.data());
+        assertArrayEquals(getExpectedMonoFileMetaAndContentEmptyContent().data(), convertedFile.data());
         assertEquals(
                 getExpectedMonoFileMetaAndContentEmptyContent().metadata().getExpiry(),
                 convertedFile.metadata().getExpiry());

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
@@ -76,28 +76,28 @@ class FileServiceStateTranslatorTest extends FileTestBase {
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoKeysAndMemo);
 
         assertArrayEquals(
-                convertedFile.data(),
-                getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys().data());
+                getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys().data(),
+                convertedFile.data());
         assertEquals(
-                convertedFile.metadata().getExpiry(),
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .getExpiry());
+                        .getExpiry(),
+                convertedFile.metadata().getExpiry());
         assertEquals(
-                convertedFile.metadata().getMemo(),
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .getMemo());
+                        .getMemo(),
+                convertedFile.metadata().getMemo());
         assertEquals(
-                MiscUtils.describe(convertedFile.metadata().getWacl()),
                 MiscUtils.describe(getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .getWacl()));
+                        .getWacl()),
+                MiscUtils.describe(convertedFile.metadata().getWacl()));
         assertEquals(
-                convertedFile.metadata().isDeleted(),
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .isDeleted());
+                        .isDeleted(),
+                convertedFile.metadata().isDeleted());
     }
 
     @Test
@@ -106,22 +106,22 @@ class FileServiceStateTranslatorTest extends FileTestBase {
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoContent);
 
         assertArrayEquals(
-                convertedFile.data(),
-                getExpectedMonoFileMetaAndContentEmptyContent().data());
+                getExpectedMonoFileMetaAndContentEmptyContent().data(),
+                convertedFile.data());
         assertEquals(
-                convertedFile.metadata().getExpiry(),
-                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getExpiry());
+                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getExpiry(),
+                convertedFile.metadata().getExpiry());
         assertEquals(
-                convertedFile.metadata().getMemo(),
-                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getMemo());
+                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getMemo(),
+                convertedFile.metadata().getMemo());
         assertEquals(
-                MiscUtils.describe(convertedFile.metadata().getWacl()),
                 MiscUtils.describe(getExpectedMonoFileMetaAndContentEmptyContent()
                         .metadata()
-                        .getWacl()));
+                        .getWacl()),
+                MiscUtils.describe(convertedFile.metadata().getWacl()));
         assertEquals(
-                convertedFile.metadata().isDeleted(),
-                getExpectedMonoFileMetaAndContentEmptyContent().metadata().isDeleted());
+                getExpectedMonoFileMetaAndContentEmptyContent().metadata().isDeleted(),
+                convertedFile.metadata().isDeleted());
     }
 
     @Test
@@ -210,7 +210,7 @@ class FileServiceStateTranslatorTest extends FileTestBase {
 
     private FileMetadataAndContent getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys() {
         com.hedera.node.app.service.mono.files.HFileMeta hFileMeta =
-                new HFileMeta(file.deleted(), null, file.expirationSecond(), null);
+                new HFileMeta(file.deleted(), null, file.expirationSecond(), "");
         return new FileMetadataAndContent(file.contents().toByteArray(), hFileMeta);
     }
 
@@ -219,6 +219,6 @@ class FileServiceStateTranslatorTest extends FileTestBase {
                 Key.newBuilder().keyList(file.keys()).build(), 1);
         com.hedera.node.app.service.mono.files.HFileMeta hFileMeta =
                 new HFileMeta(file.deleted(), keys, file.expirationSecond(), file.memo());
-        return new FileMetadataAndContent(null, hFileMeta);
+        return new FileMetadataAndContent(new byte[] {}, hFileMeta);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionResultTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionResultTest.java
@@ -178,7 +178,7 @@ class HederaEvmTransactionResultTest {
         assertEquals(GAS_LIMIT / 2, protoResult.gasUsed());
         assertEquals(bloomForAll(BESU_LOGS), protoResult.bloom());
         assertEquals(OUTPUT_DATA, protoResult.contractCallResult());
-        assertNull(protoResult.errorMessage());
+        assertEquals("", protoResult.errorMessage());
         assertNull(protoResult.senderId());
         assertEquals(CALLED_CONTRACT_ID, protoResult.contractID());
         assertEquals(pbjLogsFrom(BESU_LOGS), protoResult.logInfo());
@@ -217,7 +217,7 @@ class HederaEvmTransactionResultTest {
         assertEquals(GAS_LIMIT / 2, protoResult.gasUsed());
         assertEquals(bloomForAll(BESU_LOGS), protoResult.bloom());
         assertEquals(OUTPUT_DATA, protoResult.contractCallResult());
-        assertNull(protoResult.errorMessage());
+        assertEquals("", protoResult.errorMessage());
         assertEquals(CALLED_CONTRACT_ID, protoResult.contractID());
         assertEquals(pbjLogsFrom(BESU_LOGS), protoResult.logInfo());
         assertEquals(createdIds, protoResult.createdContractIDs());
@@ -267,7 +267,7 @@ class HederaEvmTransactionResultTest {
         assertEquals(GAS_LIMIT / 2, queryResult.gasUsed());
         assertEquals(bloomForAll(BESU_LOGS), queryResult.bloom());
         assertEquals(OUTPUT_DATA, queryResult.contractCallResult());
-        assertNull(queryResult.errorMessage());
+        assertEquals("", queryResult.errorMessage());
         assertNull(queryResult.senderId());
         assertEquals(CALLED_CONTRACT_ID, queryResult.contractID());
         assertEquals(pbjLogsFrom(BESU_LOGS), queryResult.logInfo());

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,6 +150,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.22")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.23")
     }
 }


### PR DESCRIPTION
**Description**:
This fix upgrades the PBJ dependency to v0.7.23 which contains a new implementation for a `null Bytes and Strings` fix where PBJ continues to accept `null` as an argument to model and Builder constructors, but internally ensures that model fields of these types are never `null` and instead get assigned default values (`Bytes.EMPTY` and `""` respectively), so as to prevent any NPEs when serializing such models and be compatible with Google Protobuf specification: https://github.com/hashgraph/pbj/pull/224

**Related issue(s)**:

Fixes #https://github.com/hashgraph/pbj/issues/220

**Notes for reviewer**:
PBJ v0.7.23 is released: https://central.sonatype.com/artifact/com.hedera.pbj/pbj-runtime/versions

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
