### PR TITLE
feat: improve performance of tlsPeerIdentifier to O(1)

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
@@ -191,7 +191,7 @@ public class SyncGossip implements ConnectionTracker, Lifecycle {
 
         topology = new StaticTopology(random, addressBook, selfId, basicConfig.numConnections());
         final List<PeerInfo> peers = Utilities.createPeerInfoList(addressBook, selfId);
-
+        final NetworkPeerIdentifier peerIdentifier = new NetworkPeerIdentifier(platformContext, peers);
         final SocketFactory socketFactory =
                 NetworkUtils.createSocketFactory(selfId, addressBook, keysAndCerts, platformContext.getConfiguration());
         // create an instance that can create new outbound connections
@@ -201,14 +201,14 @@ public class SyncGossip implements ConnectionTracker, Lifecycle {
         final InboundConnectionHandler inboundConnectionHandler = new InboundConnectionHandler(
                 platformContext,
                 this,
-                new NetworkPeerIdentifier(platformContext),
+                peerIdentifier,
                 selfId,
                 connectionManagers::newConnection,
                 platformContext.getTime());
         // allow other members to create connections to me
         final Address address = addressBook.getAddress(selfId);
         final ConnectionServer connectionServer = new ConnectionServer(
-                threadManager, address.getListenPort(), socketFactory, inboundConnectionHandler::handle, peers);
+                threadManager, address.getListenPort(), socketFactory, inboundConnectionHandler::handle);
         thingsToStart.add(new StoppableThreadConfiguration<>(threadManager)
                 .setPriority(threadConfig.threadPrioritySync())
                 .setNodeId(selfId)

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkPeerIdentifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkPeerIdentifier.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.network;
 
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.logging.legacy.LogMarker.SOCKET_EXCEPTIONS;
 
 import com.swirlds.common.context.PlatformContext;
@@ -26,11 +25,11 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import javax.security.auth.x500.X500Principal;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,51 +45,49 @@ public class NetworkPeerIdentifier {
      */
     private final RateLimitedLogger noPeerFoundLogger;
 
-    private final RateLimitedLogger multiplePeersFoundLogger;
+    // a mapping of X500Principal and their peers
+    private final Map<X500Principal, PeerInfo> x501PrincipalsAndPeers;
 
-    public NetworkPeerIdentifier(@NonNull final PlatformContext platformContext) {
+    /**
+     * constructor
+     *
+     * @param platformContext the platform context
+     * @param peers           list of peers
+     */
+    public NetworkPeerIdentifier(@NonNull final PlatformContext platformContext, @NonNull final List<PeerInfo> peers) {
         Objects.requireNonNull(platformContext);
+        Objects.requireNonNull(peers);
         noPeerFoundLogger = new RateLimitedLogger(logger, platformContext.getTime(), Duration.ofMinutes(5));
-        multiplePeersFoundLogger = new RateLimitedLogger(logger, platformContext.getTime(), Duration.ofMinutes(5));
+        this.x501PrincipalsAndPeers = HashMap.newHashMap(peers.size());
+        for (final PeerInfo peerInfo : peers) {
+            x501PrincipalsAndPeers.put(
+                    ((X509Certificate) peerInfo.signingCertificate()).getSubjectX500Principal(), peerInfo);
+        }
     }
 
     /**
      * identifies a client on the other end of the socket using their signing certificate.
      *
-     * @param certs        a list of TLS certificates from the connected socket
-     * @param peerInfoList List of known peers
+     * @param certs a list of TLS certificates from the connected socket
      * @return info of the identified peer
      */
-    public @Nullable PeerInfo identifyTlsPeer(
-            @NonNull final Certificate[] certs, @NonNull final List<PeerInfo> peerInfoList) {
+    public @Nullable PeerInfo identifyTlsPeer(@NonNull final Certificate[] certs) {
         Objects.requireNonNull(certs);
-        Objects.requireNonNull(peerInfoList);
+        Objects.requireNonNull(x501PrincipalsAndPeers);
         if (certs.length == 0) {
             return null;
         }
 
-        PeerInfo matchingPair = null;
         // the peer certificates chain is an ordered array of peer certificates,
         // with the peer's own certificate first followed by any certificate authorities.
         // See https://www.rfc-editor.org/rfc/rfc5246
         final X509Certificate agreementCert = (X509Certificate) certs[0];
-        final Set<PeerInfo> peers = peerInfoList.stream()
-                .filter(peerInfo -> ((X509Certificate) peerInfo.signingCertificate())
-                        .getSubjectX500Principal()
-                        .equals(agreementCert.getIssuerX500Principal()))
-                .collect(Collectors.toSet());
-        final Optional<PeerInfo> peer = peers.stream().findFirst();
-        if (peer.isEmpty()) {
+        final PeerInfo matchingPair = x501PrincipalsAndPeers.get(agreementCert.getIssuerX500Principal());
+        if (matchingPair == null) {
             noPeerFoundLogger.warn(
                     SOCKET_EXCEPTIONS.getMarker(),
                     "Unable to identify peer with the presented certificate {}.",
                     agreementCert);
-        } else {
-            if (peers.size() > 1) {
-                multiplePeersFoundLogger.info(
-                        EXCEPTION.getMarker(), "Found {} matching peers for the presented certificate", peers.size());
-            }
-            matchingPair = peer.get();
         }
         return matchingPair;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkPeerIdentifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/NetworkPeerIdentifier.java
@@ -73,7 +73,6 @@ public class NetworkPeerIdentifier {
      */
     public @Nullable PeerInfo identifyTlsPeer(@NonNull final Certificate[] certs) {
         Objects.requireNonNull(certs);
-        Objects.requireNonNull(x501PrincipalsAndPeers);
         if (certs.length == 0) {
             return null;
         }
@@ -82,13 +81,13 @@ public class NetworkPeerIdentifier {
         // with the peer's own certificate first followed by any certificate authorities.
         // See https://www.rfc-editor.org/rfc/rfc5246
         final X509Certificate agreementCert = (X509Certificate) certs[0];
-        final PeerInfo matchingPair = x501PrincipalsAndPeers.get(agreementCert.getIssuerX500Principal());
-        if (matchingPair == null) {
+        final PeerInfo matchedPeer = x501PrincipalsAndPeers.get(agreementCert.getIssuerX500Principal());
+        if (matchedPeer == null) {
             noPeerFoundLogger.warn(
                     SOCKET_EXCEPTIONS.getMarker(),
                     "Unable to identify peer with the presented certificate {}.",
                     agreementCert);
         }
-        return matchingPair;
+        return matchedPeer;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/ConnectionServer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/ConnectionServer.java
@@ -21,15 +21,13 @@ import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.common.threading.interrupt.InterruptableRunnable;
 import com.swirlds.common.threading.manager.ThreadManager;
-import com.swirlds.platform.network.PeerInfo;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,31 +44,27 @@ public class ConnectionServer implements InterruptableRunnable {
     /** responsible for creating and binding the server socket */
     private final SocketFactory socketFactory;
     /** handles newly established connections */
-    private final BiConsumer<Socket, List<PeerInfo>> newConnectionHandler;
+    private final Consumer<Socket> newConnectionHandler;
     /** a thread pool used to handle incoming connections */
     private final ExecutorService incomingConnPool;
 
-    private final List<PeerInfo> peerInfoList;
     /**
      * @param threadManager        responsible for managing thread lifecycles
      * @param port                 the port ot use
      * @param socketFactory        responsible for creating new sockets
      * @param newConnectionHandler handles a new connection after it has been created
-     * @param peerInfoList         List of all peers
      */
     public ConnectionServer(
             final ThreadManager threadManager,
             final int port,
             final SocketFactory socketFactory,
-            final BiConsumer<Socket, List<PeerInfo>> newConnectionHandler,
-            final List<PeerInfo> peerInfoList) {
+            final Consumer<Socket> newConnectionHandler) {
         this.port = port;
         this.newConnectionHandler = newConnectionHandler;
         this.socketFactory = socketFactory;
         this.incomingConnPool = Executors.newCachedThreadPool(new ThreadConfiguration(threadManager)
                 .setThreadName("sync_server")
                 .buildFactory());
-        this.peerInfoList = peerInfoList;
     }
 
     @Override
@@ -92,7 +86,7 @@ public class ConnectionServer implements InterruptableRunnable {
         while (!serverSocket.isClosed()) {
             try {
                 final Socket clientSocket = serverSocket.accept(); // listen, waiting until someone connects
-                incomingConnPool.submit(() -> newConnectionHandler.accept(clientSocket, peerInfoList));
+                incomingConnPool.submit(() -> newConnectionHandler.accept(clientSocket));
             } catch (final SocketTimeoutException expectedWithNonZeroSOTimeout) {
                 // A timeout is expected, so we won't log it
                 if (Thread.currentThread().isInterrupted()) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/InboundConnectionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/InboundConnectionHandler.java
@@ -37,7 +37,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.Socket;
 import java.time.Duration;
-import java.util.List;
 import java.util.Objects;
 import javax.net.ssl.SSLSocket;
 import org.apache.logging.log4j.LogManager;
@@ -90,17 +89,17 @@ public class InboundConnectionHandler {
      * Identifies the peer that has just established a new connection and create a {@link Connection}
      *
      * @param clientSocket the newly created socket
-     * @param peerInfoList the list of peers
      */
-    public void handle(final Socket clientSocket, final List<PeerInfo> peerInfoList) {
+    public void handle(@NonNull final Socket clientSocket) {
         final long acceptTime = time.currentTimeMillis();
+        Objects.requireNonNull(clientSocket);
         try {
             clientSocket.setTcpNoDelay(socketConfig.tcpNoDelay());
             clientSocket.setSoTimeout(socketConfig.timeoutSyncClientSocket());
 
             final SSLSocket sslSocket = (SSLSocket) clientSocket;
             final PeerInfo connectedPeer =
-                    networkPeerIdentifier.identifyTlsPeer(sslSocket.getSession().getPeerCertificates(), peerInfoList);
+                    networkPeerIdentifier.identifyTlsPeer(sslSocket.getSession().getPeerCertificates());
             if (connectedPeer == null) {
                 clientSocket.close();
                 return;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
@@ -94,21 +94,21 @@ class NetworkPeerIdentifierTest {
 
     /**
      * Tests that given a list of valid Swirlds production certificates (like the type used in mainnet),
-     * {@link NetworkPeerIdentifier#identifyTlsPeer(Certificate[], List)} is able to successfully identify a matching
+     * {@link NetworkPeerIdentifier#identifyTlsPeer(Certificate[])} is able to successfully identify a matching
      * peer.
      */
     @Test
     void testExtractPeerInfoWorksForMainnet() throws KeyStoreException, InvalidAlgorithmParameterException {
         final PKIXParameters params = new PKIXParameters(publicStores.agrTrustStore());
         final Set<TrustAnchor> trustAnchors = params.getTrustAnchors();
-        final NetworkPeerIdentifier peerIdentifier = new NetworkPeerIdentifier(platformContext);
+        final NetworkPeerIdentifier peerIdentifier = new NetworkPeerIdentifier(platformContext, peerInfoList);
         final Set<PeerInfo> matches = new HashSet<>();
 
         final Certificate[] certificates =
                 trustAnchors.stream().map(TrustAnchor::getTrustedCert).toArray(Certificate[]::new);
         for (final Certificate certificate : certificates) {
             final PeerInfo matchedPeer =
-                    peerIdentifier.identifyTlsPeer(List.of(certificate).toArray(Certificate[]::new), peerInfoList);
+                    peerIdentifier.identifyTlsPeer(List.of(certificate).toArray(Certificate[]::new));
             Assertions.assertNotNull(matchedPeer);
             matches.add(matchedPeer);
         }
@@ -121,12 +121,12 @@ class NetworkPeerIdentifierTest {
      */
     @Test
     void testReturnsIntendedPeerForMainnet() throws KeyStoreException {
-        final NetworkPeerIdentifier peerIdentifier = new NetworkPeerIdentifier(platformContext);
+        final NetworkPeerIdentifier peerIdentifier = new NetworkPeerIdentifier(platformContext, peerInfoList);
         // pick a node's agreement certificate, node20
         final Certificate certUnderTest = publicStores.agrTrustStore().getCertificate("a-node20");
 
         final PeerInfo matchedPeer =
-                peerIdentifier.identifyTlsPeer(List.of(certUnderTest).toArray(Certificate[]::new), peerInfoList);
+                peerIdentifier.identifyTlsPeer(List.of(certUnderTest).toArray(Certificate[]::new));
 
         Assertions.assertNotNull(matchedPeer);
         // assert the peer we got back is node20
@@ -152,7 +152,7 @@ class NetworkPeerIdentifierTest {
         final Certificate[] certificates = new Certificate[] {rsaCert};
 
         final PeerInfo matchedPeer =
-                new NetworkPeerIdentifier(platformContext).identifyTlsPeer(certificates, peerInfoList);
+                new NetworkPeerIdentifier(platformContext, peerInfoList).identifyTlsPeer(certificates);
         Assertions.assertNull(matchedPeer);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/InboundConnectionHandlerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/InboundConnectionHandlerTest.java
@@ -47,7 +47,6 @@ class InboundConnectionHandlerTest extends ConnectivityTestBase {
     private static final PlatformContext platformContext = TestPlatformContextBuilder.create()
             .withConfiguration(TLS_NO_IP_TOS_CONFIG)
             .build();
-    private static final NetworkPeerIdentifier identifier = new NetworkPeerIdentifier(platformContext);
     private static final ConnectionTracker ct = Mockito.mock(ConnectionTracker.class);
 
     /**
@@ -70,6 +69,7 @@ class InboundConnectionHandlerTest extends ConnectivityTestBase {
         final KeysAndCerts keysAndCerts1 = keysAndCerts.get(thisNode);
         final KeysAndCerts keysAndCerts2 = keysAndCerts.get(otherNode);
         final List<PeerInfo> peerInfoList = Utilities.createPeerInfoList(addressBook, otherNode);
+        final NetworkPeerIdentifier identifier = new NetworkPeerIdentifier(platformContext, peerInfoList);
 
         final SocketFactory socketFactory1 =
                 NetworkUtils.createSocketFactory(thisNode, addressBook, keysAndCerts1, TLS_NO_IP_TOS_CONFIG);
@@ -91,7 +91,7 @@ class InboundConnectionHandlerTest extends ConnectivityTestBase {
 
         final InboundConnectionHandler inbound = new InboundConnectionHandler(
                 platformContext, ct, identifier, thisNode, connConsumer, Time.getCurrent());
-        inbound.handle(socket, peerInfoList); // 2 can talk to 1 via tls ok
+        inbound.handle(socket); // 2 can talk to 1 via tls ok
         socket.close();
     }
 
@@ -114,6 +114,7 @@ class InboundConnectionHandlerTest extends ConnectivityTestBase {
         final KeysAndCerts keysAndCerts1 = keysAndCerts.get(thisNode);
         final KeysAndCerts keysAndCerts2 = keysAndCerts.get(otherNode);
         final List<PeerInfo> peerInfoList = Utilities.createPeerInfoList(addressBook, thisNode);
+        final NetworkPeerIdentifier identifier = new NetworkPeerIdentifier(platformContext, peerInfoList);
 
         final SocketFactory s1 =
                 NetworkUtils.createSocketFactory(thisNode, addressBook, keysAndCerts1, TLS_NO_IP_TOS_CONFIG);
@@ -131,7 +132,7 @@ class InboundConnectionHandlerTest extends ConnectivityTestBase {
 
         final InboundConnectionHandler inbound = new InboundConnectionHandler(
                 platformContext, ct, identifier, thisNode, connConsumer, Time.getCurrent());
-        inbound.handle(socket, peerInfoList);
+        inbound.handle(socket);
         Assertions.assertTrue(socket.isClosed());
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/ConnectionServerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/ConnectionServerTest.java
@@ -21,17 +21,12 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-import com.swirlds.base.utility.Pair;
-import com.swirlds.common.platform.NodeId;
-import com.swirlds.platform.network.PeerInfo;
 import com.swirlds.platform.network.connectivity.ConnectionServer;
 import com.swirlds.platform.network.connectivity.SocketFactory;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.security.cert.Certificate;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
@@ -54,19 +49,15 @@ class ConnectionServerTest {
                 .accept();
         final SocketFactory socketFactory = mock(SocketFactory.class);
         doAnswer(i -> serverSocket).when(socketFactory).createServerSocket(anyInt());
-        final AtomicReference<Pair<Socket, List<PeerInfo>>> connectionHandler = new AtomicReference<>(null);
+        final AtomicReference<Socket> connectionHandler = new AtomicReference<>(null);
 
-        final ConnectionServer server = new ConnectionServer(
-                getStaticThreadManager(),
-                0,
-                socketFactory,
-                (a, b) -> connectionHandler.set(Pair.of(a, b)),
-                List.of(new PeerInfo(new NodeId(1), "test", "host1", mock(Certificate.class))));
+        final ConnectionServer server =
+                new ConnectionServer(getStaticThreadManager(), 0, socketFactory, connectionHandler::set);
 
         server.run();
         Assertions.assertSame(
                 socket,
-                connectionHandler.get().left(),
+                connectionHandler.get(),
                 "the socket provided by accept() should have been passed to the connection handler");
 
         // test interrupt


### PR DESCRIPTION
closes #12709. 

This PR improves the certificate lookup performance of a newly connected network peer.