### PR TITLE
fix: (cherry-pick) Allow aliases only in CryptoTransfer

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -475,6 +475,7 @@ public class HandleWorkflow {
                         }
                     }
                 } catch (final HandleException ex) {
+                    ex.printStackTrace();
                     final var identifier = validationResult.status == NODE_DUE_DILIGENCE_FAILURE
                             ? "node " + creator.nodeId()
                             : "account " + payer;
@@ -570,6 +571,7 @@ public class HandleWorkflow {
                     platformStateUpdateFacility.handleTxBody(stack, platformState, txBody);
 
                 } catch (final HandleException e) {
+                    e.printStackTrace();
                     // In case of a ContractCall when it reverts, the gas charged should not be rolled back
                     rollback(e.shouldRollbackStack(), e.getStatus(), stack, recordListBuilder);
                     if (!hasWaivedFees && e.shouldRollbackStack()) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -475,7 +475,6 @@ public class HandleWorkflow {
                         }
                     }
                 } catch (final HandleException ex) {
-                    ex.printStackTrace();
                     final var identifier = validationResult.status == NODE_DUE_DILIGENCE_FAILURE
                             ? "node " + creator.nodeId()
                             : "account " + payer;
@@ -571,7 +570,6 @@ public class HandleWorkflow {
                     platformStateUpdateFacility.handleTxBody(stack, platformState, txBody);
 
                 } catch (final HandleException e) {
-                    e.printStackTrace();
                     // In case of a ContractCall when it reverts, the gas charged should not be rolled back
                     rollback(e.shouldRollbackStack(), e.getStatus(), stack, recordListBuilder);
                     if (!hasWaivedFees && e.shouldRollbackStack()) {

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/TestFixturesKeyLookup.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/TestFixturesKeyLookup.java
@@ -16,6 +16,8 @@
 
 package com.hedera.test.utils;
 
+import static com.hedera.hapi.node.base.AccountID.AccountOneOfType.ACCOUNT_NUM;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.token.Account;
@@ -38,6 +40,12 @@ public class TestFixturesKeyLookup implements ReadableAccountStore {
     @Nullable
     @Override
     public Account getAccountById(@NonNull AccountID accountID) {
+        return accountID.account().kind() == ACCOUNT_NUM ? accounts.get(accountID) : null;
+    }
+
+    @Nullable
+    @Override
+    public Account getAliasedAccountById(@NonNull final AccountID accountID) {
         final var alias = accountID.alias();
         if (alias != null && alias.length() > 0) {
             final var num = aliases.get(new ProtoBytes(alias));

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetAccountDetailsHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetAccountDetailsHandler.java
@@ -109,7 +109,7 @@ public class NetworkGetAccountDetailsHandler extends PaidQueryHandler {
 
         // The account must exist for that transaction ID
         final var accountStore = context.createStore(ReadableAccountStore.class);
-        final var account = accountStore.getAccountById(op.accountIdOrThrow());
+        final var account = accountStore.getAliasedAccountById(op.accountIdOrThrow());
         mustExist(account, INVALID_ACCOUNT_ID);
     }
 
@@ -159,7 +159,7 @@ public class NetworkGetAccountDetailsHandler extends PaidQueryHandler {
             @NonNull final ReadableTokenStore readableTokenStore,
             @NonNull final ReadableTokenRelationStore tokenRelationStore,
             @NonNull final LedgerConfig ledgerConfig) {
-        final var account = accountStore.getAccountById(accountID);
+        final var account = accountStore.getAliasedAccountById(accountID);
         if (account == null) {
             return Optional.empty();
         } else {
@@ -320,8 +320,8 @@ public class NetworkGetAccountDetailsHandler extends PaidQueryHandler {
         final var query = queryContext.query();
         final var accountStore = queryContext.createStore(ReadableAccountStore.class);
         final var op = query.accountDetailsOrThrow();
-        final var accountId = op.accountIdOrThrow();
-        final var account = accountStore.getAccountById(accountId);
+        final var accountId = op.accountIdOrElse(AccountID.DEFAULT);
+        final var account = accountStore.getAliasedAccountById(accountId);
 
         return queryContext.feeCalculator().legacyCalculate(sigValueObj -> new GetAccountDetailsResourceUsage(
                         cryptoOpsUsage, null, null)

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferEventLoggingUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/TransferEventLoggingUtils.java
@@ -102,8 +102,8 @@ public class TransferEventLoggingUtils {
             @NonNull final AccountID receiverId,
             @NonNull final ReadableAccountStore accountStore) {
         final var tokenAddress = asLongZeroAddress(tokenId.tokenNum());
-        final var senderAddress = priorityAddressOf(requireNonNull(accountStore.getAccountById(senderId)));
-        final var receiverAddress = priorityAddressOf(requireNonNull(accountStore.getAccountById(receiverId)));
+        final var senderAddress = priorityAddressOf(requireNonNull(accountStore.getAliasedAccountById(senderId)));
+        final var receiverAddress = priorityAddressOf(requireNonNull(accountStore.getAliasedAccountById(receiverId)));
         return LogBuilder.logBuilder()
                 .forLogger(tokenAddress)
                 .forEventSignature(AbiConstants.TRANSFER_EVENT)

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.token.impl;
 
+import static com.hedera.hapi.node.base.AccountID.AccountOneOfType.ACCOUNT_NUM;
 import static com.hedera.node.app.service.token.AliasUtils.asKeyFromAliasOrElse;
 import static com.hedera.node.app.service.token.AliasUtils.extractEvmAddress;
 import static com.hedera.node.app.service.token.AliasUtils.extractIdFromAddressAlias;
@@ -92,7 +93,8 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
     }
 
     /**
-     * Returns the {@link Account} for a given {@link AccountID}
+     * Returns the {@link Account} for a given {@link AccountID}. If the account has an alias
+     * set on it, it doesn't look in the alias map to find the account ID and returns null
      *
      * @param accountID the {@code AccountID} which {@code Account is requested}
      * @return an {@link Optional} with the {@code Account}, if it was found, an empty {@code
@@ -133,7 +135,37 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
     protected Account getAccountLeaf(@NonNull final AccountID id) {
         // The Account ID may be aliased, in which case we need to convert it to a number-based account ID first.
         requireNonNull(id);
-        final var accountId = unaliasedAccountId(id);
+        final var accountOneOf = id.account();
+        return accountOneOf.kind() == ACCOUNT_NUM ? accountState.get(id) : null;
+    }
+
+    /**
+     * Returns the {@link Account} for a given {@link AccountID}. If the account has an alias
+     * set on it, looks in the alias map to find the account ID. This method should only be used in
+     * {@code CryptoTransfer} since aliases are allowed only for auto-created accounts.
+     *
+     * @param accountID the {@code AccountID} which {@code Account is requested}
+     * @return an {@link Optional} with the {@code Account}, if it was found, an empty {@code
+     * Optional} otherwise
+     */
+    @Override
+    @Nullable
+    public Account getAliasedAccountById(@NonNull final AccountID accountID) {
+        return getAliasedAccountLeaf(accountID);
+    }
+
+    /**
+     * Returns the account leaf for the given account id. If the account doesn't exist, returns
+     * {@link Optional}.
+     *
+     * @param id given account number
+     * @return merkle leaf for the given account number
+     */
+    @Nullable
+    protected Account getAliasedAccountLeaf(@NonNull final AccountID id) {
+        // The Account ID may be aliased, in which case we need to convert it to a number-based account ID first.
+        requireNonNull(id);
+        final var accountId = lookupAliasedAccountId(id);
         return accountId == null ? null : accountState.get(accountId);
     }
 
@@ -151,7 +183,7 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
      * @return The result, or null if the id is invalid or there is no known alias-to-account mapping for it.
      */
     @Nullable
-    protected AccountID unaliasedAccountId(@NonNull final AccountID id) {
+    protected AccountID lookupAliasedAccountId(@NonNull final AccountID id) {
         final var accountOneOf = id.account();
         return switch (accountOneOf.kind()) {
             case ACCOUNT_NUM -> id;
@@ -187,6 +219,9 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
 
     @Override
     public void warm(@NonNull final AccountID accountID) {
-        accountState.warm(accountID);
+        final var unaliasedId = lookupAliasedAccountId(accountID);
+        if (unaliasedId != null) {
+            accountState.warm(unaliasedId);
+        }
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableAccountStore.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/WritableAccountStore.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.token.impl;
 
+import static com.hedera.hapi.node.base.AccountID.AccountOneOfType.ACCOUNT_NUM;
 import static com.hedera.node.app.service.token.AliasUtils.isAlias;
 import static java.util.Objects.requireNonNull;
 
@@ -150,7 +151,7 @@ public class WritableAccountStore extends ReadableAccountStoreImpl {
     public Account getForModify(@NonNull final AccountID id) {
         requireNonNull(id);
         // Get the account number based on the account identifier. It may be null.
-        final var accountId = unaliasedAccountId(id);
+        final var accountId = id.account().kind() == ACCOUNT_NUM ? id : null;
         return accountId == null ? null : accountState().getForModify(accountId);
     }
 
@@ -165,7 +166,8 @@ public class WritableAccountStore extends ReadableAccountStoreImpl {
     @Nullable
     public Account getOriginalValue(@NonNull final AccountID id) {
         requireNonNull(id);
-        final var accountId = unaliasedAccountId(id);
+        // Get the account number based on the account identifier. It may be null.
+        final var accountId = id.account().kind() == ACCOUNT_NUM ? id : null;
         return accountId == null ? null : accountState().getOriginalValue(accountId);
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -495,7 +495,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
 
         // get the account from account store that has all balance changes
         // commit the account with deleted flag set to true
-        final var updatedDeleteAccount = requireNonNull(accountStore.get(deletedId));
+        final var updatedDeleteAccount = requireNonNull(accountStore.getForModify(deletedId));
         final var builder = updatedDeleteAccount.copyBuilder().deleted(true);
         if (freeAliasOnDeletion == YES) {
             accountStore.removeAlias(updatedDeleteAccount.alias());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -495,7 +495,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
 
         // get the account from account store that has all balance changes
         // commit the account with deleted flag set to true
-        final var updatedDeleteAccount = requireNonNull(accountStore.getForModify(deletedId));
+        final var updatedDeleteAccount = requireNonNull(accountStore.get(deletedId));
         final var builder = updatedDeleteAccount.copyBuilder().deleted(true);
         if (freeAliasOnDeletion == YES) {
             accountStore.removeAlias(updatedDeleteAccount.alias());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountBalanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountBalanceHandler.java
@@ -83,7 +83,7 @@ public class CryptoGetAccountBalanceHandler extends FreeQueryHandler {
         final var accountStore = context.createStore(ReadableAccountStore.class);
         final CryptoGetAccountBalanceQuery op = query.cryptogetAccountBalanceOrThrow();
         if (op.hasAccountID()) {
-            final var account = accountStore.getAccountById(requireNonNull(op.accountID()));
+            final var account = accountStore.getAliasedAccountById(requireNonNull(op.accountID()));
             validateFalsePreCheck(account == null, INVALID_ACCOUNT_ID);
             validateFalsePreCheck(account.deleted(), ACCOUNT_DELETED);
         } else if (op.hasContractID()) {
@@ -110,7 +110,7 @@ public class CryptoGetAccountBalanceHandler extends FreeQueryHandler {
         response.header(header);
         if (header.nodeTransactionPrecheckCode() == OK) {
             final var account = op.hasAccountID()
-                    ? accountStore.getAccountById(op.accountIDOrThrow())
+                    ? accountStore.getAliasedAccountById(op.accountIDOrThrow())
                     : accountStore.getContractById(op.contractIDOrThrow());
             requireNonNull(account);
             response.accountID(account.accountIdOrThrow()).balance(account.tinybarBalance());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -91,7 +91,7 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
         final var accountStore = context.createStore(ReadableAccountStore.class);
         final CryptoGetInfoQuery op = query.cryptoGetInfoOrThrow();
         if (op.hasAccountID()) {
-            final var account = accountStore.getAccountById(requireNonNull(op.accountID()));
+            final var account = accountStore.getAliasedAccountById(requireNonNull(op.accountID()));
             validateFalsePreCheck(account == null, INVALID_ACCOUNT_ID);
             validateFalsePreCheck(account.deleted(), ACCOUNT_DELETED);
         } else {
@@ -145,7 +145,7 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
         final var stakingInfoStore = context.createStore(ReadableStakingInfoStore.class);
         final var stakingRewardsStore = context.createStore(ReadableNetworkStakingRewardsStore.class);
 
-        final var account = accountStore.getAccountById(accountID);
+        final var account = accountStore.getAliasedAccountById(accountID);
         if (account == null) {
             return Optional.empty();
         } else {
@@ -190,8 +190,8 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
         final var query = queryContext.query();
         final var accountStore = queryContext.createStore(ReadableAccountStore.class);
         final var op = query.cryptoGetInfoOrThrow();
-        final var accountId = op.accountIDOrThrow();
-        final var account = accountStore.getAccountById(accountId);
+        final var accountId = op.accountIDOrElse(AccountID.DEFAULT);
+        final var account = accountStore.getAliasedAccountById(accountId);
 
         return queryContext.feeCalculator().legacyCalculate(sigValueObj -> new GetAccountInfoResourceUsage(
                         cryptoOpsUsage, null, null, null)

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -179,7 +179,7 @@ public class CryptoTransferHandler implements TransactionHandler {
             @NonNull final NftTransfer nftTransfer) {
         // warm sender
         nftTransfer.ifSenderAccountID(senderAccountID -> {
-            final Account sender = accountStore.getAccountById(senderAccountID);
+            final Account sender = accountStore.getAliasedAccountById(senderAccountID);
             if (sender != null) {
                 sender.ifHeadNftId(nftStore::warm);
             }
@@ -188,7 +188,7 @@ public class CryptoTransferHandler implements TransactionHandler {
 
         // warm receiver
         nftTransfer.ifReceiverAccountID(receiverAccountID -> {
-            final Account receiver = accountStore.getAccountById(receiverAccountID);
+            final Account receiver = accountStore.getAliasedAccountById(receiverAccountID);
             if (receiver != null) {
                 receiver.ifHeadTokenId(headTokenID -> tokenRelationStore.warm(receiverAccountID, headTokenID));
                 receiver.ifHeadNftId(nftStore::warm);
@@ -254,7 +254,9 @@ public class CryptoTransferHandler implements TransactionHandler {
      * @throws HandleException if any error occurs during the process
      */
     private CryptoTransferTransactionBody ensureAndReplaceAliasesInOp(
-            final TransactionBody txn, final TransferContextImpl transferContext, final HandleContext context)
+            @NonNull final TransactionBody txn,
+            @NonNull final TransferContextImpl transferContext,
+            @NonNull final HandleContext context)
             throws HandleException {
         final var op = txn.cryptoTransferOrThrow();
 
@@ -359,7 +361,7 @@ public class CryptoTransferHandler implements TransactionHandler {
         for (final var accountAmount : transfers) {
             // Given an accountId, we need to look up the associated account.
             final var accountId = validateAccountID(accountAmount.accountIDOrElse(AccountID.DEFAULT), null);
-            final var account = accountStore.getAccountById(accountId);
+            final var account = accountStore.getAliasedAccountById(accountId);
             final var isCredit = accountAmount.amount() > 0;
             final var isDebit = accountAmount.amount() < 0;
             if (account != null) {
@@ -439,7 +441,7 @@ public class CryptoTransferHandler implements TransactionHandler {
             throws PreCheckException {
 
         // Lookup the receiver account and verify it.
-        final var receiverAccount = accountStore.getAccountById(receiverId);
+        final var receiverAccount = accountStore.getAliasedAccountById(receiverId);
         if (receiverAccount == null) {
             // It may be that the receiver account does not yet exist. If it is being addressed by alias,
             // then this is OK, as we will automatically create the account. Otherwise, fail.
@@ -480,7 +482,7 @@ public class CryptoTransferHandler implements TransactionHandler {
             throws PreCheckException {
 
         // Lookup the sender account and verify it.
-        final var senderAccount = accountStore.getAccountById(senderId);
+        final var senderAccount = accountStore.getAliasedAccountById(senderId);
         if (senderAccount == null) {
             throw new PreCheckException(INVALID_ACCOUNT_ID);
         }
@@ -499,8 +501,8 @@ public class CryptoTransferHandler implements TransactionHandler {
     private boolean receivesFungibleValue(
             final AccountID target, final CryptoTransferTransactionBody op, final ReadableAccountStore accountStore) {
         for (final var adjust : op.transfersOrElse(TransferList.DEFAULT).accountAmounts()) {
-            final var unaliasedAccount = accountStore.getAccountById(adjust.accountIDOrElse(AccountID.DEFAULT));
-            final var unaliasedTarget = accountStore.getAccountById(target);
+            final var unaliasedAccount = accountStore.getAliasedAccountById(adjust.accountIDOrElse(AccountID.DEFAULT));
+            final var unaliasedTarget = accountStore.getAliasedAccountById(target);
             if (unaliasedAccount != null
                     && unaliasedTarget != null
                     && adjust.amount() > 0
@@ -510,8 +512,8 @@ public class CryptoTransferHandler implements TransactionHandler {
         }
         for (final var transfers : op.tokenTransfers()) {
             for (final var adjust : transfers.transfers()) {
-                final var unaliasedAccount = accountStore.getAccountById(adjust.accountIDOrElse(AccountID.DEFAULT));
-                final var unaliasedTarget = accountStore.getAccountById(target);
+                final var unaliasedAccount = accountStore.getAliasedAccountById(adjust.accountIDOrElse(AccountID.DEFAULT));
+                final var unaliasedTarget = accountStore.getAliasedAccountById(target);
                 if (unaliasedAccount != null
                         && unaliasedTarget != null
                         && adjust.amount() > 0

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -160,7 +160,7 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
             mintFungible(newToken, treasuryRel, op.initialSupply(), accountStore, tokenStore, tokenRelationStore);
         }
         // Increment treasury's title count
-        final var treasuryAccount = requireNonNull(accountStore.getForModify(treasuryRel.accountIdOrThrow()));
+        final var treasuryAccount = requireNonNull(accountStore.get(treasuryRel.accountIdOrThrow()));
         accountStore.put(treasuryAccount
                 .copyBuilder()
                 .numberTreasuryTitles(treasuryAccount.numberTreasuryTitles() + 1)

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -26,6 +26,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SPENDER_DOES_NOT_HAVE_A
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hedera.node.app.service.token.impl.handlers.transfer.NFTOwnersChangeStep.validateSpenderHasAllowance;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
+import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsableForAliasedId;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
@@ -158,7 +159,8 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
             @NonNull final WritableAccountStore accountStore,
             @NonNull final WritableTokenRelationStore tokenRelStore,
             @NonNull final HandleContext handleContext) {
-        final var account = getIfUsable(accountId, accountStore, handleContext.expiryValidator(), INVALID_ACCOUNT_ID);
+        final var account =
+                getIfUsableForAliasedId(accountId, accountStore, handleContext.expiryValidator(), INVALID_ACCOUNT_ID);
         final var tokenRel = tokenRelStore.get(accountId, tokenId);
         final var config = handleContext.configuration();
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/ReplaceAliasesWithIDsInOp.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/ReplaceAliasesWithIDsInOp.java
@@ -53,7 +53,7 @@ public class ReplaceAliasesWithIDsInOp {
         // replace all aliases in hbar transfers
         for (final var aa : op.transfersOrElse(TransferList.DEFAULT).accountAmounts()) {
             if (isAlias(aa.accountIDOrThrow())) {
-                final var resolvedId = resolutions.get(aa.accountID().alias());
+                final var resolvedId = resolutions.get(aa.accountIDOrThrow().alias());
                 accountAmounts.add(aa.copyBuilder().accountID(resolvedId).build());
             } else {
                 accountAmounts.add(aa);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContextImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContextImpl.java
@@ -78,7 +78,7 @@ public class TransferContextImpl implements TransferContext {
 
     @Override
     public AccountID getFromAlias(final AccountID aliasedId) {
-        final var account = accountStore.get(aliasedId);
+        final var account = accountStore.getAliasedAccountById(aliasedId);
 
         if (account != null) {
             final var id = account.accountId();
@@ -168,7 +168,9 @@ public class TransferContextImpl implements TransferContext {
         for (final var aa : op.transfersOrElse(TransferList.DEFAULT).accountAmounts()) {
             if (aa.isApproval() && aa.amount() < 0L) {
                 maybeValidateHbarAllowance(
-                        accountStore.get(aa.accountIDOrElse(AccountID.DEFAULT)), topLevelPayer, aa.amount());
+                        accountStore.getAliasedAccountById(aa.accountIDOrElse(AccountID.DEFAULT)),
+                        topLevelPayer,
+                        aa.amount());
             }
         }
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenHandlerHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/util/TokenHandlerHelper.java
@@ -76,6 +76,11 @@ public class TokenHandlerHelper {
         throw new UnsupportedOperationException("Utility class only");
     }
 
+    public enum AccountIDType {
+        ALIASED_ID,
+        NOT_ALIASED_ID
+    }
+
     /**
      * Returns the account if it exists and is usable. A {@link HandleException} is thrown if the account is invalid.
      * Note that this method should also work with account ID's that represent smart contracts
@@ -93,7 +98,34 @@ public class TokenHandlerHelper {
             @NonNull final ReadableAccountStore accountStore,
             @NonNull final ExpiryValidator expiryValidator,
             @NonNull final ResponseCodeEnum errorIfNotUsable) {
-        return getIfUsable(accountId, accountStore, expiryValidator, errorIfNotUsable, ACCOUNT_DELETED);
+        return getIfUsable(
+                accountId,
+                accountStore,
+                expiryValidator,
+                errorIfNotUsable,
+                ACCOUNT_DELETED,
+                AccountIDType.NOT_ALIASED_ID);
+    }
+
+    /**
+     * Returns the account if it exists and is usable. A {@link HandleException} is thrown if the account is invalid.
+     * Note that this method should also work with account ID's that represent smart contracts
+     * If the account is deleted the return error code is ACCOUNT_DELETED
+     *
+     * @param accountId the ID of the account to get
+     * @param accountStore the {@link ReadableTokenStore} to use for account retrieval
+     * @param expiryValidator the {@link ExpiryValidator} to determine if the account is expired
+     * @param errorIfNotUsable the {@link ResponseCodeEnum} to use if the account is not found/usable
+     * @throws HandleException if any of the account conditions are not met
+     */
+    @NonNull
+    public static Account getIfUsableForAliasedId(
+            @NonNull final AccountID accountId,
+            @NonNull final ReadableAccountStore accountStore,
+            @NonNull final ExpiryValidator expiryValidator,
+            @NonNull final ResponseCodeEnum errorIfNotUsable) {
+        return getIfUsable(
+                accountId, accountStore, expiryValidator, errorIfNotUsable, ACCOUNT_DELETED, AccountIDType.ALIASED_ID);
     }
 
     /**
@@ -112,7 +144,13 @@ public class TokenHandlerHelper {
             @NonNull final ReadableAccountStore accountStore,
             @NonNull final ExpiryValidator expiryValidator,
             @NonNull final ResponseCodeEnum errorIfNotUsable) {
-        return getIfUsable(accountId, accountStore, expiryValidator, errorIfNotUsable, INVALID_AUTORENEW_ACCOUNT);
+        return getIfUsable(
+                accountId,
+                accountStore,
+                expiryValidator,
+                errorIfNotUsable,
+                INVALID_AUTORENEW_ACCOUNT,
+                AccountIDType.NOT_ALIASED_ID);
     }
 
     /**
@@ -132,7 +170,12 @@ public class TokenHandlerHelper {
             @NonNull final ExpiryValidator expiryValidator,
             @NonNull final ResponseCodeEnum errorIfNotUsable) {
         return getIfUsable(
-                accountId, accountStore, expiryValidator, errorIfNotUsable, INVALID_TREASURY_ACCOUNT_FOR_TOKEN);
+                accountId,
+                accountStore,
+                expiryValidator,
+                errorIfNotUsable,
+                INVALID_TREASURY_ACCOUNT_FOR_TOKEN,
+                AccountIDType.NOT_ALIASED_ID);
     }
 
     @NonNull
@@ -141,14 +184,20 @@ public class TokenHandlerHelper {
             @NonNull final ReadableAccountStore accountStore,
             @NonNull final ExpiryValidator expiryValidator,
             @NonNull final ResponseCodeEnum errorIfNotUsable,
-            @NonNull final ResponseCodeEnum errorOnAccountDeleted) {
+            @NonNull final ResponseCodeEnum errorOnAccountDeleted,
+            @NonNull final AccountIDType accountIDType) {
         requireNonNull(accountId);
         requireNonNull(accountStore);
         requireNonNull(expiryValidator);
         requireNonNull(errorIfNotUsable);
         requireNonNull(errorOnAccountDeleted);
 
-        final var acct = accountStore.getAccountById(accountId);
+        final Account acct;
+        if (accountIDType == AccountIDType.ALIASED_ID) {
+            acct = accountStore.getAliasedAccountById(accountId);
+        } else {
+            acct = accountStore.getAccountById(accountId);
+        }
         validateTrue(acct != null, errorIfNotUsable);
         final var isContract = acct.smartContract();
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.token.impl.validators;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.*;
+import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.AccountIDType.NOT_ALIASED_ID;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
@@ -138,7 +139,12 @@ public class AllowanceValidator {
         } else {
             // If owner is in modifications get the modified account from state
             return TokenHandlerHelper.getIfUsable(
-                    owner, accountStore, expiryValidator, INVALID_ALLOWANCE_OWNER_ID, INVALID_ALLOWANCE_OWNER_ID);
+                    owner,
+                    accountStore,
+                    expiryValidator,
+                    INVALID_ALLOWANCE_OWNER_ID,
+                    INVALID_ALLOWANCE_OWNER_ID,
+                    NOT_ALIASED_ID);
         }
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableAccountStoreTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/WritableAccountStoreTest.java
@@ -121,13 +121,27 @@ class WritableAccountStoreTest extends CryptoHandlerTestBase {
     }
 
     @Test
-    void getForModifyLooksForAlias() {
+    void getForModifyDoesntLookForAlias() {
         assertEquals(0, writableStore.sizeOfAliasesState());
 
         writableStore.put(account);
         writableStore.putAlias(alias.alias(), id);
 
         final var readaccount = writableStore.getForModify(alias);
+
+        assertThat(readaccount).isNull();
+        assertEquals(1, writableStore.sizeOfAliasesState());
+        assertEquals(Set.of(edKeyAlias), writableStore.modifiedAliasesInState());
+    }
+
+    @Test
+    void getWithAliasedIdLooksForAlias() {
+        assertEquals(0, writableStore.sizeOfAliasesState());
+
+        writableStore.put(account);
+        writableStore.putAlias(alias.alias(), id);
+
+        final var readaccount = writableStore.getAliasedAccountById(alias);
 
         assertThat(readaccount).isNotNull();
         assertThat(account).isEqualTo(readaccount);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
@@ -65,8 +65,8 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         final var replacedOp = getReplacedOp();
         adjustFungibleTokenChangesStep = new AdjustFungibleTokenChangesStep(replacedOp, payerId);
 
-        final var senderAccountBefore = writableAccountStore.get(ownerId);
-        final var receiverAccountBefore = writableAccountStore.get(receiver);
+        final var senderAccountBefore = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountBefore = writableAccountStore.getAliasedAccountById(receiver);
         final var senderRelBefore = writableTokenRelStore.get(ownerId, fungibleTokenId);
         final var receiverRelBefore = writableTokenRelStore.get(receiver, fungibleTokenId);
         writableTokenRelStore.put(receiverRelBefore
@@ -83,8 +83,8 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         adjustFungibleTokenChangesStep.doIn(transferContext);
 
         // see numPositiveBalances and numOwnedNfts change
-        final var senderAccountAfter = writableAccountStore.get(ownerId);
-        final var receiverAccountAfter = writableAccountStore.get(receiver);
+        final var senderAccountAfter = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountAfter = writableAccountStore.getAliasedAccountById(receiver);
         final var senderRelAfter = writableTokenRelStore.get(ownerId, fungibleTokenId);
         final var receiverRelAfter = writableTokenRelStore.get(receiver, fungibleTokenId);
 
@@ -110,8 +110,8 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         // payer is spender for allowances
         adjustFungibleTokenChangesStep = new AdjustFungibleTokenChangesStep(replacedOp, spenderId);
 
-        final var senderAccountBefore = writableAccountStore.get(ownerId);
-        final var receiverAccountBefore = writableAccountStore.get(receiver);
+        final var senderAccountBefore = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountBefore = writableAccountStore.getAliasedAccountById(receiver);
         final var senderRelBefore = writableTokenRelStore.get(ownerId, fungibleTokenId);
         final var receiverRelBefore = writableTokenRelStore.get(receiver, fungibleTokenId);
         writableTokenRelStore.put(receiverRelBefore
@@ -130,8 +130,8 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         adjustFungibleTokenChangesStep.doIn(transferContext);
 
         // see numPositiveBalances and numOwnedNfts change
-        final var senderAccountAfter = writableAccountStore.get(ownerId);
-        final var receiverAccountAfter = writableAccountStore.get(receiver);
+        final var senderAccountAfter = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountAfter = writableAccountStore.getAliasedAccountById(receiver);
         final var senderRelAfter = writableTokenRelStore.get(ownerId, fungibleTokenId);
         final var receiverRelAfter = writableTokenRelStore.get(receiver, fungibleTokenId);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
@@ -69,8 +69,8 @@ class AdjustHbarChangesStepTest extends StepsBase {
         final var replacedOp = getReplacedOp();
         adjustHbarChangesStep = new AdjustHbarChangesStep(replacedOp, payerId);
 
-        final var senderAccount = writableAccountStore.get(ownerId);
-        final var receiverAccount = writableAccountStore.get(receiver);
+        final var senderAccount = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccount = writableAccountStore.getAliasedAccountById(receiver);
 
         assertThat(senderAccount.tinybarBalance()).isEqualTo(10000L);
         assertThat(receiverAccount.tinybarBalance()).isEqualTo(10000L);
@@ -78,8 +78,8 @@ class AdjustHbarChangesStepTest extends StepsBase {
         adjustHbarChangesStep.doIn(transferContext);
 
         // see numPositiveBalances and numOwnedNfts change
-        final var senderAccountAfter = writableAccountStore.get(ownerId);
-        final var receiverAccountAfter = writableAccountStore.get(receiver);
+        final var senderAccountAfter = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountAfter = writableAccountStore.getAliasedAccountById(receiver);
 
         assertThat(senderAccountAfter.tinybarBalance()).isEqualTo(senderAccount.tinybarBalance() - 1000);
         assertThat(receiverAccountAfter.tinybarBalance()).isEqualTo(receiverAccount.tinybarBalance() + 1000);
@@ -98,8 +98,8 @@ class AdjustHbarChangesStepTest extends StepsBase {
         adjustHbarChangesStep =
                 new AdjustHbarChangesStep(replacedOp, txn.transactionIDOrThrow().accountIDOrThrow());
 
-        final var senderAccount = writableAccountStore.get(ownerId);
-        final var receiverAccount = writableAccountStore.get(receiver);
+        final var senderAccount = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccount = writableAccountStore.getAliasedAccountById(receiver);
 
         assertThat(senderAccount.tinybarBalance()).isEqualTo(10000L);
         assertThat(receiverAccount.tinybarBalance()).isEqualTo(10000L);
@@ -110,8 +110,8 @@ class AdjustHbarChangesStepTest extends StepsBase {
         adjustHbarChangesStep.doIn(transferContext);
 
         // see numPositiveBalances and numOwnedNfts change
-        final var senderAccountAfter = writableAccountStore.get(ownerId);
-        final var receiverAccountAfter = writableAccountStore.get(receiver);
+        final var senderAccountAfter = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountAfter = writableAccountStore.getAliasedAccountById(receiver);
 
         assertThat(senderAccountAfter.tinybarBalance()).isEqualTo(senderAccount.tinybarBalance() - 1000);
         assertThat(receiverAccountAfter.tinybarBalance()).isEqualTo(receiverAccount.tinybarBalance() + 1000);
@@ -138,8 +138,8 @@ class AdjustHbarChangesStepTest extends StepsBase {
         adjustHbarChangesStep =
                 new AdjustHbarChangesStep(replacedOp, txn.transactionIDOrThrow().accountIDOrThrow());
 
-        final var senderAccount = writableAccountStore.get(ownerId);
-        final var receiverAccount = writableAccountStore.get(receiver);
+        final var senderAccount = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccount = writableAccountStore.getAliasedAccountById(receiver);
 
         assertThat(senderAccount.tinybarBalance()).isEqualTo(10000L);
         assertThat(receiverAccount.tinybarBalance()).isEqualTo(10000L);
@@ -168,8 +168,8 @@ class AdjustHbarChangesStepTest extends StepsBase {
         adjustHbarChangesStep =
                 new AdjustHbarChangesStep(replacedOp, txn.transactionIDOrThrow().accountIDOrThrow());
 
-        final var senderAccount = writableAccountStore.get(ownerId);
-        final var receiverAccount = writableAccountStore.get(receiver);
+        final var senderAccount = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccount = writableAccountStore.getAliasedAccountById(receiver);
 
         assertThat(senderAccount.tinybarBalance()).isEqualTo(10000L);
         assertThat(receiverAccount.tinybarBalance()).isEqualTo(10000L);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
@@ -90,8 +90,10 @@ class EnsureAliasesStepTest extends StepsBase {
 
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(2);
         assertThat(writableAccountStore.modifiedAccountsInState()).isEmpty();
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNull();
-        assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver)))
+                .isNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(tokenReceiver)))
+                .isNull();
         assertThat(writableAliases.get(ecKeyAlias)).isNull();
         assertThat(writableAliases.get(edKeyAlias)).isNull();
 
@@ -100,8 +102,10 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAliasesInState()).hasSize(2);
         assertThat(writableAccountStore.modifiedAccountsInState()).hasSize(2);
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(4);
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
-        assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver)))
+                .isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(tokenReceiver)))
+                .isNotNull();
         assertThat(writableAliases.get(ecKeyAlias).accountNum()).isEqualTo(hbarReceiver);
         assertThat(writableAliases.get(edKeyAlias).accountNum()).isEqualTo(tokenReceiver);
 
@@ -170,9 +174,12 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAliasesInState()).hasSize(3);
         assertThat(writableAccountStore.modifiedAccountsInState()).hasSize(3);
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(5);
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
-        assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver + 2))).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver)))
+                .isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(tokenReceiver)))
+                .isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver + 2)))
+                .isNotNull();
         assertThat(writableAliases.get(evmAddressAlias1).accountNum()).isEqualTo(hbarReceiver);
         assertThat(writableAliases.get(evmAddressAlias2).accountNum()).isEqualTo(tokenReceiver);
         assertThat(writableAliases.get(evmAddressAlias3).accountNum()).isEqualTo(hbarReceiver + 2);
@@ -190,8 +197,9 @@ class EnsureAliasesStepTest extends StepsBase {
         setUpInsertingKnownAliasesToState();
 
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(2);
-        assertThat(writableAccountStore.get(unknownAliasedId)).isNotNull();
-        assertThat(writableAccountStore.get(unknownAliasedId1)).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(unknownAliasedId)).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(unknownAliasedId1))
+                .isNotNull();
 
         ensureAliasesStep.doIn(transferContext);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/NFTOwnersChangeStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/NFTOwnersChangeStepTest.java
@@ -91,8 +91,8 @@ class NFTOwnersChangeStepTest extends StepsBase {
         assertThat(nextNftBefore.hasOwnerPreviousNftId()).isTrue();
         assertThat(nextNftBefore.hasOwnerNextNftId()).isFalse();
 
-        final var senderAccount = writableAccountStore.get(ownerId);
-        final var receiverAccount = writableAccountStore.get(receiver);
+        final var senderAccount = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccount = writableAccountStore.getAliasedAccountById(receiver);
 
         final var numNftsOwnedBySender = senderAccount.numberOwnedNfts();
         assertThat(numNftsOwnedBySender).isEqualTo(2);
@@ -126,8 +126,8 @@ class NFTOwnersChangeStepTest extends StepsBase {
         assertThat(nextNft.hasOwnerNextNftId()).isFalse();
 
         // see numPositiveBalances and numOwnedNfts change
-        final var senderAccountAfter = writableAccountStore.get(ownerId);
-        final var receiverAccountAfter = writableAccountStore.get(receiver);
+        final var senderAccountAfter = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountAfter = writableAccountStore.getAliasedAccountById(receiver);
 
         final var numNftsOwnedBySenderAfter = senderAccountAfter.numberOwnedNfts();
         assertThat(numNftsOwnedBySenderAfter).isEqualTo(numNftsOwnedBySender - 1);
@@ -173,8 +173,8 @@ class NFTOwnersChangeStepTest extends StepsBase {
         final var nft = writableNftStore.get(nftIdSl1);
         assertThat(nft.ownerId()).isEqualTo(ownerId);
 
-        final var senderAccount = writableAccountStore.get(ownerId);
-        final var receiverAccount = writableAccountStore.get(receiver);
+        final var senderAccount = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccount = writableAccountStore.getAliasedAccountById(receiver);
 
         final var numNftsOwnedBySender = senderAccount.numberOwnedNfts();
         assertThat(numNftsOwnedBySender).isEqualTo(2);
@@ -199,8 +199,8 @@ class NFTOwnersChangeStepTest extends StepsBase {
         assertThat(nftChanged.ownerId()).isEqualTo(receiver);
 
         // see numPositiveBalances and numOwnedNfts change
-        final var senderAccountAfter = writableAccountStore.get(ownerId);
-        final var receiverAccountAfter = writableAccountStore.get(receiver);
+        final var senderAccountAfter = writableAccountStore.getAliasedAccountById(ownerId);
+        final var receiverAccountAfter = writableAccountStore.getAliasedAccountById(receiver);
 
         final var numNftsOwnedBySenderAfter = senderAccountAfter.numberOwnedNfts();
         assertThat(numNftsOwnedBySenderAfter).isEqualTo(numNftsOwnedBySender - 1);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
@@ -85,8 +85,10 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
 
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(2);
         assertThat(writableAccountStore.modifiedAccountsInState()).isEmpty();
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNull();
-        assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver)))
+                .isNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(tokenReceiver)))
+                .isNull();
         assertThat(writableAliases.get(ecKeyAlias)).isNull();
         assertThat(writableAliases.get(edKeyAlias)).isNull();
 
@@ -95,8 +97,10 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAliasesInState()).hasSize(2);
         assertThat(writableAccountStore.modifiedAccountsInState()).hasSize(2);
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(4);
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
-        assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver)))
+                .isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(tokenReceiver)))
+                .isNotNull();
         assertThat(writableAliases.get(ecKeyAlias).accountNum()).isEqualTo(hbarReceiver);
         assertThat(writableAliases.get(edKeyAlias).accountNum()).isEqualTo(tokenReceiver);
 
@@ -169,9 +173,12 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         assertThat(writableAccountStore.modifiedAliasesInState()).hasSize(3);
         assertThat(writableAccountStore.modifiedAccountsInState()).hasSize(3);
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(5);
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver))).isNotNull();
-        assertThat(writableAccountStore.get(asAccount(tokenReceiver))).isNotNull();
-        assertThat(writableAccountStore.get(asAccount(hbarReceiver + 2))).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver)))
+                .isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(tokenReceiver)))
+                .isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(asAccount(hbarReceiver + 2)))
+                .isNotNull();
         assertThat(writableAliases.get(evmAddressAlias1).accountNum()).isEqualTo(hbarReceiver);
         assertThat(writableAliases.get(evmAddressAlias2).accountNum()).isEqualTo(tokenReceiver);
         assertThat(writableAliases.get(evmAddressAlias3).accountNum()).isEqualTo(hbarReceiver + 2);
@@ -189,8 +196,9 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         setUpInsertingKnownAliasesToState();
 
         assertThat(writableAccountStore.sizeOfAliasesState()).isEqualTo(2);
-        assertThat(writableAccountStore.get(unknownAliasedId)).isNotNull();
-        assertThat(writableAccountStore.get(unknownAliasedId1)).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(unknownAliasedId)).isNotNull();
+        assertThat(writableAccountStore.getAliasedAccountById(unknownAliasedId1))
+                .isNotNull();
 
         ensureAliasesStep.doIn(transferContext);
 

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
@@ -105,7 +105,7 @@ public interface ReadableAccountStore {
             builder.accountNum(contractID.contractNumOrElse(0L));
         }
 
-        final var account = getAccountById(builder.build());
+        final var account = getAliasedAccountById(builder.build());
         return account == null || !account.smartContract() ? null : account;
     }
 

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
@@ -31,13 +31,25 @@ public interface ReadableAccountStore {
 
     /**
      * Fetches an {@link Account} object from state with the given {@link AccountID}. If the account could not be
-     * fetched because the given account doesn't exist, returns {@code null}.
+     * fetched because the given account doesn't exist, returns {@code null}. It doesn't look up in alias state
+     * to find the account.
+     *
+     * @param accountID given account id
+     * @return {@link Account} object if successfully fetched or {@code null} if the account doesn't exist
+     */
+    @Nullable
+    Account getAccountById(@NonNull final AccountID accountID);
+
+    /**
+     * Fetches an {@link Account} object from state with the given {@link AccountID}. If the account could not be
+     * fetched because the given account doesn't exist, returns {@code null}. It looks up in alias state
+     * to find the account.
      *
      * @param accountID given account id or alias
      * @return {@link Account} object if successfully fetched or {@code null} if the account doesn't exist
      */
     @Nullable
-    Account getAccountById(@NonNull final AccountID accountID);
+    Account getAliasedAccountById(@NonNull final AccountID accountID);
 
     /**
      * Fetches an {@link Account} object from state with the given alias. If the account could not be

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -645,6 +645,12 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return self();
     }
 
+    public T payingWithAliased(String name) {
+        payingWithAlias = true;
+        payer = Optional.of(name);
+        return self();
+    }
+
     public T withUnknownFieldIn(final UnknownFieldLocation location) {
         unknownFieldLocation = location;
         return self();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -18,6 +18,7 @@ package com.hedera.services.bdd.suites.schedule;
 
 import static com.hedera.services.bdd.spec.HapiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
@@ -26,6 +27,7 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getScheduleInfo;
@@ -41,9 +43,14 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreateFunctionless;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleSign;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromToWithAlias;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.ALIAS;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.INITIAL_BALANCE;
+import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.schedule.ScheduleUtils.ADMIN;
 import static com.hedera.services.bdd.suites.schedule.ScheduleUtils.BASIC_XFER;
 import static com.hedera.services.bdd.suites.schedule.ScheduleUtils.CONTINUE;
@@ -74,6 +81,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SCHEDULED_TRANSACTION_NOT_IN_WHITELIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SOME_SIGNATURES_WERE_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -130,7 +138,44 @@ public class ScheduleCreateSpecs extends HapiSuite {
                 worksAsExpectedWithDefaultScheduleId(),
                 infoIncludesTxnIdFromCreationReceipt(),
                 suiteCleanup(),
-                validateSignersInInfo()));
+                validateSignersInInfo(),
+                aliasNotAllowedAsPayer()));
+    }
+
+    @HapiTest
+    private HapiSpec aliasNotAllowedAsPayer() {
+        return defaultHapiSpec("BodyAndPayerCreation")
+                .given(
+                        newKeyNamed(ALIAS),
+                        cryptoCreate(PAYER).balance(INITIAL_BALANCE * ONE_HBAR),
+                        cryptoTransfer(tinyBarsFromToWithAlias(PAYER, ALIAS, 2 * ONE_HUNDRED_HBARS)),
+                        withOpContext((spec, opLog) -> updateSpecFor(spec, ALIAS)),
+                        getAliasedAccountInfo(ALIAS)
+                                .has(accountWith().expectedBalanceWithChargedUsd((2 * ONE_HUNDRED_HBARS), 0, 0)))
+                .when(
+                        scheduleCreate(
+                                        ONLY_BODY_AND_PAYER,
+                                        cryptoTransfer(tinyBarsFromTo(PAYER, GENESIS, 1))
+                                                .memo("SURPRISE!!!"))
+                                .recordingScheduledTxn()
+                                // prevent multiple runs of this test causing duplicates
+                                .withEntityMemo("" + new SecureRandom().nextLong())
+                                .designatingPayer(PAYER)
+                                .payingWithAliased(PAYER)
+                                .hasPrecheck(PAYER_ACCOUNT_NOT_FOUND),
+                        scheduleCreate(
+                                        ONLY_BODY_AND_PAYER,
+                                        cryptoTransfer(tinyBarsFromTo(PAYER, GENESIS, 1))
+                                                .memo("SURPRISE!!!"))
+                                .recordingScheduledTxn()
+                                // prevent multiple runs of this test causing duplicates
+                                .withEntityMemo("" + new SecureRandom().nextLong())
+                                .designatingPayer(PAYER)
+                                .payingWith(PAYER))
+                .then(getScheduleInfo(ONLY_BODY_AND_PAYER)
+                        .hasScheduleId(ONLY_BODY_AND_PAYER)
+                        .hasPayerAccountID(PAYER)
+                        .hasRecordedScheduledTxn());
     }
 
     @HapiTest


### PR DESCRIPTION
Cherry-pick https://github.com/hashgraph/hedera-services/pull/12754