### PR TITLE
fix: support receipt/record queries with nonce

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/RecordCache.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/records/RecordCache.java
@@ -53,7 +53,7 @@ public interface RecordCache {
      * For mono-service fidelity, records with these statuses do not prevent valid transactions with
      * the same id from reaching consensus and being handled.
      */
-    Set<ResponseCodeEnum> UNCLASSIFIABLE_STATUSES = EnumSet.of(INVALID_NODE_ACCOUNT, INVALID_PAYER_SIGNATURE);
+    Set<ResponseCodeEnum> DUE_DILIGENCE_FAILURES = EnumSet.of(INVALID_NODE_ACCOUNT, INVALID_PAYER_SIGNATURE);
     /**
      * And when ordering records for queries, we treat records with unclassifiable statuses as the
      * lowest "priority"; so that e.g. if a transaction with id {@code X} resolves to {@link ResponseCodeEnum#SUCCESS}
@@ -65,9 +65,9 @@ public interface RecordCache {
     @SuppressWarnings("java:S3358")
     Comparator<TransactionRecord> RECORD_COMPARATOR = Comparator.<TransactionRecord, ResponseCodeEnum>comparing(
                     rec -> rec.receiptOrThrow().status(),
-                    (a, b) -> UNCLASSIFIABLE_STATUSES.contains(a) == UNCLASSIFIABLE_STATUSES.contains(b)
+                    (a, b) -> DUE_DILIGENCE_FAILURES.contains(a) == DUE_DILIGENCE_FAILURES.contains(b)
                             ? 0
-                            : (UNCLASSIFIABLE_STATUSES.contains(b) ? -1 : 1))
+                            : (DUE_DILIGENCE_FAILURES.contains(b) ? -1 : 1))
             .thenComparing(rec -> rec.consensusTimestampOrElse(Timestamp.DEFAULT), TIMESTAMP_COMPARATOR);
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -48,7 +48,8 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
     private final Set<TransactionID> submittedTxns = new ConcurrentSkipListSet<>(
             Comparator.comparing(TransactionID::transactionValidStartOrThrow, TIMESTAMP_COMPARATOR)
                     .thenComparing(TransactionID::accountID, ACCOUNT_ID_COMPARATOR)
-                    .thenComparing(TransactionID::scheduled));
+                    .thenComparing(TransactionID::scheduled)
+                    .thenComparing(TransactionID::nonce));
 
     /** Used for looking up the max transaction duration window. */
     private final ConfigProvider configProvider;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -102,7 +102,8 @@ public class RecordCacheImpl implements HederaRecordCache {
      */
     private final DeduplicationCache deduplicationCache;
     /**
-     * A map of transaction IDs to the histories of all transactions that came to consensus with that ID, or their child
+     * A map of transaction IDs to the histories of all transactions that came to
+     * consensus with that ID, or their child
      * transactions. This data structure is rebuilt during reconnect or restart. Using a non-deterministic, map is
      * perfectly acceptable, as the order of these histories is not important.
      */
@@ -184,7 +185,7 @@ public class RecordCacheImpl implements HederaRecordCache {
         // to also remove from the queue any transactions that have expired.
         final WritableStates states = getWritableState();
         final WritableQueueState<TransactionRecordEntry> queue = states.getQueue(TXN_RECORD_QUEUE);
-        final SingleTransactionRecord firstRecord = transactionRecords.get(0);
+        final SingleTransactionRecord firstRecord = transactionRecords.getFirst();
         removeExpiredTransactions(queue, firstRecord.transactionRecord().consensusTimestampOrElse(Timestamp.DEFAULT));
 
         // For each transaction, in order, add to the queue and to the in-memory data structures.
@@ -224,20 +225,10 @@ public class RecordCacheImpl implements HederaRecordCache {
             final long nodeId,
             @NonNull final AccountID payerAccountId,
             @NonNull final TransactionRecord transactionRecord) {
-        // The transaction may be a preceding transaction, user transaction, or child transaction. The user transaction,
-        // alone, has a nonce of 0 in the transaction ID. Preceding transactions have no parent consensus timestamp,
-        // while child transactions have a parent consensus timestamp (the consensus timestamp of the user transaction).
-        //
-        // If the transaction is a user transaction or a preceding transaction, then it gets its own History. If the
-        // transaction is a child transaction, then it does not get its own preceding transaction, but instead is added
-        // to the History of the user transaction.
-        //
-        // And all transactions, regardless of the type, are added to the payer-reverse-index, so that queries of
-        // the payer account ID will return all transactions they paid for.
         final var txId = transactionRecord.transactionIDOrThrow();
-        // For the preceding child records parentConsensusTimestamp is not set, but the nonce will be greater than 1
-        // For the following child records parentConsensusTimestamp is also set. So to differentiate child records
-        // from user records, we check if the nonce is greater than 0.
+        // We need the hasParentConsensusTimestamp() check to detect triggered transactions that
+        // children of a ScheduleSign or ScheduleCreate (nonces were introduced after scheduled
+        // transactions, so these children still have nonce=0)
         final var isChildTx = transactionRecord.hasParentConsensusTimestamp() || txId.nonce() > 0;
         final var userTxId = isChildTx ? txId.copyBuilder().nonce(0).build() : txId;
 
@@ -247,7 +238,8 @@ public class RecordCacheImpl implements HederaRecordCache {
         // doesn't actually matter.
         final var history = histories.computeIfAbsent(userTxId, ignored -> new History());
         final var status = transactionRecord.receiptOrThrow().status();
-        if (!UNCLASSIFIABLE_STATUSES.contains(status)) {
+        // If the status indicates a due diligence failure, we don't use the result in duplicate classification
+        if (!DUE_DILIGENCE_FAILURES.contains(status)) {
             history.nodeIds().add(nodeId);
         }
 
@@ -311,6 +303,11 @@ public class RecordCacheImpl implements HederaRecordCache {
     @Nullable
     @Override
     public History getHistory(@NonNull TransactionID transactionID) {
+        logger.info(
+                "Getting history for transaction ID: {} (contained in dedup cache? {}) - history = {}",
+                transactionID,
+                deduplicationCache.contains(transactionID),
+                histories.get(transactionID));
         final var history = histories.get(transactionID);
         return history != null ? history : (deduplicationCache.contains(transactionID) ? EMPTY_HISTORY : null);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -303,11 +303,6 @@ public class RecordCacheImpl implements HederaRecordCache {
     @Nullable
     @Override
     public History getHistory(@NonNull TransactionID transactionID) {
-        logger.info(
-                "Getting history for transaction ID: {} (contained in dedup cache? {}) - history = {}",
-                transactionID,
-                deduplicationCache.contains(transactionID),
-                histories.get(transactionID));
         final var history = histories.get(transactionID);
         return history != null ? history : (deduplicationCache.contains(transactionID) ? EMPTY_HISTORY : null);
     }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
@@ -107,7 +107,10 @@ public class NetworkTransactionGetRecordHandler extends PaidQueryHandler {
         final var responseType = op.headerOrElse(QueryHeader.DEFAULT).responseType();
         responseBuilder.header(header);
         if (header.nodeTransactionPrecheckCode() == ResponseCodeEnum.OK && responseType != COST_ANSWER) {
-            final var history = recordCache.getHistory(transactionId);
+            final var topLevelTxnId = transactionId.nonce() > 0
+                    ? transactionId.copyBuilder().nonce(0).build()
+                    : transactionId;
+            final var history = recordCache.getHistory(topLevelTxnId);
             if (history == null || history.records().isEmpty()) {
                 // Can we even ever hit this case? Doesn't the validate method make sure this doesn't happen?
                 // If we do not yet have a record, then we return this. This has some asymmetry with the call to get
@@ -117,19 +120,33 @@ public class NetworkTransactionGetRecordHandler extends PaidQueryHandler {
                         .nodeTransactionPrecheckCode(RECORD_NOT_FOUND)
                         .build());
             } else {
-                // There was definitely a record, so we can return it.
-                responseBuilder.transactionRecord(history.userTransactionRecord());
-                if (op.includeDuplicates()) {
-                    responseBuilder.duplicateTransactionRecords(history.duplicateRecords());
-                }
-                if (op.includeChildRecords()) {
-                    // Sort the transaction records based on nonce, so that the user transaction is always first,
-                    // followed by any preceding transactions, followed by any child transactions.
-                    final var sortedRecords = history.childRecords().stream()
-                            .sorted(Comparator.comparingLong(
-                                    a -> a.transactionIDOrThrow().nonce()))
-                            .toList();
-                    responseBuilder.childTransactionRecords(sortedRecords);
+                // Only top-level transactions can have children and duplicates
+                if (transactionId == topLevelTxnId) {
+                    // There was definitely a record, so we can return it.
+                    responseBuilder.transactionRecord(history.userTransactionRecord());
+                    if (op.includeDuplicates()) {
+                        responseBuilder.duplicateTransactionRecords(history.duplicateRecords());
+                    }
+                    if (op.includeChildRecords()) {
+                        // Sort the transaction records based on nonce, so that the user transaction is always first,
+                        // followed by any preceding transactions, followed by any child transactions.
+                        final var sortedRecords = history.childRecords().stream()
+                                .sorted(Comparator.comparingLong(
+                                        a -> a.transactionIDOrThrow().nonce()))
+                                .toList();
+                        responseBuilder.childTransactionRecords(sortedRecords);
+                    }
+                } else {
+                    final var maybeRecord = history.childRecords().stream()
+                            .filter(record -> transactionId.equals(record.transactionID()))
+                            .findFirst();
+                    if (maybeRecord.isEmpty()) {
+                        responseBuilder.header(header.copyBuilder()
+                                .nodeTransactionPrecheckCode(RECORD_NOT_FOUND)
+                                .build());
+                    } else {
+                        responseBuilder.transactionRecord(maybeRecord.get());
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Description**:
 - Closes #12652 
 - Fix `DeduplicationCache` comparator to include `nonce`.
 - Remove some misleading comments in `RecordCacheImpl`.
 - Update receipt and record queries to fetch a specific child by `TransactionID` nonce.