### PR TITLE
fix: deterministic order of effective payer numbers

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AssessmentResult.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AssessmentResult.java
@@ -54,7 +54,11 @@ public class AssessmentResult {
             final List<TokenTransferList> inputTokenTransfers, final List<AccountAmount> inputHbarTransfers) {
         mutableInputBalanceAdjustments = buildFungibleTokenTransferMap(inputTokenTransfers);
         immutableInputTokenAdjustments = Collections.unmodifiableMap(mutableInputBalanceAdjustments.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Map.copyOf(entry.getValue()))));
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> new LinkedHashMap<>(entry.getValue()),
+                        (a, b) -> a,
+                        LinkedHashMap::new)));
 
         immutableInputHbarAdjustments = buildHbarTransferMap(inputHbarTransfers);
         mutableInputBalanceAdjustments.put(HBAR_TOKEN_ID, new LinkedHashMap<>(immutableInputHbarAdjustments));


### PR DESCRIPTION
**Description**:
 - Closes #12300 
 - Replaces `Map.copyOf()` with `LinkedHashMap::new`, as the `ImmutableCollections.MapN` returned by the former has an [intentionally random iterator](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/ImmutableCollections.java#L1266). 🤯 
     * This made the order of effective payer numbers for a fractional fee with multiple receivers non-deterministic.