### PR TITLE
chore: cherry pick 12547

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -17,7 +17,12 @@
 package com.hedera.node.app.workflows.ingest;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CALL;
+import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_ADD_LIVE_HASH;
+import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_DELETE_LIVE_HASH;
 import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
+import static com.hedera.hapi.node.base.HederaFunctionality.FREEZE;
+import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_DELETE;
+import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_UNDELETE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BUSY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
@@ -25,6 +30,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PLATFORM_NOT_ACTIVE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNAUTHORIZED;
 import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.populateEthTxData;
@@ -69,8 +75,10 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -80,6 +88,10 @@ import org.apache.logging.log4j.Logger;
  */
 public final class IngestChecker {
     private static final Logger logger = LogManager.getLogger(IngestChecker.class);
+    private static final Set<HederaFunctionality> UNSUPPORTED_TRANSACTIONS =
+            EnumSet.of(CRYPTO_ADD_LIVE_HASH, CRYPTO_DELETE_LIVE_HASH);
+    private static final Set<HederaFunctionality> PRIVILEGED_TRANSACTIONS =
+            EnumSet.of(FREEZE, SYSTEM_DELETE, SYSTEM_UNDELETE);
 
     private final CurrentPlatformStatus currentPlatformStatus;
     private final TransactionChecker transactionChecker;
@@ -204,6 +216,7 @@ public final class IngestChecker {
         }
 
         // 4. Check throttles
+        assertThrottlingPreconditions(txInfo, configuration);
         if (synchronizedThrottleAccumulator.shouldThrottle(txInfo, state)) {
             throw new PreCheckException(BUSY);
         }
@@ -243,6 +256,27 @@ public final class IngestChecker {
         solvencyPreCheck.checkSolvency(txInfo, payer, fees, true);
 
         return txInfo;
+    }
+
+    private void assertThrottlingPreconditions(
+            @NonNull final TransactionInfo txInfo, @NonNull final Configuration configuration)
+            throws PreCheckException {
+        if (UNSUPPORTED_TRANSACTIONS.contains(txInfo.functionality())) {
+            throw new PreCheckException(NOT_SUPPORTED);
+        }
+        if (PRIVILEGED_TRANSACTIONS.contains(txInfo.functionality())) {
+            final var payerNum =
+                    txInfo.payerID() == null ? Long.MAX_VALUE : txInfo.payerID().accountNumOrElse(Long.MAX_VALUE);
+            final var hederaConfig = configuration.getConfigData(HederaConfig.class);
+            // This adds a mild restriction that privileged transactions can only
+            // be issued by system accounts; (FUTURE) consider giving non-trivial
+            // minimum fees to privileged transactions that fail with UNAUTHORIZED
+            // at consensus, and adding them to normal throttle buckets, c.f.
+            // https://github.com/hashgraph/hedera-services/issues/12559
+            if (payerNum >= hederaConfig.firstUserEntity()) {
+                throw new PreCheckException(UNAUTHORIZED);
+            }
+        }
     }
 
     private void verifyPayerSignature(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -94,12 +94,14 @@ import com.hedera.services.bdd.spec.transactions.file.HapiFileCreate;
 import com.hedera.services.bdd.spec.transactions.file.HapiFileUpdate;
 import com.hedera.services.bdd.spec.transactions.file.UploadProgress;
 import com.hedera.services.bdd.spec.transactions.system.HapiFreeze;
+import com.hedera.services.bdd.spec.utilops.checks.VerifyAddLiveHashNotSupported;
 import com.hedera.services.bdd.spec.utilops.checks.VerifyGetAccountNftInfosNotSupported;
 import com.hedera.services.bdd.spec.utilops.checks.VerifyGetBySolidityIdNotSupported;
 import com.hedera.services.bdd.spec.utilops.checks.VerifyGetFastRecordNotSupported;
 import com.hedera.services.bdd.spec.utilops.checks.VerifyGetLiveHashNotSupported;
 import com.hedera.services.bdd.spec.utilops.checks.VerifyGetStakersNotSupported;
 import com.hedera.services.bdd.spec.utilops.checks.VerifyGetTokenNftInfosNotSupported;
+import com.hedera.services.bdd.spec.utilops.checks.VerifyUserFreezeNotAuthorized;
 import com.hedera.services.bdd.spec.utilops.grouping.InBlockingOrder;
 import com.hedera.services.bdd.spec.utilops.grouping.ParallelSpecOps;
 import com.hedera.services.bdd.spec.utilops.inventory.NewSpecKey;
@@ -504,6 +506,14 @@ public class UtilVerbs {
 
     public static VerifyGetTokenNftInfosNotSupported getTokenNftInfosNotSupported() {
         return new VerifyGetTokenNftInfosNotSupported();
+    }
+
+    public static VerifyAddLiveHashNotSupported verifyAddLiveHashNotSupported() {
+        return new VerifyAddLiveHashNotSupported();
+    }
+
+    public static VerifyUserFreezeNotAuthorized verifyUserFreezeNotAuthorized() {
+        return new VerifyUserFreezeNotAuthorized();
     }
 
     public static RunLoadTest runLoadTest(Supplier<HapiSpecOperation[]> opSource) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyAddLiveHashNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyAddLiveHashNotSupported.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops.checks;
+
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.getUniqueTimestampPlusSecs;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.utilops.UtilOp;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.CryptoAddLiveHashTransactionBody;
+import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.SignatureMap;
+import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+
+public class VerifyAddLiveHashNotSupported extends UtilOp {
+    private static final long USER_PAYER_NUM = 1001L;
+
+    @Override
+    protected boolean submitOp(HapiSpec spec) throws Throwable {
+        final var validStart = getUniqueTimestampPlusSecs(spec.setup().txnStartOffsetSecs());
+        final var txnId = TransactionID.newBuilder()
+                .setTransactionValidStart(validStart)
+                .setAccountID(
+                        AccountID.newBuilder().setAccountNum(USER_PAYER_NUM).build())
+                .build();
+        final var body = TransactionBody.newBuilder()
+                .setTransactionID(txnId)
+                .setNodeAccountID(AccountID.newBuilder().setAccountNum(3).build())
+                .setTransactionValidDuration(
+                        Duration.newBuilder().setSeconds(120).build())
+                .setCryptoAddLiveHash(CryptoAddLiveHashTransactionBody.getDefaultInstance())
+                .build();
+        final var txn = Transaction.newBuilder()
+                .setSignedTransactionBytes(SignedTransaction.newBuilder()
+                        .setBodyBytes(body.toByteString())
+                        .setSigMap(SignatureMap.getDefaultInstance())
+                        .build()
+                        .toByteString())
+                .build();
+        final var response =
+                spec.clients().getCryptoSvcStub(targetNodeFor(spec), useTls).addLiveHash(txn);
+        assertEquals(NOT_SUPPORTED, response.getNodeTransactionPrecheckCode());
+        return false;
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetTokenNftInfosNotSupported.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyGetTokenNftInfosNotSupported.java
@@ -18,13 +18,13 @@ package com.hedera.services.bdd.spec.utilops.checks;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.TokenGetNftInfosQuery;
-import org.junit.jupiter.api.Assertions;
 
 public class VerifyGetTokenNftInfosNotSupported extends UtilOp {
     @Override
@@ -33,8 +33,7 @@ public class VerifyGetTokenNftInfosNotSupported extends UtilOp {
         Query query = Query.newBuilder().setTokenGetNftInfos(op).build();
         Response response =
                 spec.clients().getTokenSvcStub(targetNodeFor(spec), useTls).getTokenNftInfos(query);
-        Assertions.assertEquals(
-                NOT_SUPPORTED, response.getTokenGetNftInfos().getHeader().getNodeTransactionPrecheckCode());
+        assertEquals(NOT_SUPPORTED, response.getTokenGetNftInfos().getHeader().getNodeTransactionPrecheckCode());
         return false;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyUserFreezeNotAuthorized.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyUserFreezeNotAuthorized.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops.checks;
+
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.getUniqueTimestampPlusSecs;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.utilops.UtilOp;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.FreezeTransactionBody;
+import com.hederahashgraph.api.proto.java.SignatureMap;
+import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+
+public class VerifyUserFreezeNotAuthorized extends UtilOp {
+    private static final long USER_PAYER_NUM = 1001L;
+
+    @Override
+    protected boolean submitOp(HapiSpec spec) throws Throwable {
+        final var validStart = getUniqueTimestampPlusSecs(spec.setup().txnStartOffsetSecs());
+        final var txnId = TransactionID.newBuilder()
+                .setTransactionValidStart(validStart)
+                .setAccountID(
+                        AccountID.newBuilder().setAccountNum(USER_PAYER_NUM).build())
+                .build();
+        final var body = TransactionBody.newBuilder()
+                .setTransactionID(txnId)
+                .setNodeAccountID(AccountID.newBuilder().setAccountNum(3).build())
+                .setTransactionValidDuration(
+                        Duration.newBuilder().setSeconds(120).build())
+                .setFreeze(FreezeTransactionBody.getDefaultInstance())
+                .build();
+        final var txn = Transaction.newBuilder()
+                .setSignedTransactionBytes(SignedTransaction.newBuilder()
+                        .setBodyBytes(body.toByteString())
+                        .setSigMap(SignatureMap.getDefaultInstance())
+                        .build()
+                        .toByteString())
+                .build();
+        final var response =
+                spec.clients().getCryptoSvcStub(targetNodeFor(spec), useTls).addLiveHash(txn);
+        assertEquals(UNAUTHORIZED, response.getNodeTransactionPrecheckCode());
+        return false;
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
@@ -26,6 +26,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.reduceFeeFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.verifyAddLiveHashNotSupported;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.verifyUserFreezeNotAuthorized;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
@@ -69,6 +71,14 @@ public class MiscCryptoSuite extends HapiSuite {
 
     private List<HapiSpec> negativeTests() {
         return List.of(updateWithOutOfDateKeyFails());
+    }
+
+    @HapiTest
+    final HapiSpec unsupportedAndUnauthorizedTransactionsAreNotThrottled() {
+        return defaultHapiSpec("unsupportedAndUnauthorizedTransactionsAreNotThrottled")
+                .given()
+                .when()
+                .then(verifyAddLiveHashNotSupported(), verifyUserFreezeNotAuthorized());
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Avoid `BUSY` for unsupported and unauthorized txns at ingest.