### PR TITLE
chore: 12815: restore CacheWarmer() constructor with a provided executor

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.workflows.handle;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.transaction.TransactionBody;
@@ -59,13 +60,23 @@ public class CacheWarmer {
             @NonNull final TransactionChecker checker,
             @NonNull final TransactionDispatcher dispatcher,
             @NonNull final ConfigProvider configProvider) {
+        this(
+                checker,
+                dispatcher,
+                new ForkJoinPool(configProvider
+                        .getConfiguration()
+                        .getConfigData(CacheConfig.class)
+                        .cryptoTransferWarmThreads()));
+    }
+
+    @VisibleForTesting
+    CacheWarmer(
+            @NonNull final TransactionChecker checker,
+            @NonNull final TransactionDispatcher dispatcher,
+            @NonNull final Executor executor) {
         this.checker = checker;
         this.dispatcher = requireNonNull(dispatcher);
-        final int parallelism = configProvider
-                .getConfiguration()
-                .getConfigData(CacheConfig.class)
-                .cryptoTransferWarmThreads();
-        this.executor = new ForkJoinPool(parallelism);
+        this.executor = requireNonNull(executor);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/CacheWarmerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/CacheWarmerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.workflows.handle;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import com.hedera.node.app.workflows.TransactionChecker;
+import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CacheWarmerTest {
+
+    @Mock
+    TransactionChecker checker;
+
+    @Mock
+    TransactionDispatcher dispatcher;
+
+    @Test
+    @DisplayName("Instantiation test")
+    void testInstantiation() {
+        CacheWarmer cacheWarmer = new CacheWarmer(checker, dispatcher, Runnable::run);
+        assertInstanceOf(CacheWarmer.class, cacheWarmer);
+    }
+}


### PR DESCRIPTION
**Description**:
* Restored `CacheWarmer()` constructor with provided `Executor` erroneously removed in #12753. 
* Added a unit test to keep it used.

**Related issue(s)**:

Fixes #12815

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
