### PR TITLE
fix(ci): issue with improperly generated artifact file names

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -334,7 +334,7 @@ jobs:
           mkdir -p "${ARTIFACT_BASE_DIR}"
 
           if [[ "${POLICY}" == "branch-commit"  ]]; then
-            ARTIFACT_NAME="build-${{ needs.validate.outputs.branch-name-lower }}-${{ needs.validate.outputs.commit-id-short }}"
+            ARTIFACT_NAME="build-${{ needs.validate.outputs.branch-name-safe }}-${{ needs.validate.outputs.commit-id-short }}"
           else
             ARTIFACT_NAME="build-v${{ needs.validate.outputs.version }}"
           fi


### PR DESCRIPTION
## Description

This pull request changes the following:

- Resolves an issue which results in a improperly formatted file name due to not using the properly escaped branch name.

### Related Issues

- Closes #12087 