### PR TITLE
fix: 12000 Increased timeout for `ConcurrentNodeStatusTrackerTests.setsBoundValue`

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/ConcurrentNodeStatusTrackerTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/ConcurrentNodeStatusTrackerTests.java
@@ -143,7 +143,7 @@ class ConcurrentNodeStatusTrackerTests {
         final ConcurrentNodeStatusTracker tracker = new ConcurrentNodeStatusTracker(capacity);
         final ExecutorService executor = Executors.newSingleThreadExecutor();
         final Future<?> future = executor.submit(() -> producer(tracker, value, value + 1));
-        future.get(500, TimeUnit.MILLISECONDS);
+        future.get(1, TimeUnit.SECONDS);
 
         assertEquals(KNOWN, tracker.getStatus(value), "The capacity - 1 is a valid value");
         executor.shutdown();


### PR DESCRIPTION
**Description**:

Increased `future` timeout to 1 second to stabilize the test. 


**Related issue(s)**:

Fixes #12000 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
