### PR TITLE
fix: 11507 Enabled logging exceptions processed by StandardWorkGroup into System.err.

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
@@ -184,8 +184,8 @@ public class MerkleBenchmarkUtils {
                 firstReconnectException.compareAndSet(null, t);
                 return false;
             };
-            final StandardWorkGroup workGroup = new StandardWorkGroup(
-                    getStaticThreadManager(), "synchronization-test", null, exceptionListener, false);
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "synchronization-test", null, exceptionListener);
             workGroup.execute("teaching-synchronizer-main", () -> teachingSynchronizerThread(teacher));
             workGroup.execute("learning-synchronizer-main", () -> learningSynchronizerThread(learner));
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
@@ -184,8 +184,8 @@ public class MerkleBenchmarkUtils {
                 firstReconnectException.compareAndSet(null, t);
                 return false;
             };
-            final StandardWorkGroup workGroup =
-                    new StandardWorkGroup(getStaticThreadManager(), "synchronization-test", null, exceptionListener);
+            final StandardWorkGroup workGroup = new StandardWorkGroup(
+                    getStaticThreadManager(), "synchronization-test", null, exceptionListener, false);
             workGroup.execute("teaching-synchronizer-main", () -> teachingSynchronizerThread(teacher));
             workGroup.execute("learning-synchronizer-main", () -> learningSynchronizerThread(learner));
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -268,7 +268,7 @@ public class LearningSynchronizer implements ReconnectNodeCount {
             return false;
         };
         final StandardWorkGroup workGroup =
-                new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, reconnectExceptionListener);
+                createStandardWorkGroup(threadManager, breakConnection, reconnectExceptionListener);
 
         final LearnerTreeView<T> view;
         if (root == null || !root.hasCustomReconnectView()) {
@@ -327,6 +327,13 @@ public class LearningSynchronizer implements ReconnectNodeCount {
         viewsToInitialize.addFirst(view);
 
         return view.getMerkleRoot(reconstructedRoot.get());
+    }
+
+    protected StandardWorkGroup createStandardWorkGroup(
+            ThreadManager threadManager,
+            Runnable breakConnection,
+            Function<Throwable, Boolean> reconnectExceptionListener) {
+        return new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, reconnectExceptionListener);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -267,8 +267,8 @@ public class LearningSynchronizer implements ReconnectNodeCount {
             firstReconnectException.compareAndSet(null, t);
             return false;
         };
-        final StandardWorkGroup workGroup =
-                new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, reconnectExceptionListener);
+        final StandardWorkGroup workGroup = new StandardWorkGroup(
+                threadManager, WORK_GROUP_NAME, breakConnection, reconnectExceptionListener, false);
 
         final LearnerTreeView<T> view;
         if (root == null || !root.hasCustomReconnectView()) {

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -267,8 +267,8 @@ public class LearningSynchronizer implements ReconnectNodeCount {
             firstReconnectException.compareAndSet(null, t);
             return false;
         };
-        final StandardWorkGroup workGroup = new StandardWorkGroup(
-                threadManager, WORK_GROUP_NAME, breakConnection, reconnectExceptionListener, false);
+        final StandardWorkGroup workGroup =
+                new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, reconnectExceptionListener);
 
         final LearnerTreeView<T> view;
         if (root == null || !root.hasCustomReconnectView()) {

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
@@ -151,8 +151,11 @@ public class TeachingSynchronizer {
 
         final AtomicReference<Throwable> firstReconnectException = new AtomicReference<>();
         // A future improvement might be to reuse threads between subtrees.
-        final StandardWorkGroup workGroup =
-                new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, ex -> {
+        final StandardWorkGroup workGroup = new StandardWorkGroup(
+                threadManager,
+                WORK_GROUP_NAME,
+                breakConnection,
+                ex -> {
                     Throwable cause = ex;
                     while (cause != null) {
                         if (cause instanceof SocketException socketEx) {
@@ -172,7 +175,8 @@ public class TeachingSynchronizer {
                     firstReconnectException.compareAndSet(null, ex);
                     // Let StandardWorkGroup log it as an error using the EXCEPTION marker
                     return false;
-                });
+                },
+                false);
 
         view.startTeacherTasks(this, time, workGroup, inputStream, outputStream, subtrees);
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
@@ -151,11 +151,8 @@ public class TeachingSynchronizer {
 
         final AtomicReference<Throwable> firstReconnectException = new AtomicReference<>();
         // A future improvement might be to reuse threads between subtrees.
-        final StandardWorkGroup workGroup = new StandardWorkGroup(
-                threadManager,
-                WORK_GROUP_NAME,
-                breakConnection,
-                ex -> {
+        final StandardWorkGroup workGroup =
+                new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, ex -> {
                     Throwable cause = ex;
                     while (cause != null) {
                         if (cause instanceof SocketException socketEx) {
@@ -175,8 +172,7 @@ public class TeachingSynchronizer {
                     firstReconnectException.compareAndSet(null, ex);
                     // Let StandardWorkGroup log it as an error using the EXCEPTION marker
                     return false;
-                },
-                false);
+                });
 
         view.startTeacherTasks(this, time, workGroup, inputStream, outputStream, subtrees);
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/TeachingSynchronizer.java
@@ -39,6 +39,7 @@ import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -151,28 +152,26 @@ public class TeachingSynchronizer {
 
         final AtomicReference<Throwable> firstReconnectException = new AtomicReference<>();
         // A future improvement might be to reuse threads between subtrees.
-        final StandardWorkGroup workGroup =
-                new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, ex -> {
-                    Throwable cause = ex;
-                    while (cause != null) {
-                        if (cause instanceof SocketException socketEx) {
-                            if (socketEx.getMessage().equalsIgnoreCase("Connection reset by peer")) {
-                                // Connection issues during reconnects are expected and recoverable, just
-                                // log them as info. All other exceptions should be treated as real errors
-                                logger.info(
-                                        RECONNECT.getMarker(),
-                                        "Connection reset while sending tree at {} with route {}. Aborting",
-                                        root == null ? null : root.getClass().getName(),
-                                        root == null ? "[]" : root.getRoute());
-                                return true;
-                            }
-                        }
-                        cause = cause.getCause();
+        final StandardWorkGroup workGroup = createStandardWorkGroup(threadManager, breakConnection, cause -> {
+            while (cause != null) {
+                if (cause instanceof SocketException socketEx) {
+                    if (socketEx.getMessage().equalsIgnoreCase("Connection reset by peer")) {
+                        // Connection issues during reconnects are expected and recoverable, just
+                        // log them as info. All other exceptions should be treated as real errors
+                        logger.info(
+                                RECONNECT.getMarker(),
+                                "Connection reset while sending tree at {} with route {}. Aborting",
+                                root == null ? null : root.getClass().getName(),
+                                root == null ? "[]" : root.getRoute());
+                        return true;
                     }
-                    firstReconnectException.compareAndSet(null, ex);
-                    // Let StandardWorkGroup log it as an error using the EXCEPTION marker
-                    return false;
-                });
+                }
+                cause = cause.getCause();
+            }
+            firstReconnectException.compareAndSet(null, cause);
+            // Let StandardWorkGroup log it as an error using the EXCEPTION marker
+            return false;
+        });
 
         view.startTeacherTasks(this, time, workGroup, inputStream, outputStream, subtrees);
 
@@ -189,6 +188,11 @@ public class TeachingSynchronizer {
         }
 
         logger.info(RECONNECT.getMarker(), "finished sending tree");
+    }
+
+    protected StandardWorkGroup createStandardWorkGroup(
+            ThreadManager threadManager, Runnable breakConnection, Function<Throwable, Boolean> exceptionListener) {
+        return new StandardWorkGroup(threadManager, WORK_GROUP_NAME, breakConnection, exceptionListener);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/StandardWorkGroup.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/threading/pool/StandardWorkGroup.java
@@ -78,8 +78,15 @@ public class StandardWorkGroup {
      *      listener. If the listener returns {@code true}, the exception is considered handled, and
      *      no further action is performed. If the listener returns {@code false}, it indicates the
      *      exception should be processed by the default handler, which is to log it appropriately
-     * @param logExceptionsToStdErr if true exceptions are logged to stderr which may be helpful for testing
      */
+    public StandardWorkGroup(
+            final ThreadManager threadManager,
+            final String groupName,
+            final Runnable abortAction,
+            final Function<Throwable, Boolean> exceptionListener) {
+        this(threadManager, groupName, abortAction, exceptionListener, false);
+    }
+
     public StandardWorkGroup(
             final ThreadManager threadManager,
             final String groupName,
@@ -181,10 +188,10 @@ public class StandardWorkGroup {
             }
             if (!exceptionHandled) {
                 logger.error(EXCEPTION.getMarker(), "Work Group Exception [ groupName = {} ]", groupName, ex);
-            }
-            // Log to stderr for testing purposes
-            if (logExceptionsToStdErr) {
-                ex.printStackTrace(System.err);
+                // Log to stderr for testing purposes
+                if (logExceptionsToStdErr) {
+                    ex.printStackTrace(System.err);
+                }
             }
 
             hasExceptions = true;

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/StandardWorkGroupTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/pool/StandardWorkGroupTest.java
@@ -158,10 +158,15 @@ class StandardWorkGroupTest {
     @Test
     void exceptionsPropagatedToListener() throws InterruptedException {
         final AtomicReference<Throwable> caught = new AtomicReference<>();
-        subject = new StandardWorkGroup(getStaticThreadManager(), "groupName", abortCount::incrementAndGet, ex -> {
-            caught.set(ex);
-            return true;
-        });
+        subject = new StandardWorkGroup(
+                getStaticThreadManager(),
+                "groupName",
+                abortCount::incrementAndGet,
+                ex -> {
+                    caught.set(ex);
+                    return true;
+                },
+                true);
 
         final String exceptionMessage = "ExceptionMessage";
         subject.execute("task", () -> {

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
@@ -1033,8 +1033,8 @@ public final class MerkleTestUtils {
                 firstReconnectException.compareAndSet(null, t);
                 return false;
             };
-            final StandardWorkGroup workGroup =
-                    new StandardWorkGroup(getStaticThreadManager(), "synchronization-test", null, exceptionListener);
+            final StandardWorkGroup workGroup = new StandardWorkGroup(
+                    getStaticThreadManager(), "synchronization-test", null, exceptionListener, true);
             workGroup.execute("teaching-synchronizer-main", () -> teachingSynchronizerThread(teacher));
             workGroup.execute("learning-synchronizer-main", () -> learningSynchronizerThread(learner));
 

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleTestUtils.java
@@ -1015,15 +1015,29 @@ public final class MerkleTestUtils {
                         };
                 final PlatformContext platformContext =
                         TestPlatformContextBuilder.create().build();
-                teacher = new TeachingSynchronizer(
-                        platformContext.getConfiguration(),
-                        Time.getCurrent(),
-                        getStaticThreadManager(),
-                        streams.getTeacherInput(),
-                        streams.getTeacherOutput(),
-                        desiredTree,
-                        streams::disconnect,
-                        reconnectConfig);
+                teacher =
+                        new TeachingSynchronizer(
+                                platformContext.getConfiguration(),
+                                Time.getCurrent(),
+                                getStaticThreadManager(),
+                                streams.getTeacherInput(),
+                                streams.getTeacherOutput(),
+                                desiredTree,
+                                streams::disconnect,
+                                reconnectConfig) {
+                            @Override
+                            protected StandardWorkGroup createStandardWorkGroup(
+                                    ThreadManager threadManager,
+                                    Runnable breakConnection,
+                                    Function<Throwable, Boolean> exceptionListener) {
+                                return new StandardWorkGroup(
+                                        threadManager,
+                                        "test-teaching-synchronizer",
+                                        breakConnection,
+                                        exceptionListener,
+                                        true);
+                            }
+                        };
             } else {
                 learner =
                         new LaggingLearningSynchronizer(

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapLargeReconnectTest.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapLargeReconnectTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -44,8 +43,6 @@ class VirtualMapLargeReconnectTest extends VirtualMapReconnectTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("Reconnect"), @Tag("VMAP-003"), @Tag("VMAP-003.14")})
     @Tag(TIME_CONSUMING)
     @DisplayName("Permutations of very large trees reconnecting")
-    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11507
-    @Disabled
     void largeTeacherLargerLearnerPermutations(int teacherStart, int teacherEnd, int learnerStart, int learnerEnd) {
 
         for (int i = teacherStart; i < teacherEnd; i++) {
@@ -64,8 +61,6 @@ class VirtualMapLargeReconnectTest extends VirtualMapReconnectTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("Reconnect"), @Tag("VMAP-005"), @Tag("VMAP-006")})
     @Tag(TIME_CONSUMING)
     @DisplayName("Reconnect aborts 3 times before success")
-    // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11507
-    @Disabled
     void multipleAbortedReconnectsCanSucceed(int teacherStart, int teacherEnd, int learnerStart, int learnerEnd) {
         for (int i = teacherStart; i < teacherEnd; i++) {
             teacherMap.put(new TestKey(i), new TestValue(i));

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -85,7 +85,7 @@ public class VirtualMapReconnectTestBase {
 
     // Custom reconnect config to make tests with timeouts faster
     protected static ReconnectConfig reconnectConfig = new TestConfigBuilder()
-            .withValue("reconnect.asyncStreamTimeout", "5s")
+            .withValue("reconnect.asyncStreamTimeout", "20s")
             .withValue("reconnect.maxAckDelay", "1000ms")
             .getOrCreateConfig()
             .getConfigData(ReconnectConfig.class);


### PR DESCRIPTION
**Description**:

Enabled logging exceptions processed by StandardWorkGroup into System.err. This should help with the tests failure investigations. Before this change the exceptions were just not logged at all in the testing context. 

Misc: Re-enabled tests in VirtualMapLargeReconnectTest

**Related issue(s)**:

Related to #11507 

**Notes for reviewer**:

This change is not supposed to affect production code in any way. It was added for testing purposes only. 

