### PR TITLE
fix: (cherry-pick) make `HederaSoftwareVersion` match Services upgrade semantics

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
@@ -98,13 +98,14 @@ public class HapiUtils {
     public static final Comparator<Timestamp> TIMESTAMP_COMPARATOR =
             Comparator.comparingLong(Timestamp::seconds).thenComparingInt(Timestamp::nanos);
 
-    /** A {@link Comparator} for {@link SemanticVersion}s. */
+    /** A {@link Comparator} for {@link SemanticVersion}s that ignores
+     * any semver part that cannot be parsed as an integer. */
     public static final Comparator<SemanticVersion> SEMANTIC_VERSION_COMPARATOR = Comparator.comparingInt(
                     SemanticVersion::major)
             .thenComparingInt(SemanticVersion::minor)
             .thenComparingInt(SemanticVersion::patch)
-            .thenComparing(SemanticVersion::pre)
-            .thenComparing(SemanticVersion::build);
+            .thenComparingInt(semVer -> parsedIntOrZero(semVer.pre()))
+            .thenComparingInt(semVer -> parsedIntOrZero(semVer.build()));
 
     private HapiUtils() {}
 
@@ -340,5 +341,17 @@ public class HapiUtils {
             builder.append("-");
         }
         return builder.toString();
+    }
+
+    private static int parsedIntOrZero(@Nullable final String s) {
+        if (s == null) {
+            return 0;
+        } else {
+            try {
+                return Integer.parseInt(s);
+            } catch (NumberFormatException ignore) {
+                return 0;
+            }
+        }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -266,7 +266,8 @@ public final class Hedera implements SwirldMain {
         // we need to migrate the state to a newer release, and to determine which schemas to execute.
         logger.debug("Loading Software Version");
         final var versionConfig = bootstrapConfig.getConfigData(VersionConfig.class);
-        version = new HederaSoftwareVersion(versionConfig.hapiVersion(), versionConfig.servicesVersion());
+        version = new HederaSoftwareVersion(
+                versionConfig.hapiVersion(), versionConfig.servicesVersion(), hederaConfig.configVersion());
         logger.info(
                 "Creating Hedera Consensus Node {} with HAPI {}",
                 () -> HapiUtils.toString(version.getServicesVersion()),
@@ -593,9 +594,10 @@ public final class Hedera implements SwirldMain {
         } else if (previousVersion instanceof SerializableSemVers) {
             deserializedVersion = new HederaSoftwareVersion(
                     toPbj(((SerializableSemVers) previousVersion).getProto()),
-                    toPbj(((SerializableSemVers) previousVersion).getServices()));
+                    toPbj(((SerializableSemVers) previousVersion).getServices()),
+                    0);
         } else {
-            deserializedVersion = new HederaSoftwareVersion(SemanticVersion.DEFAULT, SemanticVersion.DEFAULT);
+            deserializedVersion = new HederaSoftwareVersion(SemanticVersion.DEFAULT, SemanticVersion.DEFAULT, 0);
         }
         logger.info("Deserialized version is {}, version {}", deserializedVersion, version);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -90,7 +90,8 @@ class IngestComponentTest {
                 "memo",
                 new HederaSoftwareVersion(
                         SemanticVersion.newBuilder().major(1).build(),
-                        SemanticVersion.newBuilder().major(2).build()));
+                        SemanticVersion.newBuilder().major(2).build(),
+                        0));
 
         final var configProvider = new ConfigProviderImpl(false);
         app = DaggerHederaInjectionComponent.builder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/ServicesRegistryImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/ServicesRegistryImplTest.java
@@ -72,7 +72,7 @@ final class ServicesRegistryImplTest {
                                 .stateToCreate(StateDefinition.singleton("Singleton", Timestamp.JSON))
                                 .build())
                         .build(),
-                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION));
+                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION, 0));
         //noinspection removal
         verify(cr, atLeastOnce()).registerConstructable(any());
     }
@@ -82,13 +82,13 @@ final class ServicesRegistryImplTest {
         final var registry = new ServicesRegistryImpl(cr, genesisRecords);
         registry.register(
                 TestService.newBuilder().name("B").build(),
-                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION));
+                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION, 0));
         registry.register(
                 TestService.newBuilder().name("C").build(),
-                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION));
+                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION, 0));
         registry.register(
                 TestService.newBuilder().name("A").build(),
-                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION));
+                new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION, 0));
 
         final var registrations = registry.registrations();
         assertThat(registrations.stream().map(r -> r.service().getServiceName()))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
@@ -55,7 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DependencyMigrationTest extends MerkleTestBase {
 
-    private static final HederaSoftwareVersion VERSION = new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION);
+    private static final HederaSoftwareVersion VERSION = new HederaSoftwareVersion(CURRENT_VERSION, CURRENT_VERSION, 0);
     private static final VersionedConfigImpl VERSIONED_CONFIG =
             new VersionedConfigImpl(HederaTestConfigBuilder.createConfig(), 1);
     private static final long INITIAL_ENTITY_ID = 5;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/version/HederaSoftwareVersionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/version/HederaSoftwareVersionTest.java
@@ -46,19 +46,17 @@ final class HederaSoftwareVersionTest {
             0.0.0,       0.0.1,        <
             0.0.10,      1.0.0,        <
             0.0.0,       0.0.0,        =
-            1.2.3,       1.2.3-foo,    <
+            1.2.3,       1.2.3-alpha.1,>
             1.2.4,       1.2.3-foo,    >
             1.2.2,       1.2.3-foo,    <
-            1.2.3,       1.2.3-foo+1,  <
+            1.2.3-alpha.1,       1.2.3-alpha.2+1,  <
             1.2.4,       1.2.3-foo+1,  >
             1.2.2,       1.2.3-foo+1,  <
-            1.2.3-foo+2, 1.2.3-foo+1,  >
-            1.2.3-bar+1, 1.2.3-foo+1,  <
             """)
     @DisplayName("compareTo()")
     void compareTo(@NonNull final String a, @NonNull final String b, final String expected) {
-        final var versionA = new HederaSoftwareVersion(semver(a), semver(a));
-        final var versionB = new HederaSoftwareVersion(semver(b), semver(b));
+        final var versionA = new HederaSoftwareVersion(semver(a), semver(a), 0);
+        final var versionB = new HederaSoftwareVersion(semver(b), semver(b), 0);
 
         switch (expected) {
             case "<" -> assertThat(versionA).isLessThan(versionB);
@@ -73,7 +71,7 @@ final class HederaSoftwareVersionTest {
     void sorting() {
         final var list = new ArrayList<HederaSoftwareVersion>();
         for (int i = 0; i < 20; i++) {
-            list.add(new HederaSoftwareVersion(semver("1.2." + i), semver("1.2." + i)));
+            list.add(new HederaSoftwareVersion(semver("1.2." + i), semver("1.2." + i), 0));
         }
 
         final var rand = new Random(3375);
@@ -88,7 +86,7 @@ final class HederaSoftwareVersionTest {
     @Test
     @DisplayName("Serialization")
     void serialization() throws IOException {
-        final var version = new HederaSoftwareVersion(semver("1.2.3"), semver("4.5.6"));
+        final var version = new HederaSoftwareVersion(semver("1.2.3"), semver("4.5.6"), 0);
 
         final var serializedBytes = new ByteArrayOutputStream();
         final var out = new SerializableDataOutputStream(serializedBytes);

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
@@ -136,7 +136,8 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
 
     private final HederaSoftwareVersion softwareVersion = new HederaSoftwareVersion(
             SemanticVersion.newBuilder().major(1).minor(2).patch(3).build(),
-            SemanticVersion.newBuilder().major(1).minor(2).patch(3).build());
+            SemanticVersion.newBuilder().major(1).minor(2).patch(3).build(),
+            0);
     /** Represents "this node" in our tests. */
     protected final NodeId nodeSelfId = new NodeId(7);
     /** The AccountID of "this node" in our tests. */
@@ -314,7 +315,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
         }
 
         public App build() {
-            final var hederaSoftwareVersion = new HederaSoftwareVersion(this.hapiVersion, this.softwareVersion);
+            final var hederaSoftwareVersion = new HederaSoftwareVersion(this.hapiVersion, this.softwareVersion, 0);
 
             final SelfNodeInfo realSelfNodeInfo;
             if (this.selfNodeInfo == null) {

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HederaConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HederaConfig.java
@@ -27,6 +27,7 @@ public record HederaConfig(
         @ConfigProperty(defaultValue = "1001") @NetworkProperty long firstUserEntity,
         @ConfigProperty(defaultValue = "0") @NodeProperty long realm,
         @ConfigProperty(defaultValue = "0") @NodeProperty long shard,
+        @ConfigProperty(value = "config.version", defaultValue = "0") @NetworkProperty int configVersion,
         @ConfigProperty(value = "recordStream.sidecarMaxSizeMb", defaultValue = "256") @NetworkProperty
                 int recordStreamSidecarMaxSizeMb,
         @ConfigProperty(value = "transaction.eip2930.enabled", defaultValue = "true") @NetworkProperty


### PR DESCRIPTION
Cherry-pick : https://github.com/hashgraph/hedera-services/pull/12228