### PR TITLE
feat(ReconnectBench): generate .csv with metrics

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
@@ -156,12 +156,14 @@ public class ReconnectBench extends VirtualMapBaseBench {
             throw new RuntimeException("Failed to restore the 'teacher' map.");
         }
         teacherMap = flushMap(teacherMap);
+        BenchmarkMetrics.register(teacherMap::registerMetrics);
 
         learnerMap = restoreMap("learner");
         if (teacherMap == null) {
             throw new RuntimeException("Failed to restore the 'learner' map.");
         }
         learnerMap = flushMap(learnerMap);
+        BenchmarkMetrics.register(learnerMap::registerMetrics);
 
         teacherTree = MerkleBenchmarkUtils.createTreeForMap(teacherMap);
         copy = teacherMap.copy();


### PR DESCRIPTION
**Description**:
Adding `BenchmarkMetrics.register` calls for both the teacher and the learner maps before starting each reconnect invocation. This is similar to what e.g. the VirtualMapBench does when it calls `register` in the `createMap` after the map has been restored.

**Related issue(s)**:

Fixes #11745

**Notes for reviewer**:
Head from BenchmarkMetrics.csv:
```
time,memTot,memFree,directMem,cpuLoadProc,openFileDesc,ds_compactions_level_0_hashesSavedSpaceMb_learner,ds_compactions_level_0_hashesSavedSpaceMb_teacher,ds_compactions_level_0_hashesTimeMs_learner,ds_compactions_level_0_hashesTimeMs_teacher,ds_compactions_level_0_leafKeysSavedSpaceMb_learner,ds_compactions_level_0_leafKeysSavedSpaceMb_teacher,ds_compactions_level_0_leafKeysTimeMs_learner,ds_compactions_level_0_leafKeysTimeMs_teacher,ds_compactions_level_0_leavesSavedSpaceMb_learner,ds_compactions_level_0_leavesSavedSpaceMb_teacher,ds_compactions_level_0_leavesTimeMs_learner,ds_compactions_level_0_leavesTimeMs_teacher,ds_compactions_level_1_hashesSavedSpaceMb_learner,ds_compactions_level_1_hashesSavedSpaceMb_teacher,ds_compactions_level_1_hashesTimeMs_learner,ds_compactions_level_1_hashesTimeMs_teacher,ds_compactions_level_1_leafKeysSavedSpaceMb_learner,ds_compactions_level_1_leafKeysSavedSpaceMb_teacher,ds_compactions_level_1_leafKeysTimeMs_learner,ds_compactions_level_1_leafKeysTimeMs_teacher,ds_compactions_level_1_leavesSavedSpaceMb_learner,ds_compactions_level_1_leavesSavedSpaceMb_teacher,ds_compactions_level_1_leavesTimeMs_learner,ds_compactions_level_1_leavesTimeMs_teacher,ds_compactions_level_2_hashesSavedSpaceMb_learner,ds_compactions_level_2_hashesSavedSpaceMb_teacher,ds_compactions_level_2_hashesTimeMs_learner,ds_compactions_level_2_hashesTimeMs_teacher,ds_compactions_level_2_leafKeysSavedSpaceMb_learner,ds_compactions_level_2_leafKeysSavedSpaceMb_teacher,ds_compactions_level_2_leafKeysTimeMs_learner,ds_compactions_level_2_leafKeysTimeMs_teacher,ds_compactions_level_2_leavesSavedSpaceMb_learner,ds_compactions_level_2_leavesSavedSpaceMb_teacher,ds_compactions_level_2_leavesTimeMs_learner,ds_compactions_level_2_leavesTimeMs_teacher,ds_compactions_level_3_hashesSavedSpaceMb_learner,ds_compactions_level_3_hashesSavedSpaceMb_teacher,ds_compactions_level_3_hashesTimeMs_learner,ds_compactions_level_3_hashesTimeMs_teacher,ds_compactions_level_3_leafKeysSavedSpaceMb_learner,ds_compactions_level_3_leafKeysSavedSpaceMb_teacher,ds_compactions_level_3_leafKeysTimeMs_learner,ds_compactions_level_3_leafKeysTimeMs_teacher,ds_compactions_level_3_leavesSavedSpaceMb_learner,ds_compactions_level_3_leavesSavedSpaceMb_teacher,ds_compactions_level_3_leavesTimeMs_learner,ds_compactions_level_3_leavesTimeMs_teacher,ds_compactions_level_4_hashesSavedSpaceMb_learner,ds_compactions_level_4_hashesSavedSpaceMb_teacher,ds_compactions_level_4_hashesTimeMs_learner,ds_compactions_level_4_hashesTimeMs_teacher,ds_compactions_level_4_leafKeysSavedSpaceMb_learner,ds_compactions_level_4_leafKeysSavedSpaceMb_teacher,ds_compactions_level_4_leafKeysTimeMs_learner,ds_compactions_level_4_leafKeysTimeMs_teacher,ds_compactions_level_4_leavesSavedSpaceMb_learner,ds_compactions_level_4_leavesSavedSpaceMb_teacher,ds_compactions_level_4_leavesTimeMs_learner,ds_compactions_level_4_leavesTimeMs_teacher,ds_compactions_level_5_hashesSavedSpaceMb_learner,ds_compactions_level_5_hashesSavedSpaceMb_teacher,ds_compactions_level_5_hashesTimeMs_learner,ds_compactions_level_5_hashesTimeMs_teacher,ds_compactions_level_5_leafKeysSavedSpaceMb_learner,ds_compactions_level_5_leafKeysSavedSpaceMb_teacher,ds_compactions_level_5_leafKeysTimeMs_learner,ds_compactions_level_5_leafKeysTimeMs_teacher,ds_compactions_level_5_leavesSavedSpaceMb_learner,ds_compactions_level_5_leavesSavedSpaceMb_teacher,ds_compactions_level_5_leavesTimeMs_learner,ds_compactions_level_5_leavesTimeMs_teacher,ds_files_hashesStoreFileCount_learner,ds_files_hashesStoreFileCount_teacher,ds_files_hashesStoreFileSizeMb_learner,ds_files_hashesStoreFileSizeMb_teacher,ds_files_leafKeysStoreFileCount_learner,ds_files_leafKeysStoreFileCount_teacher,ds_files_leafKeysStoreFileSizeMb_learner,ds_files_leafKeysStoreFileSizeMb_teacher,ds_files_leavesStoreFileCount_learner,ds_files_leavesStoreFileCount_teacher,ds_files_leavesStoreFileSizeMb_learner,ds_files_leavesStoreFileSizeMb_teacher,ds_files_level_0_hashesFileSizeByLevelMb_learner,ds_files_level_0_hashesFileSizeByLevelMb_teacher,ds_files_level_0_leafKeysFileSizeByLevelMb_learner,ds_files_level_0_leafKeysFileSizeByLevelMb_teacher,ds_files_level_0_leavesFileSizeByLevelMb_learner,ds_files_level_0_leavesFileSizeByLevelMb_teacher,ds_files_level_1_hashesFileSizeByLevelMb_learner,ds_files_level_1_hashesFileSizeByLevelMb_teacher,ds_files_level_1_leafKeysFileSizeByLevelMb_learner,ds_files_level_1_leafKeysFileSizeByLevelMb_teacher,ds_files_level_1_leavesFileSizeByLevelMb_learner,ds_files_level_1_leavesFileSizeByLevelMb_teacher,ds_files_level_2_hashesFileSizeByLevelMb_learner,ds_files_level_2_hashesFileSizeByLevelMb_teacher,ds_files_level_2_leafKeysFileSizeByLevelMb_learner,ds_files_level_2_leafKeysFileSizeByLevelMb_teacher,ds_files_level_2_leavesFileSizeByLevelMb_learner,ds_files_level_2_leavesFileSizeByLevelMb_teacher,ds_files_level_3_hashesFileSizeByLevelMb_learner,ds_files_level_3_hashesFileSizeByLevelMb_teacher,ds_files_level_3_leafKeysFileSizeByLevelMb_learner,ds_files_level_3_leafKeysFileSizeByLevelMb_teacher,ds_files_level_3_leavesFileSizeByLevelMb_learner,ds_files_level_3_leavesFileSizeByLevelMb_teacher,ds_files_level_4_hashesFileSizeByLevelMb_learner,ds_files_level_4_hashesFileSizeByLevelMb_teacher,ds_files_level_4_leafKeysFileSizeByLevelMb_learner,ds_files_level_4_leafKeysFileSizeByLevelMb_teacher,ds_files_level_4_leavesFileSizeByLevelMb_learner,ds_files_level_4_leavesFileSizeByLevelMb_teacher,ds_files_level_5_hashesFileSizeByLevelMb_learner,ds_files_level_5_hashesFileSizeByLevelMb_teacher,ds_files_level_5_leafKeysFileSizeByLevelMb_learner,ds_files_level_5_leafKeysFileSizeByLevelMb_teacher,ds_files_level_5_leavesFileSizeByLevelMb_learner,ds_files_level_5_leavesFileSizeByLevelMb_teacher,ds_files_totalSizeMb_learner,ds_files_totalSizeMb_teacher,ds_flushes_hashesStoreFileSizeMb_learner,ds_flushes_hashesStoreFileSizeMb_teacher,ds_flushes_hashesWritten_learner,ds_flushes_hashesWritten_teacher,ds_flushes_leafKeysStoreFileSizeMb_learner,ds_flushes_leafKeysStoreFileSizeMb_teacher,ds_flushes_leafKeysWritten_learner,ds_flushes_leafKeysWritten_teacher,ds_flushes_leavesDeleted_learner,ds_flushes_leavesDeleted_teacher,ds_flushes_leavesStoreFileSizeMb_learner,ds_flushes_leavesStoreFileSizeMb_teacher,ds_flushes_leavesWritten_learner,ds_flushes_leavesWritten_teacher,ds_offheap_dataSourceMb_learner,ds_offheap_dataSourceMb_teacher,ds_offheap_hashesIndexMb_learner,ds_offheap_hashesIndexMb_teacher,ds_offheap_hashesListMb_learner,ds_offheap_hashesListMb_teacher,ds_offheap_leavesIndexMb_learner,ds_offheap_leavesIndexMb_teacher,ds_offheap_longKeysIndexMb_learner,ds_offheap_longKeysIndexMb_teacher,ds_offheap_objectKeyBucketsIndexMb_learner,ds_offheap_objectKeyBucketsIndexMb_teacher,ds_reads_hashes_learner,ds_reads_hashes_teacher,ds_reads_leafKeys_learner,ds_reads_leafKeys_teacher,ds_reads_leaves_learner,ds_reads_leaves_teacher,merkledb_count,vmap_lifecycle_familySizeBackpressureMs_learner,vmap_lifecycle_familySizeBackpressureMs_teacher,vmap_lifecycle_flushBacklogSize_learner,vmap_lifecycle_flushBacklogSize_teacher,vmap_lifecycle_flushBackpressureMs_learner,vmap_lifecycle_flushBackpressureMs_teacher,vmap_lifecycle_flushCount_learner,vmap_lifecycle_flushCount_teacher,vmap_lifecycle_flushDurationMs_learner,vmap_lifecycle_flushDurationMs_teacher,vmap_lifecycle_hashDurationMs_learner,vmap_lifecycle_hashDurationMs_teacher,vmap_lifecycle_mergeDurationMs_learner,vmap_lifecycle_mergeDurationMs_teacher,vmap_lifecycle_nodeCacheSizeB_learner,vmap_lifecycle_nodeCacheSizeB_teacher,vmap_lifecycle_pipelineSize_learner,vmap_lifecycle_pipelineSize_teacher,vmap_queries_addedEntities_learner,vmap_queries_addedEntities_teacher,vmap_queries_readEntities_learner,vmap_queries_readEntities_teacher,vmap_queries_removedEntities_learner,vmap_queries_removedEntities_teacher,vmap_queries_updatedEntities_learner,vmap_queries_updatedEntities_teacher,vmap_size_learner,vmap_size_teacher
2024-03-26 23:22:33 UTC,17179869184,16387145728,292786404,0.0,38,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
2024-03-26 23:22:34 UTC,17179869184,16378757120,292786404,1.3747597277615227,38,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
2024-03-26 23:22:35 UTC,17179869184,16370368512,292786404,1.3426726375390317,38,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
2024-03-26 23:22:36 UTC,17179869184,16361979904,292786405,1.339318368908393,38,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
2024-03-26 23:22:37 UTC,17179869184,16345202688,292792224,1.8030428136541221,38,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0.0,0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3609,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
2024-03-26 23:22:37 UTC,17179869184,16317939712,267603732,1.8119851956846997,33,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,2,0,0,0,0,0,0,0,2,0,14,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,14,0,2.47955322265625E-5,0.0,15918,0,0.0,0.0,4082,0,1178,0,0.5761775970458984,0.0,4082,0,69,0,8,0,45,0,8,0,8,0,0,0,0,0,0,0,544,0,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
2024-03-26 23:22:38 UTC,17179869184,16317939712,192106235,0.12651044180998744,17,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,0.0,0.0,0,0,2,0,0,0,0,0,0,0,2,0,14,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,14,0,0.0,0.0,0,0,0.0,0.0,0,0,0,0,0.0,0.0,0,0,69,0,8,0,45,0,8,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
