### PR TITLE
fix: KYC default status is true without KYC key

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EvmTokenUtil.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EvmTokenUtil.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.mono.utils;
 
 import static com.hedera.node.app.service.mono.context.primitives.StateView.tokenFreeStatusFor;
-import static com.hedera.node.app.service.mono.context.primitives.StateView.tokenKycStatusFor;
 import static com.hedera.node.app.service.mono.context.primitives.StateView.tokenPauseStatusOf;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.asKeyUnchecked;
 
@@ -32,7 +31,6 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.CustomFee;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenFreezeStatus;
-import com.hederahashgraph.api.proto.java.TokenKycStatus;
 import com.hederahashgraph.api.proto.java.TokenPauseStatus;
 import java.util.ArrayList;
 import java.util.List;
@@ -83,15 +81,13 @@ public class EvmTokenUtil {
         final var kycCandidate = token.kycKey();
         kycCandidate.ifPresentOrElse(
                 k -> {
-                    info.setDefaultKycStatus(tokenKycStatusFor(token.accountsKycGrantedByDefault())
-                                    .getNumber()
-                            == 1);
+                    info.setDefaultKycStatus(token.accountsKycGrantedByDefault());
                     final var key = asKeyUnchecked(k);
                     info.setKycKey(convertToEvmKey(key));
                 },
                 () -> {
                     info.setKycKey(new EvmKey());
-                    info.setDefaultKycStatus(TokenKycStatus.KycNotApplicable.getNumber() == 1);
+                    info.setDefaultKycStatus(true);
                 });
 
         final var supplyCandidate = token.supplyKey();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
@@ -30,6 +30,7 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TokenSupplyType;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.transaction.CustomFee;
@@ -38,7 +39,6 @@ import com.hedera.hapi.node.transaction.FractionalFee;
 import com.hedera.hapi.node.transaction.RoyaltyFee;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
@@ -305,7 +305,7 @@ public class TokenTupleUtils {
                 token.symbol(),
                 headlongAddressOf(token.treasuryAccountIdOrElse(ZERO_ACCOUNT_ID)),
                 token.memo(),
-                token.supplyType().protoOrdinal() == TokenSupplyType.FINITE_VALUE,
+                token.supplyType() == TokenSupplyType.FINITE,
                 token.maxSupply(),
                 token.accountsFrozenByDefault(),
                 keyList,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotModeOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/records/SnapshotModeOp.java
@@ -41,6 +41,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.GeneratedMessageV3;
 import com.hedera.services.bdd.junit.HapiTestEngine;
@@ -57,6 +58,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
+import com.swirlds.common.utility.CommonUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.IOException;
@@ -636,9 +638,17 @@ public class SnapshotModeOp extends UtilOp implements SnapshotOp {
                 Assertions.assertEquals(
                         expected,
                         actual,
-                        "Mismatched values, expected '" + expected + "', got '" + actual + "' - "
+                        "Mismatched values, expected '" + readable(expected) + "', got '" + readable(actual) + "' - "
                                 + mismatchContext.get());
             }
+        }
+    }
+
+    private static String readable(Object o) {
+        if (o instanceof ByteString bs) {
+            return CommonUtils.hex(bs.toByteArray());
+        } else {
+            return o.toString();
         }
     }
 


### PR DESCRIPTION
**Description**:
 - Closes #11916 
 - Fix a strange construct in `EvmTokenUtil` to answer a `getTokenInfo()` system call to either use the token's default KYC status if it has a KYC key; or `true` if it does not.
 - Eliminate a use of `protoc`-generated types in mod `TokenTupleUtils`.
 - Print hexed form of `ByteString`s when displaying diffs instead of their octet encoding.