### PR TITLE
fix: wire `HashingOutputStream` into sidecar writing (#12114)

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SidecarWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SidecarWriterV6.java
@@ -45,6 +45,9 @@ import java.util.zip.GZIPOutputStream;
 final class SidecarWriterV6 implements AutoCloseable {
     /** The maximum size of a sidecar file in bytes */
     private final int maxSideCarSizeInBytes;
+    /** The HashingOutputStream does not propagate close() to its delegate,
+     * so we need to manually call close() on the stream it wraps. */
+    private final OutputStream hashingDelegateStream;
     /** HashingOutputStream for hashing the file contents */
     private final HashingOutputStream hashingOutputStream;
     /** WritableStreamingData we are data writing to, that goes into the file */
@@ -80,13 +83,17 @@ final class SidecarWriterV6 implements AutoCloseable {
             throw new RuntimeException(e);
         }
         // create streams
-        OutputStream fout = Files.newOutputStream(file);
-        hashingOutputStream = new HashingOutputStream(wholeFileDigest, fout);
-        BufferedOutputStream bout = new BufferedOutputStream(fout);
+        final var fout = Files.newOutputStream(file);
         if (compressFile) {
-            GZIPOutputStream gout = new GZIPOutputStream(bout);
-            outputStream = new WritableStreamingData(gout);
+            GZIPOutputStream gout = new GZIPOutputStream(fout);
+            hashingDelegateStream = gout;
+            hashingOutputStream = new HashingOutputStream(wholeFileDigest, gout);
+            BufferedOutputStream bout = new BufferedOutputStream(hashingOutputStream);
+            outputStream = new WritableStreamingData(bout);
         } else {
+            hashingDelegateStream = fout;
+            hashingOutputStream = new HashingOutputStream(wholeFileDigest, fout);
+            BufferedOutputStream bout = new BufferedOutputStream(hashingOutputStream);
             outputStream = new WritableStreamingData(bout);
         }
     }
@@ -152,6 +159,7 @@ final class SidecarWriterV6 implements AutoCloseable {
     @Override
     public void close() throws IOException {
         outputStream.close();
+        hashingDelegateStream.close();
         hash = Bytes.wrap(hashingOutputStream.getDigest());
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
@@ -339,7 +339,8 @@ final class BlockRecordWriterV6Test extends AppTestBase {
             writer.close(endRunningHash);
 
             // read written file and validate hashes
-            final var readRecordStreamFile = BlockRecordReaderV6.read(recordPath);
+            final var readRecordStreamFile =
+                    com.hedera.node.app.records.impl.producers.formats.v6.BlockRecordReaderV6.read(recordPath);
             assertThat(readRecordStreamFile).isNotNull();
             assertThat(readRecordStreamFile.hapiProtoVersion()).isEqualTo(VERSION);
             assertThat(readRecordStreamFile.blockNumber()).isEqualTo(BLOCK_NUM);
@@ -353,7 +354,8 @@ final class BlockRecordWriterV6Test extends AppTestBase {
                 assertThat(recordStreamItem.record()).isEqualTo(singleTransactionRecord.transactionRecord());
             }
             assertThat(readRecordStreamFile.endObjectRunningHash()).isEqualTo(endRunningHash);
-            BlockRecordReaderV6.validateHashes(readRecordStreamFile);
+            com.hedera.node.app.records.impl.producers.formats.v6.BlockRecordReaderV6.validateHashes(
+                    readRecordStreamFile);
 
             // Check that the signature file was created.
             assertThat(Files.exists(sigPath)).isTrue();
@@ -512,8 +514,10 @@ final class BlockRecordWriterV6Test extends AppTestBase {
 
             final var logCaptor = new LogCaptor(LogManager.getLogger(BlockRecordWriterV6.class));
             assertThatThrownBy(() -> writer.close(ENDING_RUNNING_HASH_OBJ)).isInstanceOf(UncheckedIOException.class);
-            assertThat(logCaptor.warnLogs()).hasSize(1);
-            assertThat(logCaptor.warnLogs()).allMatch(msg -> msg.contains("Error closing record file"));
+            assertThat(logCaptor.warnLogs()).hasSize(2);
+            assertThat(logCaptor.warnLogs())
+                    .matches(logs -> logs.getFirst().contains("Error closing sidecar file")
+                            && logs.getLast().contains("Error closing record file"));
         }
     }
 }


### PR DESCRIPTION
This is the cherry-pick of #12114.

Closes #12113 
