### PR TITLE
fix: Add pure check to ContractDeleteHandler

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -36,6 +36,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.contract.ContractDeleteTransactionBody;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.records.ContractDeleteRecordBuilder;
 import com.hedera.node.app.service.mono.fees.calculation.contract.txns.ContractDeleteResourceUsage;
@@ -62,6 +63,12 @@ public class ContractDeleteHandler implements TransactionHandler {
     @Inject
     public ContractDeleteHandler() {
         // Exists for injection
+    }
+
+    @Override
+    public void pureChecks(@NonNull TransactionBody txn) throws PreCheckException {
+        final var op = txn.contractDeleteInstanceOrThrow();
+        mustExist(op.contractID(), INVALID_CONTRACT_ID);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/12565
Add `pureChecks()` to `ContractDeleteHandler` to ensure mandatory `contractID` is provided.