### PR TITLE
fix(pbj): stabilize hashCode() for Enums

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.8.1")
+    version("com.hedera.pbj.runtime", "0.8.3")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,6 +150,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.1")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.3")
     }
 }


### PR DESCRIPTION
**Description**:
This is a direct back-port of https://github.com/hashgraph/hedera-services/pull/12045 to release `0.48`.

I'm upgrading the PBJ dependency to v0.8.3 to introduce a Enum hashCode() implementation that is stable between runs/different VMs.

Per @netopyr suggestion, I'm opening this PR for `0.48` before the above PR for `develop` is reviewed/merged. The reason is the time it takes to pass all the PR checks.

**Related issue(s)**:

Fixes #https://github.com/hashgraph/pbj/issues/227

**Notes for reviewer**:
PBJ v0.8.3 is released: https://central.sonatype.com/artifact/com.hedera.pbj/pbj-runtime/versions

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
