### PR TITLE
Return NOT_SUPPORTED in assertThrottlingPreconditions()

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -274,7 +274,7 @@ public final class IngestChecker {
             // at consensus, and adding them to normal throttle buckets, c.f.
             // https://github.com/hashgraph/hedera-services/issues/12559
             if (payerNum >= hederaConfig.firstUserEntity()) {
-                throw new PreCheckException(UNAUTHORIZED);
+                throw new PreCheckException(NOT_SUPPORTED);
             }
         }
     }


### PR DESCRIPTION
This PR fixes tests that were failing because the wrong error code was returned