### PR TITLE
fix: 12071: Forwardport the fix for 11964 to release 0.48

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -74,7 +74,7 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
         @Positive @ConfigProperty(defaultValue = "500000000") long maxNumOfKeys,
-        @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,
+        @Min(0) @ConfigProperty(defaultValue = "0") long hashesRamToDiskThreshold,
         @Min(1) @ConfigProperty(defaultValue = "3") int compactionThreads,
         @ConstraintMethod("minNumberOfFilesInCompactionValidation") @ConfigProperty(defaultValue = "8")
                 int minNumberOfFilesInCompaction,


### PR DESCRIPTION
Fix summary: direct forwardport of https://github.com/hashgraph/hedera-services/pull/11967 to `release/0.48`.

Fixes: https://github.com/hashgraph/hedera-services/issues/12071
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
