### PR TITLE
fix: unit test and add the right response code

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.token.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
@@ -101,7 +102,7 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
         final var op = txn.cryptoUpdateAccountOrThrow();
-        validateTruePreCheck(op.hasAccountIDToUpdate(), INVALID_ACCOUNT_ID);
+        validateTruePreCheck(op.hasAccountIDToUpdate(), ACCOUNT_ID_DOES_NOT_EXIST);
         validateFalsePreCheck(
                 op.hasProxyAccountID() && !op.proxyAccountID().equals(AccountID.DEFAULT),
                 PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED);
@@ -129,7 +130,7 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
         // 4. Including above 3 conditions, if the target account is 0.0.2, new key must sign the transaction
         final var newAccountKeyMustSign = !waivers.isNewKeySignatureWaived(txn, payer);
         if (targetAccountKeyMustSign) {
-            context.requireKeyOrThrow(updateAccountId, INVALID_ACCOUNT_ID);
+            context.requireKeyOrThrow(updateAccountId, ACCOUNT_ID_DOES_NOT_EXIST);
         }
         if (newAccountKeyMustSign && op.hasKey()) {
             context.requireKeyOrThrow(op.key(), INVALID_ADMIN_KEY);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -130,7 +130,7 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
         // 4. Including above 3 conditions, if the target account is 0.0.2, new key must sign the transaction
         final var newAccountKeyMustSign = !waivers.isNewKeySignatureWaived(txn, payer);
         if (targetAccountKeyMustSign) {
-            context.requireKeyOrThrow(updateAccountId, ACCOUNT_ID_DOES_NOT_EXIST);
+            context.requireKeyOrThrow(updateAccountId, INVALID_ACCOUNT_ID);
         }
         if (newAccountKeyMustSign && op.hasKey()) {
             context.requireKeyOrThrow(op.key(), INVALID_ADMIN_KEY);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -158,6 +158,17 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
     }
 
     @Test
+    void cryptoUpdateMissingAccountID() throws PreCheckException {
+        final var txn = new CryptoUpdateBuilder().withTarget(null).build();
+
+        given(waivers.isNewKeySignatureWaived(txn, id)).willReturn(false);
+        given(waivers.isTargetAccountSignatureWaived(txn, id)).willReturn(false);
+
+        final var context = new FakePreHandleContext(readableStore, txn);
+        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_ID_DOES_NOT_EXIST);
+    }
+
+    @Test
     void cryptoUpdateNewSignatureKeyWaivedVanilla() throws PreCheckException {
         final var txn = new CryptoUpdateBuilder().withKey(key).build();
 
@@ -197,7 +208,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         given(waivers.isTargetAccountSignatureWaived(any(), any())).willReturn(false);
 
         final var context = new FakePreHandleContext(readableStore, txn);
-        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_ID_DOES_NOT_EXIST);
+        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.token.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BAD_ENCODING;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
@@ -196,7 +197,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         given(waivers.isTargetAccountSignatureWaived(any(), any())).willReturn(false);
 
         final var context = new FakePreHandleContext(readableStore, txn);
-        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_ACCOUNT_ID);
+        assertThrowsPreCheck(() -> subject.preHandle(context), ACCOUNT_ID_DOES_NOT_EXIST);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -101,6 +101,7 @@ import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
 import static com.hedera.services.bdd.suites.contract.Utils.ocWith;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AMOUNT_EXCEEDS_ALLOWANCE;
@@ -651,7 +652,7 @@ public class CryptoTransferSuite extends HapiSuite {
                                 .payingWith(GENESIS)
                                 .signedBy(GENESIS)
                                 .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                                .hasKnownStatus(ACCOUNT_ID_DOES_NOT_EXIST),
                         cryptoDelete(STAKING_REWARD)
                                 .payingWith(GENESIS)
                                 .signedBy(GENESIS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -101,7 +101,6 @@ import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
 import static com.hedera.services.bdd.suites.contract.Utils.ocWith;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AMOUNT_EXCEEDS_ALLOWANCE;
@@ -652,7 +651,7 @@ public class CryptoTransferSuite extends HapiSuite {
                                 .payingWith(GENESIS)
                                 .signedBy(GENESIS)
                                 .fee(ONE_HBAR)
-                                .hasKnownStatus(ACCOUNT_ID_DOES_NOT_EXIST),
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
                         cryptoDelete(STAKING_REWARD)
                                 .payingWith(GENESIS)
                                 .signedBy(GENESIS)


### PR DESCRIPTION
This fix supposed to provide the right response code when the account ID is not available during the crypto update

**Related issue(s)**:

Fixes #12571 

