### PR TITLE
fix: Setup metrics for WritableKVStateStack

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableKvStateMetrics.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableKvStateMetrics.java
@@ -60,7 +60,7 @@ public class OnDiskWritableKvStateMetrics {
                 .withFormat("%,d");
         metrics.getOrCreate(totalUtilizationConfig);
 
-        final double relativeFactor = 100.0 / Math.max(1.0, maxCapacity);  // in some tests, maxCapacity is 0
+        final double relativeFactor = 100.0 / Math.max(1.0, maxCapacity); // in some tests, maxCapacity is 0
         final var relativeUtilizationConfig = new Config<>(
                         "app", name + "PercentUsed", Double.class, () -> count.get() * relativeFactor)
                 .withDescription(String.format("instantaneous %% used of %s system limit", label))

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableKvStateMetrics.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskWritableKvStateMetrics.java
@@ -50,8 +50,8 @@ public class OnDiskWritableKvStateMetrics {
         if (currentValue < 0) {
             throw new IllegalArgumentException("currentValue must be non-negative");
         }
-        if (maxCapacity <= 0) {
-            throw new IllegalArgumentException("maxCapacity must be positive");
+        if (maxCapacity < 0) {
+            throw new IllegalArgumentException("maxCapacity must be non-negative");
         }
         this.count = new AtomicLong(currentValue);
 
@@ -60,7 +60,7 @@ public class OnDiskWritableKvStateMetrics {
                 .withFormat("%,d");
         metrics.getOrCreate(totalUtilizationConfig);
 
-        final double relativeFactor = 100.0 / maxCapacity;
+        final double relativeFactor = 100.0 / Math.max(1.0, maxCapacity);  // in some tests, maxCapacity is 0
         final var relativeUtilizationConfig = new Config<>(
                         "app", name + "PercentUsed", Double.class, () -> count.get() * relativeFactor)
                 .withDescription(String.format("instantaneous %% used of %s system limit", label))

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableKVStateStack.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/WritableKVStateStack.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.workflows.handle.stack;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.spi.state.WritableKVState;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Iterator;
@@ -121,5 +122,10 @@ public class WritableKVStateStack<K, V> implements WritableKVState<K, V> {
     @Override
     public long size() {
         return getCurrent().size();
+    }
+
+    @Override
+    public void setupMetrics(@NonNull Metrics metrics, @NonNull String name, @NonNull String label, long maxCapacity) {
+        getCurrent().setupMetrics(metrics, name, label, maxCapacity);
     }
 }


### PR DESCRIPTION
This PR ensure metrics are also setup for `WritableKVStateStack`

Fixes #12485 