### PR TITLE
fix: use exact math for all summed balances

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/ChildFinalizeContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/ChildFinalizeContextImpl.java
@@ -23,20 +23,24 @@ import com.hedera.node.app.service.token.records.ChildFinalizeContext;
 import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.app.workflows.dispatcher.WritableStoreFactory;
 import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Standard implementation of {@link ChildFinalizeContext}.
  */
 public class ChildFinalizeContextImpl implements ChildFinalizeContext {
+    private final Configuration configuration;
     private final ReadableStoreFactory readableStoreFactory;
     private final WritableStoreFactory writableStoreFactory;
     private final SingleTransactionRecordBuilderImpl recordBuilder;
 
     public ChildFinalizeContextImpl(
+            @NonNull final Configuration configuration,
             @NonNull final ReadableStoreFactory readableStoreFactory,
             @NonNull final WritableStoreFactory writableStoreFactory,
             @NonNull final SingleTransactionRecordBuilderImpl recordBuilder) {
+        this.configuration = requireNonNull(configuration);
         this.readableStoreFactory = requireNonNull(readableStoreFactory);
         this.writableStoreFactory = requireNonNull(writableStoreFactory);
         this.recordBuilder = requireNonNull(recordBuilder);
@@ -61,5 +65,10 @@ public class ChildFinalizeContextImpl implements ChildFinalizeContext {
     public <T> T userTransactionRecordBuilder(@NonNull final Class<T> recordBuilderClass) {
         requireNonNull(recordBuilderClass, "recordBuilderClass must not be null");
         return castRecordBuilder(recordBuilder, recordBuilderClass);
+    }
+
+    @Override
+    public @NonNull Configuration configuration() {
+        return configuration;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleContextImpl.java
@@ -797,6 +797,7 @@ public class HandleContextImpl implements HandleContext, FeeContext {
             }
         } else {
             final var finalizeContext = new ChildFinalizeContextImpl(
+                    configuration,
                     new ReadableStoreFactory(childStack),
                     new WritableStoreFactory(childStack, TokenService.NAME, configuration, storeMetricsService),
                     childRecordBuilder);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/TriggeredFinalizeContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/TriggeredFinalizeContext.java
@@ -41,7 +41,7 @@ public class TriggeredFinalizeContext extends ChildFinalizeContextImpl implement
             @NonNull final SingleTransactionRecordBuilderImpl recordBuilder,
             @NonNull final Instant consensusNow,
             @NonNull final Configuration configuration) {
-        super(readableStoreFactory, writableStoreFactory, recordBuilder);
+        super(configuration, readableStoreFactory, writableStoreFactory, recordBuilder);
         this.consensusNow = Objects.requireNonNull(consensusNow);
         this.configuration = Objects.requireNonNull(configuration);
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -60,7 +60,7 @@ public class RecordFinalizerBase {
      */
     @NonNull
     protected Map<AccountID, Long> hbarChangesFrom(
-            @NonNull final WritableAccountStore writableAccountStore, long maxLegalBalance) {
+            @NonNull final WritableAccountStore writableAccountStore, final long maxLegalBalance) {
         final var hbarChanges = new HashMap<AccountID, Long>();
         var netHbarBalance = 0L;
         for (final AccountID modifiedAcctId : writableAccountStore.modifiedAccountsInState()) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -20,6 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.hedera.node.app.service.token.impl.comparator.TokenComparators.ACCOUNT_AMOUNT_COMPARATOR;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.asAccountAmounts;
+import static com.hedera.node.app.service.token.impl.handlers.transfer.customfees.AdjustmentUtils.addExactOrThrowReason;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
@@ -52,15 +53,18 @@ public class RecordFinalizerBase {
 
     /**
      * Gets all hbar changes for all modified accounts from the given {@link WritableAccountStore}.
+     *
      * @param writableAccountStore the {@link WritableAccountStore} to get the hbar changes from
+     * @param maxLegalBalance the max legal balance for any account
      * @return a {@link Map} of {@link AccountID} to {@link Long} representing the hbar changes for all modified
      */
     @NonNull
-    protected Map<AccountID, Long> hbarChangesFrom(@NonNull final WritableAccountStore writableAccountStore) {
+    protected Map<AccountID, Long> hbarChangesFrom(
+            @NonNull final WritableAccountStore writableAccountStore, long maxLegalBalance) {
         final var hbarChanges = new HashMap<AccountID, Long>();
-        var netHbarBalance = 0;
+        var netHbarBalance = 0L;
         for (final AccountID modifiedAcctId : writableAccountStore.modifiedAccountsInState()) {
-            final var modifiedAcct = writableAccountStore.getAccountById(modifiedAcctId);
+            final var modifiedAcct = requireNonNull(writableAccountStore.getAccountById(modifiedAcctId));
             final var persistedAcct = writableAccountStore.getOriginalValue(modifiedAcctId);
             // It's possible the modified account was created in this transaction, in which case the non-existent
             // persisted account effectively has no balance (i.e. its prior balance is 0)
@@ -68,10 +72,11 @@ public class RecordFinalizerBase {
 
             // Never allow an account's net hbar balance to be negative
             validateTrue(modifiedAcct.tinybarBalance() >= 0, FAIL_INVALID);
+            validateTrue(modifiedAcct.tinybarBalance() <= maxLegalBalance, FAIL_INVALID);
 
             final var netHbarChange = modifiedAcct.tinybarBalance() - persistedBalance;
             if (netHbarChange != 0) {
-                netHbarBalance += netHbarChange;
+                netHbarBalance = addExactOrThrowReason(netHbarBalance, netHbarChange, FAIL_INVALID);
                 hbarChanges.put(modifiedAcctId, netHbarChange);
             }
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeChildRecordHandler.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.records.ChildFinalizeContext;
 import com.hedera.node.app.service.token.records.ChildRecordFinalizer;
 import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.config.data.LedgerConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import javax.inject.Inject;
@@ -62,7 +63,9 @@ public class FinalizeChildRecordHandler extends RecordFinalizerBase implements C
         final var writableTokenStore = context.writableStore(WritableTokenStore.class);
 
         /* ------------------------- Hbar changes from child transaction  ------------------------- */
-        final var hbarChanges = hbarChangesFrom(writableAccountStore);
+        final var maxLegalBalance =
+                context.configuration().getConfigData(LedgerConfig.class).totalTinyBarFloat();
+        final var hbarChanges = hbarChangesFrom(writableAccountStore, maxLegalBalance);
         if (!hbarChanges.isEmpty()) {
             // Save the modified hbar amounts so records can be written
             recordBuilder.transferList(TransferList.newBuilder()

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeParentRecordHandler.java
@@ -45,6 +45,7 @@ import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.service.token.records.ParentRecordFinalizer;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.StakingConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
@@ -104,9 +105,11 @@ public class FinalizeParentRecordHandler extends RecordFinalizerBase implements 
         }
 
         // Hbar changes from transaction including staking rewards
+        final var maxLegalBalance =
+                context.configuration().getConfigData(LedgerConfig.class).totalTinyBarFloat();
         final Map<AccountID, Long> hbarChanges;
         try {
-            hbarChanges = hbarChangesFrom(writableAccountStore);
+            hbarChanges = hbarChangesFrom(writableAccountStore, maxLegalBalance);
         } catch (HandleException e) {
             if (e.getStatus() == FAIL_INVALID) {
                 logHbarFinalizationFailInvalid(

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AdjustmentUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AdjustmentUtils.java
@@ -217,7 +217,7 @@ public class AdjustmentUtils {
         try {
             return Math.addExact(a, b);
         } catch (final ArithmeticException ignore) {
-            throw new HandleException(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
+            throw new HandleException(failureReason);
         }
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AdjustmentUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/AdjustmentUtils.java
@@ -32,11 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class AdjustmentUtils {
-    private static final Logger log = LogManager.getLogger(AdjustmentUtils.class);
     public static final Function<TokenID, Map<AccountID, Long>> ADJUSTMENTS_MAP_FACTORY =
             ignore -> new LinkedHashMap<>();
 
@@ -205,12 +202,9 @@ public class AdjustmentUtils {
         final var collector = hbarFee.feeCollectorAccountId();
         final var fixedSpec = hbarFee.fixedFee();
         if (fixedSpec != null) {
-            log.info("Adjusting hbar fees for {}", fixedSpec);
-            log.info(" - BEFORE : {}", hbarAdjustments);
             final var amount = fixedSpec.amount();
             hbarAdjustments.merge(sender, -amount, AdjustmentUtils::addExactOrThrow);
             hbarAdjustments.merge(collector, amount, AdjustmentUtils::addExactOrThrow);
-            log.info(" - AFTER : {}", hbarAdjustments);
         }
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFractionalFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomFractionalFeeAssessor.java
@@ -123,7 +123,7 @@ public class CustomFractionalFeeAssessor {
                 // make credit to the collector
                 final var map =
                         result.getMutableInputBalanceAdjustments().computeIfAbsent(denom, ADJUSTMENTS_MAP_FACTORY);
-                map.merge(collector, assessedAmount, Long::sum);
+                map.merge(collector, assessedAmount, AdjustmentUtils::addExactOrThrow);
                 result.getMutableInputBalanceAdjustments().put(denom, map);
 
                 final var finalEffPayerNums = filteredCredits.keySet();
@@ -161,7 +161,7 @@ public class CustomFractionalFeeAssessor {
             final var amount = entry.getValue();
             // Further reduce the credit to an effective payer account
             // by the amount that was redirected to fee collector accounts
-            map.merge(account, amount - creditsForToken.get(account), Long::sum);
+            map.merge(account, amount - creditsForToken.get(account), AdjustmentUtils::addExactOrThrow);
         }
         mutableInputTokenAdjustments.put(denom, map);
     }
@@ -197,8 +197,8 @@ public class CustomFractionalFeeAssessor {
      * @return the amount owned to be paid as fractional custom fee
      */
     private long amountOwed(final long givenUnits, @NonNull final FractionalFee fractionalFee) {
-        final var numerator = fractionalFee.fractionalAmount().numerator();
-        final var denominator = fractionalFee.fractionalAmount().denominator();
+        final var numerator = fractionalFee.fractionalAmountOrThrow().numerator();
+        final var denominator = fractionalFee.fractionalAmountOrThrow().denominator();
         var nominalFee = 0L;
         try {
             nominalFee = safeFractionMultiply(numerator, denominator, givenUnits);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomRoyaltyFeeAssessor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/customfees/CustomRoyaltyFeeAssessor.java
@@ -98,7 +98,7 @@ public class CustomRoyaltyFeeAssessor {
                 fixedFeeAssessor.assessFixedFee(feeMeta, receiver, fallbackFee, result);
             } else {
                 if (!isPayerExempt(feeMeta, fee, sender)) {
-                    chargeRoyalty(exchangedValue, feeMeta, fee, result);
+                    chargeRoyalty(exchangedValue, fee, result);
                 }
             }
         }
@@ -118,13 +118,11 @@ public class CustomRoyaltyFeeAssessor {
      * then the fallback fee is charged to the receiver balance. Otherwise, the royalty fee is charged to the
      * credit value of the receiver.
      * @param exchangedValues fungible values exchanged to the receiver
-     * @param feeMeta custom fee meta
      * @param fee royalty fee
      * @param result assessment result
      */
     private void chargeRoyalty(
             @NonNull List<AdjustmentUtils.ExchangedValue> exchangedValues,
-            @NonNull final CustomFeeMeta feeMeta,
             @NonNull final CustomFee fee,
             @NonNull final AssessmentResult result) {
         for (final var exchange : exchangedValues) {
@@ -188,8 +186,8 @@ public class CustomRoyaltyFeeAssessor {
         final var htsAdjustments = result.getHtsAdjustments().computeIfAbsent(denom, ADJUSTMENTS_MAP_FACTORY);
         final var mutableInputHtsAdjustments =
                 result.getMutableInputBalanceAdjustments().get(denom);
-        mutableInputHtsAdjustments.merge(account, -royalty, Long::sum);
-        htsAdjustments.merge(feeCollector, royalty, Long::sum);
+        mutableInputHtsAdjustments.merge(account, -royalty, AdjustmentUtils::addExactOrThrow);
+        htsAdjustments.merge(feeCollector, royalty, AdjustmentUtils::addExactOrThrow);
     }
 
     /**
@@ -207,7 +205,7 @@ public class CustomRoyaltyFeeAssessor {
         final var hbarAdjustments = result.getHbarAdjustments();
         final var mutableHbarAdjustments =
                 result.getMutableInputBalanceAdjustments().get(HBAR_TOKEN_ID);
-        mutableHbarAdjustments.merge(account, -royalty, Long::sum);
-        hbarAdjustments.merge(feeCollector, royalty, Long::sum);
+        mutableHbarAdjustments.merge(account, -royalty, AdjustmentUtils::addExactOrThrow);
+        hbarAdjustments.merge(feeCollector, royalty, AdjustmentUtils::addExactOrThrow);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
@@ -33,6 +33,7 @@ import static com.hedera.node.app.spi.validation.Validations.validateAccountID;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
+import static java.math.BigInteger.ZERO;
 import static java.util.Collections.emptyList;
 
 import com.hedera.hapi.node.base.AccountAmount;
@@ -47,6 +48,7 @@ import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.TokensConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
 import javax.inject.Inject;
@@ -68,16 +70,15 @@ public class CryptoTransferValidator {
      */
     public void pureChecks(@NonNull final CryptoTransferTransactionBody op) throws PreCheckException {
         final var acctAmounts = op.transfersOrElse(TransferList.DEFAULT).accountAmountsOrElse(emptyList());
+        validateTruePreCheck(isNetZeroAdjustment(acctAmounts), INVALID_ACCOUNT_AMOUNTS);
+
         final var uniqueAcctIds = new HashSet<Pair<AccountID, Boolean>>();
-        long netBalance = 0;
         // Validate hbar transfers
         for (final AccountAmount acctAmount : acctAmounts) {
             validateTruePreCheck(acctAmount.hasAccountID(), INVALID_ACCOUNT_ID);
             final var acctId = validateAccountID(acctAmount.accountIDOrThrow(), null);
             uniqueAcctIds.add(Pair.of(acctId, acctAmount.isApproval()));
-            netBalance += acctAmount.amount();
         }
-        validateTruePreCheck(netBalance == 0, INVALID_ACCOUNT_AMOUNTS);
         validateFalsePreCheck(uniqueAcctIds.size() < acctAmounts.size(), ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS);
 
         // Validate token transfers
@@ -92,19 +93,17 @@ public class CryptoTransferValidator {
             // Validate the fungible transfers
             final var uniqueTokenAcctIds = new HashSet<Pair<AccountID, Boolean>>();
             final var fungibleTransfers = tokenTransfer.transfersOrElse(emptyList());
-            long netTokenBalance = 0;
+            validateTruePreCheck(isNetZeroAdjustment(fungibleTransfers), TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN);
             boolean nonZeroFungibleValueFound = false;
             for (final AccountAmount acctAmount : fungibleTransfers) {
                 validateTruePreCheck(acctAmount.hasAccountID(), INVALID_TRANSFER_ACCOUNT_ID);
                 uniqueTokenAcctIds.add(Pair.of(acctAmount.accountIDOrThrow(), acctAmount.isApproval()));
-                netTokenBalance += acctAmount.amount();
                 if (!nonZeroFungibleValueFound && acctAmount.amount() != 0) {
                     nonZeroFungibleValueFound = true;
                 }
             }
             validateFalsePreCheck(
                     uniqueTokenAcctIds.size() < fungibleTransfers.size(), ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS);
-            validateTruePreCheck(netTokenBalance == 0, TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN);
 
             // Validate the nft transfers
             final var nftTransfers = tokenTransfer.nftTransfersOrElse(emptyList());
@@ -116,7 +115,7 @@ public class CryptoTransferValidator {
                 validateFalsePreCheck(
                         !nftIds.isEmpty() && nftIds.contains(nftTransfer.serialNumber()), INVALID_ACCOUNT_AMOUNTS);
                 validateFalsePreCheck(
-                        nftTransfer.senderAccountID().equals(nftTransfer.receiverAccountID()),
+                        nftTransfer.senderAccountIDOrThrow().equals(nftTransfer.receiverAccountID()),
                         ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS);
                 nftIds.add(nftTransfer.serialNumber());
             }
@@ -202,5 +201,13 @@ public class CryptoTransferValidator {
         }
 
         return false;
+    }
+
+    private static boolean isNetZeroAdjustment(@NonNull final List<AccountAmount> adjusts) {
+        var net = ZERO;
+        for (var adjust : adjusts) {
+            net = net.add(BigInteger.valueOf(adjust.amount()));
+        }
+        return net.equals(ZERO);
     }
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildFinalizeContext.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildFinalizeContext.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.token.records;
 
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -59,4 +60,12 @@ public interface ChildFinalizeContext {
      */
     @NonNull
     <T> T userTransactionRecordBuilder(@NonNull Class<T> recordBuilderClass);
+
+    /**
+     * Returns the current {@link Configuration} for the context.
+     *
+     * @return the configuration
+     */
+    @NonNull
+    Configuration configuration();
 }


### PR DESCRIPTION
**Description**:
  - Fixes #12667 
  - Use `BigInteger` for net-zero adjustment calculations in `CryptoTransfer` pure checks.
  - Use exact math for all custom fee summing.
  - During record finalization,
      1. Use exact math for summing net balance adjustments.
      2. Add an extra safety check in record finalization for any balance that exceeds total hbar supply. 