### PR TITLE
fix: Cherry-pick: Return NOT_SUPPORTED in assertThrottlingPreconditions()

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -278,11 +278,11 @@ public final class IngestChecker {
             final var hederaConfig = configuration.getConfigData(HederaConfig.class);
             // This adds a mild restriction that privileged transactions can only
             // be issued by system accounts; (FUTURE) consider giving non-trivial
-            // minimum fees to privileged transactions that fail with UNAUTHORIZED
+            // minimum fees to privileged transactions that fail with NOT_SUPPORTED
             // at consensus, and adding them to normal throttle buckets, c.f.
             // https://github.com/hashgraph/hedera-services/issues/12559
             if (payerNum >= hederaConfig.firstUserEntity()) {
-                throw new PreCheckException(UNAUTHORIZED);
+                throw new PreCheckException(NOT_SUPPORTED);
             }
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyUserFreezeNotAuthorized.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/checks/VerifyUserFreezeNotAuthorized.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.spec.utilops.checks;
 
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.getUniqueTimestampPlusSecs;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -58,7 +58,7 @@ public class VerifyUserFreezeNotAuthorized extends UtilOp {
                 .build();
         final var response =
                 spec.clients().getCryptoSvcStub(targetNodeFor(spec), useTls).addLiveHash(txn);
-        assertEquals(UNAUTHORIZED, response.getNodeTransactionPrecheckCode());
+        assertEquals(NOT_SUPPORTED, response.getNodeTransactionPrecheckCode());
         return false;
     }
 }


### PR DESCRIPTION
Cherry-pick of #12647 

Closes #12646 