### PR TITLE
fix: Clean up leaked virtual maps after migration

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/CongestionThrottleService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/CongestionThrottleService.java
@@ -21,8 +21,8 @@ import static com.hedera.node.app.service.mono.pbj.PbjConverter.toPbj;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.congestion.CongestionLevelStarts;
 import com.hedera.hapi.node.state.throttles.ThrottleUsageSnapshots;
+import com.hedera.node.app.hapi.utils.throttles.DeterministicThrottle;
 import com.hedera.node.app.service.mono.pbj.PbjConverter;
-import com.hedera.node.app.service.mono.state.merkle.MerkleNetworkContext;
 import com.hedera.node.app.spi.Service;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
@@ -43,7 +43,9 @@ public class CongestionThrottleService implements Service {
     public static final String NAME = "CongestionThrottleService";
     public static final String THROTTLE_USAGE_SNAPSHOTS_STATE_KEY = "THROTTLE_USAGE_SNAPSHOTS";
     public static final String CONGESTION_LEVEL_STARTS_STATE_KEY = "CONGESTION_LEVEL_STARTS";
-    private MerkleNetworkContext mnc;
+
+    private DeterministicThrottle.UsageSnapshot[] usageSnapshots;
+    private DeterministicThrottle.UsageSnapshot gasThrottleUsageSnapshot;
 
     @NonNull
     @Override
@@ -66,21 +68,20 @@ public class CongestionThrottleService implements Service {
             /** {@inheritDoc} */
             @Override
             public void migrate(@NonNull final MigrationContext ctx) {
-                if (mnc != null) {
+                if (usageSnapshots != null && gasThrottleUsageSnapshot != null) {
                     log.info("Migrating throttle usage snapshots");
                     // For diff testing we need to initialize the throttle snapshots from the saved state
                     final var throttleSnapshots = ctx.newStates().getSingleton(THROTTLE_USAGE_SNAPSHOTS_STATE_KEY);
                     throttleSnapshots.put(new ThrottleUsageSnapshots(
-                            Arrays.stream(mnc.getUsageSnapshots())
+                            Arrays.stream(usageSnapshots)
                                     .map(PbjConverter::toPbj)
                                     .toList(),
-                            toPbj(mnc.getGasThrottleUsageSnapshot())));
+                            toPbj(gasThrottleUsageSnapshot)));
 
                     // Unless we find diff testing requires, for now don't bother migrating congestion level starts
                     final var congestionLevelStarts = ctx.newStates().getSingleton(CONGESTION_LEVEL_STARTS_STATE_KEY);
                     congestionLevelStarts.put(CongestionLevelStarts.DEFAULT);
 
-                    mnc = null;
                     log.info("BBM: finished migrating congestion throttle service");
                 } else if (ctx.previousVersion() == null) {
                     log.info("Creating genesis throttle snapshots and congestion level starts");
@@ -96,7 +97,10 @@ public class CongestionThrottleService implements Service {
         });
     }
 
-    public void setFs(@Nullable final MerkleNetworkContext mnc) {
-        this.mnc = mnc;
+    public void setFs(
+            @Nullable final DeterministicThrottle.UsageSnapshot[] usageSnapshots,
+            @Nullable final DeterministicThrottle.UsageSnapshot gasThrottleUsageSnapshot) {
+        this.usageSnapshots = usageSnapshots;
+        this.gasThrottleUsageSnapshot = gasThrottleUsageSnapshot;
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/schemas/InitialModServiceAdminSchema.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/schemas/InitialModServiceAdminSchema.java
@@ -19,13 +19,11 @@ package com.hedera.node.app.service.networkadmin.impl.schemas;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
-import com.hedera.node.app.service.mono.state.merkle.MerkleNetworkContext;
 import com.hedera.node.app.service.networkadmin.impl.FreezeServiceImpl;
 import com.hedera.node.app.spi.state.MigrationContext;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.StateDefinition;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +36,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class InitialModServiceAdminSchema extends Schema {
     private static final Logger log = LogManager.getLogger(InitialModServiceAdminSchema.class);
-    private static MerkleNetworkContext mnc;
+    private static boolean merkleNetworkContextExists;
 
     public InitialModServiceAdminSchema(@NonNull final SemanticVersion version) {
         super(version);
@@ -65,15 +63,15 @@ public class InitialModServiceAdminSchema extends Schema {
                 ctx.newStates().<ProtoBytes>getSingleton(FreezeServiceImpl.UPGRADE_FILE_HASH_KEY);
         final var freezeTimeKeyState = ctx.newStates().<Timestamp>getSingleton(FreezeServiceImpl.FREEZE_TIME_KEY);
 
-        if (isGenesis || mnc != null) {
+        if (isGenesis || merkleNetworkContextExists) {
             upgradeFileHashKeyState.put(ProtoBytes.DEFAULT);
             freezeTimeKeyState.put(Timestamp.DEFAULT);
         }
-        mnc = null;
+
         log.info("BBM: finished migrating Admin service");
     }
 
-    public static void setFs(@Nullable final MerkleNetworkContext mn) {
-        mnc = mn;
+    public static void setFs(final boolean networkContextExists) {
+        merkleNetworkContextExists = networkContextExists;
     }
 }


### PR DESCRIPTION
This PR also includes a little cleanup to keep the network context out of the admin schema.

closes #12281