### PR TITLE
feat(pbj): upgrade PBJ dependency to 0.8.1

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.19")
+    version("com.hedera.pbj.runtime", "0.7.23")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.7.23")
+    version("com.hedera.pbj.runtime", "0.8.1")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
@@ -116,8 +116,9 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
                 throw new IllegalStateException("initRunningHash() can only be called once");
             }
 
-            if (runningHashes.runningHash() == null) {
-                throw new IllegalArgumentException("The initial running hash cannot be null");
+            if (runningHashes.runningHash() == null
+                    || runningHashes.runningHash().equals(Bytes.EMPTY)) {
+                throw new IllegalArgumentException("The initial running hash cannot be null or empty");
             }
 
             lastRecordHashingResult = completedFuture(runningHashes.runningHash());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
@@ -124,8 +124,8 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
             throw new IllegalStateException("initRunningHash() must only be called once");
         }
 
-        if (runningHashes.runningHash() == null) {
-            throw new IllegalArgumentException("The initial running hash cannot be null");
+        if (runningHashes.runningHash() == null || runningHashes.runningHash().equals(Bytes.EMPTY)) {
+            throw new IllegalArgumentException("The initial running hash cannot be null or empty");
         }
 
         runningHash = runningHashes.runningHash();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
@@ -191,11 +191,8 @@ public final class BlockRecordFormatV7 implements BlockRecordFormat {
     }
 
     public static final class RecordStreamItemV7ProtoCodec implements Codec<RecordStreamItemV7> {
-        public @NonNull RecordStreamItemV7 parse(@NonNull ReadableSequentialData input) {
-            return new RecordStreamItemV7(null, null, null, null, 0, 0);
-        }
-
-        public @NonNull RecordStreamItemV7 parseStrict(@NonNull ReadableSequentialData input) {
+        public @NonNull RecordStreamItemV7 parse(
+                @NonNull final ReadableSequentialData input, final boolean strictMode, final int maxDepth) {
             return new RecordStreamItemV7(null, null, null, null, 0, 0);
         }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestLongCodec.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestLongCodec.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.state.merkle;
 
 import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -39,17 +40,8 @@ class TestLongCodec implements Codec<Long> {
 
     @NonNull
     @Override
-    public Long parse(@NonNull ReadableSequentialData input) {
-        Objects.requireNonNull(input);
-        return Long.valueOf(input.readLong());
-    }
-
-    @NonNull
-    @Override
-    // Suppressing the warning that this method is the same as requiresNodePayment.
-    // To be removed if that changes
-    @SuppressWarnings("java:S4144")
-    public Long parseStrict(@NonNull ReadableSequentialData input) {
+    public Long parse(@NonNull final ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         Objects.requireNonNull(input);
         return Long.valueOf(input.readLong());
     }
@@ -72,7 +64,8 @@ class TestLongCodec implements Codec<Long> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull Long value, @NonNull ReadableSequentialData input) {
+    public boolean fastEquals(@NonNull final Long value, @NonNull final ReadableSequentialData input)
+            throws ParseException {
         Objects.requireNonNull(value);
         Objects.requireNonNull(input);
         return value.equals(parse(input));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestStringCodec.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/TestStringCodec.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.state.merkle;
 
 import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -39,17 +40,10 @@ class TestStringCodec implements Codec<String> {
 
     @NonNull
     @Override
-    public String parse(final @NonNull ReadableSequentialData input) {
+    public String parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth) {
         Objects.requireNonNull(input);
         final var len = input.readInt();
         return len == 0 ? "" : input.readBytes(len).asUtf8String();
-    }
-
-    @NonNull
-    @Override
-    public String parseStrict(final @NonNull ReadableSequentialData dataInput) {
-        Objects.requireNonNull(dataInput);
-        return parse(dataInput);
     }
 
     @Override
@@ -67,7 +61,8 @@ class TestStringCodec implements Codec<String> {
     }
 
     @Override
-    public boolean fastEquals(final @NonNull String value, final @NonNull ReadableSequentialData input) {
+    public boolean fastEquals(final @NonNull String value, final @NonNull ReadableSequentialData input)
+            throws ParseException {
         Objects.requireNonNull(value);
         Objects.requireNonNull(input);
         return value.equals(parse(input));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -301,7 +301,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                         } else {
                             // check nulls as well
                             assertThat(blockRecordManager.getNMinus3RunningHash())
-                                    .isNull();
+                                    .isEqualTo(Bytes.EMPTY);
                         }
                     }
                     j += batchSize;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
@@ -108,7 +108,7 @@ abstract class StreamFileProducerTest extends AppTestBase {
             final var runningHashes = new RunningHashes(randomBytes(32), null, null, null);
             subject.initRunningHash(runningHashes);
             assertThat(subject.getRunningHash()).isEqualTo(runningHashes.runningHash());
-            assertThat(subject.getNMinus3RunningHash()).isNull();
+            assertThat(subject.getNMinus3RunningHash()).isEqualTo(Bytes.EMPTY);
         }
     }
 
@@ -247,7 +247,7 @@ abstract class StreamFileProducerTest extends AppTestBase {
 
             // Submitting a batch of records only moves the running hash forward once, because it moves forward once
             // PER USER TRANSACTION, not per record.
-            assertThat(subject.getNMinus3RunningHash()).isNull();
+            assertThat(subject.getNMinus3RunningHash()).isEqualTo(Bytes.EMPTY);
 
             final var finalRunningHash = subject.getRunningHash();
             subject.close();

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/codecs/EntityNumCodec.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/codecs/EntityNumCodec.java
@@ -27,14 +27,9 @@ import java.io.IOException;
 public class EntityNumCodec implements Codec<EntityNum> {
     @NonNull
     @Override
-    public EntityNum parse(final @NonNull ReadableSequentialData input) throws ParseException {
+    public EntityNum parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         return new EntityNum(input.readInt());
-    }
-
-    @NonNull
-    @Override
-    public EntityNum parseStrict(@NonNull ReadableSequentialData dataInput) throws ParseException {
-        return parse(dataInput);
     }
 
     @Override

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/codec/FileServiceStateTranslatorTest.java
@@ -76,28 +76,27 @@ class FileServiceStateTranslatorTest extends FileTestBase {
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoKeysAndMemo);
 
         assertArrayEquals(
-                convertedFile.data(),
-                getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys().data());
+                getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys().data(), convertedFile.data());
         assertEquals(
-                convertedFile.metadata().getExpiry(),
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .getExpiry());
+                        .getExpiry(),
+                convertedFile.metadata().getExpiry());
         assertEquals(
-                convertedFile.metadata().getMemo(),
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .getMemo());
+                        .getMemo(),
+                convertedFile.metadata().getMemo());
         assertEquals(
-                MiscUtils.describe(convertedFile.metadata().getWacl()),
                 MiscUtils.describe(getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .getWacl()));
+                        .getWacl()),
+                MiscUtils.describe(convertedFile.metadata().getWacl()));
         assertEquals(
-                convertedFile.metadata().isDeleted(),
                 getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys()
                         .metadata()
-                        .isDeleted());
+                        .isDeleted(),
+                convertedFile.metadata().isDeleted());
     }
 
     @Test
@@ -105,23 +104,21 @@ class FileServiceStateTranslatorTest extends FileTestBase {
 
         final FileMetadataAndContent convertedFile = FileServiceStateTranslator.pbjToState(fileWithNoContent);
 
-        assertArrayEquals(
-                convertedFile.data(),
-                getExpectedMonoFileMetaAndContentEmptyContent().data());
+        assertArrayEquals(getExpectedMonoFileMetaAndContentEmptyContent().data(), convertedFile.data());
         assertEquals(
-                convertedFile.metadata().getExpiry(),
-                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getExpiry());
+                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getExpiry(),
+                convertedFile.metadata().getExpiry());
         assertEquals(
-                convertedFile.metadata().getMemo(),
-                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getMemo());
+                getExpectedMonoFileMetaAndContentEmptyContent().metadata().getMemo(),
+                convertedFile.metadata().getMemo());
         assertEquals(
-                MiscUtils.describe(convertedFile.metadata().getWacl()),
                 MiscUtils.describe(getExpectedMonoFileMetaAndContentEmptyContent()
                         .metadata()
-                        .getWacl()));
+                        .getWacl()),
+                MiscUtils.describe(convertedFile.metadata().getWacl()));
         assertEquals(
-                convertedFile.metadata().isDeleted(),
-                getExpectedMonoFileMetaAndContentEmptyContent().metadata().isDeleted());
+                getExpectedMonoFileMetaAndContentEmptyContent().metadata().isDeleted(),
+                convertedFile.metadata().isDeleted());
     }
 
     @Test
@@ -210,7 +207,7 @@ class FileServiceStateTranslatorTest extends FileTestBase {
 
     private FileMetadataAndContent getExpectedMonoFileMetaAndContentWithEmptyMemoAndKeys() {
         com.hedera.node.app.service.mono.files.HFileMeta hFileMeta =
-                new HFileMeta(file.deleted(), null, file.expirationSecond(), null);
+                new HFileMeta(file.deleted(), null, file.expirationSecond(), "");
         return new FileMetadataAndContent(file.contents().toByteArray(), hFileMeta);
     }
 
@@ -219,6 +216,6 @@ class FileServiceStateTranslatorTest extends FileTestBase {
                 Key.newBuilder().keyList(file.keys()).build(), 1);
         com.hedera.node.app.service.mono.files.HFileMeta hFileMeta =
                 new HFileMeta(file.deleted(), keys, file.expirationSecond(), file.memo());
-        return new FileMetadataAndContent(null, hFileMeta);
+        return new FileMetadataAndContent(new byte[] {}, hFileMeta);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/CodecFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/CodecFactory.java
@@ -40,7 +40,8 @@ public final class CodecFactory {
         return new Codec<>() {
             @NonNull
             @Override
-            public T parse(final @NonNull ReadableSequentialData input) throws ParseException {
+            public T parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+                    throws ParseException {
                 if (input instanceof ReadableStreamingData in) {
                     return parser.parse(in);
                 } else {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/MonoMapCodecAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/codec/MonoMapCodecAdapter.java
@@ -58,7 +58,8 @@ public class MonoMapCodecAdapter {
         return new Codec<>() {
             @NonNull
             @Override
-            public T parse(final @NonNull ReadableSequentialData input) throws ParseException {
+            public T parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+                    throws ParseException {
                 final var buffer = new byte[input.readInt()];
                 input.readBytes(buffer);
                 final var bais = new ByteArrayInputStream(buffer);
@@ -69,12 +70,6 @@ public class MonoMapCodecAdapter {
                     throw new ParseException(e);
                 }
                 return item;
-            }
-
-            @NonNull
-            @Override
-            public T parseStrict(@NonNull ReadableSequentialData dataInput) throws ParseException {
-                return parse(dataInput);
             }
 
             @Override
@@ -110,7 +105,8 @@ public class MonoMapCodecAdapter {
         return new Codec<>() {
             @NonNull
             @Override
-            public T parse(final @NonNull ReadableSequentialData input) throws ParseException {
+            public T parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+                    throws ParseException {
                 try {
                     if (input instanceof ReadableStreamingData in) {
                         final var item = factory.get();
@@ -134,12 +130,6 @@ public class MonoMapCodecAdapter {
                 } catch (final IOException e) {
                     throw new ParseException(e);
                 }
-            }
-
-            @NonNull
-            @Override
-            public T parseStrict(@NonNull ReadableSequentialData dataInput) throws ParseException {
-                return parse(dataInput);
             }
 
             @Override
@@ -186,7 +176,8 @@ public class MonoMapCodecAdapter {
         return new Codec<>() {
             @NonNull
             @Override
-            public T parse(final @NonNull ReadableSequentialData input) throws ParseException {
+            public T parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+                    throws ParseException {
                 try {
                     if (input instanceof ReadableStreamingData in) {
                         final var item = factory.get();
@@ -210,12 +201,6 @@ public class MonoMapCodecAdapter {
                 } catch (final IOException e) {
                     throw new ParseException(e);
                 }
-            }
-
-            @NonNull
-            @Override
-            public T parseStrict(@NonNull ReadableSequentialData dataInput) throws ParseException {
-                return parse(dataInput);
             }
 
             @Override

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/codec/MonoSpecialFilesAdapterCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/codec/MonoSpecialFilesAdapterCodec.java
@@ -31,7 +31,9 @@ import java.io.IOException;
 public class MonoSpecialFilesAdapterCodec implements Codec<MerkleSpecialFiles> {
     @NonNull
     @Override
-    public MerkleSpecialFiles parse(final @NonNull ReadableSequentialData input) throws ParseException {
+    public MerkleSpecialFiles parse(
+            final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         try {
             final var length = input.readInt();
             final var javaIn = new byte[length];

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/EntityNumCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/EntityNumCodec.java
@@ -27,7 +27,8 @@ import java.io.IOException;
 public class EntityNumCodec implements Codec<EntityNum> {
     @NonNull
     @Override
-    public EntityNum parse(final @NonNull ReadableSequentialData input) throws ParseException {
+    public EntityNum parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         return new EntityNum(input.readInt());
     }
 

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoContextAdapterCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoContextAdapterCodec.java
@@ -31,7 +31,9 @@ import java.io.IOException;
 public class MonoContextAdapterCodec implements Codec<MerkleNetworkContext> {
     @NonNull
     @Override
-    public MerkleNetworkContext parse(final @NonNull ReadableSequentialData input) throws ParseException {
+    public MerkleNetworkContext parse(
+            final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         try {
             final var length = input.readInt();
             final var javaIn = new byte[length];

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoRunningHashesAdapterCodec.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/serdes/MonoRunningHashesAdapterCodec.java
@@ -31,7 +31,9 @@ import java.io.IOException;
 public class MonoRunningHashesAdapterCodec implements Codec<RecordsRunningHashLeaf> {
     @NonNull
     @Override
-    public RecordsRunningHashLeaf parse(final @NonNull ReadableSequentialData input) throws ParseException {
+    public RecordsRunningHashLeaf parse(
+            final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         try {
             final var length = input.readInt();
             final var javaIn = new byte[length];

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionResultTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaEvmTransactionResultTest.java
@@ -178,7 +178,7 @@ class HederaEvmTransactionResultTest {
         assertEquals(GAS_LIMIT / 2, protoResult.gasUsed());
         assertEquals(bloomForAll(BESU_LOGS), protoResult.bloom());
         assertEquals(OUTPUT_DATA, protoResult.contractCallResult());
-        assertNull(protoResult.errorMessage());
+        assertEquals("", protoResult.errorMessage());
         assertNull(protoResult.senderId());
         assertEquals(CALLED_CONTRACT_ID, protoResult.contractID());
         assertEquals(pbjLogsFrom(BESU_LOGS), protoResult.logInfo());
@@ -217,7 +217,7 @@ class HederaEvmTransactionResultTest {
         assertEquals(GAS_LIMIT / 2, protoResult.gasUsed());
         assertEquals(bloomForAll(BESU_LOGS), protoResult.bloom());
         assertEquals(OUTPUT_DATA, protoResult.contractCallResult());
-        assertNull(protoResult.errorMessage());
+        assertEquals("", protoResult.errorMessage());
         assertEquals(CALLED_CONTRACT_ID, protoResult.contractID());
         assertEquals(pbjLogsFrom(BESU_LOGS), protoResult.logInfo());
         assertEquals(createdIds, protoResult.createdContractIDs());
@@ -267,7 +267,7 @@ class HederaEvmTransactionResultTest {
         assertEquals(GAS_LIMIT / 2, queryResult.gasUsed());
         assertEquals(bloomForAll(BESU_LOGS), queryResult.bloom());
         assertEquals(OUTPUT_DATA, queryResult.contractCallResult());
-        assertNull(queryResult.errorMessage());
+        assertEquals("", queryResult.errorMessage());
         assertNull(queryResult.senderId());
         assertEquals(CALLED_CONTRACT_ID, queryResult.contractID());
         assertEquals(pbjLogsFrom(BESU_LOGS), queryResult.logInfo());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/serdes/EntityNumCodec.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/serdes/EntityNumCodec.java
@@ -29,15 +29,10 @@ import java.io.IOException;
 public class EntityNumCodec implements Codec<EntityNum> {
     @NonNull
     @Override
-    public EntityNum parse(final @NonNull ReadableSequentialData input) throws ParseException {
+    public EntityNum parse(final @NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+            throws ParseException {
         requireNonNull(input);
         return new EntityNum(input.readInt());
-    }
-
-    @NonNull
-    @Override
-    public EntityNum parseStrict(final @NonNull ReadableSequentialData dataInput) throws ParseException {
-        return parse(requireNonNull(dataInput));
     }
 
     @Override

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,6 +150,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.23")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.1")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,6 +150,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.19")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.7.23")
     }
 }


### PR DESCRIPTION
**Description**:
Back-porting PBJ enhancements introduced in versions up to v0.8.1, specifically:
1. `maxSize` where PBJ limits the maximum size of a message that it would parse w/o exceptions
2. `null` where PBJ continues to accept `null` values for `Bytes` and `String` types as input to model and Builder constructors, but internally ensures that all model fields of these types are assigned default values instead of the `null` - `Bytes.EMPTY` and `""` respectively
3. `maxDepth` where PBJ allows clients to limit the maximum depth of nested messages that it would parse.

Essentially, I'm cherry-picking the following two commits/pull-requests from `develop`:
* https://github.com/hashgraph/hedera-services/commit/173f419619af3a289d2be114568e3665d0416827 - https://github.com/hashgraph/hedera-services/pull/11958
* https://github.com/hashgraph/hedera-services/commit/a3b64270684b0d10081a2c3420442b9f82ddbc14 - https://github.com/hashgraph/hedera-services/pull/11914

Note that the `maxSize` fix didn't require any changes in the `hedera-services` other than upgrading the PBJ dependency version, so there's not a separate commit to back-port - the v0.8.1 contains that fix already, and that's all that is needed. The commits backported here cover changes related to the `null` and the `maxDepth` changes which required modifications in `hedera-services`.

**Related issue(s)**:

Fixes #12002

**Notes for reviewer**:
This is a verbatim back-porting of the aforementioned commits w/o any additional changes. Please refer to the pull-requests linked above for any additional details if needed.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
