### PR TITLE
fix: (mod-service) Fix a case for identifying `RESTART` scenario

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -258,6 +258,38 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
             Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
         }
 
+        @Test
+        @DisplayName("Considered as Restart of schema version is before current software version")
+        void considersAsRestartIfSchemaVersionIsBeforeCurrentVersion() {
+            // Given a schema
+            final var schema = Mockito.spy(new TestSchema(versions[1]));
+
+            // When it is registered twice and migrate is called
+            schemaRegistry.register(schema);
+            schemaRegistry.migrate(
+                    merkleTree, versions[1], versions[5], config, networkInfo, mock(WritableEntityIdStore.class));
+
+            // Then migration doesn't happen but restart is called
+            Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
+            Mockito.verify(schema, Mockito.times(1)).restart(Mockito.any());
+        }
+
+        @Test
+        @DisplayName("Considered as Migration if previous version is null")
+        void considersAsMigrationIfPreviousVersionIsNull() {
+            // Given a schema
+            final var schema = Mockito.spy(new TestSchema(versions[1]));
+
+            // When it is registered twice and migrate is called
+            schemaRegistry.register(schema);
+            schemaRegistry.migrate(
+                    merkleTree, null, versions[5], config, networkInfo, mock(WritableEntityIdStore.class));
+
+            // Then migration doesn't happen but restart is called
+            Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any());
+            Mockito.verify(schema, Mockito.times(1)).restart(Mockito.any());
+        }
+
         @ParameterizedTest(name = "From ({0}, {1}]")
         @CsvSource(
                 textBlock =


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/11582

When there are no applicable schemas if the version to be migrated is same, we apply the last registered schema. In this scenario, the `ApplicationType` should be considered as `RESTART_ONLY`.

If it is considered as `MIGRATE_THEN_RESTART`, it could lead to ISS if node does a auto-reconnect since the `EntityId` service commits a different EntityId number from state.