### PR TITLE
fix: ensure ECDSA `ExpandedSigPair` always has EVM alias

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/ExpandedSignaturePair.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/ExpandedSignaturePair.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.signature;
 
+import static com.hedera.node.app.service.mono.sigs.utils.MiscCryptoUtils.extractEvmAddressFromDecompressedECDSAKey;
+import static com.hedera.node.app.signature.impl.SignatureExpanderImpl.decompressKey;
+
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.SignaturePair;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -36,10 +39,38 @@ public record ExpandedSignaturePair(
     /**
      * Gets the {@link Bytes} representing the signature signed by the private key matching the fully expanded public
      * key.
+     *
      * @return The signature bytes.
      */
     @NonNull
     public Bytes signature() {
         return sigPair.signature().as();
+    }
+
+    /**
+     * Given a (putative) compressed ECDSA public key and a {@link SignaturePair},
+     * returns the implied {@link ExpandedSignaturePair} if the key can be decompressed.
+     * Returns null if the key is not a valid compressed ECDSA public key.
+     *
+     * @param compressedEcdsaPubKey the compressed ECDSA public key
+     * @param sigPair the signature pair
+     * @return the expanded signature pair, or null if the key is not a valid compressed ECDSA public key
+     */
+    public static @Nullable ExpandedSignaturePair maybeFrom(
+            @NonNull final Bytes compressedEcdsaPubKey, @NonNull final SignaturePair sigPair) {
+        final var ecdsaPubKey = decompressKey(compressedEcdsaPubKey);
+        return ecdsaPubKey != null ? from(ecdsaPubKey, compressedEcdsaPubKey, sigPair) : null;
+    }
+
+    private static @NonNull ExpandedSignaturePair from(
+            @NonNull final Bytes ecdsaPubKey,
+            @NonNull final Bytes compressedEcdsaPubKey,
+            @NonNull final SignaturePair sigPair) {
+        final var evmAddress = extractEvmAddressFromDecompressedECDSAKey(ecdsaPubKey.toByteArray());
+        return new ExpandedSignaturePair(
+                Key.newBuilder().ecdsaSecp256k1(compressedEcdsaPubKey).build(),
+                ecdsaPubKey,
+                Bytes.wrap(evmAddress),
+                sigPair);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -700,6 +700,13 @@ public class HandleWorkflow {
             throw new HandleException(MAX_CHILD_RECORDS_EXCEEDED);
         } else {
             for (final var hollowAccount : accounts) {
+                if (hollowAccount.accountIdOrElse(AccountID.DEFAULT).equals(AccountID.DEFAULT)) {
+                    // The CryptoCreateHandler uses a "hack" to validate that a CryptoCreate with
+                    // an EVM address has signed with that alias's ECDSA key; that is, it adds a
+                    // dummy "hollow account" with the EVM address as an alias. But we don't want
+                    // to try to finalize such a dummy account, so skip it here.
+                    continue;
+                }
                 // get the verified key for this hollow account
                 final var verification =
                         ethTxVerification != null && hollowAccount.alias().equals(ethTxVerification.evmAlias())

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -53,7 +53,7 @@ import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.system.transaction.Transaction;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -356,7 +356,7 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
         }
         // If not, bootstrap the expanded signature pairs by grabbing all prefixes that are "full" keys already
         final var originals = txInfo.signatureMap().sigPairOrElse(emptyList());
-        final var expanded = new HashSet<ExpandedSignaturePair>();
+        final var expanded = new LinkedHashSet<ExpandedSignaturePair>();
         signatureExpander.expand(originals, expanded);
         // Expand the payer account key signatures if it is not a hollow account
         if (payerIsHollow == PayerIsHollow.NO) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureExpanderImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/SignatureExpanderImplTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.signature.impl;
 
+import static com.hedera.node.app.service.mono.sigs.utils.MiscCryptoUtils.extractEvmAddressFromDecompressedECDSAKey;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -410,21 +411,33 @@ final class SignatureExpanderImplTest extends AppTestBase implements Scenarios {
                                     FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[0]
                                             .uncompressedPublicKey()
                                             .ecdsaSecp256k1OrThrow(),
-                                    null,
+                                    Bytes.wrap(
+                                            extractEvmAddressFromDecompressedECDSAKey(FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[0]
+                                                    .uncompressedPublicKey()
+                                                    .ecdsaSecp256k1OrThrow()
+                                                    .toByteArray())),
                                     sigList.get(5)),
                             new ExpandedSignaturePair(
                                     FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[1].publicKey(),
                                     FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[1]
                                             .uncompressedPublicKey()
                                             .ecdsaSecp256k1OrThrow(),
-                                    null,
+                                    Bytes.wrap(
+                                            extractEvmAddressFromDecompressedECDSAKey(FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[1]
+                                                    .uncompressedPublicKey()
+                                                    .ecdsaSecp256k1OrThrow()
+                                                    .toByteArray())),
                                     sigList.get(6)),
                             new ExpandedSignaturePair(
                                     FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[2].publicKey(),
                                     FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[2]
                                             .uncompressedPublicKey()
                                             .ecdsaSecp256k1OrThrow(),
-                                    null,
+                                    Bytes.wrap(
+                                            extractEvmAddressFromDecompressedECDSAKey(FAKE_ECDSA_WITH_ALIAS_KEY_INFOS[2]
+                                                    .uncompressedPublicKey()
+                                                    .ecdsaSecp256k1OrThrow()
+                                                    .toByteArray())),
                                     sigList.get(7)));
         }
     }


### PR DESCRIPTION
**Description**:
 - Cherry-pick #11955