### PR TITLE
fix: set `SUCCESS` status in genesis records

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.workflows.handle.record;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.asAccountAmounts;
 import static com.hedera.node.app.spi.HapiUtils.ACCOUNT_ID_COMPARATOR;
 import static com.hedera.node.app.spi.HapiUtils.FUNDING_ACCOUNT_EXPIRY;
@@ -24,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Duration;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;
@@ -190,6 +192,7 @@ public class GenesisRecordsConsensusHook implements GenesisRecordsBuilder {
                         .accountAmounts(asAccountAmounts(Map.of(accountID, balance)))
                         .build());
             }
+            recordBuilder.status(SUCCESS);
 
             log.debug("Queued synthetic CryptoCreate for {} account {}", recordMemo, account);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHook.java
@@ -25,7 +25,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Duration;
-import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountRecordBuilder.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.token.records;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransferList;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -38,6 +39,12 @@ public interface GenesisAccountRecordBuilder {
      */
     @NonNull
     GenesisAccountRecordBuilder transaction(@NonNull final Transaction txn);
+
+    /**
+     * Tracks the synthetic transaction that represents the created system account
+     */
+    @NonNull
+    GenesisAccountRecordBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * Tracks the memo for the synthetic record


### PR DESCRIPTION
**Description**:
- Closes #12037 
- Set `SUCCESS` in synth record receipts.