### PR TITLE
chore(reconnect): add more logs to Learner

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -132,10 +132,15 @@ public class LearningSynchronizer implements ReconnectNodeCount {
      */
     public void synchronize() throws InterruptedException {
         try {
+            logger.info(RECONNECT.getMarker(), "learner calls receiveTree()");
             receiveTree();
+            logger.info(RECONNECT.getMarker(), "learner calls initialize()");
             initialize();
+            logger.info(RECONNECT.getMarker(), "learner calls hash()");
             hash();
+            logger.info(RECONNECT.getMarker(), "learner calls logStatistics()");
             logStatistics();
+            logger.info(RECONNECT.getMarker(), "learner is done synchronizing");
         } catch (final InterruptedException ex) {
             logger.warn(RECONNECT.getMarker(), "synchronization interrupted");
             Thread.currentThread().interrupt();
@@ -289,9 +294,23 @@ public class LearningSynchronizer implements ReconnectNodeCount {
         InterruptedException interruptException = null;
         try {
             workGroup.waitForTermination();
+
+            logger.info(
+                    RECONNECT.getMarker(),
+                    "received tree rooted at {} with route {}",
+                    root == null ? "(unknown)" : root.getClass().getName(),
+                    root == null ? "[]" : root.getRoute());
         } catch (final InterruptedException e) { // NOSONAR: Exception is rethrown below after cleanup.
             interruptException = e;
             logger.warn(RECONNECT.getMarker(), "interrupted while waiting for work group termination");
+        } catch (final Throwable t) {
+            logger.info(
+                    RECONNECT.getMarker(),
+                    "caught exception while receiving tree rooted at {} with route {}",
+                    root == null ? "(unknown)" : root.getClass().getName(),
+                    root == null ? "[]" : root.getRoute(),
+                    t);
+            throw t;
         }
 
         if (interruptException != null || workGroup.hasExceptions()) {

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerThread.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/LearnerThread.java
@@ -274,6 +274,7 @@ public class LearnerThread<T> {
                 }
             }
 
+            logger.info(RECONNECT.getMarker(), "learner thread finished the learning loop for the current subtree");
         } catch (final InterruptedException ex) {
             logger.warn(RECONNECT.getMarker(), "learner thread interrupted");
             Thread.currentThread().interrupt();


### PR DESCRIPTION
**Description**:
To assist with debugging https://github.com/hashgraph/hedera-services/issues/12046 , I'm adding more logging to the Learner code to better understand where it could possibly be stuck, if at all, when the test failure described in the issue occurs.

**Related issue(s)**:

Helps debug #12046 

**Notes for reviewer**:
Just adding a few more non-intrusive (from performance and logs noise perspectives) logs. We'll check them when that test fails again.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
