### PR TITLE
fix: Fix schedules during replay

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/statedumpers/scheduledtransactions/ScheduledTransactionsDumpUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/statedumpers/scheduledtransactions/ScheduledTransactionsDumpUtils.java
@@ -49,18 +49,22 @@ public class ScheduledTransactionsDumpUtils {
             final var byId = scheduledTransactions.byId();
             final var byEquality = scheduledTransactions.byEquality();
             final var byExpirationSecond = scheduledTransactions.byExpirationSecond();
-            System.out.printf("=== Dumping schedule transactions %s%n ======");
+
+            System.out.printf("=== Dumping schedule transactions %n ======");
+
             final var byIdDump = gatherMonoScheduledTransactionsByID(byId);
             reportOnScheduledTransactionsById(writer, byIdDump);
+            System.out.println("Size of byId in State : " + byId.size() + " and gathered : " + byIdDump.size());
 
             final var byEqualityDump = gatherMonoScheduledTransactionsByEquality(byEquality);
             reportOnScheduledTransactionsByEquality(writer, byEqualityDump);
-            // Not sure how to compare Equality Virtual map in mono and mod
+            System.out.println(
+                    "Size of byEquality in State : " + byEquality.size() + " and gathered : " + byEqualityDump.size());
+
             final var byExpiryDump = gatherMonoScheduledTransactionsByExpiry(byExpirationSecond);
             reportOnScheduledTransactionsByExpiry(writer, byExpiryDump);
-            System.out.printf(
-                    "=== mono scheduled transactions report by expiry is %d bytes at checkpoint %s%n",
-                    writer.getSize(), checkpoint.name());
+            System.out.println("Size of byExpiry in State : " + byExpirationSecond.size() + " and gathered : "
+                    + byExpiryDump.size());
         }
     }
 

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleStoreUtility.java
@@ -19,11 +19,16 @@ package com.hedera.node.app.service.schedule.impl;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.hapi.node.state.schedule.Schedule;
+import com.hedera.hapi.node.state.schedule.ScheduleList;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Objects;
 
 public final class ScheduleStoreUtility {
@@ -65,5 +70,30 @@ public final class ScheduleStoreUtility {
                 SchedulableTransactionBody.PROTOBUF.toBytes(transactionToAdd).toByteArray();
         hasher.putInt(bytes.length);
         hasher.putBytes(bytes);
+    }
+
+    private static boolean isScheduleInList(final ScheduleID scheduleId, final ScheduleList scheduleList) {
+        return scheduleList.schedulesOrElse(Collections.emptyList()).stream()
+                .anyMatch(s -> s.scheduleIdOrThrow().equals(scheduleId));
+    }
+
+    static ScheduleList addOrReplace(final Schedule schedule, @Nullable final ScheduleList scheduleList) {
+        if (scheduleList == null) {
+            return new ScheduleList(Collections.singletonList(schedule));
+        }
+        final var newScheduleList = scheduleList.copyBuilder();
+        final var scheduleId = schedule.scheduleIdOrThrow();
+        final var schedules = new ArrayList<>(scheduleList.schedulesOrElse(Collections.emptyList()));
+        if (!isScheduleInList(scheduleId, scheduleList)) {
+            schedules.add(schedule);
+        } else {
+            for (int i = 0; i < schedules.size(); i++) {
+                final var existingSchedule = schedules.get(i);
+                if (existingSchedule.scheduleIdOrThrow().equals(scheduleId)) {
+                    schedules.set(i, schedule);
+                }
+            }
+        }
+        return newScheduleList.schedules(schedules).build();
     }
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImpl.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.schedule.impl;
 
-import static java.util.Collections.emptyList;
+import static com.hedera.node.app.service.schedule.impl.ScheduleStoreUtility.addOrReplace;
 
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.Timestamp;
@@ -33,9 +33,6 @@ import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -119,26 +116,18 @@ public class WritableScheduleStoreImpl extends ReadableScheduleStoreImpl impleme
     @Override
     public void put(@NonNull final Schedule scheduleToAdd) {
         schedulesByIdMutable.put(scheduleToAdd.scheduleIdOrThrow(), scheduleToAdd);
+
         final ProtoBytes newHash = new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(scheduleToAdd));
         final ScheduleList inStateEquality = schedulesByEqualityMutable.get(newHash);
-        List<Schedule> byEquality =
-                inStateEquality != null ? new LinkedList<>(inStateEquality.schedulesOrElse(emptyList())) : null;
-        if (byEquality == null) {
-            byEquality = new LinkedList<>();
-        }
-        byEquality.add(scheduleToAdd);
-        schedulesByEqualityMutable.put(newHash, new ScheduleList(byEquality));
+        final var newEqualityScheduleList = addOrReplace(scheduleToAdd, inStateEquality);
+        schedulesByEqualityMutable.put(newHash, newEqualityScheduleList);
+
         // calculated expiration time is never null...
         final ProtoLong expirationSecond = new ProtoLong(scheduleToAdd.calculatedExpirationSecond());
         final ScheduleList inStateExpiration = schedulesByExpirationMutable.get(expirationSecond);
         // we should not be modifying the schedules list directly. This could cause ISS
-        List<Schedule> byExpiration = inStateExpiration != null ? new ArrayList<>(inStateExpiration.schedules()) : null;
-        if (byExpiration == null) {
-            byExpiration = new LinkedList<>();
-        }
-        byExpiration.add(scheduleToAdd);
-        final var newScheduleList = new ScheduleList(byExpiration);
-        schedulesByExpirationMutable.put(expirationSecond, newScheduleList);
+        final var newExpiryScheduleList = addOrReplace(scheduleToAdd, inStateExpiration);
+        schedulesByExpirationMutable.put(expirationSecond, newExpiryScheduleList);
     }
 
     @NonNull

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImplTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/WritableScheduleStoreImplTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.primitives.ProtoLong;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -67,6 +69,40 @@ class WritableScheduleStoreImplTest extends ScheduleTestBase {
         assertThat(actual.executed()).isTrue();
         assertThat(actual.resolutionTime()).isNotNull().isEqualTo(asTimestamp(testConsensusTime));
         assertThat(actual.signatories()).containsExactlyInAnyOrderElementsOf(modifiedSignatories);
+    }
+
+    @Test
+    void verifyPutDoesDedupliction() {
+        final ScheduleID idToDelete = scheduleInState.scheduleId();
+        Schedule actual = writableById.getForModify(idToDelete);
+        assertThat(actual).isNotNull();
+        assertThat(actual.signatories()).containsExactlyInAnyOrderElementsOf(scheduleInState.signatories());
+        final Set<Key> modifiedSignatories = Set.of(schedulerKey, payerKey);
+        final Schedule modified = replaceSignatoriesAndMarkExecuted(actual, modifiedSignatories, testConsensusTime);
+        final var hash = new ProtoBytes(ScheduleStoreUtility.calculateBytesHash(actual));
+
+        final var equalityList = writableByEquality.get(hash);
+        assertThat(equalityList.schedules().size()).isEqualTo(1);
+
+        final var expiryList = writableByExpiration.get(new ProtoLong(actual.calculatedExpirationSecond()));
+        assertThat(expiryList.schedules().size()).isEqualTo(1);
+
+        writableSchedules.put(modified);
+        writableSchedules.put(modified);
+        writableSchedules.put(modified);
+
+        actual = scheduleStore.get(idToDelete);
+        assertThat(actual).isNotNull();
+        assertThat(actual.executed()).isTrue();
+        assertThat(actual.resolutionTime()).isNotNull().isEqualTo(asTimestamp(testConsensusTime));
+        assertThat(actual.signatories()).containsExactlyInAnyOrderElementsOf(modifiedSignatories);
+
+        // size doesn't increase when same element is put multiple times
+        final var equalityListAfter = writableByEquality.get(hash);
+        assertThat(equalityListAfter.schedules().size()).isEqualTo(1);
+
+        final var expiryListAfter = writableByExpiration.get(new ProtoLong(actual.calculatedExpirationSecond()));
+        assertThat(expiryListAfter.schedules().size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/hashgraph/hedera-services/issues/12334

- Fixes duplicated schedules list in SchedulesByEquality Map
- Fixes dumpers to dump schedules