### PR TITLE
fix: remove spurious `createTopic()` call

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -166,8 +166,6 @@ public class TopicCreateSuite extends HapiSuite {
                                 .payingWith("payer")
                                 .signedBy("wrongKey")
                                 .hasPrecheck(INVALID_SIGNATURE),
-                        // In hedera-app, we'll allow contracts with admin keys to be auto-renew accounts
-                        createTopic("withContractAutoRenew").autoRenewAccountId(contractWithAdminKey),
                         // But contracts without admin keys will get INVALID_SIGNATURE (can't sign!)
                         createTopic("NotToBe")
                                 .autoRenewAccountId(PAY_RECEIVABLE_CONTRACT)


### PR DESCRIPTION
**Description**:
 - Remove a `createTopic()` call that did not specify an admin key along with its auto-renew account (for historical reasons, only topics with an admin key can set auto-renew accounts).