### PR TITLE
chore: reclaim EthTx lazy-create id on INSUFFICIENT_GAS; use INVALID_ACCOUNT_ID

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/CodeOrderResultFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/CodeOrderResultFactory.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.sigs.order;
 
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
@@ -135,7 +134,7 @@ public enum CodeOrderResultFactory implements SigningOrderResultFactory<Response
     static final SigningOrderResult<ResponseCodeEnum> GENERAL_PAYER_ERROR_RESULT =
             new SigningOrderResult<>(INVALID_SIGNATURE);
     static final SigningOrderResult<ResponseCodeEnum> MISSING_ACCOUNT_RESULT =
-            new SigningOrderResult<>(ACCOUNT_ID_DOES_NOT_EXIST);
+            new SigningOrderResult<>(INVALID_ACCOUNT_ID);
     static final SigningOrderResult<ResponseCodeEnum> MISSING_FILE_RESULT = new SigningOrderResult<>(INVALID_FILE_ID);
     static final SigningOrderResult<ResponseCodeEnum> MISSING_CONTRACT_RESULT =
             new SigningOrderResult<>(INVALID_CONTRACT_ID);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/order/SigRequirementsTest.java
@@ -294,7 +294,6 @@ import static com.hedera.test.factories.txns.SignedTxnFactory.MASTER_PAYER_ID;
 import static com.hedera.test.factories.txns.SignedTxnFactory.TREASURY_PAYER_ID;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.IdUtils.asTopic;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
@@ -891,7 +890,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -904,7 +903,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -917,7 +916,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -930,7 +929,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -1250,7 +1249,7 @@ public class SigRequirementsTest {
         final var summary = subject.keysForOtherParties(txn, summaryFactory);
 
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -2023,7 +2022,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -2036,7 +2035,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -2049,7 +2048,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -2062,7 +2061,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -3585,7 +3584,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -3598,7 +3597,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -4678,7 +4677,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -4691,7 +4690,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -5449,7 +5448,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -5462,7 +5461,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.hasErrorReport());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test
@@ -6016,7 +6015,7 @@ public class SigRequirementsTest {
 
         // then:
         assertTrue(summary.getOrderedKeys().isEmpty());
-        assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+        assertEquals(INVALID_ACCOUNT_ID, summary.getErrorReport());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManagerTest.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.service.mono.context.properties.PropertyNames;
 import com.hedera.node.app.service.mono.ledger.HederaLedger;
 import com.hedera.node.app.service.mono.ledger.SigImpactHistorian;
 import com.hedera.node.app.service.mono.ledger.accounts.staking.RewardCalculator;
+import com.hedera.node.app.service.mono.ledger.ids.EntityIdSource;
 import com.hedera.node.app.service.mono.records.RecordCache;
 import com.hedera.node.app.service.mono.records.RecordsHistorian;
 import com.hedera.node.app.service.mono.state.initialization.BlocklistAccountCreator;
@@ -58,6 +59,9 @@ class ServicesTxnManagerTest {
     private final long submittingMember = 1;
     private final Instant consensusTime = Instant.ofEpochSecond(1_234_567L, 890);
     private final AccountID effectivePayer = IdUtils.asAccount("0.0.75231");
+
+    @Mock
+    private EntityIdSource idSource;
 
     @Mock
     private Runnable processLogic;
@@ -122,7 +126,8 @@ class ServicesTxnManagerTest {
                 blockManager,
                 rewardCalculator,
                 bootstrapProperties,
-                blocklistAccountCreator);
+                blocklistAccountCreator,
+                idSource);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
- Closes #11881
- Closes #11878
- Reduce diff testing surface area by switching mono-service behavior to mod-service on `release/0.48` in two cases:
    1. Use `INVALID_ACCOUNT_ID` instead of `ACCOUNT_ID_DOES_NOT_EXIST` when a `CryptoTransfer` encounters a missing account id.
    2. Reclaim an entity id when an `EthereumTransaction` lazy-create fails due to `INSUFFICIENT_GAS`.
    
 ➡️ This PR *does not* need to be cherry-picked to `develop`.