### PR TITLE
fix: ContractCallLocal INSUFFICIENT_GAS ERROR

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
@@ -16,13 +16,12 @@
 
 package com.hedera.node.app.service.contract.impl.infra;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction.NOT_APPLICABLE;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asPriorityId;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
-import static org.apache.tuweni.bytes.Bytes.EMPTY;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.contract.ContractCallLocalQuery;
@@ -43,9 +42,7 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
  */
 @QueryScope
 public class HevmStaticTransactionFactory {
-    private static final long INTRINSIC_GAS_LOWER_BOUND = 21_000L;
     private final ContractsConfig contractsConfig;
-    private final GasCalculator gasCalculator;
     private final QueryContext context;
     private final AccountID payerId;
 
@@ -87,9 +84,7 @@ public class HevmStaticTransactionFactory {
     }
 
     private void assertValidCall(@NonNull final ContractCallLocalQuery body) {
-        final var minGasLimit =
-                Math.max(INTRINSIC_GAS_LOWER_BOUND, gasCalculator.transactionIntrinsicGasCost(EMPTY, false));
-        validateTrue(body.gas() >= minGasLimit, INSUFFICIENT_GAS);
+        validateTrue(body.gas() >= 0, CONTRACT_NEGATIVE_GAS);
         validateTrue(body.gas() <= contractsConfig.maxGasPerSec(), MAX_GAS_LIMIT_EXCEEDED);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
@@ -33,7 +33,6 @@ import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
-import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
  * A factory that creates a {@link HederaEvmTransaction} for static calls.
@@ -47,11 +46,9 @@ public class HevmStaticTransactionFactory {
     private final AccountID payerId;
 
     @Inject
-    public HevmStaticTransactionFactory(
-            @NonNull final QueryContext context, @NonNull final GasCalculator gasCalculator) {
+    public HevmStaticTransactionFactory(@NonNull final QueryContext context) {
         this.context = requireNonNull(context);
         this.contractsConfig = context.configuration().getConfigData(ContractsConfig.class);
-        this.gasCalculator = requireNonNull(gasCalculator);
         this.payerId = requireNonNull(context.payer());
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
@@ -41,7 +41,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Consumer;
-import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,9 +49,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class HevmStaticTransactionFactoryTest {
-    @Mock
-    private GasCalculator gasCalculator;
-
     @Mock
     private QueryContext context;
 
@@ -65,7 +61,7 @@ class HevmStaticTransactionFactoryTest {
     void setUp() {
         given(context.configuration()).willReturn(DEFAULT_CONFIG);
         given(context.payer()).willReturn(SENDER_ID);
-        subject = new HevmStaticTransactionFactory(context, gasCalculator);
+        subject = new HevmStaticTransactionFactory(context);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
@@ -72,7 +72,7 @@ class HevmStaticTransactionFactoryTest {
     void fromQueryWorkWithSenderAndUsesPriorityAddress() {
         final var query = Query.newBuilder()
                 .contractCallLocal(callLocalWith(b -> {
-                    b.gas(21_000L);
+                    b.gas(100L);
                     b.senderId(SENDER_ID);
                     b.contractID(CALLED_CONTRACT_ID);
                     b.functionParameters(CALL_DATA);
@@ -88,7 +88,7 @@ class HevmStaticTransactionFactoryTest {
         assertThat(transaction.payload()).isEqualTo(CALL_DATA);
         assertThat(transaction.chainId()).isNull();
         assertThat(transaction.value()).isZero();
-        assertThat(transaction.gasLimit()).isEqualTo(21_000L);
+        assertThat(transaction.gasLimit()).isEqualTo(100L);
         assertThat(transaction.offeredGasPrice()).isEqualTo(1L);
         assertThat(transaction.maxGasAllowance()).isZero();
         assertThat(transaction.hapiCreation()).isNull();
@@ -154,8 +154,8 @@ class HevmStaticTransactionFactoryTest {
     }
 
     @Test
-    void fromQueryFailsWithGasBelowFixedLowerBound() {
-        assertCallFailsWith(ResponseCodeEnum.INSUFFICIENT_GAS, builder -> builder.gas(20_999L));
+    void fromQueryFailsWithNegativeGas() {
+        assertCallFailsWith(ResponseCodeEnum.CONTRACT_NEGATIVE_GAS, builder -> builder.gas(-5L));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Fixes an issue where modularized code was erroring when a CONTRACT_CALL_LOCAL query had less than the minimum amount of gas required for CONTRACT_CALL transactions.

**Related issue(s)**:

Fixes #12313 

