### PR TITLE
fix: 12388: VirtualMap / DataSource metrics should not contain certain chars in the names

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbStatistics.java
@@ -125,7 +125,9 @@ public class MerkleDbStatistics {
      */
     public MerkleDbStatistics(final MerkleDbConfig dbConfig, final String label) {
         this.dbConfig = dbConfig;
-        this.label = Objects.requireNonNull(label, "label must not be null");
+        Objects.requireNonNull(label, "label must not be null");
+        // If the label contains ".", they are replaced with "_", since metric names may not contain "."
+        this.label = label.replace('.', '_');
         hashesStoreCompactionTimeMsList = new ArrayList<>();
         hashesStoreCompactionSavedSpaceMbList = new ArrayList<>();
         hashesStoreFileSizeByLevelMbList = new ArrayList<>();

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbStatisticsTest.java
@@ -382,6 +382,22 @@ class MerkleDbStatisticsTest {
         assertValueSet(metric);
     }
 
+    @Test
+    void testTableNameWithPeriod() {
+        final String complexLabel = "service." + LABEL;
+        final String expectedLabelSuffix = complexLabel.replace('.', '_');
+        final MerkleDbStatistics stats =
+                new MerkleDbStatistics(configuration.getConfigData(MerkleDbConfig.class), complexLabel);
+        stats.registerMetrics(metrics);
+
+        // given
+        final Metric metric = getMetric("files_", "totalSizeMb_" + expectedLabelSuffix);
+        // when
+        stats.setTotalFileSizeMb(10);
+        // then
+        assertValueSet(metric);
+    }
+
     private static int randomCompactionLevel() {
         return nextInt(1, 6);
     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualMapStatistics.java
@@ -97,7 +97,8 @@ public class VirtualMapStatistics {
      */
     public VirtualMapStatistics(final String label) {
         Objects.requireNonNull(label, "label must not be null");
-        this.label = label;
+        // "." may not appear in metric names
+        this.label = label.replace('.', '_');
     }
 
     /**


### PR DESCRIPTION
Fix summary: `.` are replaced with `_` in generated virtual map and data source metric names.

Fixes: https://github.com/hashgraph/hedera-services/issues/12388
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
