### PR TITLE
fix: make pureChecks required in all handlers

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/TransactionHandler.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/TransactionHandler.java
@@ -48,9 +48,7 @@ public interface TransactionHandler {
      * @throws NullPointerException if {@code txBody} is {@code null}
      * @throws PreCheckException if the transaction is invalid
      */
-    // NOTE: FUTURE: This method should not be default, but should be implemented by all
-    // transaction handlers. This is a temporary measure to avoid merge conflicts.
-    default void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {}
+    void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException;
 
     /**
      * This method can be used to perform any warm up, e.g. loading data into memory that is needed

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
@@ -33,6 +33,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.state.consensus.Topic;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicRecordBuilder;
 import com.hedera.node.app.service.mono.fees.calculation.consensus.txns.CreateTopicResourceUsage;
@@ -77,6 +78,11 @@ public class ConsensusCreateTopicHandler implements TransactionHandler {
             final var autoRenewAccountID = op.autoRenewAccount();
             context.requireKeyOrThrow(autoRenewAccountID, INVALID_AUTORENEW_ACCOUNT);
         }
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     /**

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusDeleteTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusDeleteTopicHandler.java
@@ -26,6 +26,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.state.consensus.Topic;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.consensus.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.mono.fees.calculation.consensus.txns.DeleteTopicResourceUsage;
@@ -62,6 +63,11 @@ public class ConsensusDeleteTopicHandler implements TransactionHandler {
         // To delete a topic, the transaction must be signed by the admin key. If there is no admin
         // key, then it is impossible to delete the topic.
         context.requireKeyOrThrow(topic.adminKey(), UNAUTHORIZED);
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     /**

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -94,6 +94,11 @@ public class ConsensusSubmitMessageHandler implements TransactionHandler {
         }
     }
 
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
+    }
+
     /**
      * Given the appropriate context, submits a message to a topic.
      *

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
@@ -40,6 +40,7 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.consensus.ConsensusUpdateTopicTransactionBody;
 import com.hedera.hapi.node.state.consensus.Topic;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.consensus.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.mono.fees.calculation.consensus.txns.UpdateTopicResourceUsage;
@@ -100,6 +101,11 @@ public class ConsensusUpdateTopicHandler implements TransactionHandler {
                 context.requireKeyOrThrow(autoRenewAccountID, INVALID_AUTORENEW_ACCOUNT);
             }
         }
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     private boolean onlyExtendsExpiry(@NonNull final ConsensusUpdateTopicTransactionBody op) {

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
@@ -20,6 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -51,6 +52,11 @@ public class NetworkUncheckedSubmitHandler implements TransactionHandler {
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
         throw new PreCheckException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -17,8 +17,10 @@
 package com.hedera.node.app.service.contract.impl.handlers;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CALL;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.throwIfUnsuccessful;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.spi.validation.Validations.mustExist;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -75,8 +77,9 @@ public class ContractCallHandler implements TransactionHandler {
     }
 
     @Override
-    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+    public void pureChecks(@NonNull TransactionBody txn) throws PreCheckException {
+        final var op = txn.contractCallOrThrow();
+        mustExist(op.contractID(), INVALID_CONTRACT_ID);
     }
 
     @NonNull

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome.ExternalizeAbortResult;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
@@ -32,6 +33,7 @@ import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -70,6 +72,11 @@ public class ContractCallHandler implements TransactionHandler {
     @Override
     public void preHandle(@NonNull final PreHandleContext context) {
         // No non-payer signatures to verify
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @NonNull

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome.ExternalizeAbortResult;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
@@ -68,6 +69,11 @@ public class ContractCreateHandler implements TransactionHandler {
         outcome.addCreateDetailsTo(context.recordBuilder(ContractCreateRecordBuilder.class), ExternalizeAbortResult.NO);
 
         throwIfUnsuccessful(outcome.status());
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -75,7 +75,6 @@ public class ContractDeleteHandler implements TransactionHandler {
         mustExist(contractID, INVALID_CONTRACT_ID);
     }
 
-
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -66,10 +66,15 @@ public class ContractDeleteHandler implements TransactionHandler {
     }
 
     @Override
-    public void pureChecks(@NonNull TransactionBody txn) throws PreCheckException {
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
         final var op = txn.contractDeleteInstanceOrThrow();
-        mustExist(op.contractID(), INVALID_CONTRACT_ID);
+        validateFalsePreCheck(op.permanentRemoval(), PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION);
+
+        // The contract ID must be present on the transaction
+        final var contractID = op.contractID();
+        mustExist(contractID, INVALID_CONTRACT_ID);
     }
+
 
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
@@ -91,16 +96,6 @@ public class ContractDeleteHandler implements TransactionHandler {
         } else if (op.hasTransferContractID()) {
             context.requireKeyIfReceiverSigRequired(op.transferContractID(), INVALID_CONTRACT_ID);
         }
-    }
-
-    @Override
-    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        final var op = txn.contractDeleteInstanceOrThrow();
-        validateFalsePreCheck(op.permanentRemoval(), PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION);
-
-        // The contract ID must be present on the transaction
-        final var contractID = op.contractID();
-        mustExist(contractID, INVALID_CONTRACT_ID);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -36,6 +36,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.contract.ContractDeleteTransactionBody;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.records.ContractDeleteRecordBuilder;
 import com.hedera.node.app.service.mono.fees.calculation.contract.txns.ContractDeleteResourceUsage;
@@ -68,12 +69,8 @@ public class ContractDeleteHandler implements TransactionHandler {
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
         final var op = context.body().contractDeleteInstanceOrThrow();
-        validateFalsePreCheck(op.permanentRemoval(), PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION);
-        // The contract ID must be present on the transaction
-        final var contractID = op.contractID();
-        mustExist(contractID, INVALID_CONTRACT_ID);
         // A contract corresponding to that contract ID must exist in state (otherwise we have nothing to delete)
-        final var contract = context.createStore(ReadableAccountStore.class).getContractById(contractID);
+        final var contract = context.createStore(ReadableAccountStore.class).getContractById(op.contractIDOrThrow());
         mustExist(contract, INVALID_CONTRACT_ID);
         // If there is not an admin key, then the contract is immutable. Otherwise, the transaction must
         // be signed by the admin key.
@@ -88,6 +85,16 @@ public class ContractDeleteHandler implements TransactionHandler {
         } else if (op.hasTransferContractID()) {
             context.requireKeyIfReceiverSigRequired(op.transferContractID(), INVALID_CONTRACT_ID);
         }
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        final var op = txn.contractDeleteInstanceOrThrow();
+        validateFalsePreCheck(op.permanentRemoval(), PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION);
+
+        // The contract ID must be present on the transaction
+        final var contractID = op.contractID();
+        mustExist(contractID, INVALID_CONTRACT_ID);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.contract.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -46,6 +47,11 @@ public class ContractSystemDeleteHandler implements TransactionHandler {
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         throw new PreCheckException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.contract.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -46,6 +47,11 @@ public class ContractSystemUndeleteHandler implements TransactionHandler {
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         throw new PreCheckException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -29,6 +29,7 @@ import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.SENTINEL_ACCOUNT_ID;
 import static com.hedera.node.app.spi.HapiUtils.EMPTY_KEY_LIST;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
+import static com.hedera.node.app.spi.validation.Validations.mustExist;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
@@ -100,8 +101,9 @@ public class ContractUpdateHandler implements TransactionHandler {
     }
 
     @Override
-    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+    public void pureChecks(@NonNull TransactionBody txn) throws PreCheckException {
+        final var op = txn.contractUpdateInstanceOrThrow();
+        mustExist(op.contractID(), INVALID_CONTRACT_ID);
     }
 
     private boolean isAdminSigRequired(final ContractUpdateTransactionBody op) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -40,6 +40,7 @@ import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.contract.ContractUpdateTransactionBody;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.records.ContractUpdateRecordBuilder;
 import com.hedera.node.app.service.mono.fees.calculation.contract.txns.ContractUpdateResourceUsage;
@@ -96,6 +97,11 @@ public class ContractUpdateHandler implements TransactionHandler {
         if (op.hasAutoRenewAccountId() && !op.autoRenewAccountIdOrThrow().equals(AccountID.DEFAULT)) {
             context.requireKeyOrThrow(op.autoRenewAccountIdOrThrow(), INVALID_AUTORENEW_ACCOUNT);
         }
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     private boolean isAdminSigRequired(final ContractUpdateTransactionBody op) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -27,6 +27,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.contract.EthereumTransactionBody;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxSigs;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome.ExternalizeAbortResult;
@@ -82,6 +83,11 @@ public class EthereumTransactionHandler implements TransactionHandler {
                 context.body().ethereumTransactionOrThrow(),
                 context.createStore(ReadableFileStore.class),
                 context.configuration());
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
@@ -85,14 +85,12 @@ class ContractDeleteHandlerTest {
     }
 
     @Test
-    void preHandleRejectsPermanentRemoval() {
+    void pureChecksRejectsPermanentRemoval() {
         final var txn = TransactionBody.newBuilder()
                 .contractDeleteInstance(
                         ContractDeleteTransactionBody.newBuilder().permanentRemoval(true))
                 .build();
-        given(preHandleContext.body()).willReturn(txn);
-
-        final var ex = assertThrows(PreCheckException.class, () -> subject.preHandle(preHandleContext));
+        final var ex = assertThrows(PreCheckException.class, () -> subject.pureChecks(txn));
         assertEquals(PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION, ex.responseCode());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -48,6 +49,11 @@ public class CryptoAddLiveHashHandler implements TransactionHandler {
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
         throw new PreCheckException(ResponseCodeEnum.NOT_SUPPORTED);
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @Override

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteLiveHashHandler.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -46,6 +47,11 @@ public class CryptoDeleteLiveHashHandler implements TransactionHandler {
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
         throw new PreCheckException(ResponseCodeEnum.NOT_SUPPORTED);
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        // nothing to do
     }
 
     @Override

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -35,7 +35,7 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
-import com.hedera.hapi.node.token.TokenAssociateTransactionBody;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.mono.fees.calculation.token.txns.TokenAssociateResourceUsage;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -66,13 +66,14 @@ import javax.inject.Singleton;
 public class TokenAssociateToAccountHandler extends BaseTokenHandler implements TransactionHandler {
 
     @Inject
-    public TokenAssociateToAccountHandler() {}
+    public TokenAssociateToAccountHandler() {
+        // Exists for injection
+    }
 
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
         final var op = context.body().tokenAssociateOrThrow();
-        pureChecks(op);
 
         final var target = op.accountOrElse(AccountID.DEFAULT);
         context.requireKeyOrThrow(target, INVALID_ACCOUNT_ID);
@@ -101,7 +102,10 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
     /**
      * Performs checks independent of state or context
      */
-    private void pureChecks(@NonNull final TokenAssociateTransactionBody op) throws PreCheckException {
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        final var op = txn.tokenAssociateOrThrow();
+
         if (!op.hasAccount()) {
             throw new PreCheckException(ResponseCodeEnum.INVALID_ACCOUNT_ID);
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
@@ -52,7 +53,6 @@ public class TokenPauseHandler implements TransactionHandler {
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
-        preCheck(context);
         final var op = context.body().tokenPause();
         final var tokenStore = context.createStore(ReadableTokenStore.class);
         final var tokenMeta = tokenStore.getTokenMeta(op.tokenOrElse(TokenID.DEFAULT));
@@ -83,19 +83,13 @@ public class TokenPauseHandler implements TransactionHandler {
         final var copyBuilder = token.copyBuilder();
         copyBuilder.paused(true);
         tokenStore.put(copyBuilder.build());
-        final var record = context.recordBuilder(TokenBaseRecordBuilder.class);
-        record.tokenType(token.tokenType());
+        final var recordBuilder = context.recordBuilder(TokenBaseRecordBuilder.class);
+        recordBuilder.tokenType(token.tokenType());
     }
 
-    /**
-     * Validate semantics for the given transaction body.
-     * @param context the {@link PreHandleContext} which collects all information that will be
-     *                passed to {@link #handle}
-     * @throws NullPointerException if one of the arguments is {@code null}
-     * @throws PreCheckException if the transaction body is invalid
-     */
-    private void preCheck(@NonNull final PreHandleContext context) throws PreCheckException {
-        final var op = context.body().tokenPause();
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        final var op = txn.tokenPauseOrThrow();
         if (!op.hasToken()) {
             throw new PreCheckException(INVALID_TOKEN_ID);
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
@@ -51,8 +52,6 @@ public class TokenUnpauseHandler implements TransactionHandler {
 
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
-
-        preCheck(context);
 
         final var op = context.body().tokenUnpause();
         final var tokenStore = context.createStore(ReadableTokenStore.class);
@@ -84,19 +83,13 @@ public class TokenUnpauseHandler implements TransactionHandler {
         final var copyBuilder = token.copyBuilder();
         copyBuilder.paused(false);
         tokenStore.put(copyBuilder.build());
-        final var record = context.recordBuilder(TokenBaseRecordBuilder.class);
-        record.tokenType(token.tokenType());
+        final var recordBuilder = context.recordBuilder(TokenBaseRecordBuilder.class);
+        recordBuilder.tokenType(token.tokenType());
     }
 
-    /**
-     * Validate semantics for the given transaction body.
-     * @param context the {@link PreHandleContext} which collects all information that will be
-     *                passed to {@link #handle}
-     * @throws NullPointerException if one of the arguments is {@code null}
-     * @throws PreCheckException if the transaction body is invalid
-     */
-    private void preCheck(@NonNull final PreHandleContext context) throws PreCheckException {
-        final var op = context.body().tokenUnpause();
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        final var op = txn.tokenUnpauseOrThrow();
         if (!op.hasToken()) {
             throw new PreCheckException(INVALID_TOKEN_ID);
         }

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilPrngHandler.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilPrngHandler.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.util.impl.handlers;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.SubType;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.util.impl.records.PrngRecordBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
@@ -58,8 +59,13 @@ public class UtilPrngHandler implements TransactionHandler {
      */
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
+        // nothing to do
+    }
+
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
         // Negative ranges are not allowed
-        if (context.body().utilPrngOrThrow().range() < 0) {
+        if (txn.utilPrngOrThrow().range() < 0) {
             throw new PreCheckException(ResponseCodeEnum.INVALID_PRNG_RANGE);
         }
     }

--- a/hedera-node/hedera-util-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/module-info.java
@@ -6,7 +6,7 @@ module com.hedera.node.app.service.util.impl {
     requires transitive com.hedera.pbj.runtime;
     requires transitive dagger;
     requires transitive javax.inject;
-    requires com.hedera.node.hapi;
+    requires transitive com.hedera.node.hapi;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
     requires static java.compiler; // javax.annotation.processing.Generated

--- a/hedera-node/hedera-util-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/module-info.java
@@ -3,10 +3,10 @@ import com.hedera.node.app.service.util.impl.UtilServiceImpl;
 module com.hedera.node.app.service.util.impl {
     requires transitive com.hedera.node.app.service.util;
     requires transitive com.hedera.node.app.spi;
+    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive dagger;
     requires transitive javax.inject;
-    requires transitive com.hedera.node.hapi;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
     requires static java.compiler; // javax.annotation.processing.Generated

--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/UtilPrngHandlerTest.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/UtilPrngHandlerTest.java
@@ -88,21 +88,19 @@ class UtilPrngHandlerTest {
     }
 
     @Test
-    void preHandleValidatesRange() {
+    void pureChecksValidatesRange() {
         final var body = TransactionBody.newBuilder()
                 .utilPrng(UtilPrngTransactionBody.newBuilder())
                 .build();
-        given(preHandleContext.body()).willReturn(body);
-        assertThatCode(() -> subject.preHandle(preHandleContext)).doesNotThrowAnyException();
+        assertThatCode(() -> subject.pureChecks(body)).doesNotThrowAnyException();
     }
 
     @Test
     void rejectsInvalidRange() {
         givenTxnWithRange(-10000);
-        given(preHandleContext.body())
-                .willReturn(TransactionBody.newBuilder().utilPrng(txn).build());
+        final var body = TransactionBody.newBuilder().utilPrng(txn).build();
 
-        assertThatThrownBy(() -> subject.preHandle(preHandleContext))
+        assertThatThrownBy(() -> subject.pureChecks(body))
                 .isInstanceOf(PreCheckException.class)
                 .has(responseCode(INVALID_PRNG_RANGE));
     }
@@ -110,23 +108,19 @@ class UtilPrngHandlerTest {
     @Test
     void acceptsPositiveAndZeroRange() {
         givenTxnWithRange(10000);
-        given(preHandleContext.body())
-                .willReturn(TransactionBody.newBuilder().utilPrng(txn).build());
-        assertThatCode(() -> subject.preHandle(preHandleContext)).doesNotThrowAnyException();
+        final var body = TransactionBody.newBuilder().utilPrng(txn).build();
+        assertThatCode(() -> subject.pureChecks(body)).doesNotThrowAnyException();
 
         givenTxnWithRange(0);
-        given(preHandleContext.body())
-                .willReturn(TransactionBody.newBuilder().utilPrng(txn).build());
-        assertThatCode(() -> subject.preHandle(preHandleContext)).doesNotThrowAnyException();
+        assertThatCode(() -> subject.pureChecks(body)).doesNotThrowAnyException();
     }
 
     @Test
     void acceptsNoRange() {
         givenTxnWithoutRange();
-        given(preHandleContext.body())
-                .willReturn(TransactionBody.newBuilder().utilPrng(txn).build());
+        final var body = TransactionBody.newBuilder().utilPrng(txn).build();
 
-        assertThatCode(() -> subject.preHandle(preHandleContext)).doesNotThrowAnyException();
+        assertThatCode(() -> subject.pureChecks(body)).doesNotThrowAnyException();
     }
 
     @Test
@@ -247,10 +241,9 @@ class UtilPrngHandlerTest {
     @Test
     void anyNegativeValueThrowsInPrecheck() {
         givenTxnWithRange(Integer.MIN_VALUE);
-        given(preHandleContext.body())
-                .willReturn(TransactionBody.newBuilder().utilPrng(txn).build());
+        final var body = TransactionBody.newBuilder().utilPrng(txn).build();
 
-        assertThatThrownBy(() -> subject.preHandle(preHandleContext))
+        assertThatThrownBy(() -> subject.pureChecks(body))
                 .isInstanceOf(PreCheckException.class)
                 .has(responseCode(INVALID_PRNG_RANGE));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -206,6 +206,21 @@ public class TokenAssociationSpecs extends HapiSuite {
     }
 
     @HapiTest
+    public HapiSpec accountIdMustBeSet() {
+        final var account = "account";
+        return defaultHapiSpec("accountIdMustBeSet")
+                .given(
+                        newKeyNamed(SIMPLE),
+                        tokenCreate("a").decimals(1),
+                        tokenCreate("b").decimals(2),
+                        tokenCreate("c").decimals(3),
+                        tokenCreate("tbd").adminKey(SIMPLE).decimals(4),
+                        cryptoCreate(account).balance(0L))
+                .when()
+                .then(tokenAssociate("fake account", "a", "b", "c", "tbd").hasKnownStatus(INVALID_SIGNATURE));
+    }
+
+    @HapiTest
     public HapiSpec contractInfoQueriesAsExpected() {
         final var contract = "contract";
         return defaultHapiSpec("ContractInfoQueriesAsExpected")
@@ -278,8 +293,8 @@ public class TokenAssociationSpecs extends HapiSuite {
                         withOpContext((spec, opLog) -> {
                             var subOp = getTxnRecord(CREATION);
                             allRunFor(spec, subOp);
-                            var record = subOp.getResponseRecord();
-                            now.set(record.getConsensusTimestamp().getSeconds());
+                            var responseRecord = subOp.getResponseRecord();
+                            now.set(responseRecord.getConsensusTimestamp().getSeconds());
                         }),
                         sourcing(() -> tokenCreate(expiringToken)
                                 .decimals(666)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -206,21 +206,6 @@ public class TokenAssociationSpecs extends HapiSuite {
     }
 
     @HapiTest
-    public HapiSpec accountIdMustBeSet() {
-        final var account = "account";
-        return defaultHapiSpec("accountIdMustBeSet")
-                .given(
-                        newKeyNamed(SIMPLE),
-                        tokenCreate("a").decimals(1),
-                        tokenCreate("b").decimals(2),
-                        tokenCreate("c").decimals(3),
-                        tokenCreate("tbd").adminKey(SIMPLE).decimals(4),
-                        cryptoCreate(account).balance(0L))
-                .when()
-                .then(tokenAssociate("fake account", "a", "b", "c", "tbd").hasKnownStatus(INVALID_SIGNATURE));
-    }
-
-    @HapiTest
     public HapiSpec contractInfoQueriesAsExpected() {
         final var contract = "contract";
         return defaultHapiSpec("ContractInfoQueriesAsExpected")
@@ -293,8 +278,8 @@ public class TokenAssociationSpecs extends HapiSuite {
                         withOpContext((spec, opLog) -> {
                             var subOp = getTxnRecord(CREATION);
                             allRunFor(spec, subOp);
-                            var responseRecord = subOp.getResponseRecord();
-                            now.set(responseRecord.getConsensusTimestamp().getSeconds());
+                            var record = subOp.getResponseRecord();
+                            now.set(record.getConsensusTimestamp().getSeconds());
                         }),
                         sourcing(() -> tokenCreate(expiringToken)
                                 .decimals(666)


### PR DESCRIPTION
**Description**:
TransactionHandler had a default empty implementation of pureChecks, which meant that all inheriting classes could optionally implement pureChecks or accept the empty default. This PR removes the default empty implementation and adds overrides for all implementing classes which previously lacked one.

**Related issue(s)**:
Fixes #12644 

