### PR TITLE
refactor: PlatformContext to configure Consensus

### DIFF
--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -28,7 +28,7 @@ mainModuleInfo {
 
 jmhModuleInfo {
     requires("com.swirlds.base")
-    requires("com.swirlds.config.api")
+    requires("com.swirlds.common")
     requires("com.swirlds.platform.core")
     requires("com.swirlds.platform.test")
     requires("com.swirlds.common.test.fixtures")

--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
@@ -17,13 +17,11 @@
 package com.swirlds.platform.core.jmh;
 
 import com.swirlds.base.utility.Pair;
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.WeightGenerators;
-import com.swirlds.config.api.Configuration;
+import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.Consensus;
 import com.swirlds.platform.ConsensusImpl;
-import com.swirlds.platform.config.DefaultConfiguration;
-import com.swirlds.platform.consensus.ConsensusConfig;
-import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.test.NoOpConsensusMetrics;
 import com.swirlds.platform.test.event.emitter.StandardEventEmitter;
 import com.swirlds.platform.test.event.source.EventSourceFactory;
@@ -77,12 +75,12 @@ public class ConsensusBenchmark {
         final StandardEventEmitter emitter = new StandardEventEmitter(generator);
         events = emitter.emitEvents(numEvents);
 
-        final Configuration configuration = DefaultConfiguration.buildBasicConfiguration();
+        final PlatformContext platformContext =
+                TestPlatformContextBuilder.create().build();
         consensus = new ConsensusImpl(
-                configuration.getConfigData(ConsensusConfig.class),
+                platformContext,
                 new NoOpConsensusMetrics(),
-                emitter.getGraphGenerator().getAddressBook(),
-                configuration.getConfigData(EventConfig.class).getAncientMode());
+                emitter.getGraphGenerator().getAddressBook());
     }
 
     @Benchmark

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
@@ -25,7 +25,6 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.utility.Threshold;
 import com.swirlds.platform.consensus.AncestorSearch;
 import com.swirlds.platform.consensus.CandidateWitness;
-import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.consensus.ConsensusConstants;
 import com.swirlds.platform.consensus.ConsensusRounds;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
@@ -35,7 +34,6 @@ import com.swirlds.platform.consensus.CountingVote;
 import com.swirlds.platform.consensus.InitJudges;
 import com.swirlds.platform.consensus.NonAncientEventWindow;
 import com.swirlds.platform.consensus.RoundElections;
-import com.swirlds.platform.consensus.SequentialRingBuffer;
 import com.swirlds.platform.consensus.ThreadSafeConsensusInfo;
 import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.eventhandling.EventConfig;
@@ -202,15 +200,7 @@ public class ConsensusImpl extends ThreadSafeConsensusInfo implements Consensus 
             @NonNull final PlatformContext platformContext,
             @NonNull final ConsensusMetrics consensusMetrics,
             @NonNull final AddressBook addressBook) {
-        super(
-                platformContext.getConfiguration().getConfigData(ConsensusConfig.class),
-                new SequentialRingBuffer<>(
-                        ConsensusConstants.ROUND_FIRST,
-                        platformContext
-                                        .getConfiguration()
-                                        .getConfigData(ConsensusConfig.class)
-                                        .roundsExpired()
-                                * 2));
+        super(platformContext);
         this.consensusMetrics = consensusMetrics;
 
         // until we implement address book changes, we will just use the use this address book

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
@@ -20,6 +20,7 @@ import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
 import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 import static com.swirlds.platform.consensus.ConsensusConstants.FIRST_CONSENSUS_NUMBER;
 
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.utility.Threshold;
 import com.swirlds.platform.consensus.AncestorSearch;
@@ -37,6 +38,7 @@ import com.swirlds.platform.consensus.RoundElections;
 import com.swirlds.platform.consensus.SequentialRingBuffer;
 import com.swirlds.platform.consensus.ThreadSafeConsensusInfo;
 import com.swirlds.platform.event.AncientMode;
+import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.gossip.shadowgraph.Generations;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
@@ -52,7 +54,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -144,8 +145,6 @@ import org.apache.logging.log4j.Logger;
 public class ConsensusImpl extends ThreadSafeConsensusInfo implements Consensus {
 
     private static final Logger logger = LogManager.getLogger(ConsensusImpl.class);
-    /** consensus configuration */
-    private final ConsensusConfig config;
     /** the only address book currently, until address book changes are implemented */
     private final AddressBook addressBook;
     /** metrics related to consensus */
@@ -195,25 +194,33 @@ public class ConsensusImpl extends ThreadSafeConsensusInfo implements Consensus 
     /**
      * Constructs an empty object (no events) to keep track of elections and calculate consensus.
      *
-     * @param config consensus configuration
+     * @param platformContext  the platform context containing configuration
      * @param consensusMetrics metrics related to consensus
-     * @param addressBook the global address book, which never changes
-     * @param ancientMode describes how we are currently computing "ancientness" of events
+     * @param addressBook      the global address book, which never changes
      */
     public ConsensusImpl(
-            @NonNull final ConsensusConfig config,
+            @NonNull final PlatformContext platformContext,
             @NonNull final ConsensusMetrics consensusMetrics,
-            @NonNull final AddressBook addressBook,
-            @NonNull final AncientMode ancientMode) {
-        super(config, new SequentialRingBuffer<>(ConsensusConstants.ROUND_FIRST, config.roundsExpired() * 2));
-        this.config = config;
+            @NonNull final AddressBook addressBook) {
+        super(
+                platformContext.getConfiguration().getConfigData(ConsensusConfig.class),
+                new SequentialRingBuffer<>(
+                        ConsensusConstants.ROUND_FIRST,
+                        platformContext
+                                        .getConfiguration()
+                                        .getConfigData(ConsensusConfig.class)
+                                        .roundsExpired()
+                                * 2));
         this.consensusMetrics = consensusMetrics;
 
         // until we implement address book changes, we will just use the use this address book
         this.addressBook = addressBook;
 
         this.rounds = new ConsensusRounds(config, getStorage(), addressBook);
-        this.ancientMode = Objects.requireNonNull(ancientMode);
+        this.ancientMode = platformContext
+                .getConfiguration()
+                .getConfigData(EventConfig.class)
+                .getAncientMode();
     }
 
     @Override

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -70,7 +70,6 @@ import com.swirlds.platform.components.state.StateManagementComponent;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.config.ThreadConfig;
 import com.swirlds.platform.config.TransactionConfig;
-import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.consensus.NonAncientEventWindow;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.crypto.KeysAndCerts;
@@ -751,11 +750,7 @@ public class SwirldsPlatform implements Platform {
                 intakeEventCounter,
                 () -> emergencyState.getState("emergency reconnect")) {};
 
-        consensusRef.set(new ConsensusImpl(
-                platformContext.getConfiguration().getConfigData(ConsensusConfig.class),
-                consensusMetrics,
-                getAddressBook(),
-                ancientMode));
+        consensusRef.set(new ConsensusImpl(platformContext, consensusMetrics, getAddressBook()));
 
         if (startedFromGenesis) {
             initialAncientThreshold = 0;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ThreadSafeConsensusInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ThreadSafeConsensusInfo.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 public class ThreadSafeConsensusInfo implements GraphGenerations, RoundNumberProvider {
     private static final Logger LOG = LogManager.getLogger(ThreadSafeConsensusInfo.class);
 
-    private final ConsensusConfig config;
+    protected final ConsensusConfig config;
     private final SequentialRingBuffer<MinimumJudgeInfo> storage;
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ThreadSafeConsensusInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ThreadSafeConsensusInfo.java
@@ -16,6 +16,8 @@
 
 package com.swirlds.platform.consensus;
 
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.LogMarker;
 import com.swirlds.platform.state.MinimumJudgeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -23,8 +25,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * All information provided by {@link com.swirlds.platform.Consensus} that needs to be accessed at
- * any time by any thread.
+ * All information provided by {@link com.swirlds.platform.Consensus} that needs to be accessed at any time by any
+ * thread.
  */
 public class ThreadSafeConsensusInfo implements GraphGenerations, RoundNumberProvider {
     private static final Logger LOG = LogManager.getLogger(ThreadSafeConsensusInfo.class);
@@ -33,8 +35,8 @@ public class ThreadSafeConsensusInfo implements GraphGenerations, RoundNumberPro
     private final SequentialRingBuffer<MinimumJudgeInfo> storage;
 
     /**
-     * The minimum judge generation number from the oldest non-expired round, if we have expired any
-     * rounds. Else, this is {@link GraphGenerations#FIRST_GENERATION}.
+     * The minimum judge generation number from the oldest non-expired round, if we have expired any rounds. Else, this
+     * is {@link GraphGenerations#FIRST_GENERATION}.
      *
      * <p>Updated only on consensus thread, read concurrently from gossip threads.
      */
@@ -44,35 +46,35 @@ public class ThreadSafeConsensusInfo implements GraphGenerations, RoundNumberPro
     private volatile long minGenNonAncient = GraphGenerations.FIRST_GENERATION;
 
     /**
-     * The minimum judge generation number from the most recent fame-decided round, if there is one.
-     * Else, this is {@link GraphGenerations#FIRST_GENERATION}.
+     * The minimum judge generation number from the most recent fame-decided round, if there is one. Else, this is
+     * {@link GraphGenerations#FIRST_GENERATION}.
      *
      * <p>Updated only on consensus thread, read concurrently from gossip threads.
      */
     private volatile long maxRoundGeneration = GraphGenerations.FIRST_GENERATION;
 
     /**
-     * maximum round number of all events stored in "storage", or -1 if none. This is the max round
-     * created of all events ever added to the hashgraph.
+     * maximum round number of all events stored in "storage", or -1 if none. This is the max round created of all
+     * events ever added to the hashgraph.
      */
     private volatile long maxRound = ConsensusConstants.ROUND_UNDEFINED;
     /**
-     * minimum round number of all events stored in "storage", or -1 if none. This may not be the min
-     * round created of all events ever added to the hashgraph, since some of the older rounds may
-     * have been decided and discarded.
+     * minimum round number of all events stored in "storage", or -1 if none. This may not be the min round created of
+     * all events ever added to the hashgraph, since some of the older rounds may have been decided and discarded.
      */
     private volatile long minRound = ConsensusConstants.ROUND_UNDEFINED;
     /** fame has been decided for all rounds less than this, but not for this round. */
     private volatile long fameDecidedBelow = ConsensusConstants.ROUND_FIRST;
 
     /**
-     * @param config consensus configuration
-     * @param storage round storage
+     * @param platformContext platform context
      */
-    public ThreadSafeConsensusInfo(
-            @NonNull final ConsensusConfig config, @NonNull final SequentialRingBuffer<MinimumJudgeInfo> storage) {
-        this.config = config;
-        this.storage = storage;
+    public ThreadSafeConsensusInfo(@NonNull final PlatformContext platformContext) {
+        final Configuration config = platformContext.getConfiguration();
+        this.config = config.getConfigData(ConsensusConfig.class);
+        this.storage = new SequentialRingBuffer<>(
+                ConsensusConstants.ROUND_FIRST,
+                config.getConfigData(ConsensusConfig.class).roundsExpired() * 2);
     }
 
     /**

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/GenerateConsensus.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/GenerateConsensus.java
@@ -16,15 +16,16 @@
 
 package com.swirlds.platform.test.consensus;
 
-import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.consensus.ConsensusConfig;
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.test.fixtures.event.generator.StandardGraphGenerator;
 import com.swirlds.platform.test.fixtures.event.source.EventSource;
 import com.swirlds.platform.test.fixtures.event.source.StandardEventSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 /**
@@ -45,13 +46,12 @@ public final class GenerateConsensus {
      * @return consensus rounds
      */
     public static Deque<ConsensusRound> generateConsensusRounds(
-            final int numNodes, final int numEvents, final long seed) {
+            @NonNull PlatformContext platformContext, final int numNodes, final int numEvents, final long seed) {
+        Objects.requireNonNull(platformContext);
         final List<EventSource<?>> eventSources = new ArrayList<>();
         IntStream.range(0, numNodes).forEach(i -> eventSources.add(new StandardEventSource(false)));
         final StandardGraphGenerator generator = new StandardGraphGenerator(seed, eventSources);
-        final TestIntake intake = new TestIntake(
-                generator.getAddressBook(),
-                new TestConfigBuilder().getOrCreateConfig().getConfigData(ConsensusConfig.class));
+        final TestIntake intake = new TestIntake(platformContext, generator.getAddressBook());
 
         // generate events and feed them to consensus
         for (int i = 0; i < numEvents; i++) {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
@@ -24,15 +24,12 @@ import static org.mockito.Mockito.mock;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.common.wiring.model.WiringModel;
 import com.swirlds.common.wiring.schedulers.TaskScheduler;
 import com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType;
-import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.Consensus;
 import com.swirlds.platform.ConsensusImpl;
 import com.swirlds.platform.components.ConsensusEngine;
-import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.consensus.NonAncientEventWindow;
 import com.swirlds.platform.event.GossipEvent;
@@ -76,21 +73,16 @@ public class TestIntake implements LoadableFromSignedState {
     private final WiringModel model;
 
     /**
+     * @param platformContext the platform context used to configure this intake.
      * @param addressBook the address book used by this intake
      */
-    public TestIntake(@NonNull final AddressBook addressBook, @NonNull final ConsensusConfig consensusConfig) {
+    public TestIntake(@NonNull PlatformContext platformContext, @NonNull final AddressBook addressBook) {
         final NodeId selfId = new NodeId(0);
 
         final Time time = Time.getCurrent();
         output = new ConsensusOutput(time);
 
-        // FUTURE WORK: Broaden this test sweet to include testing ancient threshold via birth round.
-        consensus = new ConsensusImpl(
-                consensusConfig, ConsensusUtils.NOOP_CONSENSUS_METRICS, addressBook, GENERATION_THRESHOLD);
-
-        final PlatformContext platformContext = TestPlatformContextBuilder.create()
-                .withConfiguration(new TestConfigBuilder().getOrCreateConfig())
-                .build();
+        consensus = new ConsensusImpl(platformContext, ConsensusUtils.NOOP_CONSENSUS_METRICS, addressBook);
 
         shadowGraph = new Shadowgraph(platformContext, mock(AddressBook.class));
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestNode.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestNode.java
@@ -18,9 +18,8 @@ package com.swirlds.platform.test.consensus.framework;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.Consensus;
-import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.test.consensus.TestIntake;
 import com.swirlds.platform.test.event.emitter.EventEmitter;
@@ -42,7 +41,7 @@ public class ConsensusTestNode {
      * Creates a new instance.
      *
      * @param eventEmitter the emitter of events
-     * @param intake the instance to apply events to
+     * @param intake       the instance to apply events to
      */
     public ConsensusTestNode(@NonNull final EventEmitter<?> eventEmitter, @NonNull final TestIntake intake) {
         this.eventEmitter = eventEmitter;
@@ -53,14 +52,16 @@ public class ConsensusTestNode {
     /**
      * Creates a new instance with a freshly seeded {@link EventEmitter}.
      *
-     * @param eventEmitter the emitter of events
+     * @param platformContext the platform context
+     * @param eventEmitter    the emitter of events
      */
-    public static @NonNull ConsensusTestNode genesisContext(@NonNull final EventEmitter<?> eventEmitter) {
+    public static @NonNull ConsensusTestNode genesisContext(
+            @NonNull final PlatformContext platformContext, @NonNull final EventEmitter<?> eventEmitter) {
         return new ConsensusTestNode(
                 eventEmitter,
                 new TestIntake(
-                        eventEmitter.getGraphGenerator().getAddressBook(),
-                        new TestConfigBuilder().getOrCreateConfig().getConfigData(ConsensusConfig.class)));
+                        Objects.requireNonNull(platformContext),
+                        eventEmitter.getGraphGenerator().getAddressBook()));
     }
 
     /** Simulates a restart on a node */
@@ -75,21 +76,19 @@ public class ConsensusTestNode {
     }
 
     /**
-     * Create a new {@link ConsensusTestNode} that will be created by simulating a reconnect with
-     * this context
+     * Create a new {@link ConsensusTestNode} that will be created by simulating a reconnect with this context
      *
+     * @param platformContext the platform context
      * @return a new {@link ConsensusTestNode}
      */
-    public @NonNull ConsensusTestNode reconnect() {
+    public @NonNull ConsensusTestNode reconnect(@NonNull final PlatformContext platformContext) {
         // create a new context
         final EventEmitter<?> newEmitter = eventEmitter.cleanCopy(random.nextLong());
         newEmitter.reset();
 
         final ConsensusTestNode consensusTestNode = new ConsensusTestNode(
                 newEmitter,
-                new TestIntake(
-                        newEmitter.getGraphGenerator().getAddressBook(),
-                        new TestConfigBuilder().getOrCreateConfig().getConfigData(ConsensusConfig.class)));
+                new TestIntake(platformContext, newEmitter.getGraphGenerator().getAddressBook()));
         consensusTestNode.intake.loadSnapshot(
                 Objects.requireNonNull(getOutput().getConsensusRounds().peekLast())
                         .getSnapshot());

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestOrchestrator.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/ConsensusTestOrchestrator.java
@@ -16,12 +16,14 @@
 
 package com.swirlds.platform.test.consensus.framework;
 
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.EventConstants;
 import com.swirlds.platform.test.consensus.framework.validation.ConsensusOutputValidation;
 import com.swirlds.platform.test.consensus.framework.validation.Validations;
 import com.swirlds.platform.test.fixtures.event.generator.GraphGenerator;
 import com.swirlds.platform.test.gui.TestGuiSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -39,9 +41,13 @@ public class ConsensusTestOrchestrator {
         this.totalEventNum = totalEventNum;
     }
 
-    /** Adds a new node to the test context by simulating a reconnect */
-    public void addReconnectNode() {
-        final ConsensusTestNode node = nodes.get(0).reconnect();
+    /**
+     * Adds a new node to the test context by simulating a reconnect
+     *
+     * @param platformContext the platform context to use for the new node
+     */
+    public void addReconnectNode(@NonNull PlatformContext platformContext) {
+        final ConsensusTestNode node = nodes.get(0).reconnect(platformContext);
         node.getEventEmitter().setCheckpoint(currentSequence);
         node.addEvents(currentSequence);
         nodes.add(node);
@@ -116,8 +122,8 @@ public class ConsensusTestOrchestrator {
     }
 
     /**
-     * Restarts all nodes with events and generations stored in the signed state. This is the
-     * currently implemented restart, it discards all non-consensus events.
+     * Restarts all nodes with events and generations stored in the signed state. This is the currently implemented
+     * restart, it discards all non-consensus events.
      */
     public void restartAllNodes() {
         final long lastRoundDecided = nodes.get(0).getConsensus().getLastRoundDecided();
@@ -134,8 +140,8 @@ public class ConsensusTestOrchestrator {
     }
 
     /**
-     * Configures the graph generators of all nodes with the given configurator. This must be done
-     * for all nodes so that the generators generate the same graphs
+     * Configures the graph generators of all nodes with the given configurator. This must be done for all nodes so that
+     * the generators generate the same graphs
      */
     public ConsensusTestOrchestrator configGenerators(final Consumer<GraphGenerator<?>> configurator) {
         for (final ConsensusTestNode node : nodes) {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/TestInput.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/framework/TestInput.java
@@ -16,11 +16,20 @@
 
 package com.swirlds.platform.test.consensus.framework;
 
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.WeightGenerator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public record TestInput(int numberOfNodes, @NonNull WeightGenerator weightGenerator, long seed, int eventsToGenerate) {
+/**
+ * Holds the input to a consensus test.
+ */
+public record TestInput(
+        @NonNull PlatformContext platformContext,
+        int numberOfNodes,
+        @NonNull WeightGenerator weightGenerator,
+        long seed,
+        int eventsToGenerate) {
     public @NonNull TestInput setNumberOfNodes(int numberOfNodes) {
-        return new TestInput(numberOfNodes, weightGenerator, seed, eventsToGenerate);
+        return new TestInput(platformContext, numberOfNodes, weightGenerator, seed, eventsToGenerate);
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/gui/TestGuiSource.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/gui/TestGuiSource.java
@@ -16,8 +16,7 @@
 
 package com.swirlds.platform.test.gui;
 
-import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.consensus.ConsensusConfig;
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.gui.hashgraph.HashgraphGuiSource;
 import com.swirlds.platform.gui.hashgraph.internal.FinalShadowgraphGuiSource;
@@ -43,13 +42,18 @@ public class TestGuiSource {
     private final HashgraphGuiSource guiSource;
     private ConsensusSnapshot savedSnapshot;
 
-    public TestGuiSource(final long seed, final int numNodes) {
+    /**
+     * Construct a {@link TestGuiSource} with the given platform context, seed, and number of nodes.
+     *
+     * @param platformContext the platform context
+     * @param seed            the seed
+     * @param numNodes        the number of nodes
+     */
+    public TestGuiSource(@NonNull final PlatformContext platformContext, final long seed, final int numNodes) {
         graphGenerator = new StandardGraphGenerator(seed, generateSources(numNodes));
         graphGenerator.reset();
 
-        intake = new TestIntake(
-                graphGenerator.getAddressBook(),
-                new TestConfigBuilder().getOrCreateConfig().getConfigData(ConsensusConfig.class));
+        intake = new TestIntake(platformContext, graphGenerator.getAddressBook());
 
         guiSource = new FinalShadowgraphGuiSource(intake.getShadowGraph(), graphGenerator.getAddressBook());
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamReportingToolTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamReportingToolTest.java
@@ -16,6 +16,8 @@
 
 package com.swirlds.platform.test.cli;
 
+import static com.swirlds.platform.test.consensus.ConsensusTestArgs.DEFAULT_PLATFORM_CONTEXT;
+
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.test.fixtures.RandomUtils;
@@ -75,8 +77,8 @@ class EventStreamReportingToolTest {
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds");
 
         // generate consensus events
-        final Deque<ConsensusRound> rounds =
-                GenerateConsensus.generateConsensusRounds(numNodes, numEvents, random.nextLong());
+        final Deque<ConsensusRound> rounds = GenerateConsensus.generateConsensusRounds(
+                DEFAULT_PLATFORM_CONTEXT, numNodes, numEvents, random.nextLong());
         if (rounds.isEmpty()) {
             Assertions.fail("events are excepted to reach consensus");
         }
@@ -120,8 +122,8 @@ class EventStreamReportingToolTest {
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds");
 
         // generate consensus events
-        final Deque<ConsensusRound> rounds =
-                GenerateConsensus.generateConsensusRounds(numNodes, numEvents, random.nextLong());
+        final Deque<ConsensusRound> rounds = GenerateConsensus.generateConsensusRounds(
+                DEFAULT_PLATFORM_CONTEXT, numNodes, numEvents, random.nextLong());
         if (rounds.isEmpty()) {
             Assertions.fail("events are excepted to reach consensus");
         }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamSingleFileRepairTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/cli/EventStreamSingleFileRepairTest.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.test.cli;
 
 import static com.swirlds.platform.recovery.internal.EventStreamSingleFileRepairer.DAMAGED_SUFFIX;
 import static com.swirlds.platform.recovery.internal.EventStreamSingleFileRepairer.REPAIRED_SUFFIX;
+import static com.swirlds.platform.test.consensus.ConsensusTestArgs.DEFAULT_PLATFORM_CONTEXT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -120,8 +121,8 @@ class EventStreamSingleFileRepairTest {
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds");
 
         // generate consensus events
-        final Deque<ConsensusRound> rounds =
-                GenerateConsensus.generateConsensusRounds(numNodes, numEvents, random.nextLong());
+        final Deque<ConsensusRound> rounds = GenerateConsensus.generateConsensusRounds(
+                DEFAULT_PLATFORM_CONTEXT, numNodes, numEvents, random.nextLong());
         if (rounds.isEmpty()) {
             Assertions.fail("events are excepted to reach consensus");
         }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestArgs.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestArgs.java
@@ -24,6 +24,8 @@ import static com.swirlds.common.test.fixtures.WeightGenerators.RANDOM;
 import static com.swirlds.common.test.fixtures.WeightGenerators.RANDOM_REAL_WEIGHT;
 import static com.swirlds.common.test.fixtures.WeightGenerators.SINGLE_NODE_STRONG_MINORITY;
 
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
@@ -35,41 +37,56 @@ public class ConsensusTestArgs {
     public static final String SINGLE_NODE_STRONG_MINORITY_DESC = "Single Node With Strong Minority Weight";
     public static final String ONE_THIRD_NODES_ZERO_WEIGHT_DESC = "One Third of Nodes Have Zero Weight";
     public static final String RANDOM_WEIGHT_DESC = "Random Weight, Real Total Weight Value";
+    public static final PlatformContext DEFAULT_PLATFORM_CONTEXT =
+            TestPlatformContextBuilder.create().build();
 
     static Stream<Arguments> orderInvarianceTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(2, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(2, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(50, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(50, RANDOM, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 2, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 2, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 9, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 50, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 50, RANDOM, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> reconnectSimulation() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(4, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 4, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)),
                 Arguments.of(
-                        new ConsensusTestParams(10, SINGLE_NODE_STRONG_MINORITY, SINGLE_NODE_STRONG_MINORITY_DESC)),
-                Arguments.of(new ConsensusTestParams(10, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(10, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 4, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 10, SINGLE_NODE_STRONG_MINORITY, SINGLE_NODE_STRONG_MINORITY_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 10, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 10, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> staleEvent() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(6, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(6, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(6, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 6, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 6, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 6, ONE_THIRD_ZERO_WEIGHT, ONE_THIRD_NODES_ZERO_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> forkingTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(2, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 2, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> partitionTests() {
@@ -85,14 +102,18 @@ public class ConsensusTestArgs {
                 // of the test, not the consensus algorithm.
                 // Arguments.of(new ConsensusTestParams(5, INCREMENTING,
                 // INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 9, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> subQuorumPartitionTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(7, BALANCED_REAL_WEIGHT, BALANCED_REAL_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
                 Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 7, BALANCED_REAL_WEIGHT, BALANCED_REAL_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 9, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT,
                         9,
                         ONE_THIRD_ZERO_WEIGHT,
                         ONE_THIRD_NODES_ZERO_WEIGHT_DESC,
@@ -104,22 +125,27 @@ public class ConsensusTestArgs {
 
     static Stream<Arguments> cliqueTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(4, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 4, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 9, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> variableRateTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(2, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 2, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> nodeUsesStaleOtherParents() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(2, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 2, BALANCED, BALANCED_WEIGHT_DESC)),
                 Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT,
                         4,
                         INCREMENTING,
                         INCREMENTAL_NODE_WEIGHT_DESC,
@@ -127,46 +153,58 @@ public class ConsensusTestArgs {
                         // than what was previously
                         // set
                         458078453642476240L)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> nodeProvidesStaleOtherParents() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> quorumOfNodesGoDownTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(2, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 2, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> subQuorumOfNodesGoDownTests() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(2, BALANCED, BALANCED_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 2, BALANCED, BALANCED_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 4, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(
+                        new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 9, RANDOM_REAL_WEIGHT, RANDOM_WEIGHT_DESC)));
     }
 
     static Stream<Arguments> ancientEventTests() {
-        return Stream.of(Arguments.of(new ConsensusTestParams(4, BALANCED, BALANCED_WEIGHT_DESC)));
+        return Stream.of(
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 4, BALANCED, BALANCED_WEIGHT_DESC)));
     }
 
     public static Stream<Arguments> restartWithEventsParams() {
         return Stream.of(
-                Arguments.of(new ConsensusTestParams(5, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(10, RANDOM, RANDOM_WEIGHT_DESC)),
-                Arguments.of(new ConsensusTestParams(20, RANDOM, RANDOM_WEIGHT_DESC)));
+                Arguments.of(new ConsensusTestParams(
+                        DEFAULT_PLATFORM_CONTEXT, 5, INCREMENTING, INCREMENTAL_NODE_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 10, RANDOM, RANDOM_WEIGHT_DESC)),
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 20, RANDOM, RANDOM_WEIGHT_DESC)));
     }
 
     public static Stream<Arguments> migrationTestParams() {
-        return Stream.of(Arguments.of(new ConsensusTestParams(27, RANDOM, RANDOM_WEIGHT_DESC)));
+        return Stream.of(
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 27, RANDOM, RANDOM_WEIGHT_DESC)));
     }
 
     public static Stream<Arguments> nodeRemoveTestParams() {
-        return Stream.of(Arguments.of(new ConsensusTestParams(4, RANDOM, RANDOM_WEIGHT_DESC)));
+        return Stream.of(
+                Arguments.of(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 4, RANDOM, RANDOM_WEIGHT_DESC)));
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestDefinitions.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestDefinitions.java
@@ -529,7 +529,7 @@ public final class ConsensusTestDefinitions {
         orchestrator.generateEvents(0.5);
         orchestrator.validate(
                 Validations.standard().ratios(EventRatioValidation.blank().setMinimumConsensusRatio(0.5)));
-        orchestrator.addReconnectNode();
+        orchestrator.addReconnectNode(input.platformContext());
 
         orchestrator.clearOutput();
         orchestrator.generateEvents(0.5);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestParams.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestParams.java
@@ -16,9 +16,16 @@
 
 package com.swirlds.platform.test.consensus;
 
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.WeightGenerator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
-public record ConsensusTestParams(int numNodes, WeightGenerator weightGenerator, String weightDesc, long... seeds) {
+public record ConsensusTestParams(
+        @NonNull PlatformContext platformContext,
+        int numNodes,
+        @NonNull WeightGenerator weightGenerator,
+        @NonNull String weightDesc,
+        long... seeds) {
     @Override
     public String toString() {
         return numNodes + " nodes, " + weightDesc;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestRunner.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestRunner.java
@@ -51,13 +51,15 @@ public class ConsensusTestRunner {
             for (final long seed : params.seeds()) {
                 System.out.println("Running seed: " + seed);
 
-                test.accept(new TestInput(params.numNodes(), params.weightGenerator(), seed, eventsToGenerate));
+                test.accept(new TestInput(
+                        params.platformContext(), params.numNodes(), params.weightGenerator(), seed, eventsToGenerate));
             }
 
             for (int i = 0; i < iterations; i++) {
                 final long seed = new Random().nextLong();
                 System.out.println("Running seed: " + seed);
-                test.accept(new TestInput(params.numNodes(), params.weightGenerator(), seed, eventsToGenerate));
+                test.accept(new TestInput(
+                        params.platformContext(), params.numNodes(), params.weightGenerator(), seed, eventsToGenerate));
             }
         } catch (final Throwable e) {
             throw new RuntimeException(e);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.test.consensus;
 
 import static com.swirlds.common.test.fixtures.WeightGenerators.RANDOM;
+import static com.swirlds.platform.test.consensus.ConsensusTestArgs.DEFAULT_PLATFORM_CONTEXT;
 import static com.swirlds.platform.test.consensus.ConsensusTestArgs.RANDOM_WEIGHT_DESC;
 
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
@@ -253,7 +254,7 @@ class ConsensusTests {
     void syntheticSnapshotTest() {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::syntheticSnapshot)
-                .setParams(new ConsensusTestParams(4, RANDOM, RANDOM_WEIGHT_DESC))
+                .setParams(new ConsensusTestParams(DEFAULT_PLATFORM_CONTEXT, 4, RANDOM, RANDOM_WEIGHT_DESC))
                 .setIterations(NUM_ITER)
                 .run();
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/IntakeAndConsensusTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/IntakeAndConsensusTests.java
@@ -18,10 +18,11 @@ package com.swirlds.platform.test.consensus;
 
 import static com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags.TIME_CONSUMING;
 
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.consensus.ConsensusConfig_;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.EventConstants;
@@ -71,13 +72,15 @@ class IntakeAndConsensusTests {
                 .withValue(ConsensusConfig_.ROUNDS_EXPIRED, 25)
                 .getOrCreateConfig();
 
-        final ConsensusConfig consensusConfig = configuration.getConfigData(ConsensusConfig.class);
+        final PlatformContext platformContext = TestPlatformContextBuilder.create()
+                .withConfiguration(configuration)
+                .build();
 
         // the generated events are first fed into consensus so that round created is calculated before we start
         // using them
-        final GeneratorWithConsensus generator = new GeneratorWithConsensus(seed, numNodes, consensusConfig);
-        final TestIntake node1 = new TestIntake(generator.getAddressBook(), consensusConfig);
-        final TestIntake node2 = new TestIntake(generator.getAddressBook(), consensusConfig);
+        final GeneratorWithConsensus generator = new GeneratorWithConsensus(platformContext, seed, numNodes);
+        final TestIntake node1 = new TestIntake(platformContext, generator.getAddressBook());
+        final TestIntake node2 = new TestIntake(platformContext, generator.getAddressBook());
 
         // first we generate events regularly, until we have some ancient rounds
         final int firstBatchSize = 5000;
@@ -184,11 +187,13 @@ class IntakeAndConsensusTests {
         private final TestIntake intake;
 
         @SuppressWarnings("unchecked")
-        public GeneratorWithConsensus(final long seed, final int numNodes, final ConsensusConfig consensusConfig) {
+        public GeneratorWithConsensus(
+                @NonNull final PlatformContext platformContext, final long seed, final int numNodes) {
+            Objects.requireNonNull(platformContext);
             final List<StandardEventSource> eventSources =
                     Stream.generate(StandardEventSource::new).limit(numNodes).toList();
             generator = new StandardGraphGenerator(seed, (List<EventSource<?>>) (List<?>) eventSources);
-            intake = new TestIntake(generator.getAddressBook(), consensusConfig);
+            intake = new TestIntake(platformContext, generator.getAddressBook());
         }
 
         @Override

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/gui/HashgraphGuiTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/gui/HashgraphGuiTest.java
@@ -16,6 +16,8 @@
 
 package com.swirlds.platform.test.gui;
 
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +29,9 @@ class HashgraphGuiTest {
         final int numNodes = 4;
         final int initialEvents = 0;
 
-        final TestGuiSource guiSource = new TestGuiSource(seed, numNodes);
+        final PlatformContext platformContext =
+                TestPlatformContextBuilder.create().build();
+        final TestGuiSource guiSource = new TestGuiSource(platformContext, seed, numNodes);
         guiSource.generateEvents(initialEvents);
         guiSource.runGui();
     }


### PR DESCRIPTION
**Description**:
This PR passes the `PlatformContext` to configure `ConsensusImpl` and related tests.  Isolating this work to this PR will make the PR for consensus supporting birthRound based ancient thresholds less cluttered. 

**Related issue(s)**:

Fixes #11953 

**Notes for reviewer**:
No functionality should have changed.  

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
