### PR TITLE
fix: apply consistent auto-renew account policy

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImpl.java
@@ -220,7 +220,7 @@ public class ExpiryValidatorImpl implements ExpiryValidator {
         validateTrue(
                 accountID.shardNum() == hederaConfig.shard() && accountID.realmNum() == hederaConfig.realm(),
                 INVALID_AUTORENEW_ACCOUNT);
-        if (accountID.accountNum() == 0L) {
+        if (accountID.hasAccountNum() && accountID.accountNumOrThrow() == 0L) {
             // 0L is a sentinel number that says to remove the current auto-renew account
             return;
         }
@@ -230,7 +230,6 @@ public class ExpiryValidatorImpl implements ExpiryValidator {
             if (account == null || account.deleted()) {
                 throw new HandleException(INVALID_AUTORENEW_ACCOUNT);
             }
-            validateFalse(account.smartContract(), INVALID_AUTORENEW_ACCOUNT);
         } catch (final InvalidTransactionException e) {
             throw new HandleException(PbjConverter.toPbj(e.getResponseCode()));
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogic.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.txns.consensus;
 
-import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateFalse;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_ACCOUNT_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
@@ -95,7 +94,6 @@ public final class TopicCreateTransitionLogic implements TransitionLogic {
         Account autoRenewAccount = null;
         if (op.hasAutoRenewAccount()) {
             autoRenewAccount = accountStore.loadAccountOrFailWith(autoRenewAccountId, INVALID_AUTORENEW_ACCOUNT);
-            validateFalse(autoRenewAccount.isSmartContract(), INVALID_AUTORENEW_ACCOUNT);
             validateTrue(op.hasAdminKey(), AUTORENEW_ACCOUNT_NOT_ALLOWED);
         }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/consensus/TopicUpdateTransitionLogic.java
@@ -206,7 +206,8 @@ public class TopicUpdateTransitionLogic implements TransitionLogic {
             transactionContext.setStatus(AUTORENEW_ACCOUNT_NOT_ALLOWED);
             return false;
         }
-        if (validator.queryableAccountStatus(newAutoRenewAccount, accounts.get()) != OK) {
+        final var autoRenewNum = EntityNum.fromAccountId(newAutoRenewAccount);
+        if (validator.queryableAccountOrContractStatus(autoRenewNum, accounts.get()) != OK) {
             transactionContext.setStatus(INVALID_AUTORENEW_ACCOUNT);
             return false;
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -29,7 +29,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_BYTEC
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
@@ -167,13 +166,6 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
         // https://github.com/hashgraph/hedera-services/issues/3037
         if (key.isEmpty()) {
             key = STANDIN_CONTRACT_ID_KEY;
-        }
-
-        if (op.hasAutoRenewAccountId()) {
-            final var autoRenewAccountId = Id.fromGrpcAccount(op.getAutoRenewAccountId());
-            final var autoRenewAccount =
-                    accountStore.loadAccountOrFailWith(autoRenewAccountId, INVALID_AUTORENEW_ACCOUNT);
-            validateFalse(autoRenewAccount.isSmartContract(), INVALID_AUTORENEW_ACCOUNT);
         }
 
         // --- Load the model objects ---

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -29,6 +29,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_BYTEC
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
@@ -166,6 +167,11 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
         // https://github.com/hashgraph/hedera-services/issues/3037
         if (key.isEmpty()) {
             key = STANDIN_CONTRACT_ID_KEY;
+        }
+
+        if (op.hasAutoRenewAccountId()) {
+            final var autoRenewAccountId = Id.fromGrpcAccount(op.getAutoRenewAccountId());
+            accountStore.loadAccountOrFailWith(autoRenewAccountId, INVALID_AUTORENEW_ACCOUNT);
         }
 
         // --- Load the model objects ---

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
@@ -515,20 +515,23 @@ class MerkleTopicUpdateTransitionLogicTest {
 
     private void givenTransactionWithInvalidAutoRenewAccount() {
         givenTransaction(getBasicValidTransactionBodyBuilder().setAutoRenewAccount(MISSING_ACCOUNT));
-        given(validator.queryableAccountStatus(eq(MISSING_ACCOUNT), any())).willReturn(INVALID_ACCOUNT_ID);
+        given(validator.queryableAccountOrContractStatus(eq(EntityNum.fromAccountId(MISSING_ACCOUNT)), any()))
+                .willReturn(INVALID_ACCOUNT_ID);
     }
 
     private void givenTransactionWithAutoRenewAccountClearingAdminKey() {
         givenTransaction(getBasicValidTransactionBodyBuilder()
                 .setAdminKey(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()))
                 .setAutoRenewAccount(MISC_ACCOUNT));
-        given(validator.queryableAccountStatus(eq(MISC_ACCOUNT), any())).willReturn(OK);
+        given(validator.queryableAccountOrContractStatus(eq(EntityNum.fromAccountId(MISC_ACCOUNT)), any()))
+                .willReturn(OK);
         given(validator.hasGoodEncoding(any())).willReturn(true);
     }
 
     private void givenTransactionWithAutoRenewAccountNotClearingAdminKey() {
         givenTransaction(getBasicValidTransactionBodyBuilder().setAutoRenewAccount(MISC_ACCOUNT));
-        given(validator.queryableAccountStatus(eq(MISC_ACCOUNT), any())).willReturn(OK);
+        given(validator.queryableAccountOrContractStatus(eq(EntityNum.fromAccountId(MISC_ACCOUNT)), any()))
+                .willReturn(OK);
         given(validator.hasGoodEncoding(any())).willReturn(true);
     }
 
@@ -552,7 +555,8 @@ class MerkleTopicUpdateTransitionLogicTest {
         var clearKey = Key.newBuilder().setKeyList(KeyList.getDefaultInstance());
         givenTransaction(
                 getBasicValidTransactionBodyBuilder().setAdminKey(clearKey).setSubmitKey(clearKey));
-        given(validator.queryableAccountStatus(eq(MISC_ACCOUNT), any())).willReturn(OK);
+        given(validator.queryableAccountOrContractStatus(eq(EntityNum.fromAccountId(MISC_ACCOUNT)), any()))
+                .willReturn(OK);
         given(validator.hasGoodEncoding(any())).willReturn(true);
     }
 
@@ -569,7 +573,8 @@ class MerkleTopicUpdateTransitionLogicTest {
         given(validator.hasGoodEncoding(updatedAdminKey)).willReturn(true);
         given(validator.hasGoodEncoding(updatedSubmitKey)).willReturn(true);
         given(validator.isValidExpiry(any())).willReturn(true);
-        given(validator.queryableAccountStatus(eq(MISC_ACCOUNT), any())).willReturn(OK);
+        given(validator.queryableAccountOrContractStatus(eq(EntityNum.fromAccountId(MISC_ACCOUNT)), any()))
+                .willReturn(OK);
     }
 
     private void givenTransactionWithInvalidMemo() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogicTest.java
@@ -158,7 +158,6 @@ class TopicCreateTransitionLogicTest {
         given(transactionContext.accessor()).willReturn(accessor);
         given(accessor.getTxn()).willReturn(transactionBody);
         given(accountStore.loadAccountOrFailWith(any(), any())).willReturn(autoRenew);
-        given(autoRenew.isSmartContract()).willReturn(false);
         given(validator.isValidAutoRenewPeriod(Duration.newBuilder()
                         .setSeconds(VALID_AUTORENEW_PERIOD_SECONDS)
                         .build()))
@@ -269,7 +268,6 @@ class TopicCreateTransitionLogicTest {
                         .build()))
                 .willReturn(true);
         given(accountStore.loadAccountOrFailWith(any(), any())).willReturn(autoRenew);
-        given(autoRenew.isSmartContract()).willReturn(false);
 
         assertFailsWith(() -> subject.doStateTransition(), AUTORENEW_ACCOUNT_NOT_ALLOWED);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
@@ -27,7 +27,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FILE_DELETED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
@@ -768,9 +767,6 @@ class ContractCreateTransitionLogicTest {
                         Bytes.of(bytecode),
                         txnCtx.consensusTime()))
                 .willReturn(result);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
         given(properties.enabledSidecars()).willReturn(EnumSet.of(SidecarType.CONTRACT_BYTECODE));
 
         // when:
@@ -796,9 +792,6 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
         final var result = TransactionProcessingResult.successful(
                 null,
                 1234L,
@@ -836,7 +829,6 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
-        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();
@@ -857,9 +849,6 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
 
         final var output = Bytes.of(123);
         final var result = TransactionProcessingResult.successful(
@@ -900,7 +889,6 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
-        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();
@@ -920,9 +908,6 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
         final var output = Bytes.of(123);
         final var result = TransactionProcessingResult.successful(
                 null, 1234L, 0L, 124L, output, contractAccount.getId().asEvmAddress(), Map.of(), List.of());
@@ -961,7 +946,6 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
-        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         sidecarUtilsMockedStatic.verify(() -> SidecarUtils.createContractBytecodeSidecarFrom(
                 contractAccount.getId().asGrpcContract(), output.toArrayUnsafe()));
         // and:
@@ -984,9 +968,6 @@ class ContractCreateTransitionLogicTest {
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
         given(worldState.get(senderAccount.getId().asEvmAddress())).willReturn(worldSenderAccount);
         given(worldSenderAccount.getNonce()).willReturn(5644L);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
         final var result = TransactionProcessingResult.successful(
                 null, 1234L, 0L, 124L, Bytes.EMPTY, create1ContractAddress, Map.of(), new ArrayList<>());
         given(txnCtx.consensusTime()).willReturn(consensusTime);
@@ -1019,7 +1000,6 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
-        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();
@@ -1040,9 +1020,6 @@ class ContractCreateTransitionLogicTest {
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
         given(worldState.get(senderAccount.getId().asEvmAddress())).willReturn(worldSenderAccount);
         given(worldSenderAccount.getNonce()).willReturn(5644L);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
 
         final var output = Bytes.of(123);
         final var result = TransactionProcessingResult.successful(
@@ -1094,7 +1071,6 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
-        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         verify(recordsHistorian)
                 .trackFirstFollowingChildRecord(
                         nextChildRecordSourceId, opBuilder, recordBuilder, List.of(sidecarRecord));
@@ -1121,9 +1097,6 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
         given(worldState.getContractNonces()).willReturn(targetContractNonces);
-        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
-                .willReturn(autoRenewModel);
-        given(autoRenewModel.isSmartContract()).willReturn(false);
         final var result = TransactionProcessingResult.successful(
                 null,
                 1234L,
@@ -1162,7 +1135,6 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
-        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
@@ -27,6 +27,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FILE_DELETED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
@@ -767,6 +768,8 @@ class ContractCreateTransitionLogicTest {
                         Bytes.of(bytecode),
                         txnCtx.consensusTime()))
                 .willReturn(result);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
         given(properties.enabledSidecars()).willReturn(EnumSet.of(SidecarType.CONTRACT_BYTECODE));
 
         // when:
@@ -792,6 +795,8 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
         final var result = TransactionProcessingResult.successful(
                 null,
                 1234L,
@@ -829,6 +834,7 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
+        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();
@@ -849,6 +855,8 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
 
         final var output = Bytes.of(123);
         final var result = TransactionProcessingResult.successful(
@@ -889,6 +897,7 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
+        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();
@@ -908,6 +917,8 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
         final var output = Bytes.of(123);
         final var result = TransactionProcessingResult.successful(
                 null, 1234L, 0L, 124L, output, contractAccount.getId().asEvmAddress(), Map.of(), List.of());
@@ -946,6 +957,7 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
+        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         sidecarUtilsMockedStatic.verify(() -> SidecarUtils.createContractBytecodeSidecarFrom(
                 contractAccount.getId().asGrpcContract(), output.toArrayUnsafe()));
         // and:
@@ -968,6 +980,8 @@ class ContractCreateTransitionLogicTest {
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
         given(worldState.get(senderAccount.getId().asEvmAddress())).willReturn(worldSenderAccount);
         given(worldSenderAccount.getNonce()).willReturn(5644L);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
         final var result = TransactionProcessingResult.successful(
                 null, 1234L, 0L, 124L, Bytes.EMPTY, create1ContractAddress, Map.of(), new ArrayList<>());
         given(txnCtx.consensusTime()).willReturn(consensusTime);
@@ -1000,6 +1014,7 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
+        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();
@@ -1020,6 +1035,8 @@ class ContractCreateTransitionLogicTest {
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
         given(worldState.get(senderAccount.getId().asEvmAddress())).willReturn(worldSenderAccount);
         given(worldSenderAccount.getNonce()).willReturn(5644L);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
 
         final var output = Bytes.of(123);
         final var result = TransactionProcessingResult.successful(
@@ -1071,6 +1088,7 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
+        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         verify(recordsHistorian)
                 .trackFirstFollowingChildRecord(
                         nextChildRecordSourceId, opBuilder, recordBuilder, List.of(sidecarRecord));
@@ -1097,6 +1115,8 @@ class ContractCreateTransitionLogicTest {
         given(txnCtx.accessor()).willReturn(accessor);
         given(worldState.getCreatedContractIds()).willReturn(secondaryCreations);
         given(worldState.getContractNonces()).willReturn(targetContractNonces);
+        given(accountStore.loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT))
+                .willReturn(autoRenewModel);
         final var result = TransactionProcessingResult.successful(
                 null,
                 1234L,
@@ -1135,6 +1155,7 @@ class ContractCreateTransitionLogicTest {
         verify(worldState).resetHapiSenderCustomizer();
         verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
         verify(accountStore).loadAccount(senderAccount.getId());
+        verify(accountStore).loadAccountOrFailWith(Id.fromGrpcAccount(autoRenewAccount), INVALID_AUTORENEW_ACCOUNT);
         // and:
         final var customizerUsed = captor.getValue();
         final var changes = customizerUsed.accountCustomizer().getChanges();

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AssessmentResult.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AssessmentResult.java
@@ -54,7 +54,11 @@ public class AssessmentResult {
             final List<TokenTransferList> inputTokenTransfers, final List<AccountAmount> inputHbarTransfers) {
         mutableInputBalanceAdjustments = buildFungibleTokenTransferMap(inputTokenTransfers);
         immutableInputTokenAdjustments = Collections.unmodifiableMap(mutableInputBalanceAdjustments.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Map.copyOf(entry.getValue()))));
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> new LinkedHashMap<>(entry.getValue()),
+                        (a, b) -> a,
+                        LinkedHashMap::new)));
 
         immutableInputHbarAdjustments = buildHbarTransferMap(inputHbarTransfers);
         mutableInputBalanceAdjustments.put(HBAR_TOKEN_ID, new LinkedHashMap<>(immutableInputHbarAdjustments));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -167,9 +167,7 @@ public class TopicCreateSuite extends HapiSuite {
                                 .signedBy("wrongKey")
                                 .hasPrecheck(INVALID_SIGNATURE),
                         // In hedera-app, we'll allow contracts with admin keys to be auto-renew accounts
-                        createTopic("nonExistentAutoRenewAccount")
-                                .autoRenewAccountId(contractWithAdminKey)
-                                .hasKnownStatusFrom(INVALID_AUTORENEW_ACCOUNT),
+                        createTopic("withContractAutoRenew").autoRenewAccountId(contractWithAdminKey),
                         // But contracts without admin keys will get INVALID_SIGNATURE (can't sign!)
                         createTopic("NotToBe")
                                 .autoRenewAccountId(PAY_RECEIVABLE_CONTRACT)


### PR DESCRIPTION
**Description**:
 - Cherry-pick #12317 
 - Closes #12251 by allowing [this transaction](https://hashscan.io/mainnet/transaction/1710257012.152064484) to use the expected contract as auto-renew account for a `createToken()` HTS call.
 - Avoids adding another pointless special case to auto-renew account validation by also allowing contracts and topics to use contract auto-renew accounts.