### PR TITLE
feat: Disable token associations in AccountInfo, ContractInfo, and AccountBalance

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
@@ -50,7 +50,7 @@ public record TokensConfig(
         @ConfigProperty(value = "autoCreations.isEnabled", defaultValue = "true") @NetworkProperty
                 boolean autoCreationsIsEnabled,
         @ConfigProperty(value = "maxMetadataBytes", defaultValue = "100") @NetworkProperty int tokensMaxMetadataBytes,
-        @ConfigProperty(value = "balancesInQueries.enabled", defaultValue = "true") @NetworkProperty
+        @ConfigProperty(value = "balancesInQueries.enabled", defaultValue = "false") @NetworkProperty
                 boolean balancesInQueriesEnabled,
         @ConfigProperty(value = "nfts.maxBatchSizeUpdate", defaultValue = "10") @NetworkProperty
                 int nftsMaxBatchSizeUpdate) {}

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -84,6 +85,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -201,9 +204,10 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .has(responseCode(ResponseCodeEnum.ACCOUNT_DELETED));
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     @DisplayName("failed response is correctly handled in findResponse")
-    void getsResponseIfFailedResponse() {
+    void getsResponseIfFailedResponse(boolean balancesInQueriesEnabled) {
         final var responseHeader = ResponseHeader.newBuilder()
                 .nodeTransactionPrecheckCode(ResponseCodeEnum.INVALID_ACCOUNT_ID)
                 .build();
@@ -212,23 +216,24 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         when(context.query()).thenReturn(query);
         when(context.createStore(ReadableAccountStore.class)).thenReturn(readableStore);
 
-        setupConfig();
+        setupConfig(balancesInQueriesEnabled);
 
         final var response = subject.findResponse(context, responseHeader);
         final var op = response.cryptoGetInfo();
         assertEquals(ResponseCodeEnum.INVALID_ACCOUNT_ID, op.header().nodeTransactionPrecheckCode());
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     @DisplayName("fail FAIL_INVALID test")
-    void getsCorrectResponseHeadIfAccountInfoNotFound() {
+    void getsCorrectResponseHeadIfAccountInfoNotFound(boolean balancesInQueriesEnabled) {
         final var responseHeader = getOkResponse();
 
         setupAccountStore();
         setupTokenStore();
         setupTokenRelationStore();
         setupStakingInfoStore();
-        setupConfig();
+        setupConfig(balancesInQueriesEnabled);
 
         final var query = createCryptoGetInfoQuery(4);
         when(context.query()).thenReturn(query);
@@ -238,18 +243,19 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         assertEquals(getFailInvalidResponse(), cryptoGetInfoResponse.header());
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     @DisplayName("OK response is correctly handled in findResponse")
-    void getsResponseIfOkResponse() {
+    void getsResponseIfOkResponse(boolean balancesInQueriesEnabled) {
         final var responseHeader = getOkResponse();
-        final var expectedInfo = getExpectedAccountInfo();
+        final var expectedInfo = getExpectedAccountInfo(balancesInQueriesEnabled);
 
         account = account.copyBuilder().stakedNodeId(0).declineReward(false).build();
         setupAccountStore();
 
-        given(token1.decimals()).willReturn(100);
-        given(token1.symbol()).willReturn("FOO");
-        given(token1.tokenId()).willReturn(asToken(3L));
+        lenient().when(token1.decimals()).thenReturn(100); // only needed when balancesInQueriesEnabled is true
+        lenient().when(token1.symbol()).thenReturn("FOO"); // only needed when balancesInQueriesEnabled is true
+        when(token1.tokenId()).thenReturn(asToken(3L));
         setupTokenStore(token1);
 
         final var tokenRelation = TokenRelation.newBuilder()
@@ -265,7 +271,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         setupTokenRelationStore(tokenRelation);
         setupStakingInfoStore();
         setupStakingRewardsStore();
-        setupConfig();
+        setupConfig(balancesInQueriesEnabled);
         final var query = createCryptoGetInfoQuery(accountNum);
         when(context.query()).thenReturn(query);
 
@@ -275,21 +281,22 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         assertEquals(expectedInfo, cryptoGetInfoResponse.accountInfo());
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     @DisplayName("check multiple token relations list")
-    void checkMulitpleTokenRelations() {
+    void checkMulitpleTokenRelations(boolean balancesInQueriesEnabled) {
         final var responseHeader = getOkResponse();
-        final var expectedInfo = getExpectedAccountInfos();
+        final var expectedInfo = getExpectedAccountInfos(balancesInQueriesEnabled);
 
         account = account.copyBuilder().stakedNodeId(0).declineReward(false).build();
         setupAccountStore();
 
-        given(token1.decimals()).willReturn(100);
-        given(token2.decimals()).willReturn(50);
-        given(token1.symbol()).willReturn("FOO");
-        given(token2.symbol()).willReturn("BAR");
-        given(token1.tokenId()).willReturn(asToken(3L));
-        given(token2.tokenId()).willReturn(asToken(4L));
+        lenient().when(token1.decimals()).thenReturn(100); // only needed when balancesInQueriesEnabled is true
+        lenient().when(token2.decimals()).thenReturn(50); // only needed when balancesInQueriesEnabled is true
+        lenient().when(token1.symbol()).thenReturn("FOO"); // only needed when balancesInQueriesEnabled is true
+        lenient().when(token2.symbol()).thenReturn("BAR"); // only needed when balancesInQueriesEnabled is true
+        when(token1.tokenId()).thenReturn(asToken(3L));
+        when(token2.tokenId()).thenReturn(asToken(4L));
         setupTokenStore(token1, token2);
 
         final var tokenRelation1 = TokenRelation.newBuilder()
@@ -325,7 +332,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         setupTokenRelationStore(tokenRelation1, tokenRelation2, tokenRelation3);
         setupStakingInfoStore();
         setupStakingRewardsStore();
-        setupConfig();
+        setupConfig(balancesInQueriesEnabled);
 
         final var query = createCryptoGetInfoQuery(accountNum);
         when(context.query()).thenReturn(query);
@@ -335,13 +342,16 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
 
         assertEquals(ResponseCodeEnum.OK, cryptoGetInfoResponse.header().nodeTransactionPrecheckCode());
         assertEquals(expectedInfo, cryptoGetInfoResponse.accountInfo());
-        assertEquals(2, cryptoGetInfoResponse.accountInfo().tokenRelationships().size());
+        assertEquals(
+                balancesInQueriesEnabled ? 2 : 0,
+                cryptoGetInfoResponse.accountInfo().tokenRelationships().size());
     }
 
-    @Test
-    void testStakeNumber() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testStakeNumber(boolean balancesInQueriesEnabled) {
         final var responseHeader = getOkResponse();
-        final var expectedInfo = getExpectedAccountInfo2();
+        final var expectedInfo = getExpectedAccountInfo2(balancesInQueriesEnabled);
 
         account = account.copyBuilder()
                 .stakedAccountId(AccountID.newBuilder().accountNum(1).build())
@@ -349,9 +359,9 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .build();
         setupAccountStore();
 
-        given(token1.decimals()).willReturn(100);
-        given(token1.symbol()).willReturn("FOO");
-        given(token1.tokenId()).willReturn(asToken(3L));
+        lenient().when(token1.decimals()).thenReturn(100); // only needed when balancesInQueriesEnabled is true
+        lenient().when(token1.symbol()).thenReturn("FOO"); // only needed when balancesInQueriesEnabled is true
+        when(token1.tokenId()).thenReturn(asToken(3L));
         setupTokenStore(token1);
 
         final var tokenRelation = TokenRelation.newBuilder()
@@ -367,7 +377,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         setupTokenRelationStore(tokenRelation);
         setupStakingInfoStore();
         setupStakingRewardsStore();
-        setupConfig();
+        setupConfig(balancesInQueriesEnabled);
         final var query = createCryptoGetInfoQuery(accountNum);
         when(context.query()).thenReturn(query);
 
@@ -377,11 +387,12 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         assertEquals(expectedInfo, cryptoGetInfoResponse.accountInfo());
     }
 
-    @Test
-    void testEvmAddressAlias() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testEvmAddressAlias(boolean balancesInQueriesEnabled) {
         final Bytes evmAddress = Bytes.wrap(CommonUtils.unhex("6aeb3773ea468a814d954e6dec795bfee7d76e26"));
         final var responseHeader = getOkResponse();
-        final var expectedInfo = getExpectedAccountInfoEvm(evmAddress);
+        final var expectedInfo = getExpectedAccountInfoEvm(balancesInQueriesEnabled);
 
         account = account.copyBuilder()
                 .stakedNodeId(0)
@@ -390,9 +401,9 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .build();
         setupAccountStore();
 
-        given(token1.decimals()).willReturn(100);
-        given(token1.symbol()).willReturn("FOO");
-        given(token1.tokenId()).willReturn(asToken(3L));
+        lenient().when(token1.decimals()).thenReturn(100); // only needed when balancesInQueriesEnabled is true
+        lenient().when(token1.symbol()).thenReturn("FOO"); // only needed when balancesInQueriesEnabled is true
+        when(token1.tokenId()).thenReturn(asToken(3L));
         setupTokenStore(token1);
 
         final var tokenRelation = TokenRelation.newBuilder()
@@ -408,7 +419,7 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         setupTokenRelationStore(tokenRelation);
         setupStakingInfoStore();
         setupStakingRewardsStore();
-        setupConfig();
+        setupConfig(balancesInQueriesEnabled);
         final var query = createCryptoGetInfoQuery(accountNum);
         when(context.query()).thenReturn(query);
 
@@ -470,16 +481,18 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
         when(context.createStore(ReadableNetworkStakingRewardsStore.class)).thenReturn(readableRewardsStore);
     }
 
-    private void setupConfig() {
-        final var config = HederaTestConfigBuilder.create()
+    private void setupConfig(boolean balancesInQueriesEnabled) {
+        final var configBuilder = HederaTestConfigBuilder.create()
                 .withValue("tokens.maxRelsPerInfoQuery", 2)
-                .withValue("ledger.id", "0x03")
-                .getOrCreateConfig();
-        given(context.configuration()).willReturn(config);
+                .withValue("ledger.id", "0x03");
+        if (balancesInQueriesEnabled) {
+            configBuilder.withValue("tokens.balancesInQueries.enabled", true);
+        }
+        given(context.configuration()).willReturn(configBuilder.getOrCreateConfig());
     }
 
-    private AccountInfo getExpectedAccountInfo() {
-        return AccountInfo.newBuilder()
+    private AccountInfo getExpectedAccountInfo(boolean balancesInQueriesEnabled) {
+        final var builder = AccountInfo.newBuilder()
                 .key(key)
                 .accountID(id)
                 .receiverSigRequired(true)
@@ -494,13 +507,15 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .ethereumNonce(0)
                 .alias(alias.alias())
                 .contractAccountID("0000000000000000000000000000000000000003")
-                .tokenRelationships(getExpectedTokenRelationship())
-                .stakingInfo(getExpectedStakingInfo())
-                .build();
+                .stakingInfo(getExpectedStakingInfo());
+        if (balancesInQueriesEnabled) {
+            builder.tokenRelationships(getExpectedTokenRelationship());
+        }
+        return builder.build();
     }
 
-    private AccountInfo getExpectedAccountInfo2() {
-        return AccountInfo.newBuilder()
+    private AccountInfo getExpectedAccountInfo2(boolean balancesInQueriesEnabled) {
+        final var builder = AccountInfo.newBuilder()
                 .key(key)
                 .accountID(id)
                 .receiverSigRequired(true)
@@ -515,13 +530,15 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .ethereumNonce(0)
                 .alias(alias.alias())
                 .contractAccountID("0000000000000000000000000000000000000003")
-                .tokenRelationships(getExpectedTokenRelationship())
-                .stakingInfo(getExpectedStakingInfo2())
-                .build();
+                .stakingInfo(getExpectedStakingInfo2());
+        if (balancesInQueriesEnabled) {
+            builder.tokenRelationships(getExpectedTokenRelationship());
+        }
+        return builder.build();
     }
 
-    private AccountInfo getExpectedAccountInfoEvm(Bytes evmAddress) {
-        return AccountInfo.newBuilder()
+    private AccountInfo getExpectedAccountInfoEvm(boolean balancesInQueriesEnabled) {
+        final var builder = AccountInfo.newBuilder()
                 .key(key)
                 .accountID(id)
                 .receiverSigRequired(true)
@@ -535,13 +552,15 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .maxAutomaticTokenAssociations(10)
                 .ethereumNonce(0)
                 .contractAccountID("6aeb3773ea468a814d954e6dec795bfee7d76e26")
-                .tokenRelationships(getExpectedTokenRelationship())
-                .stakingInfo(getExpectedStakingInfo())
-                .build();
+                .stakingInfo(getExpectedStakingInfo());
+        if (balancesInQueriesEnabled) {
+            builder.tokenRelationships(getExpectedTokenRelationship());
+        }
+        return builder.build();
     }
 
-    private AccountInfo getExpectedAccountInfos() {
-        return AccountInfo.newBuilder()
+    private AccountInfo getExpectedAccountInfos(boolean balancesInQueriesEnabled) {
+        final var builder = AccountInfo.newBuilder()
                 .key(key)
                 .accountID(id)
                 .receiverSigRequired(true)
@@ -556,9 +575,11 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
                 .ethereumNonce(0)
                 .alias(alias.alias())
                 .contractAccountID("0000000000000000000000000000000000000003")
-                .tokenRelationships(getExpectedTokenRelationships())
-                .stakingInfo(getExpectedStakingInfo())
-                .build();
+                .stakingInfo(getExpectedStakingInfo());
+        if (balancesInQueriesEnabled) {
+            builder.tokenRelationships(getExpectedTokenRelationships());
+        }
+        return builder.build();
     }
 
     private List<TokenRelationship> getExpectedTokenRelationship() {


### PR DESCRIPTION
This PR disables the listing of token associations in `AccountInfo`, `ContractInfo`, and `AccountBalance` as defined in [HIP-367](https://hips.hedera.com/hip/hip-367)

Fixes #12291 