### PR TITLE
fix: Add null check for autorenew account update

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
@@ -112,7 +112,7 @@ public class TokenUpdateValidator {
         getIfUsable(resolvedAutoRenewId, readableAccountStore, expiryValidator, INVALID_AUTORENEW_ACCOUNT);
         // If token has an existing auto-renewal account, validate its expiration
         // FUTURE : Not sure why we should validate existing auto-renew account. Retained as in mono-service
-        if (!resolvedAutoRenewId.equals(AccountID.DEFAULT)) {
+        if (!resolvedAutoRenewId.equals(AccountID.DEFAULT) && existingAutoRenewId != null) {
             getIfUsable(existingAutoRenewId, readableAccountStore, expiryValidator, INVALID_AUTORENEW_ACCOUNT);
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -377,6 +377,21 @@ public class TokenUpdateSpecs extends HapiSuite {
     }
 
     @HapiTest
+    public HapiSpec changeAutoRenewAccount() {
+        var account = "autoRenewAccount";
+
+        return defaultHapiSpec("AutoRenewAccountChange")
+                .given(
+                        newKeyNamed("adminKey"),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        cryptoCreate(account).balance(0L))
+                .when(
+                        tokenCreate("tbu").adminKey("adminKey").treasury(TOKEN_TREASURY),
+                        tokenUpdate("tbu").autoRenewPeriod(1_000_000_000).autoRenewAccount(account))
+                .then(getTokenInfo("tbu").hasAutoRenewAccount(account));
+    }
+
+    @HapiTest
     public HapiSpec nameChanges() {
         var hopefullyUnique = "ORIGINAL" + TxnUtils.randomUppercase(5);
 


### PR DESCRIPTION
**Description**:
`TokenUpdate` can throw `NullPointerException`. This PR adds the necessary checks.

**Related issue(s)**:

Fixes #12205

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
