### PR TITLE
feat(cancun): EIP-6780 SELFDESTRUCT semantics

### DIFF
--- a/hedera-node/docs/design/services/smart-contract-service/cancun-fork-support.md
+++ b/hedera-node/docs/design/services/smart-contract-service/cancun-fork-support.md
@@ -143,3 +143,4 @@ Verify that the new behavior of the `SELFDESTRUCT` operation is correct:
 * For both of the above, verify that the hbar balance is correctly sent to their beneficiary
   * But only where allowed by Hedera semantics (e.g., w.r.t. beneficiary account existence and type,
     and required signatures)
+

--- a/hedera-node/docs/design/services/smart-contract-service/cancun-fork-support.md
+++ b/hedera-node/docs/design/services/smart-contract-service/cancun-fork-support.md
@@ -56,6 +56,8 @@ Opcodes that interact with blobs should not cause the contracts to break, but sh
 It is not a goal to introduce blobs into Hedera. It is also not a goal to restrict design space nor to dictate future
 design directions for support or non-support of blobs.
 
+Cancun support in mono-services.
+
 ## Implementation
 
 ### New Cancun EVM
@@ -102,12 +104,16 @@ sufficient.
 <!-- **TODO(Nana): Set them in the EVM versions how? Is there a specific class that needs to be updated or a method that needs to be overridden?** -->
 
 
-### Update HederaSelfDestructOperation behavior
+### Update Hedera's CustomSelfDestructOperation behavior
 
-Either with a new class or a class that takes a constructor parameter, update the HederaSelfDestructOperation so that it
-will behave consistently with the EIP-6780 `SELFDESTRUCT` rules.
+The current Hedera override class, `CustomSelfDestructOperation`, will be updated so that it registers, 
+with the frame, the executing contract for deletion if either:
+* pre-Cancun semantics, or
+* post-Cancun semantics and the contract was created in the same frame
+  * the latter information is available in the frame itself
 
-<!-- **TODO(Nana): Please specify which option the implementation should follow. Feel free to note that the other wasn't chosen for reason X** -->
+A constructor parameter will choose which semantics to implement (which matches the way BESU does it,
+    though it isn't _necessary_ to match it).
 
 ## Acceptance Tests
 
@@ -134,5 +140,6 @@ Verify that the new behavior of the `SELFDESTRUCT` operation is correct:
 
 * Verify that a self-destruct of a contract created in the same transaction deletes the contract
 * Verify that a self-destruct of a contract not created in the same transaction leaves the contract in place
-* For both of the above, verify that the HTS tokens are correctly sent to their beneficiary
-  * But only where allowed by Hedera semantics (e.g., w.r.t. token approvals)
+* For both of the above, verify that the hbar balance is correctly sent to their beneficiary
+  * But only where allowed by Hedera semantics (e.g., w.r.t. beneficiary account existence and type,
+    and required signatures)

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
@@ -41,6 +41,7 @@ import com.hedera.node.app.service.contract.impl.exec.operations.CustomLogOperat
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSLoadOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSStoreOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation.UseEIP6780Semantics;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomStaticCallOperation;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
@@ -301,7 +302,7 @@ public interface V030Module {
     @ServicesV030
     static Operation provideSelfDestructOperation(
             @NonNull final GasCalculator gasCalculator, @ServicesV030 @NonNull final AddressChecks addressChecks) {
-        return new CustomSelfDestructOperation(gasCalculator, addressChecks);
+        return new CustomSelfDestructOperation(gasCalculator, addressChecks, UseEIP6780Semantics.NO);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
@@ -42,6 +42,7 @@ import com.hedera.node.app.service.contract.impl.exec.operations.CustomPrevRanda
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSLoadOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSStoreOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation.UseEIP6780Semantics;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomStaticCallOperation;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
@@ -311,7 +312,7 @@ public interface V034Module {
     @ServicesV034
     static Operation provideSelfDestructOperation(
             @NonNull final GasCalculator gasCalculator, @ServicesV034 @NonNull final AddressChecks addressChecks) {
-        return new CustomSelfDestructOperation(gasCalculator, addressChecks);
+        return new CustomSelfDestructOperation(gasCalculator, addressChecks, UseEIP6780Semantics.NO);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
@@ -42,6 +42,7 @@ import com.hedera.node.app.service.contract.impl.exec.operations.CustomPrevRanda
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSLoadOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSStoreOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation.UseEIP6780Semantics;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomStaticCallOperation;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
@@ -311,7 +312,7 @@ public interface V038Module {
     @ServicesV038
     static Operation provideSelfDestructOperation(
             @NonNull final GasCalculator gasCalculator, @ServicesV038 @NonNull final AddressChecks addressChecks) {
-        return new CustomSelfDestructOperation(gasCalculator, addressChecks);
+        return new CustomSelfDestructOperation(gasCalculator, addressChecks, UseEIP6780Semantics.NO);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/V046Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/V046Module.java
@@ -42,6 +42,7 @@ import com.hedera.node.app.service.contract.impl.exec.operations.CustomPrevRanda
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSLoadOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSStoreOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation.UseEIP6780Semantics;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomStaticCallOperation;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
@@ -311,7 +312,7 @@ public interface V046Module {
     @ServicesV046
     static Operation provideSelfDestructOperation(
             @NonNull final GasCalculator gasCalculator, @ServicesV046 @NonNull final AddressChecks addressChecks) {
-        return new CustomSelfDestructOperation(gasCalculator, addressChecks);
+        return new CustomSelfDestructOperation(gasCalculator, addressChecks, UseEIP6780Semantics.NO);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
@@ -42,6 +42,7 @@ import com.hedera.node.app.service.contract.impl.exec.operations.CustomPrevRanda
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSLoadOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSStoreOperation;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation.UseEIP6780Semantics;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomStaticCallOperation;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
@@ -324,8 +325,9 @@ public interface V050Module {
     @ServicesV050
     static Operation provideSelfDestructOperation(
             @NonNull final GasCalculator gasCalculator, @ServicesV050 @NonNull final AddressChecks addressChecks) {
-        return new CustomSelfDestructOperation(gasCalculator, addressChecks);
-    }
+        // Here we adopt EIP-6780 semantics, for SELFDESTRUCT, for the first time
+        return new CustomSelfDestructOperation(gasCalculator, addressChecks, UseEIP6780Semantics.YES);
+   }
 
     @Provides
     @IntoSet

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
@@ -327,7 +327,7 @@ public interface V050Module {
             @NonNull final GasCalculator gasCalculator, @ServicesV050 @NonNull final AddressChecks addressChecks) {
         // Here we adopt EIP-6780 semantics, for SELFDESTRUCT, for the first time
         return new CustomSelfDestructOperation(gasCalculator, addressChecks, UseEIP6780Semantics.YES);
-   }
+    }
 
     @Provides
     @IntoSet

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSelfDestructOperationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/operations/CustomSelfDestructOperationTest.java
@@ -20,12 +20,15 @@ import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExcep
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertSameResult;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.node.app.service.contract.impl.exec.AddressChecks;
 import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation.UseEIP6780Semantics;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -36,9 +39,9 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.UnderflowException;
 import org.hyperledger.besu.evm.operation.Operation;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -69,20 +72,25 @@ class CustomSelfDestructOperationTest {
 
     private CustomSelfDestructOperation subject;
 
-    @BeforeEach
-    void setUp() {
-        subject = new CustomSelfDestructOperation(gasCalculator, addressChecks);
+    void createSubject(@NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        subject = new CustomSelfDestructOperation(gasCalculator, addressChecks, useEIP6780Semantics);
     }
 
-    @Test
-    void catchesUnderflowWhenStackIsEmpty() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void catchesUnderflowWhenStackIsEmpty(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         given(frame.popStackItem()).willThrow(UnderflowException.class);
         final var expected = new Operation.OperationResult(0L, ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
         assertSameResult(expected, subject.execute(frame, evm));
     }
 
-    @Test
-    void rejectsSystemBeneficiaryAsMissing() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void rejectsSystemBeneficiaryAsMissing(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         given(frame.popStackItem()).willReturn(BENEFICIARY);
         given(addressChecks.isSystemAccount(BENEFICIARY)).willReturn(true);
         given(gasCalculator.selfDestructOperationGasCost(null, Wei.ZERO)).willReturn(123L);
@@ -90,8 +98,11 @@ class CustomSelfDestructOperationTest {
         assertSameResult(expected, subject.execute(frame, evm));
     }
 
-    @Test
-    void respectsHederaCustomHaltReason() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void respectsHederaCustomHaltReason(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         given(frame.popStackItem()).willReturn(BENEFICIARY);
         given(frame.getRecipientAddress()).willReturn(TBD);
         given(addressChecks.isPresent(BENEFICIARY, frame)).willReturn(true);
@@ -103,8 +114,11 @@ class CustomSelfDestructOperationTest {
         assertSameResult(expected, subject.execute(frame, evm));
     }
 
-    @Test
-    void rejectsSelfDestructInStaticChanges() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void rejectsSelfDestructInStaticChanges(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         givenRunnableSelfDestruct();
         given(frame.isStatic()).willReturn(true);
         given(gasCalculator.getColdAccountAccessCost()).willReturn(COLD_ACCESS_COST);
@@ -114,8 +128,11 @@ class CustomSelfDestructOperationTest {
         assertSameResult(expected, subject.execute(frame, evm));
     }
 
-    @Test
-    void haltsSelfDestructWithInsufficientGas() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void haltsSelfDestructWithInsufficientGas(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         givenRunnableSelfDestruct();
         given(frame.warmUpAddress(BENEFICIARY)).willReturn(true);
         given(gasCalculator.selfDestructOperationGasCost(null, INHERITANCE)).willReturn(123L);
@@ -123,8 +140,11 @@ class CustomSelfDestructOperationTest {
         assertSameResult(expected, subject.execute(frame, evm));
     }
 
-    @Test
-    void haltsSelfDestructOnFailedInheritanceTransfer() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void haltsSelfDestructOnFailedInheritanceTransfer(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         givenRunnableSelfDestruct();
         givenWarmBeneficiaryWithSufficientGas();
         given(proxyWorldUpdater.tryTransfer(TBD, BENEFICIARY, INHERITANCE.toLong(), true))
@@ -133,11 +153,38 @@ class CustomSelfDestructOperationTest {
         assertSameResult(expected, subject.execute(frame, evm));
     }
 
-    @Test
-    void finalizesFrameAsExpected() {
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void finalizesFrameAsExpected(@NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
         givenRunnableSelfDestruct();
         givenWarmBeneficiaryWithSufficientGas();
         given(frame.getContractAddress()).willReturn(TBD);
+        given(proxyWorldUpdater.tryTransfer(TBD, BENEFICIARY, INHERITANCE.toLong(), false))
+                .willReturn(Optional.empty());
+        final var expected = new Operation.OperationResult(123L, null);
+        assertSameResult(expected, subject.execute(frame, evm));
+
+        switch (useEIP6780Semantics) {
+            case NO -> verify(frame).addSelfDestruct(TBD);
+            case YES -> verify(frame, never()).addSelfDestruct(TBD); // NOT created in same frame
+        }
+
+        verify(frame).addRefund(BENEFICIARY, INHERITANCE);
+        verify(frame).setState(MessageFrame.State.CODE_SUCCESS);
+    }
+
+    @ParameterizedTest
+    @EnumSource(CustomSelfDestructOperation.UseEIP6780Semantics.class)
+    void finalizesFrameAsExpectedIfCreatedInSameTransaction(
+            @NonNull final CustomSelfDestructOperation.UseEIP6780Semantics useEIP6780Semantics) {
+        createSubject(useEIP6780Semantics);
+        givenRunnableSelfDestruct();
+        givenWarmBeneficiaryWithSufficientGas();
+        given(frame.getContractAddress()).willReturn(TBD);
+        if (useEIP6780Semantics == UseEIP6780Semantics.YES) {
+            given(frame.wasCreatedInTransaction(TBD)).willReturn(true);
+        }
         given(proxyWorldUpdater.tryTransfer(TBD, BENEFICIARY, INHERITANCE.toLong(), false))
                 .willReturn(Optional.empty());
         final var expected = new Operation.OperationResult(123L, null);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SelfDestructSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SelfDestructSuite.java
@@ -18,6 +18,7 @@ package com.hedera.services.bdd.suites.contract.opcodes;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
@@ -28,6 +29,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_LOG_DATA;
@@ -47,6 +49,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
@@ -58,6 +61,11 @@ import org.junit.jupiter.api.Tag;
 public class SelfDestructSuite extends HapiSuite {
 
     private final Logger LOGGER = LogManager.getLogger(SelfDestructSuite.class);
+
+    private static final String EVM_VERSION_PROPERTY = "contracts.evm.version";
+    private static final String DYNAMIC_EVM_PROPERTY = "contracts.evm.version.dynamic";
+    private static final String EVM_VERSION_046 = "v0.46";
+    private static final String EVM_VERSION_049 = "v0.49";
 
     private static final String SELF_DESTRUCT_CALLABLE_CONTRACT = "SelfDestructCallable";
     private static final String DESTROY_EXPLICIT_BENEFICIARY = "destroyExplicitBeneficiary";
@@ -77,14 +85,17 @@ public class SelfDestructSuite extends HapiSuite {
         return List.of(
                 hscsEvm008SelfDestructInConstructorWorks(),
                 hscsEvm008SelfDestructWhenCalling(),
-                selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn(),
-                selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed(),
-                testSelfDestructForSystemAccounts());
+                selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn(EVM_VERSION_046),
+                selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn(EVM_VERSION_049),
+                selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed(EVM_VERSION_046),
+                selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed(EVM_VERSION_049),
+                testSelfDestructForSystemAccounts(EVM_VERSION_046),
+                testSelfDestructForSystemAccounts(EVM_VERSION_049));
     }
 
     @Override
     public boolean canRunConcurrent() {
-        return true;
+        return false;
     }
 
     @HapiTest
@@ -130,10 +141,24 @@ public class SelfDestructSuite extends HapiSuite {
     }
 
     @HapiTest
-    final HapiSpec selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn() {
+    final HapiSpec selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn46() {
+        return selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn(EVM_VERSION_046);
+    }
+
+    @HapiTest
+    final HapiSpec selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn49() {
+        return selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn(EVM_VERSION_049);
+    }
+
+    final HapiSpec selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn(
+            @NonNull final String evmVersion) {
         final AtomicLong beneficiaryId = new AtomicLong();
-        return defaultHapiSpec("selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn")
+        return propertyPreservingHapiSpec(
+                        "selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn" + evmVersion)
+                .preserving(EVM_VERSION_PROPERTY, DYNAMIC_EVM_PROPERTY)
                 .given(
+                        overriding(DYNAMIC_EVM_PROPERTY, "true"),
+                        overriding(EVM_VERSION_PROPERTY, evmVersion),
                         cryptoCreate(BENEFICIARY)
                                 .balance(ONE_HUNDRED_HBARS)
                                 .receiverSigRequired(true)
@@ -152,9 +177,24 @@ public class SelfDestructSuite extends HapiSuite {
     }
 
     @HapiTest
-    final HapiSpec selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed() {
-        return defaultHapiSpec("selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed")
+    final HapiSpec selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed46() {
+        return selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed(EVM_VERSION_046);
+    }
+
+    @HapiTest
+    final HapiSpec selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed49() {
+        return selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed(EVM_VERSION_049);
+    }
+
+    final HapiSpec selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed(
+            @NonNull final String evmVersion) {
+        return propertyPreservingHapiSpec(
+                        "selfDestructViaCallLocalWithAccount999ResultsInLocalCallModificationPrecheckFailed"
+                                + evmVersion)
+                .preserving(EVM_VERSION_PROPERTY, DYNAMIC_EVM_PROPERTY)
                 .given(
+                        overriding(DYNAMIC_EVM_PROPERTY, "true"),
+                        overriding(EVM_VERSION_PROPERTY, evmVersion),
                         uploadInitCode(SELF_DESTRUCT_CALLABLE_CONTRACT),
                         contractCreate(SELF_DESTRUCT_CALLABLE_CONTRACT).balance(ONE_HBAR))
                 .when(contractCallLocal(
@@ -164,7 +204,16 @@ public class SelfDestructSuite extends HapiSuite {
     }
 
     @HapiTest
-    final HapiSpec testSelfDestructForSystemAccounts() {
+    final HapiSpec testSelfDestructForSystemAccounts46() {
+        return testSelfDestructForSystemAccounts(EVM_VERSION_046);
+    }
+
+    @HapiTest
+    final HapiSpec testSelfDestructForSystemAccounts49() {
+        return testSelfDestructForSystemAccounts(EVM_VERSION_049);
+    }
+
+    final HapiSpec testSelfDestructForSystemAccounts(@NonNull final String evmVersion) {
         final AtomicLong deployer = new AtomicLong();
         final var nonExistingAccountsOps = createOpsArray(
                 nonExistingSystemAccounts,
@@ -177,9 +226,11 @@ public class SelfDestructSuite extends HapiSuite {
 
         System.arraycopy(nonExistingAccountsOps, 0, opsArray, 0, nonExistingAccountsOps.length);
         System.arraycopy(existingAccountsOps, 0, opsArray, nonExistingAccountsOps.length, existingAccountsOps.length);
-
-        return defaultHapiSpec("testSelfDestructForSystemAccounts")
+        return propertyPreservingHapiSpec("testSelfDestructForSystemAccounts" + evmVersion)
+                .preserving(EVM_VERSION_PROPERTY, DYNAMIC_EVM_PROPERTY)
                 .given(
+                        overriding(DYNAMIC_EVM_PROPERTY, "true"),
+                        overriding(EVM_VERSION_PROPERTY, evmVersion),
                         cryptoCreate(BENEFICIARY)
                                 .balance(ONE_HUNDRED_HBARS)
                                 .receiverSigRequired(false)


### PR DESCRIPTION
**Description**:

Post-Cancun SELFDESTRUCT only sweeps if contract was _not_ created in same transaction.

**Related issue(s)**:

Fixes #11702 .

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
