### PR TITLE
fix: 12466 Fixed NPE intermitently occurring after 0.47 -> 0.48 migration

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -46,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -608,10 +607,6 @@ public final class MerkleDb {
         return getInstance(defaultInstancePath);
     }
 
-    private void storeMetadata() {
-        storeMetadata(storageDir, getPrimaryTables());
-    }
-
     /**
      * Writes database metadata file to the specified dir. Only table configs from the given list of
      * tables are included.
@@ -623,13 +618,19 @@ public final class MerkleDb {
      *   <li>(for every table) table ID, table Name, and table serialization config
      * </ul>
      *
-     * @param dir Folder to write metadata file to
-     * @param tables List of tables to include to the metadata file
+     * This method has to be synchronized, as it's totally possible for multiple tables to be processed
+     * at the same time, and we'd like to guarantee that the metadata file is consistent.
      */
-    @SuppressWarnings("rawtypes")
-    private void storeMetadata(final Path dir, final Collection<TableMetadata> tables) {
+    private synchronized void storeMetadata() {
+        final Set<TableMetadata> tables = new HashSet<>();
+        for (int i = 0; i < tableConfigs.length(); i++) {
+            final TableMetadata tableMetadata = tableConfigs.get(i);
+            if ((tableMetadata != null) && primaryTables.contains(i)) {
+                tables.add(tableMetadata);
+            }
+        }
         if (config.usePbj()) {
-            final Path dbMetadataFile = dir.resolve(METADATA_FILENAME);
+            final Path dbMetadataFile = storageDir.resolve(METADATA_FILENAME);
             try (final OutputStream fileOut =
                     Files.newOutputStream(dbMetadataFile, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
                 final WritableSequentialData out = new WritableStreamingData(fileOut);
@@ -641,7 +642,7 @@ public final class MerkleDb {
                 throw new UncheckedIOException(z);
             }
         } else {
-            final Path dbMetadataFile = dir.resolve(METADATA_FILENAME_OLD);
+            final Path dbMetadataFile = storageDir.resolve(METADATA_FILENAME_OLD);
             try (final OutputStream fileOut =
                             Files.newOutputStream(dbMetadataFile, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
                     SerializableDataOutputStream out = new SerializableDataOutputStream(fileOut)) {
@@ -759,26 +760,6 @@ public final class MerkleDb {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns the set of primary tables in this database. The corresponding data source may
-     * or may not be opened.
-     *
-     * @return Set of all tables in the database
-     */
-    private Set<TableMetadata> getPrimaryTables() {
-        // I wish there was AtomicReferenceArray.stream()
-        final Set<TableMetadata> tables = new HashSet<>();
-        for (int i = 0; i < tableConfigs.length(); i++) {
-            final TableMetadata tableMetadata = tableConfigs.get(i);
-            if ((tableMetadata != null) && primaryTables.contains(i)) {
-                tables.add(tableConfigs.get(i));
-            }
-        }
-        // If this method is ever used outside this class, change it to return an
-        // unmodifiable set instead
-        return tables;
     }
 
     /**


### PR DESCRIPTION
**Description:**

This PR addresses possible data race that can happen after 0.47 -> 0.48 migration.

This is a cherry-pick of this PR - https://github.com/hashgraph/hedera-services/pull/12467

**Related issue(s)**:

Fixes #12466 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
