### PR TITLE
chore: Implement un-HAPI tests for TokenAssociateToAccountHandler

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
@@ -147,7 +147,7 @@ public class FileUpdateHandler implements TransactionHandler {
 
         // First validate this file is mutable; and the pending mutations are allowed
         if (wantsToMutateNonExpiryField(fileUpdate)) {
-            validateFalse(file.keys() == null, UNAUTHORIZED);
+            validateTrue(file.hasKeys() && file.keys().hasKeys() && !file.keys().keys().isEmpty(), UNAUTHORIZED);
             validateMaybeNewMemo(handleContext.attributeValidator(), fileUpdate);
         }
 

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
@@ -147,7 +147,11 @@ public class FileUpdateHandler implements TransactionHandler {
 
         // First validate this file is mutable; and the pending mutations are allowed
         if (wantsToMutateNonExpiryField(fileUpdate)) {
-            validateTrue(file.hasKeys() && file.keys().hasKeys() && !file.keys().keys().isEmpty(), UNAUTHORIZED);
+            validateTrue(
+                    file.hasKeys()
+                            && file.keys().hasKeys()
+                            && !file.keys().keys().isEmpty(),
+                    UNAUTHORIZED);
             validateMaybeNewMemo(handleContext.attributeValidator(), fileUpdate);
         }
 

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
@@ -147,11 +147,14 @@ public class FileUpdateHandler implements TransactionHandler {
 
         // First validate this file is mutable; and the pending mutations are allowed
         if (wantsToMutateNonExpiryField(fileUpdate)) {
-            validateTrue(
-                    file.hasKeys()
-                            && file.keys().hasKeys()
-                            && !file.keys().keys().isEmpty(),
-                    UNAUTHORIZED);
+            if (handleContext.hasPrivilegedAuthorization() != SystemPrivilege.AUTHORIZED) {
+                validateTrue(
+                        file.hasKeys()
+                                && file.keys().hasKeys()
+                                && !file.keys().keys().isEmpty(),
+                        UNAUTHORIZED);
+            }
+
             validateMaybeNewMemo(handleContext.attributeValidator(), fileUpdate);
         }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.token.impl.handlers;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
@@ -25,6 +26,7 @@ import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.txnEstim
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.impl.comparator.TokenComparators.TOKEN_ID_COMPARATOR;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
+import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
@@ -138,6 +140,7 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
         // Check that the account exists
         final var account = accountStore.get(accountId);
         validateTrue(account != null, INVALID_ACCOUNT_ID);
+        validateFalse(account.deleted(), ACCOUNT_DELETED);
 
         // Check that the given tokens exist and are usable
         final var tokens = new ArrayList<Token>();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -256,8 +256,8 @@ public abstract class HapiSpecOperation {
                 return Optional.empty();
             }
             if (verboseLoggingOn) {
-                String message = MessageFormat.format("{0}{1} failed - {2}", spec.logPrefix(), this, t);
-                log.warn(message);
+                String message = MessageFormat.format("{0}{1} failed", spec.logPrefix(), this);
+                log.warn(message, t);
             } else if (!loggingOff) {
                 String message = MessageFormat.format("{0}{1} failed - {2}!", spec.logPrefix(), this, t.getMessage());
                 log.warn(message);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigControl.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigControl.java
@@ -140,6 +140,10 @@ public class SigControl implements Serializable {
         return new SigControl(M, childControls);
     }
 
+    public static SigControl emptyList() {
+        return new SigControl(LIST);
+    }
+
     protected SigControl(Nature nature) {
         this.nature = nature;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
@@ -291,10 +291,12 @@ public class HapiContractCall extends HapiBaseCall<HapiContractCall> {
         ContractCallTransactionBody opBody = spec.txns()
                 .<ContractCallTransactionBody, ContractCallTransactionBody.Builder>body(
                         ContractCallTransactionBody.class, builder -> {
-                            if (!tryAsHexedAddressIfLenMatches) {
-                                builder.setContractID(spec.registry().getContractId(contract));
-                            } else {
-                                builder.setContractID(TxnUtils.asContractId(contract, spec));
+                            if (contract != null) {
+                                if (!tryAsHexedAddressIfLenMatches) {
+                                    builder.setContractID(spec.registry().getContractId(contract));
+                                } else {
+                                    builder.setContractID(TxnUtils.asContractId(contract, spec));
+                                }
                             }
                             builder.setFunctionParameters(ByteString.copyFrom(callData));
                             valueSent.ifPresent(builder::setAmount);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
@@ -124,7 +124,7 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
     }
 
     public HapiFileCreate key(String keyName) {
-        this.keyName = Optional.of(keyName);
+        this.keyName = Optional.ofNullable(keyName);
         return this;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -242,7 +242,7 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
     }
 
     public HapiTokenCreate name(final String name) {
-        this.name = Optional.of(name);
+        this.name = Optional.ofNullable(name);
         return this;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -91,6 +91,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_G
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
@@ -260,6 +261,15 @@ public class ContractCallSuite extends HapiSuite {
                 hollowCreationFailsCleanly(),
                 repeatedCreate2FailsWithInterpretableActionSidecars(),
                 callStaticCallToLargeAddress());
+    }
+
+    @HapiTest
+    public HapiSpec canHandleInvalidContractCallTransactions() {
+        return defaultHapiSpec("canHandleInvalidContractCallTransactions")
+                .given()
+                .when()
+                .then(
+                        contractCall(null).hasPrecheck(INVALID_CONTRACT_ID));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -268,8 +268,7 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec("canHandleInvalidContractCallTransactions")
                 .given()
                 .when()
-                .then(
-                        contractCall(null).hasPrecheck(INVALID_CONTRACT_ID));
+                .then(contractCall(null).hasPrecheck(INVALID_CONTRACT_ID));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -93,6 +93,7 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.transactions.TxnVerbs;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
@@ -351,6 +352,21 @@ public class FileUpdateSuite extends HapiSuite {
                         getFileContents("test").hasContents(ignore -> new4k),
                         getFileInfo("test").hasMemo(secondMemo));
     }
+
+    @HapiTest
+    public HapiSpec cannotUpdateImmutableFile() {
+        final String file1 = "FILE_1";
+        final String file2 = "FILE_2";
+        return defaultHapiSpec("CannotUpdateImmutableFile")
+                .given(
+                        fileCreate(file1).contents("Hello World").unmodifiable(),
+                        fileCreate(file2).contents("Hello World").waclShape(SigControl.emptyList()))
+                .when()
+                .then(
+                        fileUpdate(file1).contents("Goodbye World").signedBy(DEFAULT_PAYER).hasKnownStatus(UNAUTHORIZED),
+                        fileUpdate(file2).contents("Goodbye World").signedBy(DEFAULT_PAYER).hasKnownStatus(UNAUTHORIZED));
+    }
+
 
     @HapiTest
     final HapiSpec cannotUpdateExpirationPastMaxLifetime() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -363,10 +363,15 @@ public class FileUpdateSuite extends HapiSuite {
                         fileCreate(file2).contents("Hello World").waclShape(SigControl.emptyList()))
                 .when()
                 .then(
-                        fileUpdate(file1).contents("Goodbye World").signedBy(DEFAULT_PAYER).hasKnownStatus(UNAUTHORIZED),
-                        fileUpdate(file2).contents("Goodbye World").signedBy(DEFAULT_PAYER).hasKnownStatus(UNAUTHORIZED));
+                        fileUpdate(file1)
+                                .contents("Goodbye World")
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(UNAUTHORIZED),
+                        fileUpdate(file2)
+                                .contents("Goodbye World")
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(UNAUTHORIZED));
     }
-
 
     @HapiTest
     final HapiSpec cannotUpdateExpirationPastMaxLifetime() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -147,11 +147,18 @@ public class TokenAssociationSpecs extends HapiSuite {
                         tokenDelete(TBD_TOKEN))
                 .when()
                 .then(
-                        tokenAssociate(null, VANILLA_TOKEN).fee(DEFAULT_FEE).signedBy(DEFAULT_PAYER).hasPrecheck(INVALID_ACCOUNT_ID),
-                        tokenAssociate(unknownID, VANILLA_TOKEN).fee(DEFAULT_FEE).signedBy(DEFAULT_PAYER).hasPrecheck(INVALID_ACCOUNT_ID),
+                        tokenAssociate(null, VANILLA_TOKEN)
+                                .fee(DEFAULT_FEE)
+                                .signedBy(DEFAULT_PAYER)
+                                .hasPrecheck(INVALID_ACCOUNT_ID),
+                        tokenAssociate(unknownID, VANILLA_TOKEN)
+                                .fee(DEFAULT_FEE)
+                                .signedBy(DEFAULT_PAYER)
+                                .hasPrecheck(INVALID_ACCOUNT_ID),
                         tokenAssociate(BOB, VANILLA_TOKEN).fee(DEFAULT_FEE).hasKnownStatus(ACCOUNT_DELETED),
                         tokenAssociate(ALICE, List.of()).hasKnownStatus(SUCCESS),
-                        tokenAssociate(ALICE, VANILLA_TOKEN, VANILLA_TOKEN).hasPrecheck(TOKEN_ID_REPEATED_IN_TOKEN_LIST),
+                        tokenAssociate(ALICE, VANILLA_TOKEN, VANILLA_TOKEN)
+                                .hasPrecheck(TOKEN_ID_REPEATED_IN_TOKEN_LIST),
                         tokenAssociate(ALICE, unknownID).hasKnownStatus(INVALID_TOKEN_ID),
                         tokenAssociate(ALICE, TBD_TOKEN).hasKnownStatus(TOKEN_WAS_DELETED),
                         tokenAssociate(ALICE, KNOWABLE_TOKEN).hasKnownStatus(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT));
@@ -170,8 +177,7 @@ public class TokenAssociationSpecs extends HapiSuite {
                         tokenCreate(KNOWABLE_TOKEN).treasury(TOKEN_TREASURY),
                         tokenAssociate(ALICE, KNOWABLE_TOKEN))
                 .when()
-                .then(
-                        tokenAssociate(ALICE, VANILLA_TOKEN).hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED));
+                .then(tokenAssociate(ALICE, VANILLA_TOKEN).hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -131,18 +131,18 @@ public class TokenAssociationSpecs extends HapiSuite {
 
     @HapiTest
     public HapiSpec canHandleInvalidAssociateTransactions() {
-        final String ALICE = "ALICE";
-        final String BOB = "BOB";
+        final String alice = "ALICE";
+        final String bob = "BOB";
         final String unknownID = "0.0." + Long.MAX_VALUE;
         return defaultHapiSpec("CanHandleInvalidAssociateTransactions")
                 .given(
                         newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ALICE),
-                        cryptoCreate(BOB),
-                        cryptoDelete(BOB),
+                        cryptoCreate(alice),
+                        cryptoCreate(bob),
+                        cryptoDelete(bob),
                         tokenCreate(VANILLA_TOKEN),
                         tokenCreate(KNOWABLE_TOKEN),
-                        tokenAssociate(ALICE, KNOWABLE_TOKEN),
+                        tokenAssociate(alice, KNOWABLE_TOKEN),
                         tokenCreate(TBD_TOKEN).adminKey(MULTI_KEY),
                         tokenDelete(TBD_TOKEN))
                 .when()
@@ -155,29 +155,31 @@ public class TokenAssociationSpecs extends HapiSuite {
                                 .fee(DEFAULT_FEE)
                                 .signedBy(DEFAULT_PAYER)
                                 .hasPrecheck(INVALID_ACCOUNT_ID),
-                        tokenAssociate(BOB, VANILLA_TOKEN).fee(DEFAULT_FEE).hasKnownStatus(ACCOUNT_DELETED),
-                        tokenAssociate(ALICE, List.of()).hasKnownStatus(SUCCESS),
-                        tokenAssociate(ALICE, VANILLA_TOKEN, VANILLA_TOKEN)
+                        tokenAssociate(bob, VANILLA_TOKEN).fee(DEFAULT_FEE).hasKnownStatus(ACCOUNT_DELETED),
+                        tokenAssociate(alice, List.of()).hasKnownStatus(SUCCESS),
+                        tokenAssociate(alice, VANILLA_TOKEN, VANILLA_TOKEN)
                                 .hasPrecheck(TOKEN_ID_REPEATED_IN_TOKEN_LIST),
-                        tokenAssociate(ALICE, unknownID).hasKnownStatus(INVALID_TOKEN_ID),
-                        tokenAssociate(ALICE, TBD_TOKEN).hasKnownStatus(TOKEN_WAS_DELETED),
-                        tokenAssociate(ALICE, KNOWABLE_TOKEN).hasKnownStatus(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT));
+                        tokenAssociate(alice, unknownID).hasKnownStatus(INVALID_TOKEN_ID),
+                        tokenAssociate(alice, TBD_TOKEN).hasKnownStatus(TOKEN_WAS_DELETED),
+                        tokenAssociate(alice, KNOWABLE_TOKEN).hasKnownStatus(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT));
     }
 
     @HapiTest
     public HapiSpec canLimitMaxTokensPerAccountTransactions() {
-        final String ALICE = "ALICE";
+        final String alice = "ALICE";
+        final String treasury2 = "TREASURY_2";
         return propertyPreservingHapiSpec("CanHandleInvalidAssociateTransactions")
                 .preserving("tokens.maxPerAccount", "entities.limitTokenAssociations")
                 .given(
                         overridingTwo("tokens.maxPerAccount", "1", "entities.limitTokenAssociations", "true"),
-                        cryptoCreate(ALICE),
+                        cryptoCreate(alice),
                         cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(VANILLA_TOKEN),
-                        tokenCreate(KNOWABLE_TOKEN).treasury(TOKEN_TREASURY),
-                        tokenAssociate(ALICE, KNOWABLE_TOKEN))
+                        cryptoCreate(treasury2),
+                        tokenCreate(VANILLA_TOKEN).treasury(TOKEN_TREASURY),
+                        tokenCreate(KNOWABLE_TOKEN).treasury(treasury2),
+                        tokenAssociate(alice, KNOWABLE_TOKEN))
                 .when()
-                .then(tokenAssociate(ALICE, VANILLA_TOKEN).hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED));
+                .then(tokenAssociate(alice, VANILLA_TOKEN).hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -191,14 +191,18 @@ public class TokenCreateSpecs extends HapiSuite {
     public HapiSpec canHandleInvalidTokenCreateTransactions() {
         final String alice = "ALICE";
         return defaultHapiSpec("canHandleInvalidTokenCreateTransactions")
-                .given(
-                        cryptoCreate(alice)
-                )
+                .given(cryptoCreate(alice))
                 .when()
                 .then(
                         tokenCreate(null).hasKnownStatus(MISSING_TOKEN_NAME),
-                        tokenCreate(A_TOKEN).treasury(alice).signedBy(DEFAULT_PAYER).hasKnownStatus(INVALID_SIGNATURE),
-                        tokenCreate(A_TOKEN).treasury(alice).signedBy(DEFAULT_PAYER, alice).hasKnownStatus(SUCCESS));
+                        tokenCreate(A_TOKEN)
+                                .treasury(alice)
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate(A_TOKEN)
+                                .treasury(alice)
+                                .signedBy(DEFAULT_PAYER, alice)
+                                .hasKnownStatus(SUCCESS));
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -18,7 +18,10 @@ package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.*;
+import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.OP_BODY;
+import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.SIGNED_TRANSACTION;
+import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.TRANSACTION;
+import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.TRANSACTION_BODY;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairs;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairsInAnyOrder;
@@ -56,7 +59,37 @@ import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.FUL
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.HIGHLY_NON_DETERMINISTIC_FEES;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TOKEN_NAMES;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_MUST_BE_POSITIVE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_NOT_FULLY_SPECIFIED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_ROYALTY_FEE_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTION_DIVIDES_BY_ZERO;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_DECIMALS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID_IN_CUSTOM_FEES;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_INITIAL_SUPPLY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MAX_SUPPLY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_NAME;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_SYMBOL;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ROYALTY_FRACTION_CANNOT_EXCEED_ONE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NAME_TOO_LONG;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_SYMBOL_TOO_LONG;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_HAS_UNKNOWN_FIELDS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -152,6 +185,20 @@ public class TokenCreateSpecs extends HapiSuite {
                 baseCreationsHaveExpectedPrices(),
                 /* HIP-23 */
                 validateNewTokenAssociations());
+    }
+
+    @HapiTest
+    public HapiSpec canHandleInvalidTokenCreateTransactions() {
+        final String alice = "ALICE";
+        return defaultHapiSpec("canHandleInvalidTokenCreateTransactions")
+                .given(
+                        cryptoCreate(alice)
+                )
+                .when()
+                .then(
+                        tokenCreate(null).hasKnownStatus(MISSING_TOKEN_NAME),
+                        tokenCreate(A_TOKEN).treasury(alice).signedBy(DEFAULT_PAYER).hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate(A_TOKEN).treasury(alice).signedBy(DEFAULT_PAYER, alice).hasKnownStatus(SUCCESS));
     }
 
     /**


### PR DESCRIPTION
**Description**:
This PR adds HAPI tests to `TokenAssociationSpec` which check invalid transactions are handled correctly.

**Related issue(s)**:
Fixes #12675 

