### PR TITLE
fix: Small refactor in Custom Fees

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFixedFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFixedFeeAssessor.java
@@ -50,10 +50,6 @@ public class CustomFixedFeeAssessor {
             @NonNull final CustomFeeMeta feeMeta, @NonNull final AccountID sender, final AssessmentResult result) {
         for (final var fee : feeMeta.customFees()) {
             if (fee.fee().kind().equals(CustomFee.FeeOneOfType.FIXED_FEE)) {
-                final var collector = fee.feeCollectorAccountId();
-                if (sender.equals(collector)) {
-                    continue;
-                }
                 // This is a top-level fixed fee, not a fallback royalty fee
                 assessFixedFee(feeMeta, sender, fee, result);
             }


### PR DESCRIPTION

In this Merge Request I am focusing on two things. 

1. Removing potentialy unnecessary code in [CustomFixedFeeAssessor.java](https://github.com/hashgraph/hedera-services/pull/12135/files#diff-e78394239c8a571a4e394bf5bb237044ffc07fadd51a907dc33be2631064074a). This check, that I am removing, is present down the line in function [isPayerExempt](https://github.com/hashgraph/hedera-services/blob/162806246304637fb21d0a044dab4246d224042a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/StandardCustomPayerExemptions.java#L56C17-L56C36)
2. I refactored `CustomFractionalFeeAssessor.java` so it's a tad more readable. Just splitting a big function into several small. 