### PR TITLE
fix: tokenAssociate throws IndexOutOfBoundsException

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -174,7 +174,7 @@ public class BaseTokenHandler {
         linkTokenRels(account, newTokenRels, tokenRelStore);
 
         // FUTURE - We may need to return a proper error status when tokens are empty
-        if (!tokens.isEmpty()) {
+        if (!newTokenRels.isEmpty()) {
             // Now replace the account's old head token number with the new head token number. This is
             // how we link the new tokenRels to the account
             final var firstOfNewTokenRels = newTokenRels.get(0);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -173,19 +173,22 @@ public class BaseTokenHandler {
         // Link the new token relations to the account
         linkTokenRels(account, newTokenRels, tokenRelStore);
 
-        // Now replace the account's old head token number with the new head token number. This is
-        // how we link the new tokenRels to the account
-        final var firstOfNewTokenRels = newTokenRels.get(0);
-        final var updatedAcct = account.copyBuilder()
-                // replace the head token number with the first token number of the new tokenRels
-                .headTokenId(firstOfNewTokenRels.tokenId())
-                // and also update the account's total number of token associations
-                .numberAssociations(account.numberAssociations() + newTokenRels.size())
-                .build();
+        // FUTURE - We may need to return a proper error status when tokens are empty
+        if (!tokens.isEmpty()) {
+            // Now replace the account's old head token number with the new head token number. This is
+            // how we link the new tokenRels to the account
+            final var firstOfNewTokenRels = newTokenRels.get(0);
+            final var updatedAcct = account.copyBuilder()
+                    // replace the head token number with the first token number of the new tokenRels
+                    .headTokenId(firstOfNewTokenRels.tokenId())
+                    // and also update the account's total number of token associations
+                    .numberAssociations(account.numberAssociations() + newTokenRels.size())
+                    .build();
 
-        // Save the results
-        accountStore.put(updatedAcct);
-        newTokenRels.forEach(tokenRelStore::put);
+            // Save the results
+            accountStore.put(updatedAcct);
+            newTokenRels.forEach(tokenRelStore::put);
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds additional check to ensure that newly created token relation list is not empty. This way we prevent IndexOutOfBoundsException when passing no tokens param to the request body.


**Related issue(s)**:

Fixes #12440

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This is a quick fix and it match mono behaviour, and return is SUCCES, but we may need to return a proper error status when tokens are empty.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
