### PR TITLE
fix: create sidecar metadata before writing `RecordStreamFile` footer

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -414,7 +414,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      */
     private BlockInfo infoOfJustFinished(
             @NonNull final BlockInfo lastBlockInfo,
-            final long justFinishedBlockNumber,
+            @NonNull final long justFinishedBlockNumber,
             @NonNull final Bytes hashOfJustFinishedBlock,
             @NonNull final Instant currentBlockFirstTransactionTime) {
         // compute new block hashes bytes

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -414,7 +414,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      */
     private BlockInfo infoOfJustFinished(
             @NonNull final BlockInfo lastBlockInfo,
-            @NonNull final long justFinishedBlockNumber,
+            final long justFinishedBlockNumber,
             @NonNull final Bytes hashOfJustFinishedBlock,
             @NonNull final Instant currentBlockFirstTransactionTime) {
         // compute new block hashes bytes

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
@@ -273,14 +273,13 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
             if (gzipOutputStream != null) gzipOutputStream.flush();
             fileOutputStream.flush();
 
+            closeSidecarFileWriter();
             writeFooter(endRunningHash);
 
             outputStream.close();
             bufferedOutputStream.close();
             if (gzipOutputStream != null) gzipOutputStream.close();
             fileOutputStream.close();
-
-            closeSidecarFileWriter();
 
             // write signature file, this tells the uploader that this record file set is complete
             writeSignatureFile(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -141,7 +141,7 @@ fun includeAllProjects(containingFolder: String) {
 }
 
 // The HAPI API version to use for Protobuf sources.
-val hapiProtoVersion = "0.47.3"
+val hapiProtoVersion = "0.48.0"
 
 dependencyResolutionManagement {
     // Protobuf tool versions


### PR DESCRIPTION
**Description**:
 - Closes #12090 
 - Populate the `BlockRecordWriterV6#sidecarMetadata` field _before_ writing the corresponding `RecordStreamFile` "footer".
 - Bump HAPI proto version for record stream to `0.48.0`.