### PR TITLE
fix: Return REQUIRED_KEY in CryptoCreate if no alias is used

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -133,7 +133,7 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         final var keyIsEmpty = isEmpty(key);
         if (!isInternal && keyIsEmpty) {
             if (key == null) {
-                throw new PreCheckException(INVALID_ALIAS_KEY);
+                throw new PreCheckException(alias.length() > 0 ? INVALID_ALIAS_KEY : KEY_REQUIRED);
             } else if (key.hasThresholdKey() || key.hasKeyList()) {
                 throw new PreCheckException(KEY_REQUIRED);
             } else {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -26,6 +26,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_I
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RECEIVE_RECORD_THRESHOLD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SEND_RECORD_THRESHOLD;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
@@ -525,6 +526,20 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
     @Test
     void validateKeyRequired() {
         txn = new CryptoCreateBuilder().withStakedAccountId(3).withKey(null).build();
+        setupConfig();
+        setupExpiryValidator();
+
+        final var msg = assertThrows(PreCheckException.class, () -> subject.pureChecks(txn));
+        assertEquals(KEY_REQUIRED, msg.responseCode());
+    }
+
+    @Test
+    void validateKeyRequiredWithAlias() {
+        txn = new CryptoCreateBuilder()
+                .withStakedAccountId(3)
+                .withKey(null)
+                .withAlias(Bytes.wrap("alias"))
+                .build();
         setupConfig();
         setupExpiryValidator();
 


### PR DESCRIPTION
This PR changes the error handling of CryptoCreate slightly. When no alias is provided, we want to return `REQUIRED_KEY` instead of `INVALID_ALIAS_KEY`.

Fixes #12563 