### PR TITLE
fix: Enable pureChecks in TokenAssociateToAccountHandler

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -35,7 +35,7 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
-import com.hedera.hapi.node.token.TokenAssociateTransactionBody;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.mono.fees.calculation.token.txns.TokenAssociateResourceUsage;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -72,7 +72,6 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
         final var op = context.body().tokenAssociateOrThrow();
-        pureChecks(op);
 
         final var target = op.accountOrElse(AccountID.DEFAULT);
         context.requireKeyOrThrow(target, INVALID_ACCOUNT_ID);
@@ -101,7 +100,10 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
     /**
      * Performs checks independent of state or context
      */
-    private void pureChecks(@NonNull final TokenAssociateTransactionBody op) throws PreCheckException {
+    @Override
+    public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
+        final var op = txn.tokenAssociateOrThrow();
+
         if (!op.hasAccount()) {
             throw new PreCheckException(ResponseCodeEnum.INVALID_ACCOUNT_ID);
         }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
@@ -114,9 +114,8 @@ class TokenAssociateToAccountHandlerTest {
         @Test
         void txnWithRepeatedTokenIdsThrows() throws PreCheckException {
             final var txn = newAssociateTxn(ACCOUNT_888, List.of(TOKEN_300, TOKEN_400, TOKEN_300));
-            final var context = new FakePreHandleContext(readableAccountStore, txn);
 
-            assertThatThrownBy(() -> subject.preHandle(context))
+            assertThatThrownBy(() -> subject.pureChecks(txn))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(TOKEN_ID_REPEATED_IN_TOKEN_LIST));
         }


### PR DESCRIPTION
This PR fixes `TokenAssociateToAccountHandler`, which had a `pureChecks()` method, but it did not override the standard version.

Fixes #12566 