### PR TITLE
fix: Hapi local call to deleted contract behaviour

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.contract.impl.handlers;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CALL_LOCAL;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_DELETED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
@@ -89,11 +88,7 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
         // nothing
         // to call)
         final var contract = context.createStore(ReadableAccountStore.class).getContractById(contractID);
-        if (contract != null) {
-            if (contract.deleted()) {
-                throw new PreCheckException(CONTRACT_DELETED);
-            }
-        } else {
+        if (contract == null) {
             final var tokenID =
                     TokenID.newBuilder().tokenNum(contractID.contractNum()).build();
             final var tokenContract =


### PR DESCRIPTION
**Description**:
This PR changes Hapi local call to behave as if the contract is missing in order to be EVM compatible

**Related issue(s)**:

Fixes #11664 
