### PR TITLE
fix: Allow scheduled transactions to have preceding transactions

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
@@ -589,8 +589,8 @@ public class HandleContextImpl implements HandleContext, FeeContext {
         requireNonNull(txBody, "txBody must not be null");
         requireNonNull(recordBuilderClass, "recordBuilderClass must not be null");
 
-        if (category != TransactionCategory.USER && category != TransactionCategory.CHILD) {
-            throw new IllegalArgumentException("Only user- or child-transactions can dispatch preceding transactions");
+        if (category == PRECEDING) {
+            throw new IllegalArgumentException("A preceding transaction cannot dispatch preceding transactions");
         }
 
         final var precedingRecordBuilder = recordBuilderFactory.get();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
@@ -1182,7 +1182,9 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         @ParameterizedTest
         @EnumSource(TransactionCategory.class)
         void testDispatchPrecedingWithNonUserTxnFails(final TransactionCategory category) {
-            if (category != TransactionCategory.USER && category != TransactionCategory.CHILD) {
+            if (category != TransactionCategory.USER
+                    && category != TransactionCategory.CHILD
+                    && category != TransactionCategory.SCHEDULED) {
                 // given
                 final var context = createContext(defaultTransactionBody(), category);
 


### PR DESCRIPTION
This PR also allows scheduled transactions to have preceding transactions.

Fixes #12625 