### PR TITLE
fix: 11964: Hashes RAM to disk threshold is incorrect for legacy MerkleDb tables, fileStore and smartContractIterableKvStore

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -70,7 +70,7 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
         @Positive @ConfigProperty(defaultValue = "500000000") long maxNumOfKeys,
-        @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,
+        @Min(0) @ConfigProperty(defaultValue = "0") long hashesRamToDiskThreshold,
         @Min(1) @ConfigProperty(defaultValue = "3") int compactionThreads,
         @ConstraintMethod("minNumberOfFilesInCompactionValidation") @ConfigProperty(defaultValue = "8")
                 int minNumberOfFilesInCompaction,


### PR DESCRIPTION
Fix summary:
* Default value for `hashesRamToDiskThreshold` MerkleDb config is set to 0
* On nodes with this threshold set to 0 in MerkleDb metadata, it will result in correct threshold value used. All hashes will be loaded from disk
* On nodes with a different threshold value, the overridden value from loaded MerkleDb metadata will be used, the default will be ignored

Co-authored-by: Oleg Mazurov <oleg.mazurov@swirldslabs.com>
Fixes: https://github.com/hashgraph/hedera-services/issues/11964
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
