### PR TITLE
feat: address book serializes text hostnames

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -239,9 +239,9 @@ public class AddressBookUtils {
                 nickname,
                 selfname,
                 weight,
-                internalIp.getHostAddress(),
+                parts[5], // FQDN Support: use original string for internal address
                 internalPort,
-                externalIp.getHostAddress(),
+                parts[7], // FQDN Support: use original string for external address
                 externalPort,
                 memoToUse);
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
@@ -463,6 +463,12 @@ class AddressBookTests {
     void roundTripSerializeAndDeserializeCompatibleWithConfigTxt() throws ParseException {
         final RandomAddressBookGenerator generator = new RandomAddressBookGenerator(getRandomPrintSeed());
         final AddressBook addressBook = generator.build();
+        // FQDN Support: modify address in address book to have a text based host name.
+        addressBook.add(addressBook
+                .getAddress(addressBook.getNodeId(0))
+                .copySetHostnameInternal("localhost")
+                .copySetHostnameExternal("localhost"));
+
         // make one of the memo fields an empty string
         final NodeId firstNode = addressBook.getNodeId(0);
         addressBook.add(addressBook.getAddress(firstNode).copySetMemo(""));


### PR DESCRIPTION
**Description**:
This PR ensures that we store and serialize text based hostnames when they are given in config.txt.    Roundtrip serialization and deserialization is verified by using the string "localhost" as a hostname for an address.  

**Related issue(s)**:

Fixes #12508
