### PR TITLE
feat(build): fail if Gradle is started with Java 20 or older

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -42,11 +42,10 @@ version =
 val MIN_JAVA_VERSION = JavaVersion.VERSION_21
 val CUR_JAVA_VERSION = JavaVersion.current()
 if (CUR_JAVA_VERSION.ordinal < MIN_JAVA_VERSION.ordinal) {
-    System.err.println("ERROR: Gradle is started with Java " + CUR_JAVA_VERSION
+    throw StopExecutionException("ERROR: Gradle is started with Java " + CUR_JAVA_VERSION
             + ". This project requires running Gradle with Java " + MIN_JAVA_VERSION + " or above."
             + " Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version "
             + MIN_JAVA_VERSION + " or above.");
-    System.exit(1);
 }
 
 java {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -41,11 +41,18 @@ version =
 // Fail the build if Gradle is started with an old version of Java
 val MIN_JAVA_VERSION = JavaVersion.VERSION_21
 val CUR_JAVA_VERSION = JavaVersion.current()
+
 if (CUR_JAVA_VERSION.ordinal < MIN_JAVA_VERSION.ordinal) {
-    throw StopExecutionException("ERROR: Gradle is started with Java " + CUR_JAVA_VERSION
-            + ". This project requires running Gradle with Java " + MIN_JAVA_VERSION + " or above."
-            + " Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version "
-            + MIN_JAVA_VERSION + " or above.");
+    throw StopExecutionException(
+        "ERROR: Gradle is started with Java " +
+            CUR_JAVA_VERSION +
+            ". This project requires running Gradle with Java " +
+            MIN_JAVA_VERSION +
+            " or above." +
+            " Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version " +
+            MIN_JAVA_VERSION +
+            " or above."
+    )
 }
 
 java {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -38,9 +38,20 @@ plugins {
 version =
     providers.fileContents(rootProject.layout.projectDirectory.versionTxt()).asText.get().trim()
 
+// Fail the build if Gradle is started with an old version of Java
+val MIN_JAVA_VERSION = JavaVersion.VERSION_21
+val CUR_JAVA_VERSION = JavaVersion.current()
+if (CUR_JAVA_VERSION.ordinal < MIN_JAVA_VERSION.ordinal) {
+    System.err.println("ERROR: Gradle is started with Java " + CUR_JAVA_VERSION
+            + ". This project requires running Gradle with Java " + MIN_JAVA_VERSION + " or above."
+            + " Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version "
+            + MIN_JAVA_VERSION + " or above.");
+    System.exit(1);
+}
+
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = MIN_JAVA_VERSION
+    targetCompatibility = MIN_JAVA_VERSION
 
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -160,14 +160,3 @@ dependencyResolutionManagement {
         plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.5")
     }
 }
-
-// Fail the build if Gradle is started with an old version of Java
-val MIN_JAVA_VERSION = JavaVersion.VERSION_21
-val CUR_JAVA_VERSION = JavaVersion.current()
-if (CUR_JAVA_VERSION.ordinal < MIN_JAVA_VERSION.ordinal) {
-    System.err.println("ERROR: Gradle is started with Java " + CUR_JAVA_VERSION
-            + ". This project requires running Gradle with Java " + MIN_JAVA_VERSION + " or above."
-            + " Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version "
-            + MIN_JAVA_VERSION + " or above.");
-    System.exit(1);
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -160,3 +160,14 @@ dependencyResolutionManagement {
         plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.5")
     }
 }
+
+// Fail the build if Gradle is started with an old version of Java
+val MIN_JAVA_VERSION = JavaVersion.VERSION_21
+val CUR_JAVA_VERSION = JavaVersion.current()
+if (CUR_JAVA_VERSION.ordinal < MIN_JAVA_VERSION.ordinal) {
+    System.err.println("ERROR: Gradle is started with Java " + CUR_JAVA_VERSION
+            + ". This project requires running Gradle with Java " + MIN_JAVA_VERSION + " or above."
+            + " Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version "
+            + MIN_JAVA_VERSION + " or above.");
+    System.exit(1);
+}


### PR DESCRIPTION
**Description**:
Require Gradle to be started using Java 21+. Fail the build if the default JDK (in JAVA_HOME/PATH) points to an older version of Java.

**Related issue(s)**:

Fixes #12779

**Notes for reviewer**:
For testing purposes, when JAVA_HOME points to Java 17, the build fails as:

```
$ g qualityGate

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/anthony/ws/27-buildJavaVersion/hedera-services/platform-sdk/platform-apps/tests/AddressBookTestingTool/build.gradle.kts' line: 17

* What went wrong:
An exception occurred applying plugin request [id: 'com.hedera.hashgraph.application']
> Failed to apply plugin 'com.hedera.hashgraph.java'.
   > ERROR: Gradle is started with Java 17. This project requires running Gradle with Java 21 or above. Please check your JAVA_HOME and/or PATH and configure the default JDK to use Java version 21 or above.
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
