### PR TITLE
chore: divide summed lazy-create cost by gas price

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/SystemContractGasCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/SystemContractGasCalculator.java
@@ -89,6 +89,15 @@ public class SystemContractGasCalculator {
     }
 
     /**
+     * Returns the gas price for the top-level HAPI operation.
+     *
+     * @return the gas price for the top-level HAPI operation
+     */
+    public long topLevelGasPrice() {
+        return tinybarValues.topLevelTinybarGasPrice();
+    }
+
+    /**
      * Given a dispatch type, returns the canonical gas requirement for that dispatch type.
      * Useful when providing a ballpark gas requirement in the absence of a valid
      * transaction body for the dispatch type.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -189,20 +189,18 @@ public class HandleHederaOperations implements HederaOperations {
     public long lazyCreationCostInGas(@NonNull final Address recipient) {
         final var payerId = context.payer();
         // Calculate gas for a CryptoCreateTransactionBody with an alias address
-        final var createFee = gasCalculator.topLevelGasRequirement(
-                TransactionBody.newBuilder()
-                        .cryptoCreateAccount(CREATE_TXN_BODY_BUILDER.alias(tuweniToPbjBytes(recipient)))
-                        .build(),
-                payerId);
+        final var synthCreation = TransactionBody.newBuilder()
+                .cryptoCreateAccount(CREATE_TXN_BODY_BUILDER.alias(tuweniToPbjBytes(recipient)))
+                .build();
+        final var createFee = gasCalculator.canonicalPriceInTinybars(synthCreation, payerId);
 
         // Calculate gas for an update TransactionBody
-        final var updateFee = gasCalculator.topLevelGasRequirement(
-                TransactionBody.newBuilder()
-                        .cryptoUpdateAccount(UPDATE_TXN_BODY_BUILDER)
-                        .build(),
-                payerId);
+        final var synthUpdate = TransactionBody.newBuilder()
+                .cryptoUpdateAccount(UPDATE_TXN_BODY_BUILDER)
+                .build();
+        final var updateFee = gasCalculator.canonicalPriceInTinybars(synthUpdate, payerId);
 
-        return createFee + updateFee;
+        return (createFee + updateFee) / gasCalculator.topLevelGasPrice();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
@@ -74,4 +74,10 @@ class SystemContractGasCalculatorTest {
         given(tinybarValues.childTransactionTinybarGasPrice()).willReturn(2L);
         assertEquals(6L, subject.gasCostInTinybars(3L));
     }
+
+    @Test
+    void delegatesTopLevelGasPrice() {
+        given(tinybarValues.topLevelTinybarGasPrice()).willReturn(123L);
+        assertEquals(123L, subject.topLevelGasPrice());
+    }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -237,9 +237,10 @@ class HandleHederaOperationsTest {
     @Test
     void lazyCreationCostInGasTest() {
         given(context.payer()).willReturn(A_NEW_ACCOUNT_ID);
-        given(gasCalculator.topLevelGasRequirement(any(), eq(A_NEW_ACCOUNT_ID)))
+        given(gasCalculator.canonicalPriceInTinybars(any(), eq(A_NEW_ACCOUNT_ID)))
                 .willReturn(6L)
                 .willReturn(5L);
+        given(gasCalculator.topLevelGasPrice()).willReturn(1L);
         assertEquals(11L, subject.lazyCreationCostInGas(NON_SYSTEM_LONG_ZERO_ADDRESS));
     }
 


### PR DESCRIPTION
**Description**:
 - Closes #12266 
 - For mono-service fidelity, wait to divide by gas price until _after_ summing the tinybar costs of the synthetic create and update transactions.