### PR TITLE
feat: construct schedulers automatically

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/component/SchedulerLabel.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/component/SchedulerLabel.java
@@ -23,11 +23,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates a method parameter used to implement a transformer/filter. Use this to override the name of the task
- * scheduler used to operate the transformer/filter.
+ * Annotates a name that should be used as an override for the task scheduler's name instead of a component's interface
+ * name. Can also be used to annotate a method parameter used to implement a transformer/filter (these get turned into
+ * direct schedulers, which need to be named).
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface SchedulerLabel {
 
     /**

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/component/ComponentWiringTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/wiring/component/ComponentWiringTests.java
@@ -23,8 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.common.wiring.model.WiringModel;
-import com.swirlds.common.wiring.schedulers.TaskScheduler;
-import com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType;
+import com.swirlds.common.wiring.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.common.wiring.wires.input.InputWire;
 import com.swirlds.common.wiring.wires.output.OutputWire;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -109,6 +108,7 @@ public class ComponentWiringTests {
         }
     }
 
+    @SchedulerLabel("actuallyCallThisSomethingDifferent")
     private interface ComponentWithListOutput {
         @NonNull
         List<String> handleInputA(@NonNull String s);
@@ -154,14 +154,11 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<Long> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final ComponentWiring<FooBarBaz, Long> fooBarBazWiring =
-                new ComponentWiring<>(wiringModel, FooBarBaz.class, scheduler);
+                new ComponentWiring<>(wiringModel, FooBarBaz.class, schedulerConfiguration);
+        assertEquals("FooBarBaz", fooBarBazWiring.getSchedulerName());
 
         assertThrows(IllegalArgumentException.class, () -> fooBarBazWiring.getInputWire((x, y) -> 0L));
         assertThrows(IllegalArgumentException.class, () -> fooBarBazWiring.getInputWire((x, y) -> {}));
@@ -178,14 +175,11 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<Long> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final ComponentWiring<FooBarBaz, Long> fooBarBazWiring =
-                new ComponentWiring<>(wiringModel, FooBarBaz.class, scheduler);
+                new ComponentWiring<>(wiringModel, FooBarBaz.class, schedulerConfiguration);
+        assertEquals("FooBarBaz", fooBarBazWiring.getSchedulerName());
 
         final FooBarBazImpl fooBarBazImpl = new FooBarBazImpl();
 
@@ -270,16 +264,13 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<Long> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final FooBarBazImpl fooBarBazImpl = new FooBarBazImpl();
 
         final ComponentWiring<FooBarBaz, Long> fooBarBazWiring =
-                new ComponentWiring<>(wiringModel, FooBarBaz.class, scheduler);
+                new ComponentWiring<>(wiringModel, FooBarBaz.class, schedulerConfiguration);
+        assertEquals("FooBarBaz", fooBarBazWiring.getSchedulerName());
 
         if (bindLocation == 0) {
             fooBarBazWiring.bind(fooBarBazImpl);
@@ -342,16 +333,13 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<Long> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final FooBarBazImpl fooBarBazImpl = new FooBarBazImpl();
 
         final ComponentWiring<FooBarBaz, Long> fooBarBazWiring =
-                new ComponentWiring<>(wiringModel, FooBarBaz.class, scheduler);
+                new ComponentWiring<>(wiringModel, FooBarBaz.class, schedulerConfiguration);
+        assertEquals("FooBarBaz", fooBarBazWiring.getSchedulerName());
 
         if (bindLocation == 0) {
             fooBarBazWiring.bind(fooBarBazImpl);
@@ -416,14 +404,11 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<List<String>> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final ComponentWiring<ComponentWithListOutput, List<String>> componentWiring =
-                new ComponentWiring<>(wiringModel, ComponentWithListOutput.class, scheduler);
+                new ComponentWiring<>(wiringModel, ComponentWithListOutput.class, schedulerConfiguration);
+        assertEquals("actuallyCallThisSomethingDifferent", componentWiring.getSchedulerName());
 
         if (bindLocation == 0) {
             componentWiring.bind(new ComponentWithListOutputImpl());
@@ -458,14 +443,11 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<List<String>> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final ComponentWiring<ComponentWithListOutput, List<String>> componentWiring =
-                new ComponentWiring<>(wiringModel, ComponentWithListOutput.class, scheduler);
+                new ComponentWiring<>(wiringModel, ComponentWithListOutput.class, schedulerConfiguration);
+        assertEquals("actuallyCallThisSomethingDifferent", componentWiring.getSchedulerName());
 
         if (bindLocation == 0) {
             componentWiring.bind(new ComponentWithListOutputImpl());
@@ -509,17 +491,11 @@ public class ComponentWiringTests {
 
         final WiringModel wiringModel = WiringModel.create(platformContext, ForkJoinPool.commonPool());
 
-        final TaskScheduler<List<String>> scheduler = wiringModel
-                .schedulerBuilder("test")
-                .withType(TaskSchedulerType.DIRECT)
-                .withUncaughtExceptionHandler((t, e) -> {
-                    e.printStackTrace();
-                })
-                .build()
-                .cast();
+        final TaskSchedulerConfiguration schedulerConfiguration = TaskSchedulerConfiguration.parse("DIRECT");
 
         final ComponentWiring<ComponentWithListOutput, List<String>> componentWiring =
-                new ComponentWiring<>(wiringModel, ComponentWithListOutput.class, scheduler);
+                new ComponentWiring<>(wiringModel, ComponentWithListOutput.class, schedulerConfiguration);
+        assertEquals("actuallyCallThisSomethingDifferent", componentWiring.getSchedulerName());
 
         if (bindLocation == 0) {
             componentWiring.bind(new ComponentWithListOutputImpl());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulers.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulers.java
@@ -40,7 +40,6 @@ import com.swirlds.platform.event.preconsensus.PcesSequencer;
 import com.swirlds.platform.event.preconsensus.PcesWriter;
 import com.swirlds.platform.event.stream.EventStreamManager;
 import com.swirlds.platform.event.validation.EventSignatureValidator;
-import com.swirlds.platform.event.validation.InternalEventValidator;
 import com.swirlds.platform.eventhandling.ConsensusRoundHandler;
 import com.swirlds.platform.eventhandling.TransactionPrehandler;
 import com.swirlds.platform.gossip.shadowgraph.Shadowgraph;
@@ -65,7 +64,6 @@ import java.util.List;
  *
  * @param eventHasherScheduler                      the scheduler for the event hasher
  * @param postHashCollectorScheduler                the scheduler for the post hash collector
- * @param internalEventValidatorScheduler           the scheduler for the internal event validator
  * @param eventDeduplicatorScheduler                the scheduler for the event deduplicator
  * @param eventSignatureValidatorScheduler          the scheduler for the event signature validator
  * @param orphanBufferScheduler                     the scheduler for the orphan buffer
@@ -92,7 +90,6 @@ import java.util.List;
 public record PlatformSchedulers(
         @NonNull TaskScheduler<GossipEvent> eventHasherScheduler,
         @NonNull TaskScheduler<GossipEvent> postHashCollectorScheduler,
-        @NonNull TaskScheduler<GossipEvent> internalEventValidatorScheduler,
         @NonNull TaskScheduler<GossipEvent> eventDeduplicatorScheduler,
         @NonNull TaskScheduler<GossipEvent> eventSignatureValidatorScheduler,
         @NonNull TaskScheduler<List<GossipEvent>> orphanBufferScheduler,
@@ -149,11 +146,6 @@ public record PlatformSchedulers(
                         .withExternalBackPressure(true)
                         .withUnhandledTaskMetricEnabled(true)
                         .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                        .build()
-                        .cast(),
-                model.schedulerBuilder("internalEventValidator")
-                        .configure(config.internalEventValidator())
-                        .withHyperlink(platformCoreHyperlink(InternalEventValidator.class))
                         .build()
                         .cast(),
                 model.schedulerBuilder("eventDeduplicator")

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -173,12 +173,12 @@ public class PlatformWiring implements Startable, Stoppable, Clearable {
 
         this.platformContext = Objects.requireNonNull(platformContext);
 
-        final PlatformSchedulersConfig schedulersConfig =
+        final PlatformSchedulersConfig config =
                 platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
 
         final int coreCount = Runtime.getRuntime().availableProcessors();
-        final int parallelism = (int) Math.max(
-                1, schedulersConfig.defaultPoolMultiplier() * coreCount + schedulersConfig.defaultPoolConstant());
+        final int parallelism =
+                (int) Math.max(1, config.defaultPoolMultiplier() * coreCount + config.defaultPoolConstant());
         final ForkJoinPool defaultPool = new ForkJoinPool(parallelism);
         logger.info(STARTUP.getMarker(), "Default platform pool parallelism: {}", parallelism);
 
@@ -216,8 +216,8 @@ public class PlatformWiring implements Startable, Stoppable, Clearable {
         eventHasherWiring = new ComponentWiring<>(model, EventHasher.class, schedulers.eventHasherScheduler());
         postHashCollectorWiring =
                 new PassThroughWiring<>(model, "GossipEvent", schedulers.postHashCollectorScheduler());
-        internalEventValidatorWiring = new ComponentWiring<>(
-                model, InternalEventValidator.class, schedulers.internalEventValidatorScheduler());
+        internalEventValidatorWiring =
+                new ComponentWiring<>(model, InternalEventValidator.class, config.internalEventValidator());
         eventDeduplicatorWiring =
                 new ComponentWiring<>(model, EventDeduplicator.class, schedulers.eventDeduplicatorScheduler());
         eventSignatureValidatorWiring = new ComponentWiring<>(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/generate-platform-diagram.sh
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/generate-platform-diagram.sh
@@ -23,7 +23,7 @@ pcli diagram \
     -s 'eventCreationManager:non-validated events:🍎' \
     -s 'Mystery Input:mystery data:X' \
     -s 'stateSigner:signature transactions:🖋️' \
-    -g 'Event Validation:internalEventValidator,eventDeduplicator,eventSignatureValidator' \
+    -g 'Event Validation:InternalEventValidator,eventDeduplicator,eventSignatureValidator' \
     -g 'Event Hashing:eventHasher,postHashCollector' \
     -g 'Orphan Buffer:orphanBuffer,orphanBufferSplitter' \
     -g 'Consensus Engine:consensusEngine,consensusEngineSplitter,eventWindowManager,getKeystoneEventSequenceNumber' \


### PR DESCRIPTION
closes #12503 

There was a minor change to the wiring diagram (`internalEventValidator` become `InternalEventValidator`), but I did not merge that file to avoid merge conflicts with other branches that are currently open.
