### PR TITLE
fix: long hostnames supported in addressbook serialization

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/Address.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/Address.java
@@ -67,7 +67,6 @@ public class Address implements SelfSerializable {
         public static final int X509_CERT_SUPPORT = 6;
     }
 
-    private static final int MAX_IP_LENGTH = 16;
     private static final int STRING_MAX_BYTES = 512;
 
     /** The serialization version of this class, defaulting to most recent version.  Deserialization will override. */
@@ -579,9 +578,9 @@ public class Address implements SelfSerializable {
         selfName = inStream.readNormalisedString(STRING_MAX_BYTES);
         weight = inStream.readLong();
 
-        hostnameInternal = inStream.readNormalisedString(MAX_IP_LENGTH);
+        hostnameInternal = inStream.readNormalisedString(STRING_MAX_BYTES);
         portInternal = inStream.readInt();
-        hostnameExternal = inStream.readNormalisedString(MAX_IP_LENGTH);
+        hostnameExternal = inStream.readNormalisedString(STRING_MAX_BYTES);
         portExternal = inStream.readInt();
 
         if (version < ClassVersion.X509_CERT_SUPPORT) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
@@ -334,6 +334,11 @@ class AddressBookTests {
                 .setSize(100)
                 .build();
 
+        // FQDN Support: addresses must support long text based host names.
+        original.add(original.getAddress(original.getNodeId(0))
+                .copySetHostnameInternal(
+                        "this.is.a.really.long.host.name.that.should.be.able.to.fit.in.the.address.book"));
+
         // make sure that certs are part of the round trip test.
         assertNotNull(original.getAddress(new NodeId(0)).getSigCert());
         assertNotNull(original.getAddress(new NodeId(0)).getAgreeCert());


### PR DESCRIPTION
**Description**:
Address book needs to support long hostnames.   This PR shifts the restriction from 16 characters (IP Address length) to 512 characters.


Fixes #12611 

