### PR TITLE
fix: 12466 Fixed NPE intermitently occurring after 0.47 -> 0.48 migration

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -46,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;


### PR DESCRIPTION
**Description**:

This PR addresses possible data race that can happen after 0.47 -> 0.48 migration. 

**Related issue(s)**:

Fixes #12466

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
