### PR TITLE
fix: use `0` for missing auto-renew period in `getTokenInfo()` result

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ReturnTypes.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ReturnTypes.java
@@ -87,7 +87,7 @@ public class ReturnTypes {
                         + "(bool,address,bytes,bytes,address)" // inheritedAccountKey, contractId, ed25519, ECDSA_secp256k1, delegatableContractId
                     + ")[],"
                     // Expiry
-                    + "(uint32,address,uint32)" // second, autoRenewAccount, autoRenewPeriod
+                    + "(int64,address,int64)" // second, autoRenewAccount, autoRenewPeriod
                 + ")"
 
                 + ",int64,bool,bool,bool," // totalSupply, deleted, defaultKycStatus, pauseStatus

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/TokenTupleUtils.java
@@ -65,7 +65,7 @@ public class TokenTupleUtils {
         return Tuple.of(
                 token.expirationSecond(),
                 headlongAddressOf(token.autoRenewAccountIdOrElse(ZERO_ACCOUNT_ID)),
-                token.autoRenewSeconds());
+                Math.max(0, token.autoRenewSeconds()));
     }
 
     /**


### PR DESCRIPTION
**Description**:
 - Closes #12538 
 - Use `0` instead of `-1` for an unset auto-renew period for backward compatibility.
 - Fix `struct Expiry` ABI types to `int64` instead of `uint32` c.f. the published ABI [here](https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L69).