### PR TITLE
chore: rely on protobuf release 48 branch instead of main

### DIFF
--- a/hedera-node/hapi/build.gradle.kts
+++ b/hedera-node/hapi/build.gradle.kts
@@ -25,7 +25,7 @@ description = "Hedera API"
 
 // Add downloaded HAPI repo protobuf files into build directory and add to sources to build them
 tasks.cloneHederaProtobufs {
-    branchOrTag = "main"
+    branchOrTag = "v0.48.3-release"
     // As long as the 'branchOrTag' above is not stable, run always:
     outputs.upToDateWhen { false }
 }


### PR DESCRIPTION
We created a branch in the protobufs repo – `v0.48.3-release` – so we can depend on a fixed commit instead of using `main`. This PR updates this release branch to use the protobufs release branch. 

(Note: done because the 'tag' part of `branchOrTag` in the build file seems to be broken)