### PR TITLE
fix: treat an out-of-range allowance amount as an invalid op

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
@@ -87,8 +87,9 @@ public class HtsSystemContract extends AbstractFullContract implements HederaSys
                 // without setting a halt reason to simulate mono-service for differential testing
                 return haltResult(contractsConfigOf(frame).precompileHtsDefaultGasCost());
             }
-        } catch (final Exception e) {
-            log.warn("Failed to create HTS call from input {}", input, e);
+        } catch (final Exception ignore) {
+            // Input that cannot be translated to an executable call, for any
+            // reason, halts the frame and consumes all remaining gas
             return haltResult(INVALID_OPERATION, frame.getRemainingGas());
         }
         return resultOfExecuting(attempt, call, input, frame);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
@@ -36,15 +36,14 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhance
 import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.math.BigInteger;
 
 public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
     protected final VerificationStrategy verificationStrategy;
     protected final AccountID senderId;
     protected final TokenID tokenId;
     protected final AccountID spenderId;
-    protected final BigInteger amount;
     protected final TokenType tokenType;
+    protected final long amount;
 
     // too many parameters
     @SuppressWarnings("java:S107")
@@ -55,7 +54,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
             @NonNull final AccountID senderId,
             @NonNull final TokenID tokenId,
             @NonNull final AccountID spenderId,
-            @NonNull final BigInteger amount,
+            final long amount,
             @NonNull final TokenType tokenType,
             final boolean isViewCall) {
         super(gasCalculator, enhancement, isViewCall);
@@ -98,7 +97,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
                 .nftAllowances(NftRemoveAllowance.newBuilder()
                         .tokenId(tokenId)
                         .owner(ownerId)
-                        .serialNumbers(amount.longValue())
+                        .serialNumbers(amount)
                         .build())
                 .build();
     }
@@ -110,7 +109,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
                         .spender(spenderId)
                         .delegatingSpender(delegateSpenderId)
                         .owner(ownerId)
-                        .serialNumbers(amount.longValue())
+                        .serialNumbers(amount)
                         .build())
                 .build();
     }
@@ -122,7 +121,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
                                 .tokenId(tokenId)
                                 .spender(spenderId)
                                 .owner(ownerId)
-                                .amount(amount.longValue())
+                                .amount(amount)
                                 .build())
                         .build()
                 : CryptoApproveAllowanceTransactionBody.newBuilder()
@@ -130,7 +129,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
                                 .tokenId(tokenId)
                                 .spender(spenderId)
                                 .owner(ownerId)
-                                .serialNumbers(amount.longValue())
+                                .serialNumbers(amount)
                                 .build())
                         .build();
     }
@@ -144,7 +143,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractHtsCall {
     }
 
     protected @Nullable AccountID getMaybeOwnerId() {
-        final var nft = enhancement.nativeOperations().getNft(tokenId.tokenNum(), amount.longValue());
+        final var nft = enhancement.nativeOperations().getNft(tokenId.tokenNum(), amount);
         if (nft == null) {
             return null;
         }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
@@ -33,7 +33,6 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.LogBui
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.math.BigInteger;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.log.Log;
@@ -48,7 +47,7 @@ public class ClassicGrantApprovalCall extends AbstractGrantApprovalCall {
             @NonNull final AccountID senderId,
             @NonNull final TokenID token,
             @NonNull final AccountID spender,
-            @NonNull final BigInteger amount,
+            final long amount,
             @NonNull final TokenType tokenType) {
         super(gasCalculator, enhancement, verificationStrategy, senderId, token, spender, amount, tokenType, false);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
@@ -31,7 +31,6 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.math.BigInteger;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
@@ -45,7 +44,7 @@ public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
             @NonNull final AccountID senderId,
             @NonNull final TokenID tokenId,
             @NonNull final AccountID spenderId,
-            @NonNull final BigInteger amount,
+            final long amount,
             @NonNull final TokenType tokenType) {
         super(gasCalculator, enhancement, verificationStrategy, senderId, tokenId, spenderId, amount, tokenType, false);
     }
@@ -66,10 +65,10 @@ public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
         } else {
             if (tokenType.equals(TokenType.NON_FUNGIBLE_UNIQUE)) {
                 GrantApprovalLoggingUtils.logSuccessfulNFTApprove(
-                        tokenId, senderId, spenderId, amount.longValue(), readableAccountStore(), frame);
+                        tokenId, senderId, spenderId, amount, readableAccountStore(), frame);
             } else {
                 GrantApprovalLoggingUtils.logSuccessfulFTApprove(
-                        tokenId, senderId, spenderId, amount.longValue(), readableAccountStore(), frame);
+                        tokenId, senderId, spenderId, amount, readableAccountStore(), frame);
             }
             final var encodedOutput = tokenType.equals(TokenType.FUNGIBLE_COMMON)
                     ? GrantApprovalTranslator.ERC_GRANT_APPROVAL.getOutputs().encodeElements(true)

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
@@ -36,7 +36,6 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.granta
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
 import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
-import java.math.BigInteger;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -72,7 +71,7 @@ public class ClassicGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.FUNGIBLE_COMMON);
         given(systemContractOperations.dispatch(any(), any(), any(), any())).willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
@@ -95,7 +94,7 @@ public class ClassicGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         given(systemContractOperations.dispatch(any(), any(), any(), any())).willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
@@ -46,7 +46,6 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.granta
 import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.HtsCallTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import java.math.BigInteger;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
@@ -89,7 +88,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.FUNGIBLE_COMMON);
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),
@@ -121,7 +120,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),
@@ -156,7 +155,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID.tokenNum(), 100L)).willReturn(nft);
         given(nativeOperations.getToken(NON_FUNGIBLE_TOKEN_ID.tokenNum())).willReturn(token);
@@ -182,7 +181,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         // make sure nft is found
         given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID.tokenNum(), 100L)).willReturn(nft);
@@ -213,7 +212,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         // make sure nft is found
         given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID.tokenNum(), 100L)).willReturn(null);
@@ -240,7 +239,7 @@ class ERCGrantApprovalCallTest extends HtsCallTestBase {
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
                 REVOKE_APPROVAL_SPENDER_ID,
-                BigInteger.valueOf(100L),
+                100L,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),


### PR DESCRIPTION
- Closes #12267 
- Treat an `approve(address, amount)` call to the HTS system contract as an invalid operation when `amount` is outside range of a 64-bit `long`.
    * This is both backward-compatible, and more in line with the overall convention that if an `HtsCallAttempt` cannot be translated into a plausible `TransactionBody`, it halts as an invalid operation.