### PR TITLE
fix: Fix signing requirements for updating metadata on Token

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -398,10 +398,11 @@ public class BaseTokenHandler {
      * @return true if the given token update op is an expiry-only update op
      */
     public static boolean isExpiryOnlyUpdateOp(@NonNull final TokenUpdateTransactionBody op) {
-        final var defaultOp = TokenUpdateTransactionBody.DEFAULT;
-        final var copyDefaultWithExpiry =
-                defaultOp.copyBuilder().expiry(op.expiry()).token(op.token()).build();
-        return op.equals(copyDefaultWithExpiry);
+        final var defaultWithExpiry = TokenUpdateTransactionBody.newBuilder()
+                .expiry(op.expiry())
+                .token(op.token())
+                .build();
+        return op.equals(defaultWithExpiry);
     }
 
     /**
@@ -413,13 +414,11 @@ public class BaseTokenHandler {
      * @return true if the given token update op is an metadata-only update op
      */
     public static boolean isMetadataOnlyUpdateOp(@NonNull final TokenUpdateTransactionBody op) {
-        final var defaultOp = TokenUpdateTransactionBody.DEFAULT;
-        final var copyDefaultWithMetadata = defaultOp
-                .copyBuilder()
+        final var defaultWithMetadata = TokenUpdateTransactionBody.newBuilder()
                 .metadata(op.metadata())
                 .token(op.token())
                 .build();
-        return op.equals(copyDefaultWithMetadata);
+        return op.equals(defaultWithMetadata);
     }
 
     @NonNull

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -398,6 +398,9 @@ public class BaseTokenHandler {
      * @return true if the given token update op is an expiry-only update op
      */
     public static boolean isExpiryOnlyUpdateOp(@NonNull final TokenUpdateTransactionBody op) {
+        if (!op.hasExpiry()) {
+            return false;
+        }
         final var defaultWithExpiry = TokenUpdateTransactionBody.newBuilder()
                 .expiry(op.expiry())
                 .token(op.token())
@@ -414,6 +417,9 @@ public class BaseTokenHandler {
      * @return true if the given token update op is an metadata-only update op
      */
     public static boolean isMetadataOnlyUpdateOp(@NonNull final TokenUpdateTransactionBody op) {
+        if (!op.hasMetadata()) {
+            return false;
+        }
         final var defaultWithMetadata = TokenUpdateTransactionBody.newBuilder()
                 .metadata(op.metadata())
                 .token(op.token())

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -404,6 +404,24 @@ public class BaseTokenHandler {
         return op.equals(copyDefaultWithExpiry);
     }
 
+    /**
+     * Returns true if the given token update op is a metadata-only update op.
+     * This is needed for validating whether a token update op has admin key present on the token,
+     * to update any other fields other than metadata.
+     * For updating metadata we need signature from either admin key or metadata key
+     * @param op the token update op to check
+     * @return true if the given token update op is an metadata-only update op
+     */
+    public static boolean isMetadataOnlyUpdateOp(@NonNull final TokenUpdateTransactionBody op) {
+        final var defaultOp = TokenUpdateTransactionBody.DEFAULT;
+        final var copyDefaultWithMetadata = defaultOp
+                .copyBuilder()
+                .metadata(op.metadata())
+                .token(op.token())
+                .build();
+        return op.equals(copyDefaultWithMetadata);
+    }
+
     @NonNull
     public static TokenID asToken(final long num) {
         return TokenID.newBuilder().tokenNum(num).build();

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -135,7 +135,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
                             .build())
                     .build();
             context.requireKey(threshKey);
-        } else if (token.hasAdminKey() && !isExpiryOnlyUpdateOp(op)) {
+        } else if (!isExpiryOnlyUpdateOp(op) && token.hasAdminKey()) {
             // For expiry only op admin key is not required
             context.requireKey(token.adminKey());
         }
@@ -198,11 +198,6 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
                 transferTokensToNewTreasury(existingTreasury, newTreasury, token, tokenRelStore, accountStore);
             }
         }
-        // It is required for the token to have an admin Key or metadata key to update metadata
-        if (isMetadataOnlyUpdateOp(op)) {
-            validateTrue(token.hasAdminKey() || token.hasMetadataKey(), TOKEN_HAS_NO_METADATA_KEY);
-        }
-
         final var tokenBuilder = customizeToken(token, resolvedExpiry, op);
         tokenStore.put(tokenBuilder.build());
         recordBuilder.tokenType(token.tokenType());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -422,7 +422,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         if (isMetadataOnlyUpdateOp(op)) {
             validateTrue(originalToken.hasAdminKey() || originalToken.hasMetadataKey(), TOKEN_IS_IMMUTABLE);
         } else if (!isExpiryOnlyUpdateOp(op)) {
-            validateFalse(originalToken.hasAdminKey(), TOKEN_IS_IMMUTABLE);
+            validateTrue(originalToken.hasAdminKey(), TOKEN_IS_IMMUTABLE);
         }
 
         if (op.hasAdminKey()) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -39,7 +39,6 @@ import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.spi.key.KeyUtils.isValid;
 import static com.hedera.node.app.spi.validation.AttributeValidator.isKeyRemoval;
-import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
@@ -18,10 +18,12 @@ package com.hedera.node.app.service.token.impl.validators;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
+import static com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler.isExpiryOnlyUpdateOp;
 import static com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler.isMetadataOnlyUpdateOp;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.spi.key.KeyUtils.isEmpty;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
+import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -29,7 +31,6 @@ import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.TokenUpdateTransactionBody;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
-import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -59,8 +60,8 @@ public class TokenUpdateValidator {
         // For updating only metadata the transaction should have admin key or metadata key
         if (isMetadataOnlyUpdateOp(op)) {
             validateTrue(token.hasAdminKey() || token.hasMetadataKey(), TOKEN_IS_IMMUTABLE);
-        } else if (isEmpty(token.adminKey())) {
-            validateTrue(BaseTokenHandler.isExpiryOnlyUpdateOp(op), TOKEN_IS_IMMUTABLE);
+        } else if (!isExpiryOnlyUpdateOp(op)) {
+            validateFalse(isEmpty(token.adminKey()), TOKEN_IS_IMMUTABLE);
         }
         // validate memo
         if (op.hasMemo()) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -578,7 +578,7 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
     }
 
     public T blankMetadata() {
-        memo = Optional.of("");
+        metadata = Optional.of("");
         return self();
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
@@ -364,16 +364,12 @@ public class HapiTokenUpdate extends HapiTxnOp<HapiTokenUpdate> {
                             }
                             newMetadataKey.ifPresent(
                                     k -> b.setMetadataKey(spec.registry().getKey(k)));
-                            try {
-                                if (newMetadata.isPresent()) {
-                                    var metadataValue = BytesValue.newBuilder()
-                                            .setValue(ByteString.copyFrom(
-                                                    newMetadata.orElseThrow().getBytes()))
-                                            .build();
-                                    b.setMetadata(metadataValue);
-                                }
-                            } catch (Exception e) {
-                                log.warn("Failed to parse metadata", e);
+                            if (newMetadata.isPresent()) {
+                                var metadataValue = BytesValue.newBuilder()
+                                        .setValue(ByteString.copyFrom(
+                                                newMetadata.orElseThrow().getBytes()))
+                                        .build();
+                                b.setMetadata(metadataValue);
                             }
                         });
         return b -> b.setTokenUpdate(opBody);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMetadataSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMetadataSpecs.java
@@ -293,10 +293,10 @@ public class TokenMetadataSpecs extends HapiSuite {
                                 .initialSupply(500)
                                 .decimals(1)
                                 .metaData(metadata),
-                        getTokenInfo(PRIMARY).hasMetadata(metadata).logged())
+                        getTokenInfo(PRIMARY).hasMetadata(metadata))
                 .then(
-                        tokenUpdate(PRIMARY).newMetadata("newMetadata").signedBy(GENESIS, METADATA_KEY),
-                        getTokenInfo(PRIMARY).hasMetadata("newMetadata").logged());
+                        tokenUpdate(PRIMARY).newMetadata("newMetadata").signedBy(DEFAULT_PAYER, METADATA_KEY),
+                        getTokenInfo(PRIMARY).hasMetadata("newMetadata"));
     }
 
     @HapiTest
@@ -323,10 +323,10 @@ public class TokenMetadataSpecs extends HapiSuite {
                                 .initialSupply(500)
                                 .decimals(1)
                                 .metaData(metadata),
-                        getTokenInfo(PRIMARY).hasMetadata(metadata).logged())
+                        getTokenInfo(PRIMARY).hasMetadata(metadata))
                 .then(
-                        tokenUpdate(PRIMARY).newMetadata("newMetadata").signedBy(GENESIS, ADMIN_KEY),
-                        getTokenInfo(PRIMARY).hasMetadata("newMetadata").logged());
+                        tokenUpdate(PRIMARY).newMetadata("newMetadata").signedBy(DEFAULT_PAYER, ADMIN_KEY),
+                        getTokenInfo(PRIMARY).hasMetadata("newMetadata"));
     }
 
     @HapiTest
@@ -356,7 +356,7 @@ public class TokenMetadataSpecs extends HapiSuite {
                         getTokenInfo(PRIMARY).logged(),
                         tokenUpdate(PRIMARY)
                                 .newMetadata("newMetadata")
-                                .signedBy(GENESIS)
+                                .signedBy(DEFAULT_PAYER)
                                 .hasKnownStatus(INVALID_SIGNATURE))
                 .then();
     }
@@ -387,7 +387,7 @@ public class TokenMetadataSpecs extends HapiSuite {
                         getTokenInfo(PRIMARY).logged(),
                         tokenUpdate(PRIMARY)
                                 .newMetadata("newMetadata")
-                                .signedBy(GENESIS)
+                                .signedBy(DEFAULT_PAYER)
                                 .hasKnownStatus(TOKEN_IS_IMMUTABLE))
                 .then();
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMetadataSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMetadataSpecs.java
@@ -275,7 +275,7 @@ public class TokenMetadataSpecs extends HapiSuite {
         String metadata = "metadata";
         String saltedName = salted(PRIMARY);
 
-        return defaultHapiSpec("updatingMetadataOnTokenNeedsAdminOrMetadataKey", NONDETERMINISTIC_TOKEN_NAMES)
+        return defaultHapiSpec("updatingMetadataWorksWithMetadataKey", NONDETERMINISTIC_TOKEN_NAMES)
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(100L),
                         newKeyNamed(ADMIN_KEY),
@@ -288,7 +288,6 @@ public class TokenMetadataSpecs extends HapiSuite {
                                 .name(saltedName)
                                 .treasury(TOKEN_TREASURY)
                                 .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-                                .adminKey(ADMIN_KEY)
                                 .metadataKey(METADATA_KEY)
                                 .maxSupply(1000)
                                 .initialSupply(500)
@@ -306,7 +305,7 @@ public class TokenMetadataSpecs extends HapiSuite {
         String metadata = "metadata";
         String saltedName = salted(PRIMARY);
 
-        return defaultHapiSpec("updatingMetadataOnTokenNeedsAdminOrMetadataKey", NONDETERMINISTIC_TOKEN_NAMES)
+        return defaultHapiSpec("updatingMetadataWorksWithAdminKey", NONDETERMINISTIC_TOKEN_NAMES)
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(100L),
                         newKeyNamed(ADMIN_KEY),
@@ -336,7 +335,7 @@ public class TokenMetadataSpecs extends HapiSuite {
         String metadata = "metadata";
         String saltedName = salted(PRIMARY);
 
-        return defaultHapiSpec("updatingMetadataOnTokenNeedsAdminOrMetadataKey", NONDETERMINISTIC_TOKEN_NAMES)
+        return defaultHapiSpec("cannotUpdateMetadataWithoutAdminOrMetadataKeySignature", NONDETERMINISTIC_TOKEN_NAMES)
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(100L),
                         newKeyNamed(ADMIN_KEY),
@@ -368,7 +367,7 @@ public class TokenMetadataSpecs extends HapiSuite {
         String metadata = "metadata";
         String saltedName = salted(PRIMARY);
 
-        return defaultHapiSpec("updatingMetadataOnTokenNeedsAdminOrMetadataKey", NONDETERMINISTIC_TOKEN_NAMES)
+        return defaultHapiSpec("cannotUpdateMetadataOnImmutableToken", NONDETERMINISTIC_TOKEN_NAMES)
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(100L),
                         newKeyNamed(ADMIN_KEY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -133,7 +133,47 @@ public class TokenUpdateSpecs extends HapiSuite {
                 updateUniqueTreasuryWithNfts(),
                 updateHappyPath(),
                 safeToUpdateCustomFeesWithNewFallbackWhileTransferring(),
-                tokenUpdateCanClearMemo());
+                tokenUpdateCanClearMemo(),
+                canUpdateExpiryOnlyOpWithoutAdminKey());
+    }
+
+    @HapiTest
+    private HapiSpec canUpdateExpiryOnlyOpWithoutAdminKey() {
+        final var smallBuffer = 12_345L;
+        final var okExpiry = defaultMaxLifetime + Instant.now().getEpochSecond() - smallBuffer;
+        String originalMemo = "First things first";
+        String saltedName = salted("primary");
+        final var civilian = "civilian";
+        return defaultHapiSpec("ValidatesNewExpiry")
+                .given(
+                        cryptoCreate(civilian).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        newKeyNamed("adminKey"),
+                        newKeyNamed("freezeKey"),
+                        newKeyNamed("newFreezeKey"),
+                        newKeyNamed("kycKey"),
+                        newKeyNamed("newKycKey"),
+                        newKeyNamed("supplyKey"),
+                        newKeyNamed("newSupplyKey"),
+                        newKeyNamed("wipeKey"),
+                        newKeyNamed("newWipeKey"),
+                        newKeyNamed("pauseKey"),
+                        newKeyNamed("newPauseKey"),
+                        tokenCreate("primary")
+                                .name(saltedName)
+                                .entityMemo(originalMemo)
+                                .treasury(TOKEN_TREASURY)
+                                .initialSupply(500)
+                                .decimals(1)
+                                .adminKey("adminKey")
+                                .freezeKey("freezeKey")
+                                .kycKey("kycKey")
+                                .supplyKey("supplyKey")
+                                .wipeKey("wipeKey")
+                                .pauseKey("pauseKey")
+                                .payingWith(civilian))
+                .when()
+                .then(tokenUpdate("primary").expiry(okExpiry).signedBy(GENESIS));
     }
 
     @HapiTest


### PR DESCRIPTION
Fixes #12387 

- Fixes signing requirements for TokenUpdate to require either adminKey or metadataKey, when updating `metadata` field
- Also fixes signing requirements for expiry only update. Previously it failed with `INVALID_SIGNATURE` if there is no adminKey signature for expiry only update operation