### PR TITLE
fix: set provided expiry on new schedule

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/HandlerUtility.java
@@ -210,9 +210,8 @@ public final class HandlerUtility {
         final TransactionID parentTransactionId = currentTransaction.transactionIDOrThrow();
         final ScheduleCreateTransactionBody createTransaction = currentTransaction.scheduleCreateOrThrow();
         final AccountID schedulerAccount = parentTransactionId.accountIDOrThrow();
-        final Timestamp providedExpirationTime = createTransaction.expirationTime();
         final long calculatedExpirationTime =
-                calculateExpiration(providedExpirationTime, currentConsensusTime, maxLifeSeconds);
+                calculateExpiration(createTransaction.expirationTime(), currentConsensusTime, maxLifeSeconds);
         final ScheduleID nullId = null;
 
         Schedule.Builder builder = Schedule.newBuilder();
@@ -223,6 +222,8 @@ public final class HandlerUtility {
         builder.schedulerAccountId(schedulerAccount);
         builder.scheduleValidStart(parentTransactionId.transactionValidStart());
         builder.calculatedExpirationSecond(calculatedExpirationTime);
+        builder.providedExpirationSecond(
+                createTransaction.expirationTimeOrElse(Timestamp.DEFAULT).seconds());
         builder.originalCreateTransaction(currentTransaction);
         builder.memo(createTransaction.memo());
         builder.scheduledTransaction(createTransaction.scheduledTransactionBody());


### PR DESCRIPTION
**Description**:
 - Closes #12516 
 - Ensure schedules are created with a provided expiration second, if given; this is part of the schedule's "fingerprint" used in detecting identical schedules.