### PR TITLE
fix: refactor pure checks smart contracts network admin

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
@@ -50,19 +50,21 @@ public class NetworkUncheckedSubmitHandler implements TransactionHandler {
 
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
+        // this will never actually get called
+        // because pureChecks will always throw
         requireNonNull(context);
         throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+        throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // this will never actually get called
-        // because preHandle will always throw
+        // because pureChecks will always throw
         requireNonNull(context);
         throw new HandleException(NOT_SUPPORTED);
     }

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
@@ -145,8 +145,7 @@ class FreezeHandlerTest {
                             .freezeType(freezeType)
                             .build())
                     .build();
-            given(preHandleContext.body()).willReturn(txn);
-            assertThrowsPreCheck(() -> subject.preHandle(preHandleContext), INVALID_FREEZE_TRANSACTION_BODY);
+            assertThrowsPreCheck(() -> subject.pureChecks(txn), INVALID_FREEZE_TRANSACTION_BODY);
         }
     }
 
@@ -166,8 +165,7 @@ class FreezeHandlerTest {
                             .freezeType(freezeType)
                             .startTime(Timestamp.newBuilder().seconds(1000).build()))
                     .build();
-            given(preHandleContext.body()).willReturn(txn);
-            assertThrowsPreCheck(() -> subject.preHandle(preHandleContext), FREEZE_START_TIME_MUST_BE_FUTURE);
+            assertThrowsPreCheck(() -> subject.pureChecks(txn), FREEZE_START_TIME_MUST_BE_FUTURE);
         }
     }
 
@@ -255,8 +253,7 @@ class FreezeHandlerTest {
                             .updateFile(FileID.newBuilder().fileNum(150L))
                             .build())
                     .build();
-            given(preHandleContext.body()).willReturn(txn);
-            assertThrowsPreCheck(() -> subject.preHandle(preHandleContext), FREEZE_UPDATE_FILE_HASH_DOES_NOT_MATCH);
+            assertThrowsPreCheck(() -> subject.pureChecks(txn), FREEZE_UPDATE_FILE_HASH_DOES_NOT_MATCH);
         }
     }
 
@@ -458,8 +455,7 @@ class FreezeHandlerTest {
                 .freeze(FreezeTransactionBody.newBuilder().build())
                 // do not set freeze start time
                 .build();
-        given(preHandleContext.body()).willReturn(txn);
-        assertThrowsPreCheck(() -> subject.preHandle(preHandleContext), INVALID_FREEZE_TRANSACTION_BODY);
+        assertThrowsPreCheck(() -> subject.pureChecks(txn), INVALID_FREEZE_TRANSACTION_BODY);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -30,6 +30,7 @@ import static com.hedera.node.app.spi.validation.Validations.mustExist;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -74,7 +75,7 @@ public class ContractDeleteHandler implements TransactionHandler {
         final var contractID = op.contractID();
         mustExist(contractID, INVALID_CONTRACT_ID);
 
-        validateTrue(op.hasTransferAccountID() || op.hasTransferContractID(), OBTAINER_REQUIRED);
+        validateTruePreCheck(op.hasTransferAccountID() || op.hasTransferContractID(), OBTAINER_REQUIRED);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -73,6 +73,8 @@ public class ContractDeleteHandler implements TransactionHandler {
         // The contract ID must be present on the transaction
         final var contractID = op.contractID();
         mustExist(contractID, INVALID_CONTRACT_ID);
+
+        validateTrue(op.hasTransferAccountID() || op.hasTransferContractID(), OBTAINER_REQUIRED);
     }
 
     @Override
@@ -100,7 +102,6 @@ public class ContractDeleteHandler implements TransactionHandler {
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         final var op = context.body().contractDeleteInstanceOrThrow();
-        validateTrue(op.hasTransferAccountID() || op.hasTransferContractID(), OBTAINER_REQUIRED);
         final var accountStore = context.readableStore(ReadableAccountStore.class);
         final var toBeDeleted = requireNonNull(accountStore.getContractById(op.contractIDOrThrow()));
         validateFalse(toBeDeleted.deleted(), CONTRACT_DELETED);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemDeleteHandler.java
@@ -46,18 +46,20 @@ public class ContractSystemDeleteHandler implements TransactionHandler {
 
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
+        // this will never actually get called
+        // because pureChecks will always throw
         throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+        throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // this will never actually get called
-        // because preHandle will always throw
+        // because pureChecks will always throw
         throw new HandleException(NOT_SUPPORTED);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractSystemUndeleteHandler.java
@@ -46,18 +46,20 @@ public class ContractSystemUndeleteHandler implements TransactionHandler {
 
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
+        // this will never actually get called
+        // because pureChecks will always throw
         throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+        throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // this will never actually get called
-        // because preHandle will always throw
+        // because pureChecks will always throw
         throw new HandleException(NOT_SUPPORTED);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -85,7 +85,7 @@ public class ContractUpdateHandler implements TransactionHandler {
 
         if (isAdminSigRequired(op)) {
             final var accountStore = context.createStore(ReadableAccountStore.class);
-            final var targetId = op.contractIDOrElse(ContractID.DEFAULT);
+            final var targetId = op.contractIDOrThrow();
             final var maybeContract = accountStore.getContractById(targetId);
             if (maybeContract != null && maybeContract.keyOrThrow().key().kind() == Key.KeyOneOfType.CONTRACT_ID) {
                 throw new PreCheckException(MODIFYING_IMMUTABLE_CONTRACT);
@@ -104,6 +104,10 @@ public class ContractUpdateHandler implements TransactionHandler {
     public void pureChecks(@NonNull TransactionBody txn) throws PreCheckException {
         final var op = txn.contractUpdateInstanceOrThrow();
         mustExist(op.contractID(), INVALID_CONTRACT_ID);
+
+        if (op.hasAdminKey() && processAdminKey(op)) {
+            throw new PreCheckException(INVALID_ADMIN_KEY);
+        }
     }
 
     private boolean isAdminSigRequired(final ContractUpdateTransactionBody op) {
@@ -143,10 +147,6 @@ public class ContractUpdateHandler implements TransactionHandler {
             @NonNull final ReadableAccountStore accountStore) {
         validateTrue(contract != null, INVALID_CONTRACT_ID);
         validateTrue(!contract.deleted(), INVALID_CONTRACT_ID);
-
-        if (op.hasAdminKey() && processAdminKey(op)) {
-            throw new HandleException(INVALID_ADMIN_KEY);
-        }
 
         if (op.hasExpirationTime()) {
             try {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
@@ -120,9 +120,11 @@ class ContractDeleteHandlerTest {
 
     @Test
     void failsWithoutObtainerSet() {
-        givenFailContextWith(missingObtainer(VALID_CONTRACT_ADDRESS));
-
-        assertFailsWith(OBTAINER_REQUIRED, () -> subject.handle(context));
+        final var txn = TransactionBody.newBuilder()
+                        .contractDeleteInstance(missingObtainer(VALID_CONTRACT_ADDRESS))
+                        .build();
+        final var ex = assertThrows(PreCheckException.class, () -> subject.pureChecks(txn));
+        assertEquals(OBTAINER_REQUIRED, ex.responseCode());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
@@ -121,8 +121,8 @@ class ContractDeleteHandlerTest {
     @Test
     void failsWithoutObtainerSet() {
         final var txn = TransactionBody.newBuilder()
-                        .contractDeleteInstance(missingObtainer(VALID_CONTRACT_ADDRESS))
-                        .build();
+                .contractDeleteInstance(missingObtainer(VALID_CONTRACT_ADDRESS))
+                .build();
         final var ex = assertThrows(PreCheckException.class, () -> subject.pureChecks(txn));
         assertEquals(OBTAINER_REQUIRED, ex.responseCode());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
@@ -135,9 +135,8 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
                 .contractUpdateInstance(ContractUpdateTransactionBody.newBuilder())
                 .transactionID(transactionID)
                 .build();
-        final var context = new FakePreHandleContext(accountStore, txn);
 
-        assertThrowsPreCheck(() -> subject.preHandle(context), INVALID_CONTRACT_ID);
+        assertThrowsPreCheck(() -> subject.pureChecks(txn), INVALID_CONTRACT_ID);
     }
 
     @Test
@@ -202,41 +201,30 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
 
     @Test
     void handleWithInvalidKeyFails() {
-        when(accountStore.getContractById(targetContract)).thenReturn(contract);
-
-        given(context.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
         final var txn = TransactionBody.newBuilder()
                 .contractUpdateInstance(ContractUpdateTransactionBody.newBuilder()
                         .contractID(targetContract)
                         .adminKey(Key.newBuilder()))
                 .transactionID(transactionID)
                 .build();
-        when(context.body()).thenReturn(txn);
 
-        assertFailsWith(INVALID_ADMIN_KEY, () -> subject.handle(context));
+        assertThrowsPreCheck(() -> subject.pureChecks(txn), INVALID_ADMIN_KEY);
     }
 
     @Test
-    void handleWithInvalidContractIdKeyFails() {
-        when(accountStore.getContractById(targetContract)).thenReturn(contract);
-
-        given(context.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
+    void invalidContractIdKeyFails() {
         final var txn = TransactionBody.newBuilder()
                 .contractUpdateInstance(ContractUpdateTransactionBody.newBuilder()
                         .contractID(targetContract)
                         .adminKey(Key.newBuilder().contractID(ContractID.DEFAULT)))
                 .transactionID(transactionID)
                 .build();
-        when(context.body()).thenReturn(txn);
 
-        assertFailsWith(INVALID_ADMIN_KEY, () -> subject.handle(context));
+        assertThrowsPreCheck(() -> subject.pureChecks(txn), INVALID_ADMIN_KEY);
     }
 
     @Test
     void handleWithAValidContractIdKeyFails() {
-        when(accountStore.getContractById(targetContract)).thenReturn(contract);
-
-        given(context.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
         final var txn = TransactionBody.newBuilder()
                 .contractUpdateInstance(ContractUpdateTransactionBody.newBuilder()
                         .contractID(targetContract)
@@ -244,9 +232,8 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
                                 .contractID(ContractID.newBuilder().contractNum(100))))
                 .transactionID(transactionID)
                 .build();
-        when(context.body()).thenReturn(txn);
 
-        assertFailsWith(INVALID_ADMIN_KEY, () -> subject.handle(context));
+        assertThrowsPreCheck(() -> subject.pureChecks(txn), INVALID_ADMIN_KEY);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -73,9 +73,9 @@ public class ContractUpdateSuite extends HapiSuite {
 
     private static final Logger log = LogManager.getLogger(ContractUpdateSuite.class);
 
-    private static final long defaultMaxLifetime =
+    private static final long DEFAULT_MAX_LIFETIME =
             Long.parseLong(HapiSpecSetup.getDefaultNodeProps().get("entities.maxLifetime"));
-    private static final long ONE_DAY = 60 * 60 * 24;
+    private static final long ONE_DAY = 60L * 60L * 24L;
     private static final long ONE_MONTH = 30 * ONE_DAY;
     public static final String ADMIN_KEY = "adminKey";
     public static final String NEW_ADMIN_KEY = "newAdminKey";
@@ -252,7 +252,7 @@ public class ContractUpdateSuite extends HapiSuite {
     @HapiTest
     final HapiSpec rejectsExpiryTooFarInTheFuture() {
         final var smallBuffer = 12_345L;
-        final var excessiveExpiry = defaultMaxLifetime + Instant.now().getEpochSecond() + smallBuffer;
+        final var excessiveExpiry = DEFAULT_MAX_LIFETIME + Instant.now().getEpochSecond() + smallBuffer;
 
         return defaultHapiSpec("RejectsExpiryTooFarInTheFuture", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
@@ -331,7 +331,7 @@ public class ContractUpdateSuite extends HapiSuite {
                         uploadInitCode(CONTRACT),
                         contractCreate(CONTRACT).adminKey(ADMIN_KEY))
                 .when(
-                        contractUpdate(CONTRACT).improperlyEmptyingAdminKey().hasKnownStatus(INVALID_ADMIN_KEY),
+                        contractUpdate(CONTRACT).improperlyEmptyingAdminKey().hasPrecheck(INVALID_ADMIN_KEY),
                         contractUpdate(CONTRACT).properlyEmptyingAdminKey())
                 .then(contractUpdate(CONTRACT).newKey(NEW_ADMIN_KEY).hasKnownStatus(MODIFYING_IMMUTABLE_CONTRACT));
     }
@@ -345,7 +345,7 @@ public class ContractUpdateSuite extends HapiSuite {
                 .then(contractUpdate(contract)
                         .useDeprecatedAdminKey()
                         .signedBy(GENESIS, contract)
-                        .hasKnownStatus(INVALID_ADMIN_KEY));
+                        .hasPrecheck(INVALID_ADMIN_KEY));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
Refactor pureChecks for Smart Contracts and Network Admin services. Move any checks which do not rely on state from preHandle and handle methods to pureChecks method for each transaction handler.

**Related issue(s)**:
Fixes #12689
Related to #12644 
