### PR TITLE
fix: Add EETs and pureChecks in few handlers

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseCryptoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseCryptoHandler.java
@@ -72,4 +72,15 @@ public class BaseCryptoHandler {
         }
         return false;
     }
+
+    /**
+     * Checks if the accountID has an account number or alias
+     * @param accountID   the accountID to check
+     * @return {@code true} if the accountID has an account number or alias, {@code false} otherwise
+     */
+    public static boolean hasAccountNumOrAlias(@Nullable final AccountID accountID) {
+        return accountID != null
+                && ((accountID.hasAccountNum() && accountID.accountNumOrThrow() != 0L)
+                        || (accountID.hasAlias() && accountID.aliasOrThrow().length() > 0));
+    }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.token.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
@@ -24,13 +25,15 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TO
 import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.txnEstimateFactory;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.impl.comparator.TokenComparators.TOKEN_ID_COMPARATOR;
+import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.hasAccountNumOrAlias;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
@@ -104,13 +107,11 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
         final var op = txn.tokenAssociateOrThrow();
 
-        if (!op.hasAccount()) {
-            throw new PreCheckException(ResponseCodeEnum.INVALID_ACCOUNT_ID);
-        }
+        validateTruePreCheck(hasAccountNumOrAlias(op.account()), INVALID_ACCOUNT_ID);
+        validateTruePreCheck(op.hasTokens(), INVALID_TOKEN_ID);
+        validateFalsePreCheck(op.tokensOrThrow().contains(TokenID.DEFAULT), INVALID_TOKEN_ID);
 
-        if (TokenListChecks.repeatsItself(op.tokensOrThrow())) {
-            throw new PreCheckException(TOKEN_ID_REPEATED_IN_TOKEN_LIST);
-        }
+        validateFalsePreCheck(TokenListChecks.repeatsItself(op.tokensOrThrow()), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -78,6 +78,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -152,7 +153,8 @@ public class ContractCreateSuite extends HapiSuite {
                 newAccountsCanUsePureContractIdKey(),
                 createContractWithStakingFields(),
                 disallowCreationsOfEmptyInitCode(),
-                createCallInConstructor());
+                createCallInConstructor(),
+                cannotSetMaxAutomaticAssociations());
     }
 
     @Override
@@ -697,6 +699,16 @@ public class ContractCreateSuite extends HapiSuite {
                                 .logged())
                 .when()
                 .then();
+    }
+
+    @HapiTest
+    private HapiSpec cannotSetMaxAutomaticAssociations() {
+        return defaultHapiSpec("cannotSetMaxAutomaticAssociations")
+                .given(uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT))
+                .when()
+                .then(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
+                        .maxAutomaticTokenAssociations(10)
+                        .hasKnownStatus(NOT_SUPPORTED));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -50,6 +50,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -105,7 +106,8 @@ public class ContractUpdateSuite extends HapiSuite {
                 eip1014AddressAlwaysHasPriority(),
                 immutableContractKeyFormIsStandard(),
                 updateAutoRenewAccountWorks(),
-                updateStakingFieldsWorks());
+                updateStakingFieldsWorks(),
+                cannotUpdateMaxAutomaticAssociations());
     }
 
     @HapiTest
@@ -455,6 +457,17 @@ public class ContractUpdateSuite extends HapiSuite {
                             .hasBytecode(spec.registry().getBytes("initialBytecode"));
                     allRunFor(spec, op);
                 }));
+    }
+
+    @HapiTest
+    private HapiSpec cannotUpdateMaxAutomaticAssociations() {
+        return defaultHapiSpec("cannotUpdateMaxAutomaticAssociations")
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        uploadInitCode(CONTRACT),
+                        contractCreate(CONTRACT).adminKey(ADMIN_KEY))
+                .when()
+                .then(contractUpdate(CONTRACT).newMaxAutomaticAssociations(20).hasKnownStatus(NOT_SUPPORTED));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileSuite.java
@@ -39,6 +39,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 
@@ -196,7 +197,7 @@ public class DissociatePrecompileSuite extends HapiSuite {
                         childRecordsCheck(
                                 nullTokenArray,
                                 CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)),
+                                recordWith().status(INVALID_TOKEN_ID)),
                         childRecordsCheck(
                                 nonExistingTokensInArray,
                                 CONTRACT_REVERT_EXECUTED,
@@ -283,7 +284,7 @@ public class DissociatePrecompileSuite extends HapiSuite {
                         childRecordsCheck(
                                 nullToken,
                                 CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)));
+                                recordWith().status(INVALID_TOKEN_ID)));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -49,6 +49,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TREASURY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
@@ -111,7 +112,8 @@ public class TokenAssociationSpecs extends HapiSuite {
                 contractInfoQueriesAsExpected(),
                 dissociateHasExpectedSemanticsForDeletedTokens(),
                 dissociateHasExpectedSemanticsForDissociatedContracts(),
-                canDissociateFromDeletedTokenWithAlreadyDissociatedTreasury());
+                canDissociateFromDeletedTokenWithAlreadyDissociatedTreasury(),
+                associateAndDissociateNeedsValidAccountAndToken());
     }
 
     @Override
@@ -502,6 +504,22 @@ public class TokenAssociationSpecs extends HapiSuite {
                         getAccountInfo("test").logged(),
                         tokenDissociate("test", FREEZABLE_TOKEN_OFF_BY_DEFAULT).logged(),
                         getAccountInfo("test").logged());
+    }
+
+    @HapiTest
+    private HapiSpec associateAndDissociateNeedsValidAccountAndToken() {
+        final var account = "account";
+        return defaultHapiSpec("dissociationNeedsAccount")
+                .given(
+                        newKeyNamed(SIMPLE),
+                        tokenCreate("a").decimals(1),
+                        cryptoCreate(account).key(SIMPLE).balance(0L))
+                .when(
+                        tokenAssociate("0.0.0", "a").signedBy(DEFAULT_PAYER).hasPrecheck(INVALID_ACCOUNT_ID),
+                        tokenDissociate("0.0.0", "a").signedBy(DEFAULT_PAYER).hasPrecheck(INVALID_ACCOUNT_ID))
+                .then(
+                        tokenAssociate(account, "0.0.0").hasPrecheck(INVALID_TOKEN_ID),
+                        tokenDissociate(account, "0.0.0").hasPrecheck(INVALID_TOKEN_ID));
     }
 
     public static HapiSpecOperation[] basicKeysAndTokens() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -126,7 +126,7 @@ public class TokenAssociationSpecs extends HapiSuite {
         return defaultHapiSpec("HandlesUseOfDefaultTokenId", SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES)
                 .given()
                 .when()
-                .then(tokenAssociate(DEFAULT_PAYER, "0.0.0").hasKnownStatus(INVALID_TOKEN_ID));
+                .then(tokenAssociate(DEFAULT_PAYER, "0.0.0").hasPrecheck(INVALID_TOKEN_ID));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -151,7 +151,8 @@ public class TokenCreateSpecs extends HapiSuite {
                 createsFungibleInfiniteByDefault(),
                 baseCreationsHaveExpectedPrices(),
                 /* HIP-23 */
-                validateNewTokenAssociations());
+                validateNewTokenAssociations(),
+                missingTreasurySignatureFails());
     }
 
     /**
@@ -530,6 +531,95 @@ public class TokenCreateSpecs extends HapiSuite {
                                         .balance(0)
                                         .kyc(TokenKycStatus.KycNotApplicable)
                                         .freeze(TokenFreezeStatus.FreezeNotApplicable)));
+    }
+
+    @HapiTest
+    public HapiSpec missingTreasurySignatureFails() {
+        String memo = "JUMP";
+        String saltedName = salted(PRIMARY);
+        final var pauseKey = "pauseKey";
+        return defaultHapiSpec("missingTreasurySignatureFails", NONDETERMINISTIC_TOKEN_NAMES)
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        cryptoCreate(AUTO_RENEW_ACCOUNT).balance(0L),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed("freezeKey"),
+                        newKeyNamed("kycKey"),
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed("wipeKey"),
+                        newKeyNamed("feeScheduleKey"),
+                        newKeyNamed(pauseKey))
+                .when(
+                        tokenCreate(PRIMARY)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .entityMemo(memo)
+                                .name(saltedName)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(AUTO_RENEW_ACCOUNT)
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .maxSupply(1000)
+                                .initialSupply(500)
+                                .decimals(1)
+                                .adminKey(ADMIN_KEY)
+                                .freezeKey("freezeKey")
+                                .kycKey("kycKey")
+                                .supplyKey(SUPPLY_KEY)
+                                .wipeKey("wipeKey")
+                                .feeScheduleKey("feeScheduleKey")
+                                .pauseKey(pauseKey)
+                                .signedBy(DEFAULT_PAYER, ADMIN_KEY, AUTO_RENEW_ACCOUNT)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate(PRIMARY)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .entityMemo(memo)
+                                .name(saltedName)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(AUTO_RENEW_ACCOUNT)
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .maxSupply(1000)
+                                .initialSupply(500)
+                                .decimals(1)
+                                .adminKey(ADMIN_KEY)
+                                .freezeKey("freezeKey")
+                                .kycKey("kycKey")
+                                .supplyKey(SUPPLY_KEY)
+                                .wipeKey("wipeKey")
+                                .feeScheduleKey("feeScheduleKey")
+                                .pauseKey(pauseKey)
+                                .signedBy(DEFAULT_PAYER, ADMIN_KEY, AUTO_RENEW_ACCOUNT, TOKEN_TREASURY)
+                                .via(CREATE_TXN))
+                .then(
+                        withOpContext((spec, opLog) -> {
+                            var createTxn = getTxnRecord(CREATE_TXN);
+                            allRunFor(spec, createTxn);
+                            var timestamp = createTxn
+                                    .getResponseRecord()
+                                    .getConsensusTimestamp()
+                                    .getSeconds();
+                            spec.registry().saveExpiry(PRIMARY, timestamp + THREE_MONTHS_IN_SECONDS);
+                        }),
+                        getTokenInfo(PRIMARY)
+                                .logged()
+                                .hasRegisteredId(PRIMARY)
+                                .hasTokenType(TokenType.FUNGIBLE_COMMON)
+                                .hasSupplyType(TokenSupplyType.FINITE)
+                                .hasEntityMemo(memo)
+                                .hasName(saltedName)
+                                .hasTreasury(TOKEN_TREASURY)
+                                .hasAutoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .hasValidExpiry()
+                                .hasDecimals(1)
+                                .hasAdminKey(PRIMARY)
+                                .hasFreezeKey(PRIMARY)
+                                .hasKycKey(PRIMARY)
+                                .hasSupplyKey(PRIMARY)
+                                .hasWipeKey(PRIMARY)
+                                .hasFeeScheduleKey(PRIMARY)
+                                .hasPauseKey(PRIMARY)
+                                .hasPauseStatus(TokenPauseStatus.Unpaused)
+                                .hasMaxSupply(1000)
+                                .hasTotalSupply(500)
+                                .hasAutoRenewAccount(AUTO_RENEW_ACCOUNT));
     }
 
     @HapiTest


### PR DESCRIPTION
Fixes #11306 
Fixes #3629 
Fixes #3630 

- Add tests for validating max-automatic_associations in contracts; 
- Added more pureChecks in `TokenAssociateHandler` and `TokenDissociateHandler` to fail early for invalid accountID and tokenID