### PR TITLE
fix: 11507 Catch possible exception thrown by `PairedStreams.close`

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
@@ -78,8 +78,7 @@ public class MerkleBenchmarkUtils {
             final Configuration configuration,
             final ReconnectConfig reconnectConfig)
             throws Exception {
-        PairedStreams streams = new PairedStreams(configuration.getConfigData(SocketConfig.class));
-        try {
+        try (PairedStreams streams = new PairedStreams(configuration.getConfigData(SocketConfig.class))) {
             final LearningSynchronizer learner;
             final TeachingSynchronizer teacher;
 
@@ -138,13 +137,6 @@ public class MerkleBenchmarkUtils {
 
             final MerkleNode generatedTree = learner.getRoot();
             return (T) generatedTree;
-        } finally {
-            try {
-                streams.close();
-            } catch (IOException e) {
-                // test code, no danger
-                e.printStackTrace();
-            }
         }
     }
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
@@ -78,7 +78,8 @@ public class MerkleBenchmarkUtils {
             final Configuration configuration,
             final ReconnectConfig reconnectConfig)
             throws Exception {
-        try (PairedStreams streams = new PairedStreams(configuration.getConfigData(SocketConfig.class))) {
+        PairedStreams streams = new PairedStreams(configuration.getConfigData(SocketConfig.class));
+        try {
             final LearningSynchronizer learner;
             final TeachingSynchronizer teacher;
 
@@ -137,6 +138,13 @@ public class MerkleBenchmarkUtils {
 
             final MerkleNode generatedTree = learner.getRoot();
             return (T) generatedTree;
+        } finally {
+            try {
+                streams.close();
+            } catch (IOException e) {
+                // test code, no danger
+                e.printStackTrace();
+            }
         }
     }
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/PairedStreams.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/PairedStreams.java
@@ -83,19 +83,24 @@ public class PairedStreams implements AutoCloseable {
 
     @Override
     public void close() throws IOException {
-        teacherOutput.close();
-        teacherInput.close();
-        learnerOutput.close();
-        learnerInput.close();
+        try {
+            teacherOutput.close();
+            teacherInput.close();
+            learnerOutput.close();
+            learnerInput.close();
 
-        teacherOutputBuffer.close();
-        teacherInputBuffer.close();
-        learnerOutputBuffer.close();
-        learnerInputBuffer.close();
+            teacherOutputBuffer.close();
+            teacherInputBuffer.close();
+            learnerOutputBuffer.close();
+            learnerInputBuffer.close();
 
-        server.close();
-        teacherSocket.close();
-        learnerSocket.close();
+            server.close();
+            teacherSocket.close();
+            learnerSocket.close();
+        } catch (IOException e) {
+            // test code, no danger
+            throw new IOException("Failed to close all streams", e);
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/StandardWorkGroup.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/StandardWorkGroup.java
@@ -177,6 +177,7 @@ public class StandardWorkGroup {
             }
             if (!exceptionHandled) {
                 logger.error(EXCEPTION.getMarker(), "Work Group Exception [ groupName = {} ]", groupName, ex);
+                ex.printStackTrace(System.err);
             }
 
             hasExceptions = true;

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapLargeReconnectTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapLargeReconnectTest.java
@@ -25,7 +25,6 @@ import com.swirlds.virtual.merkle.TestValue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -42,8 +41,6 @@ class VirtualMapLargeReconnectTest extends VirtualMapReconnectTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("Reconnect"), @Tag("VMAP-003"), @Tag("VMAP-003.14")})
     @Tag(TIME_CONSUMING)
     @DisplayName("Permutations of very large trees reconnecting")
-    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11507
-    @Disabled
     void largeTeacherLargerLearnerPermutations(int teacherStart, int teacherEnd, int learnerStart, int learnerEnd) {
 
         for (int i = teacherStart; i < teacherEnd; i++) {
@@ -62,8 +59,6 @@ class VirtualMapLargeReconnectTest extends VirtualMapReconnectTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("Reconnect"), @Tag("VMAP-005"), @Tag("VMAP-006")})
     @Tag(TIME_CONSUMING)
     @DisplayName("Reconnect aborts 3 times before success")
-    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11507
-    @Disabled
     void multipleAbortedReconnectsCanSucceed(int teacherStart, int teacherEnd, int learnerStart, int learnerEnd) {
         for (int i = teacherStart; i < teacherEnd; i++) {
             teacherMap.put(new TestKey(i), new TestValue(i));


### PR DESCRIPTION
**Description**:

In some cases, there may be unfortunate circumstances under which PairedStreams have to deal with underlying streams that are already closed before the PairedStreams.close call. The test shouldn't fail in this case.

**Related issue(s)**:

Fixes (hopefully) #11507 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
