### PR TITLE
feat(ReconnectBench): fuzz slow I/O delay emulation

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
@@ -72,11 +72,25 @@ public class ReconnectBench extends VirtualMapBaseBench {
     public long delayStorageMicroseconds;
 
     /**
+     * A percentage fuzz range for the delayStorageMicroseconds values,
+     * e.g. 0.15 for a -15%..+15% range around the value.
+     */
+    @Param({"0.15"})
+    public double delayStorageFuzzRangePercent;
+
+    /**
      * Emulated delay for serializeMessage() calls in both Teaching- and Learning-Synchronizers,
      * or zero for no delay. This emulates slow network I/O when sending data.
      */
     @Param({"0"})
     public long delayNetworkMicroseconds;
+
+    /**
+     * A percentage fuzz range for the delayNetworkMicroseconds values,
+     * e.g. 0.15 for a -15%..+15% range around the value.
+     */
+    @Param({"0.15"})
+    public double delayNetworkFuzzRangePercent;
 
     private VirtualMap<BenchmarkKey, BenchmarkValue> teacherMap;
     private VirtualMap<BenchmarkKey, BenchmarkValue> learnerMap;
@@ -214,6 +228,13 @@ public class ReconnectBench extends VirtualMapBaseBench {
     @Benchmark
     public void reconnect() throws Exception {
         node = MerkleBenchmarkUtils.hashAndTestSynchronization(
-                learnerTree, teacherTree, delayStorageMicroseconds, delayNetworkMicroseconds, configuration);
+                learnerTree,
+                teacherTree,
+                randomSeed,
+                delayStorageMicroseconds,
+                delayStorageFuzzRangePercent,
+                delayNetworkMicroseconds,
+                delayNetworkFuzzRangePercent,
+                configuration);
     }
 }

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
@@ -55,8 +55,11 @@ public class MerkleBenchmarkUtils {
     public static <T extends MerkleNode> T hashAndTestSynchronization(
             final MerkleNode startingTree,
             final MerkleNode desiredTree,
+            final long randomSeed,
             final long delayStorageMicroseconds,
+            final double delayStorageFuzzRangePercent,
             final long delayNetworkMicroseconds,
+            final double delayNetworkFuzzRangePercent,
             final Configuration configuration)
             throws Exception {
         System.out.println("------------");
@@ -74,8 +77,11 @@ public class MerkleBenchmarkUtils {
         return testSynchronization(
                 startingTree,
                 desiredTree,
+                randomSeed,
                 delayStorageMicroseconds,
+                delayStorageFuzzRangePercent,
                 delayNetworkMicroseconds,
+                delayNetworkFuzzRangePercent,
                 configuration,
                 reconnectConfig);
     }
@@ -87,8 +93,11 @@ public class MerkleBenchmarkUtils {
     private static <T extends MerkleNode> T testSynchronization(
             final MerkleNode startingTree,
             final MerkleNode desiredTree,
+            final long randomSeed,
             final long delayStorageMicroseconds,
+            final double delayStorageFuzzRangePercent,
             final long delayNetworkMicroseconds,
+            final double delayNetworkFuzzRangePercent,
             final Configuration configuration,
             final ReconnectConfig reconnectConfig)
             throws Exception {
@@ -132,8 +141,11 @@ public class MerkleBenchmarkUtils {
                         streams.getLearnerInput(),
                         streams.getLearnerOutput(),
                         startingTree,
+                        randomSeed,
                         delayStorageMicroseconds,
+                        delayStorageFuzzRangePercent,
                         delayNetworkMicroseconds,
+                        delayNetworkFuzzRangePercent,
                         () -> {
                             try {
                                 streams.disconnect();
@@ -148,8 +160,11 @@ public class MerkleBenchmarkUtils {
                         streams.getTeacherInput(),
                         streams.getTeacherOutput(),
                         desiredTree,
+                        randomSeed,
                         delayStorageMicroseconds,
+                        delayStorageFuzzRangePercent,
                         delayNetworkMicroseconds,
+                        delayNetworkFuzzRangePercent,
                         () -> {
                             try {
                                 streams.disconnect();

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/BenchmarkSlowLearningSynchronizer.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/BenchmarkSlowLearningSynchronizer.java
@@ -33,8 +33,11 @@ import com.swirlds.common.threading.pool.StandardWorkGroup;
  */
 public class BenchmarkSlowLearningSynchronizer extends LearningSynchronizer {
 
+    private final long randomSeed;
     private final long delayStorageMicroseconds;
+    private final double delayStorageFuzzRangePercent;
     private final long delayNetworkMicroseconds;
+    private final double delayNetworkFuzzRangePercent;
 
     /**
      * Create a new learning synchronizer with simulated latency.
@@ -43,14 +46,20 @@ public class BenchmarkSlowLearningSynchronizer extends LearningSynchronizer {
             final MerkleDataInputStream in,
             final MerkleDataOutputStream out,
             final MerkleNode root,
+            final long randomSeed,
             final long delayStorageMicroseconds,
+            final double delayStorageFuzzRangePercent,
             final long delayNetworkMicroseconds,
+            final double delayNetworkFuzzRangePercent,
             final Runnable breakConnection,
             final ReconnectConfig reconnectConfig) {
         super(getStaticThreadManager(), in, out, root, breakConnection, reconnectConfig);
 
+        this.randomSeed = randomSeed;
         this.delayStorageMicroseconds = delayStorageMicroseconds;
+        this.delayStorageFuzzRangePercent = delayStorageFuzzRangePercent;
         this.delayNetworkMicroseconds = delayNetworkMicroseconds;
+        this.delayNetworkFuzzRangePercent = delayNetworkFuzzRangePercent;
     }
 
     /**
@@ -60,6 +69,13 @@ public class BenchmarkSlowLearningSynchronizer extends LearningSynchronizer {
     protected AsyncOutputStream<QueryResponse> buildOutputStream(
             final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
         return new BenchmarkSlowAsyncOutputStream<>(
-                out, workGroup, delayStorageMicroseconds, delayNetworkMicroseconds, reconnectConfig);
+                out,
+                workGroup,
+                randomSeed,
+                delayStorageMicroseconds,
+                delayStorageFuzzRangePercent,
+                delayNetworkMicroseconds,
+                delayNetworkFuzzRangePercent,
+                reconnectConfig);
     }
 }

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/BenchmarkSlowTeachingSynchronizer.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/BenchmarkSlowTeachingSynchronizer.java
@@ -36,8 +36,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class BenchmarkSlowTeachingSynchronizer extends TeachingSynchronizer {
 
+    private final long randomSeed;
     private final long delayStorageMicroseconds;
+    private final double delayStorageFuzzRangePercent;
     private final long delayNetworkMicroseconds;
+    private final double delayNetworkFuzzRangePercent;
 
     /**
      * Create a new teaching synchronizer with simulated latency.
@@ -47,8 +50,11 @@ public class BenchmarkSlowTeachingSynchronizer extends TeachingSynchronizer {
             final MerkleDataInputStream in,
             final MerkleDataOutputStream out,
             final MerkleNode root,
+            final long randomSeed,
             final long delayStorageMicroseconds,
+            final double delayStorageFuzzRangePercent,
             final long delayNetworkMicroseconds,
+            final double delayNetworkFuzzRangePercent,
             final Runnable breakConnection,
             final ReconnectConfig reconnectConfig) {
         super(
@@ -60,8 +66,12 @@ public class BenchmarkSlowTeachingSynchronizer extends TeachingSynchronizer {
                 root,
                 breakConnection,
                 reconnectConfig);
+
+        this.randomSeed = randomSeed;
         this.delayStorageMicroseconds = delayStorageMicroseconds;
+        this.delayStorageFuzzRangePercent = delayStorageFuzzRangePercent;
         this.delayNetworkMicroseconds = delayNetworkMicroseconds;
+        this.delayNetworkFuzzRangePercent = delayNetworkFuzzRangePercent;
     }
 
     /**
@@ -71,6 +81,13 @@ public class BenchmarkSlowTeachingSynchronizer extends TeachingSynchronizer {
     protected <T> AsyncOutputStream<Lesson<T>> buildOutputStream(
             final StandardWorkGroup workGroup, final SerializableDataOutputStream out) {
         return new BenchmarkSlowAsyncOutputStream<>(
-                out, workGroup, delayStorageMicroseconds, delayNetworkMicroseconds, reconnectConfig);
+                out,
+                workGroup,
+                randomSeed,
+                delayStorageMicroseconds,
+                delayStorageFuzzRangePercent,
+                delayNetworkMicroseconds,
+                delayNetworkFuzzRangePercent,
+                reconnectConfig);
     }
 }

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/LongFuzzer.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/LongFuzzer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.benchmark.reconnect.lag;
+
+import java.util.Random;
+
+/**
+ * A generator of random long values in a given percentage range around a given base value.
+ *
+ * @param value a base value
+ * @param random a Random instance, or null for no fuzz
+ * @param rangePercent a rangePercent, e.g. 0.15 for a -15%..+15% range around the base value.
+ */
+public record LongFuzzer(long value, Random random, double rangePercent) {
+    /**
+     * Returns the next long value in the range -rangePercent..+rangePercent around the base value.
+     * @return the next long value
+     */
+    public long next() {
+        if (random == null || rangePercent == .0) return value;
+
+        // Generate a random fuzz percentage in the range -rangePercent..+rangePercent, e.g. -0.15..+0.15 for 15% range
+        final double fuzzPercent = random.nextDouble(rangePercent * 2.) - rangePercent;
+        return (long) ((double) value * (1. + fuzzPercent));
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing a `LongFuzzer` and using it to fuzz the emulated storage and network I/O delays in the ReconnectBench. The fuzz amount is configured in the form of a percentage range around the base value of the delay. I'm using the original and a negative Random seed values for the storage and network delays fuzzers correspondingly to make the fuzz amounts different between the two.

**Related issue(s)**:

Fixes #12343 

**Notes for reviewer**:
```
$ gr jmhReconnect
...
Benchmark                 (delayNetworkFuzzRangePercent)  (delayNetworkMicroseconds)  (delayStorageFuzzRangePercent)  (delayStorageMicroseconds)  (keySize)  (maxKey)  (numFiles)  (numRecords)  (numThreads)  (randomSeed)  (recordSize)  (teacherAddProbability)  (teacherModifyProbability)  (teacherRemoveProbability)  Mode  Cnt  Score   Error  Units
ReconnectBench.reconnect                            0.15                          50                            0.15                         100          8   1000000         100          1000            32    9823452658           128                     0.01                        0.01                        0.01  avgt    7  4.777 ± 0.528   s/op

Benchmark result is saved to /Users/anthony/ws/15-jmh/hedera-services/platform-sdk/swirlds-benchmarks/build/results/jmh/results-reconnect.txt

BUILD SUCCESSFUL in 2m 19s
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
