### PR TITLE
fix: block no migration

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
@@ -43,6 +43,9 @@ public final class BlockInfoTranslator {
             throws IOException {
         requireNonNull(merkleNetworkContext);
         final var blockInfoBuilder = new BlockInfo.Builder()
+                // Mono-service kept the current (in-progress) block number in state,
+                // while mod-service keeps the last finished block number in state; so
+                // subtract 1 to get the last finished block number here
                 .lastBlockNumber(merkleNetworkContext.getAlignmentBlockNo() - 1)
                 .blockHashes(getBlockHashes(merkleNetworkContext.getBlockHashes()));
         if (merkleNetworkContext.firstConsTimeOfCurrentBlock().getEpochSecond() > 0) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslator.java
@@ -43,7 +43,7 @@ public final class BlockInfoTranslator {
             throws IOException {
         requireNonNull(merkleNetworkContext);
         final var blockInfoBuilder = new BlockInfo.Builder()
-                .lastBlockNumber(merkleNetworkContext.getAlignmentBlockNo())
+                .lastBlockNumber(merkleNetworkContext.getAlignmentBlockNo() - 1)
                 .blockHashes(getBlockHashes(merkleNetworkContext.getBlockHashes()));
         if (merkleNetworkContext.firstConsTimeOfCurrentBlock().getEpochSecond() > 0) {
             blockInfoBuilder.firstConsTimeOfCurrentBlock(Timestamp.newBuilder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/codec/BlockInfoTranslatorTest.java
@@ -102,7 +102,7 @@ class BlockInfoTranslatorTest {
                 .put(hash3)
                 .array();
         return BlockInfo.newBuilder()
-                .lastBlockNumber(5L)
+                .lastBlockNumber(4L)
                 .firstConsTimeOfCurrentBlock(CONSENSUS_TIME)
                 .blockHashes(Bytes.wrap(result));
     }


### PR DESCRIPTION
**Description**:
 - Closes #12427 
 - Migrates last block number to `(current - 1)` from mono state.