### PR TITLE
fix: ContractCallLocal INSUFFICIENT_GAS ERROR

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmStaticTransactionFactory.java
@@ -16,12 +16,13 @@
 
 package com.hedera.node.app.service.contract.impl.infra;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_NEGATIVE_GAS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction.NOT_APPLICABLE;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asPriorityId;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
+import static org.apache.tuweni.bytes.Bytes.EMPTY;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.contract.ContractCallLocalQuery;
@@ -33,6 +34,7 @@ import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
  * A factory that creates a {@link HederaEvmTransaction} for static calls.
@@ -41,14 +43,18 @@ import javax.inject.Inject;
  */
 @QueryScope
 public class HevmStaticTransactionFactory {
+    private static final long INTRINSIC_GAS_LOWER_BOUND = 21_000L;
     private final ContractsConfig contractsConfig;
+    private final GasCalculator gasCalculator;
     private final QueryContext context;
     private final AccountID payerId;
 
     @Inject
-    public HevmStaticTransactionFactory(@NonNull final QueryContext context) {
+    public HevmStaticTransactionFactory(
+            @NonNull final QueryContext context, @NonNull final GasCalculator gasCalculator) {
         this.context = requireNonNull(context);
         this.contractsConfig = context.configuration().getConfigData(ContractsConfig.class);
+        this.gasCalculator = requireNonNull(gasCalculator);
         this.payerId = requireNonNull(context.payer());
     }
 
@@ -81,7 +87,9 @@ public class HevmStaticTransactionFactory {
     }
 
     private void assertValidCall(@NonNull final ContractCallLocalQuery body) {
-        validateTrue(body.gas() >= 0, CONTRACT_NEGATIVE_GAS);
+        final var minGasLimit =
+                Math.max(INTRINSIC_GAS_LOWER_BOUND, gasCalculator.transactionIntrinsicGasCost(EMPTY, false));
+        validateTrue(body.gas() >= minGasLimit, INSUFFICIENT_GAS);
         validateTrue(body.gas() <= contractsConfig.maxGasPerSec(), MAX_GAS_LIMIT_EXCEEDED);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmStaticTransactionFactoryTest.java
@@ -41,6 +41,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Consumer;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +50,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class HevmStaticTransactionFactoryTest {
+    @Mock
+    private GasCalculator gasCalculator;
+
     @Mock
     private QueryContext context;
 
@@ -61,14 +65,14 @@ class HevmStaticTransactionFactoryTest {
     void setUp() {
         given(context.configuration()).willReturn(DEFAULT_CONFIG);
         given(context.payer()).willReturn(SENDER_ID);
-        subject = new HevmStaticTransactionFactory(context);
+        subject = new HevmStaticTransactionFactory(context, gasCalculator);
     }
 
     @Test
     void fromQueryWorkWithSenderAndUsesPriorityAddress() {
         final var query = Query.newBuilder()
                 .contractCallLocal(callLocalWith(b -> {
-                    b.gas(100L);
+                    b.gas(21_000L);
                     b.senderId(SENDER_ID);
                     b.contractID(CALLED_CONTRACT_ID);
                     b.functionParameters(CALL_DATA);
@@ -84,7 +88,7 @@ class HevmStaticTransactionFactoryTest {
         assertThat(transaction.payload()).isEqualTo(CALL_DATA);
         assertThat(transaction.chainId()).isNull();
         assertThat(transaction.value()).isZero();
-        assertThat(transaction.gasLimit()).isEqualTo(100L);
+        assertThat(transaction.gasLimit()).isEqualTo(21_000L);
         assertThat(transaction.offeredGasPrice()).isEqualTo(1L);
         assertThat(transaction.maxGasAllowance()).isZero();
         assertThat(transaction.hapiCreation()).isNull();
@@ -150,8 +154,8 @@ class HevmStaticTransactionFactoryTest {
     }
 
     @Test
-    void fromQueryFailsWithNegativeGas() {
-        assertCallFailsWith(ResponseCodeEnum.CONTRACT_NEGATIVE_GAS, builder -> builder.gas(-5L));
+    void fromQueryFailsWithGasBelowFixedLowerBound() {
+        assertCallFailsWith(ResponseCodeEnum.INSUFFICIENT_GAS, builder -> builder.gas(20_999L));
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -47,6 +47,7 @@ import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFo
 import static com.hedera.services.bdd.suites.utils.MiscEETUtils.metadata;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
@@ -103,6 +104,8 @@ public class ContractCallLocalSuite extends HapiSuite {
     public List<HapiSpec> getSpecsInSuite() {
         return List.of(
                 invalidDeletedContract(),
+                gasBelowIntrinsicGasFails(),
+                insufficientGasFails(),
                 invalidContractID(),
                 impureCallFails(),
                 insufficientFeeFails(),
@@ -199,6 +202,28 @@ public class ContractCallLocalSuite extends HapiSuite {
                                         .resultViaFunctionName("getIndirect", CONTRACT, isLiteralResult(new Object[] {
                                             BigInteger.valueOf(7L)
                                         }))));
+    }
+
+    @HapiTest
+    final HapiSpec gasBelowIntrinsicGasFails() {
+        return defaultHapiSpec("gasBelowIntrinsicGasFails", NONDETERMINISTIC_TRANSACTION_FEES)
+                .given(cryptoCreate("payer"), uploadInitCode(CONTRACT), contractCreate(CONTRACT))
+                .when(contractCall(CONTRACT, "create").gas(785_000))
+                .then(
+                        sleepFor(3_000L),
+                        contractCallLocal(CONTRACT, "getIndirect").gas(2_000L).hasAnswerOnlyPrecheck(INSUFFICIENT_GAS));
+    }
+
+    @HapiTest
+    final HapiSpec insufficientGasFails() {
+        return defaultHapiSpec("insufficientGasFails", NONDETERMINISTIC_TRANSACTION_FEES)
+                .given(cryptoCreate("payer"), uploadInitCode(CONTRACT), contractCreate(CONTRACT))
+                .when(contractCall(CONTRACT, "create").gas(785_000))
+                .then(
+                        sleepFor(3_000L),
+                        contractCallLocal(CONTRACT, "getIndirect")
+                                .gas(22_000L)
+                                .hasAnswerOnlyPrecheck(INSUFFICIENT_GAS));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
-Revert PR #12362 
-Reimplement fix for an issue where modularized code was erroring when a CONTRACT_CALL_LOCAL query had less than the minimum amount of gas required for CONTRACT_CALL transactions.
-Maintain INTRINSIC_GAS_LOWER_BOUND minimum gas requirement
-Add EET which duplicated the error 

**Related issue(s)**:
Fixes #12313
