### PR TITLE
fix: use Bytes instead of String for SCHEDULES_BY_EQUALITY_KEY

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ReadableScheduleStoreImpl.java
@@ -17,13 +17,14 @@
 package com.hedera.node.app.service.schedule.impl;
 
 import com.hedera.hapi.node.base.ScheduleID;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.primitives.ProtoString;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.state.schedule.ScheduleList;
 import com.hedera.node.app.service.schedule.ReadableScheduleStore;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import com.hedera.node.app.spi.state.ReadableStates;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
@@ -40,7 +41,7 @@ public class ReadableScheduleStoreImpl implements ReadableScheduleStore {
 
     private final ReadableKVState<ScheduleID, Schedule> schedulesById;
     private final ReadableKVState<ProtoLong, ScheduleList> schedulesByExpirationSecond;
-    private final ReadableKVState<ProtoString, ScheduleList> schedulesByStringHash;
+    private final ReadableKVState<ProtoBytes, ScheduleList> schedulesByStringHash;
 
     /**
      * Create a new {@link ReadableScheduleStore} instance.
@@ -71,8 +72,8 @@ public class ReadableScheduleStoreImpl implements ReadableScheduleStore {
     @Override
     @Nullable
     public List<Schedule> getByEquality(final @NonNull Schedule scheduleToMatch) {
-        String stringHash = ScheduleStoreUtility.calculateStringHash(scheduleToMatch);
-        final ScheduleList inStateValue = schedulesByStringHash.get(new ProtoString(stringHash));
+        Bytes bytesHash = ScheduleStoreUtility.calculateBytesHash(scheduleToMatch);
+        final ScheduleList inStateValue = schedulesByStringHash.get(new ProtoBytes(bytesHash));
         return inStateValue != null ? inStateValue.schedules() : null;
     }
 

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
@@ -18,10 +18,10 @@ package com.hedera.node.app.service.schedule.impl;
 
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.hapi.node.state.schedule.Schedule;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -32,7 +32,7 @@ public final class ScheduleStoreUtility {
     // @todo('7773') This requires rebuilding the equality virtual map on migration,
     //      because it's different from ScheduleVirtualValue (and must be, due to PBJ shift)
     @SuppressWarnings("UnstableApiUsage")
-    public static String calculateStringHash(@NonNull final Schedule scheduleToHash) {
+    public static Bytes calculateBytesHash(@NonNull final Schedule scheduleToHash) {
         Objects.requireNonNull(scheduleToHash);
         final Hasher hasher = Hashing.sha256().newHasher();
         if (scheduleToHash.memo() != null) {
@@ -49,7 +49,7 @@ public final class ScheduleStoreUtility {
         //               differential testing completes
         hasher.putLong(scheduleToHash.providedExpirationSecond());
         hasher.putBoolean(scheduleToHash.waitForExpiry());
-        return hasher.hash().toString();
+        return Bytes.wrap(hasher.hash().asBytes());
     }
 
     @SuppressWarnings("UnstableApiUsage")
@@ -57,13 +57,6 @@ public final class ScheduleStoreUtility {
         final byte[] keyBytes = Key.PROTOBUF.toBytes(keyToAdd).toByteArray();
         hasher.putInt(keyBytes.length);
         hasher.putBytes(keyBytes);
-    }
-
-    @SuppressWarnings("UnstableApiUsage")
-    private static void addToHash(final Hasher hasher, final AccountID accountToAdd) {
-        final byte[] accountIdBytes = AccountID.PROTOBUF.toBytes(accountToAdd).toByteArray();
-        hasher.putInt(accountIdBytes.length);
-        hasher.putBytes(accountIdBytes);
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImpl.java
@@ -20,8 +20,8 @@ import static java.util.Collections.emptyList;
 
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.primitives.ProtoString;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.state.schedule.ScheduleList;
 import com.hedera.node.app.service.schedule.WritableScheduleStore;
@@ -49,7 +49,7 @@ public class WritableScheduleStoreImpl extends ReadableScheduleStoreImpl impleme
     private static final String SCHEDULE_MISSING_FOR_DELETE_MESSAGE =
             "Schedule to be deleted, %1$s, not found in state.";
     private final WritableKVState<ScheduleID, Schedule> schedulesByIdMutable;
-    private final WritableKVState<ProtoString, ScheduleList> schedulesByEqualityMutable;
+    private final WritableKVState<ProtoBytes, ScheduleList> schedulesByEqualityMutable;
     private final WritableKVState<ProtoLong, ScheduleList> schedulesByExpirationMutable;
 
     /**
@@ -107,7 +107,7 @@ public class WritableScheduleStoreImpl extends ReadableScheduleStoreImpl impleme
     @Override
     public void put(@NonNull final Schedule scheduleToAdd) {
         schedulesByIdMutable.put(scheduleToAdd.scheduleIdOrThrow(), scheduleToAdd);
-        final ProtoString newHash = new ProtoString(ScheduleStoreUtility.calculateStringHash(scheduleToAdd));
+        final ProtoBytes newHash = new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(scheduleToAdd));
         final ScheduleList inStateEquality = schedulesByEqualityMutable.get(newHash);
         List<Schedule> byEquality =
                 inStateEquality != null ? new LinkedList<>(inStateEquality.schedulesOrElse(emptyList())) : null;
@@ -159,7 +159,7 @@ public class WritableScheduleStoreImpl extends ReadableScheduleStoreImpl impleme
                 for (final var schedule : scheduleList.schedules()) {
                     schedulesByIdMutable.remove(schedule.scheduleIdOrThrow());
 
-                    final ProtoString hash = new ProtoString(ScheduleStoreUtility.calculateStringHash(schedule));
+                    final ProtoBytes hash = new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(schedule));
                     schedulesByEqualityMutable.remove(hash);
                     logger.info("Purging expired schedule {} from state.", schedule.scheduleIdOrThrow());
                 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/schemas/InitialModServiceScheduleSchema.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/schemas/InitialModServiceScheduleSchema.java
@@ -22,8 +22,8 @@ import static com.hedera.node.app.service.schedule.impl.ScheduleServiceImpl.SCHE
 
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.primitives.ProtoString;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.state.schedule.ScheduleList;
 import com.hedera.node.app.service.mono.state.merkle.MerkleScheduledTransactions;
@@ -143,7 +143,7 @@ public final class InitialModServiceScheduleSchema extends Schema {
             log.info("BBM: finished schedule by expiration migration");
 
             log.info("BBM: doing schedule by equality migration");
-            final WritableKVState<ProtoString, ScheduleList> schedulesByEquality =
+            final WritableKVState<ProtoBytes, ScheduleList> schedulesByEquality =
                     ctx.newStates().get(SCHEDULES_BY_EQUALITY_KEY);
             fs.byEquality().forEachNode((scheduleEqualityVirtualKey, sevv) -> {
                 sevv.getIds().forEach(new BiConsumer<String, Long>() {
@@ -152,7 +152,7 @@ public final class InitialModServiceScheduleSchema extends Schema {
                         var schedule = schedulesById.get(
                                 ScheduleID.newBuilder().scheduleNum(scheduleId).build());
                         if (schedule != null) {
-                            final var equalityKey = new ProtoString(ScheduleStoreUtility.calculateStringHash(schedule));
+                            final var equalityKey = new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(schedule));
                             final var existingList = schedulesByEquality.get(equalityKey);
                             final List<Schedule> existingSchedules = existingList == null
                                     ? new ArrayList<>()
@@ -190,7 +190,7 @@ public final class InitialModServiceScheduleSchema extends Schema {
         return StateDefinition.inMemory(SCHEDULES_BY_EXPIRY_SEC_KEY, ProtoLong.PROTOBUF, ScheduleList.PROTOBUF);
     }
 
-    private static StateDefinition<ProtoString, ScheduleList> schedulesByEquality() {
-        return StateDefinition.inMemory(SCHEDULES_BY_EQUALITY_KEY, ProtoString.PROTOBUF, ScheduleList.PROTOBUF);
+    private static StateDefinition<ProtoBytes, ScheduleList> schedulesByEquality() {
+        return StateDefinition.inMemory(SCHEDULES_BY_EQUALITY_KEY, ProtoBytes.PROTOBUF, ScheduleList.PROTOBUF);
     }
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/schemas/InitialModServiceScheduleSchema.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/schemas/InitialModServiceScheduleSchema.java
@@ -27,9 +27,6 @@ import com.hedera.hapi.node.state.primitives.ProtoLong;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.state.schedule.ScheduleList;
 import com.hedera.node.app.service.mono.state.merkle.MerkleScheduledTransactions;
-import com.hedera.node.app.service.mono.state.submerkle.RichInstant;
-import com.hedera.node.app.service.mono.state.virtual.schedule.ScheduleSecondVirtualValue;
-import com.hedera.node.app.service.mono.state.virtual.temporal.SecondSinceEpocVirtualKey;
 import com.hedera.node.app.service.schedule.impl.ScheduleStoreUtility;
 import com.hedera.node.app.service.schedule.impl.codec.ScheduleServiceStateTranslator;
 import com.hedera.node.app.spi.state.MigrationContext;
@@ -48,7 +45,6 @@ import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.collections.api.block.procedure.primitive.LongProcedure;
-import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 
 /**
  * General schema for the schedule service
@@ -96,73 +92,68 @@ public final class InitialModServiceScheduleSchema extends Schema {
                     throw new RuntimeException(e);
                 }
             });
-            if (schedulesById.isModified()) ((WritableKVStateBase) schedulesById).commit();
+            if (schedulesById.isModified()) ((WritableKVStateBase<?, ?>) schedulesById).commit();
             log.info("BBM: finished schedule by id migration");
 
             log.info("BBM: doing schedule by expiration migration");
             final WritableKVState<ProtoLong, ScheduleList> schedulesByExpiration =
                     ctx.newStates().get(SCHEDULES_BY_EXPIRY_SEC_KEY);
-            fs.byExpirationSecond()
-                    .forEachNode((secondSinceEpocVirtualKey, sVv) -> sVv.getIds().forEach(new BiConsumer<RichInstant, ImmutableLongList>() {
-                        @Override
-                        public void accept(RichInstant richInstant, ImmutableLongList scheduleIds) {
+            fs.byExpirationSecond().forEachNode((secondSinceEpocVirtualKey, sVv) -> sVv.getIds()
+                    .forEach((richInstant, scheduleIds) -> {
+                        List<Schedule> schedules = new ArrayList<>();
+                        scheduleIds.forEach((LongProcedure) scheduleId -> {
+                            var schedule = schedulesById.get(ScheduleID.newBuilder()
+                                    .scheduleNum(scheduleId)
+                                    .build());
+                            if (schedule != null) schedules.add(schedule);
+                            else {
+                                log.info("BBM: ERROR: no schedule for expiration->id "
+                                        + richInstant
+                                        + " -> "
+                                        + scheduleId);
+                            }
+                        });
 
-                            List<Schedule> schedules = new ArrayList<>();
-                            scheduleIds.forEach((LongProcedure) scheduleId -> {
-                                var schedule = schedulesById.get(ScheduleID.newBuilder()
-                                        .scheduleNum(scheduleId)
-                                        .build());
-                                if (schedule != null) schedules.add(schedule);
-                                else {
-                                    log.info("BBM: ERROR: no schedule for expiration->id "
-                                            + richInstant
-                                            + " -> "
-                                            + scheduleId);
-                                }
-                            });
-
-                            schedulesByExpiration.put(
-                                    ProtoLong.newBuilder()
-                                            .value(secondSinceEpocVirtualKey.getKeyAsLong())
-                                            .build(),
-                                    ScheduleList.newBuilder()
-                                            .schedules(schedules)
-                                            .build());
-                        }
+                        schedulesByExpiration.put(
+                                ProtoLong.newBuilder()
+                                        .value(secondSinceEpocVirtualKey.getKeyAsLong())
+                                        .build(),
+                                ScheduleList.newBuilder().schedules(schedules).build());
                     }));
-            if (schedulesByExpiration.isModified()) ((WritableKVStateBase) schedulesByExpiration).commit();
+            if (schedulesByExpiration.isModified()) ((WritableKVStateBase<?, ?>) schedulesByExpiration).commit();
             log.info("BBM: finished schedule by expiration migration");
 
             log.info("BBM: doing schedule by equality migration");
             final WritableKVState<ProtoBytes, ScheduleList> schedulesByEquality =
                     ctx.newStates().get(SCHEDULES_BY_EQUALITY_KEY);
-            fs.byEquality().forEachNode((scheduleEqualityVirtualKey, sevv) -> {
-                sevv.getIds().forEach(new BiConsumer<String, Long>() {
-                    @Override
-                    public void accept(String scheduleObjHash, Long scheduleId) {
-                        var schedule = schedulesById.get(
-                                ScheduleID.newBuilder().scheduleNum(scheduleId).build());
-                        if (schedule != null) {
-                            final var equalityKey = new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(schedule));
-                            final var existingList = schedulesByEquality.get(equalityKey);
-                            final List<Schedule> existingSchedules = existingList == null
-                                    ? new ArrayList<>()
-                                    : new ArrayList<>(existingList.schedulesOrElse(Collections.emptyList()));
-                            existingSchedules.add(schedule);
-                            schedulesByEquality.put(
-                                    equalityKey,
-                                    ScheduleList.newBuilder()
-                                            .schedules(existingSchedules)
-                                            .build());
-                        } else {
-                            log.error("BBM: ERROR: no schedule for scheduleObjHash->id "
-                                    + scheduleObjHash + " -> "
-                                    + scheduleId);
+            fs.byEquality().forEachNode((scheduleEqualityVirtualKey, sevv) -> sevv.getIds()
+                    .forEach(new BiConsumer<String, Long>() {
+                        @Override
+                        public void accept(String scheduleObjHash, Long scheduleId) {
+                            var schedule = schedulesById.get(ScheduleID.newBuilder()
+                                    .scheduleNum(scheduleId)
+                                    .build());
+                            if (schedule != null) {
+                                final var equalityKey =
+                                        new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(schedule));
+                                final var existingList = schedulesByEquality.get(equalityKey);
+                                final List<Schedule> existingSchedules = existingList == null
+                                        ? new ArrayList<>()
+                                        : new ArrayList<>(existingList.schedulesOrElse(Collections.emptyList()));
+                                existingSchedules.add(schedule);
+                                schedulesByEquality.put(
+                                        equalityKey,
+                                        ScheduleList.newBuilder()
+                                                .schedules(existingSchedules)
+                                                .build());
+                            } else {
+                                log.error("BBM: ERROR: no schedule for scheduleObjHash->id "
+                                        + scheduleObjHash + " -> "
+                                        + scheduleId);
+                            }
                         }
-                    }
-                });
-            });
-            if (schedulesByEquality.isModified()) ((WritableKVStateBase) schedulesByEquality).commit();
+                    }));
+            if (schedulesByEquality.isModified()) ((WritableKVStateBase<?, ?>) schedulesByEquality).commit();
             log.info("BBM: finished schedule by equality migration");
 
             log.info("BBM: finished schedule service migration migration");

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
@@ -239,10 +239,9 @@ public class ScheduleTestBase {
 
     // ConsensusSubmitMessage,CryptoTransfer,TokenMint,TokenBurn,CryptoApproveAllowance
     protected SchedulableTransactionBody createAlternateScheduled() {
-        final SchedulableTransactionBody scheduledTxn = SchedulableTransactionBody.newBuilder()
+        return SchedulableTransactionBody.newBuilder()
                 .tokenBurn(TokenBurnTransactionBody.newBuilder())
                 .build();
-        return scheduledTxn;
     }
 
     /**
@@ -472,10 +471,9 @@ public class ScheduleTestBase {
     }
 
     private SchedulableTransactionBody createSampleScheduled() {
-        final SchedulableTransactionBody scheduledTxn = SchedulableTransactionBody.newBuilder()
+        return SchedulableTransactionBody.newBuilder()
                 .cryptoCreateAccount(CryptoCreateTransactionBody.newBuilder())
                 .build();
-        return scheduledTxn;
     }
 
     private TransactionBody alternateCreateTransaction(final TransactionBody originalTransaction) {

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/ScheduleTestBase.java
@@ -47,7 +47,6 @@ import com.hedera.hapi.node.scheduled.ScheduleCreateTransactionBody;
 import com.hedera.hapi.node.scheduled.ScheduleDeleteTransactionBody;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.primitives.ProtoString;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.state.schedule.ScheduleList;
 import com.hedera.hapi.node.state.token.Account;
@@ -132,19 +131,7 @@ public class ScheduleTestBase {
             Bytes.fromHex("9834701927540926570495640961948794713207439248567184729049081327");
     protected static final Bytes OTHER_KEY_HEX =
             Bytes.fromHex("983470192754092657adbdbeef61948794713207439248567184729049081327");
-    // A few random values for fake schedule hashes
-    protected static final String SCHEDULE_IN_STATE_SHA256 =
-            "5a89e2e2ef363aa047e2ca032cc8fbff02cf64f5536e350bc252dcbc6e76fd76";
-    protected static final String SCHEDULE_IN_STATE_0_EXPIRE_SHA256 =
-            "4a9a1bd0a6487bac0924da771d4bb62ed72391c15602eaee394991929bdde427";
-    protected static final String SCHEDULE_IN_STATE_PAYER_IS_ADMIN_SHA256 =
-            "ef76f6e13f805b9ab5ae0e6fd9fd5976aba14e1b1f7cb4ecbd07fbc298f90ee5";
-    protected static final String SCHEDULE_IN_STATE_ALTERNATE_SCHEDULED_SHA256 =
-            "1e2ec1fa33fce66166497aeffa8a0af690e257cafad02063a13191cabc2c2de3";
-    protected static final String SCHEDULE_IN_STATE_ODD_MEMO_SHA256 =
-            "7788f7de741c9ef2e7bf371095ea497a0eaed1ad9b6cba2489f34f565ee70556";
-    protected static final String SCHEDULE_IN_STATE_WAIT_EXPIRE_SHA256 =
-            "87cfae9fd8f15126af9ba8be0155c57f1cf0838c4915f4e0ea297a15d5d3a3b9";
+
     protected static final String SCHEDULED_TRANSACTION_MEMO = "Les ħ2ᛏᚺᛂ🌕 goo";
     protected static final String ODD_MEMO = "she had marvelous judgement, Don... if not particularly good taste.";
     // a few typed null values to avoid casting null
@@ -200,10 +187,10 @@ public class ScheduleTestBase {
     protected WritableKVState<ProtoBytes, AccountID> accountAliases;
     protected Map<AccountID, Account> accountsMapById;
     protected Map<ScheduleID, Schedule> scheduleMapById;
-    protected Map<ProtoString, ScheduleList> scheduleMapByEquality;
+    protected Map<ProtoBytes, ScheduleList> scheduleMapByEquality;
     protected Map<ProtoLong, ScheduleList> scheduleMapByExpiration;
     protected WritableKVState<ScheduleID, Schedule> writableById;
-    protected WritableKVState<ProtoString, ScheduleList> writableByEquality;
+    protected WritableKVState<ProtoBytes, ScheduleList> writableByEquality;
     protected WritableKVState<ProtoLong, ScheduleList> writableByExpiration;
     protected Map<String, WritableKVState<?, ?>> writableStatesMap;
     protected ReadableStates states;

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
@@ -57,7 +57,7 @@ public interface ReadableScheduleStore {
      *     These may not actually be equal to the provided schedule, and further comparison should be performed.
      */
     @Nullable
-    public List<Schedule> getByEquality(final @NonNull Schedule scheduleToMatch);
+    List<Schedule> getByEquality(final @NonNull Schedule scheduleToMatch);
 
     /**
      * Given a time as seconds since the epoch, find all schedules currently in state that expire at that time.
@@ -70,7 +70,7 @@ public interface ReadableScheduleStore {
      * @return a {@link List<Schedule>} of entries that have expiration times within the requested second.
      */
     @Nullable
-    public List<Schedule> getByExpirationSecond(final long expirationTime);
+    List<Schedule> getByExpirationSecond(final long expirationTime);
 
     /**
      * Returns the number of schedules in state, for use in enforcing creation limits.

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ReadableScheduleStore.java
@@ -42,7 +42,7 @@ public interface ReadableScheduleStore {
      * @return the schedule with the given id
      */
     @Nullable
-    Schedule get(final @Nullable ScheduleID id);
+    Schedule get(@Nullable ScheduleID id);
 
     /**
      * Get a set of schedules that are "hash equal" to the provided Schedule.


### PR DESCRIPTION
**Description**:
Update the map in state for SCHEDULES_BY_EQUALITY_KEY to use Bytes instead of String for modularized code.

**Related issue(s)**:
Fixes #11971 

