### PR TITLE
fix: remove null checks for non-nullable runningHash()

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
@@ -116,9 +116,8 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
                 throw new IllegalStateException("initRunningHash() can only be called once");
             }
 
-            if (runningHashes.runningHash() == null
-                    || runningHashes.runningHash().equals(Bytes.EMPTY)) {
-                throw new IllegalArgumentException("The initial running hash cannot be null or empty");
+            if (runningHashes.runningHash().equals(Bytes.EMPTY)) {
+                throw new IllegalArgumentException("The initial running hash cannot be empty");
             }
 
             lastRecordHashingResult = completedFuture(runningHashes.runningHash());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
@@ -124,8 +124,8 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
             throw new IllegalStateException("initRunningHash() must only be called once");
         }
 
-        if (runningHashes.runningHash() == null || runningHashes.runningHash().equals(Bytes.EMPTY)) {
-            throw new IllegalArgumentException("The initial running hash cannot be null or empty");
+        if (runningHashes.runningHash().equals(Bytes.EMPTY)) {
+            throw new IllegalArgumentException("The initial running hash cannot be empty");
         }
 
         runningHash = runningHashes.runningHash();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -299,7 +299,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                                             .getNMinus3RunningHash()
                                             .toHex());
                         } else {
-                            // check nulls as well
+                            // check empty as well
                             assertThat(blockRecordManager.getNMinus3RunningHash())
                                     .isEqualTo(Bytes.EMPTY);
                         }


### PR DESCRIPTION
**Description**:
As suggested at https://github.com/hashgraph/hedera-services/pull/12003 , I'm removing redundant `null` checks for the `runningHash()` values because with the latest PBJ (v0.7.23+), this field of type `Bytes` can never be `null`.

**Related issue(s)**:

Fixes #12031

**Notes for reviewer**:
None.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
