### PR TITLE
perf: reduced warmup overhead #11915;  warm treasury account for token transfer #12278

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableKVState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableKVState.java
@@ -30,7 +30,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 /**
  * An implementation of {@link ReadableKVState} backed by a {@link VirtualMap}, resulting in a state
@@ -41,14 +40,10 @@ import java.util.function.Consumer;
  */
 public final class OnDiskReadableKVState<K, V> extends ReadableKVStateBase<K, V> {
 
-    private static final Consumer<Runnable> DEFAULT_RUNNER = Thread::startVirtualThread;
-
     /** The backing merkle data structure to use */
     private final VirtualMap<OnDiskKey<K>, OnDiskValue<V>> virtualMap;
 
     private final StateMetadata<K, V> md;
-
-    private final Consumer<Runnable> runner;
 
     /**
      * Create a new instance
@@ -56,20 +51,12 @@ public final class OnDiskReadableKVState<K, V> extends ReadableKVStateBase<K, V>
      * @param md the state metadata
      * @param virtualMap the backing merkle structure to use
      */
+    @VisibleForTesting
     public OnDiskReadableKVState(
             @NonNull final StateMetadata<K, V> md, @NonNull final VirtualMap<OnDiskKey<K>, OnDiskValue<V>> virtualMap) {
-        this(md, virtualMap, DEFAULT_RUNNER);
-    }
-
-    @VisibleForTesting
-    OnDiskReadableKVState(
-            @NonNull final StateMetadata<K, V> md,
-            @NonNull final VirtualMap<OnDiskKey<K>, OnDiskValue<V>> virtualMap,
-            @NonNull final Consumer<Runnable> runner) {
         super(md.stateDefinition().stateKey());
         this.md = md;
         this.virtualMap = Objects.requireNonNull(virtualMap);
-        this.runner = runner;
     }
 
     /** {@inheritDoc} */
@@ -135,6 +122,6 @@ public final class OnDiskReadableKVState<K, V> extends ReadableKVStateBase<K, V>
     @Override
     public void warm(@NonNull final K key) {
         final var k = new OnDiskKey<>(md, key);
-        runner.accept(() -> virtualMap.warm(k));
+        virtualMap.warm(k);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
@@ -30,6 +30,8 @@ import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.prehandle.PreHandleResult;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.data.CacheConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.events.ConsensusEvent;
@@ -54,8 +56,17 @@ public class CacheWarmer {
     private final Executor executor;
 
     @Inject
-    public CacheWarmer(@NonNull final TransactionChecker checker, @NonNull final TransactionDispatcher dispatcher) {
-        this(checker, dispatcher, ForkJoinPool.commonPool());
+    public CacheWarmer(
+            @NonNull final TransactionChecker checker,
+            @NonNull final TransactionDispatcher dispatcher,
+            @NonNull final ConfigProvider configProvider) {
+        this(
+                checker,
+                dispatcher,
+                new ForkJoinPool(configProvider
+                        .getConfiguration()
+                        .getConfigData(CacheConfig.class)
+                        .cryptoTransferWarmThreads()));
     }
 
     @VisibleForTesting

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.workflows.handle;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.transaction.TransactionBody;
@@ -60,23 +59,13 @@ public class CacheWarmer {
             @NonNull final TransactionChecker checker,
             @NonNull final TransactionDispatcher dispatcher,
             @NonNull final ConfigProvider configProvider) {
-        this(
-                checker,
-                dispatcher,
-                new ForkJoinPool(configProvider
-                        .getConfiguration()
-                        .getConfigData(CacheConfig.class)
-                        .cryptoTransferWarmThreads()));
-    }
-
-    @VisibleForTesting
-    CacheWarmer(
-            @NonNull final TransactionChecker checker,
-            @NonNull final TransactionDispatcher dispatcher,
-            @NonNull final Executor executor) {
         this.checker = checker;
         this.dispatcher = requireNonNull(dispatcher);
-        this.executor = requireNonNull(executor);
+        final int parallelism = configProvider
+                .getConfiguration()
+                .getConfigData(CacheConfig.class)
+                .cryptoTransferWarmThreads();
+        this.executor = new ForkJoinPool(parallelism);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableStateTest.java
@@ -116,7 +116,7 @@ class OnDiskReadableStateTest extends MerkleTestBase {
     @Test
     @DisplayName("The method warm() calls the appropriate method on the virtual map")
     void warm(@Mock VirtualMap<OnDiskKey<String>, OnDiskValue<String>> virtualMapMock) {
-        final var state = new OnDiskReadableKVState<>(md, virtualMapMock, Runnable::run);
+        final var state = new OnDiskReadableKVState<>(md, virtualMapMock);
         state.warm(A_KEY);
         verify(virtualMapMock).warm(new OnDiskKey<>(md, A_KEY));
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -54,6 +54,7 @@ import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Nft;
+import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.AssessedCustomFee;
 import com.hedera.hapi.node.transaction.TransactionBody;
@@ -155,19 +156,21 @@ public class CryptoTransferHandler implements TransactionHandler {
 
         // warm all accounts from the transfer list
         final TransferList transferList = op.transfersOrElse(TransferList.DEFAULT);
-        transferList.accountAmountsOrElse(emptyList()).parallelStream()
+        transferList.accountAmountsOrElse(emptyList()).stream()
                 .map(AccountAmount::accountID)
                 .filter(Objects::nonNull)
                 .forEach(accountStore::warm);
 
         // warm all token-data from the token transfer list
         final List<TokenTransferList> tokenTransfers = op.tokenTransfersOrElse(emptyList());
-        tokenTransfers.parallelStream()
+        tokenTransfers.stream()
                 .filter(TokenTransferList::hasToken)
                 .filter(TokenTransferList::hasNftTransfers)
                 .forEach(tokenTransferList -> {
                     final TokenID tokenID = tokenTransferList.tokenOrThrow();
-                    tokenStore.warm(tokenID);
+                    final Token token = tokenStore.get(tokenID);
+                    final AccountID treasuryID = token == null ? null : token.treasuryAccountId();
+                    if (treasuryID != null) accountStore.warm(treasuryID);
                     final List<NftTransfer> nftTransfers = tokenTransferList.nftTransfersOrThrow();
                     for (final NftTransfer nftTransfer : nftTransfers) {
                         warmNftTransfer(accountStore, nftStore, tokenRelationStore, tokenID, nftTransfer);


### PR DESCRIPTION
**Description**:
* eliminated creating a `VirtualThread` for each `VirtualMap.warm()` call
* removed `parallelStream()` from tasks already running with sufficient parallelism
* replaced `ForkJoinPool.commonPool()` with a dedicated `ForkJoinPool`
* added warming up token treasury accounts

**Related issue(s)**:

Fixes #11915 #12278 

**Notes for reviewer**:
Effect of the fix has been tested with the NFT transfer benchmark and confirmed by profiling.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
