### PR TITLE
fix: contractCalls to etheretumContractCalls NPE

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -35,7 +35,7 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleSign;
-import static com.hedera.services.bdd.spec.utilops.UtilStateChange.initializeEthereumAccountForSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilStateChange.createEthereumAccountForSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilStateChange.isEthereumAccountCreatedForSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
@@ -358,16 +358,16 @@ public class HapiSpec implements Runnable {
             return;
         }
 
-        List<HapiSpecOperation> ops;
+        List<HapiSpecOperation> ops = new ArrayList<>();
 
         if (!suitePrefix.endsWith(ETH_SUFFIX)) {
-            ops = Stream.of(given, when, then).flatMap(Arrays::stream).toList();
+            ops.addAll(Stream.of(given, when, then).flatMap(Arrays::stream).toList());
         } else {
             if (!isEthereumAccountCreatedForSpec(this)) {
-                initializeEthereumAccountForSpec(this);
+                ops.addAll(createEthereumAccountForSpec(this));
             }
-            ops = UtilVerbs.convertHapiCallsToEthereumCalls(
-                    Stream.of(given, when, then).flatMap(Arrays::stream).toList());
+            ops.addAll(UtilVerbs.convertHapiCallsToEthereumCalls(
+                Stream.of(given, when, then).flatMap(Arrays::stream).toList()));
         }
 
         try {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -367,7 +367,7 @@ public class HapiSpec implements Runnable {
                 ops.addAll(createEthereumAccountForSpec(this));
             }
             ops.addAll(UtilVerbs.convertHapiCallsToEthereumCalls(
-                Stream.of(given, when, then).flatMap(Arrays::stream).toList()));
+                    Stream.of(given, when, then).flatMap(Arrays::stream).toList()));
         }
 
         try {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
@@ -16,7 +16,7 @@
 
 package com.hedera.services.bdd.spec.utilops;
 
-import static com.hedera.services.bdd.spec.utilops.UtilStateChange.initializeEthereumAccountForSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilStateChange.createEthereumAccountForSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilStateChange.isEthereumAccountCreatedForSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.convertHapiCallsToEthereumCalls;
 
@@ -33,7 +33,7 @@ public class CustomSpecAssert extends UtilOp {
     public static void allRunFor(final HapiSpec spec, final List<HapiSpecOperation> ops) {
         if (spec.isUsingEthCalls()) {
             if (!isEthereumAccountCreatedForSpec(spec)) {
-                initializeEthereumAccountForSpec(spec);
+                ops.addAll(createEthereumAccountForSpec(spec));
             }
             executeEthereumOps(spec, ops);
         } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
@@ -82,7 +82,7 @@ public class UtilStateChange {
     private static List<HapiSpecOperation> createEthereumAccount(final String secp256k1Key, final String txnName) {
         final var newSpecKey = new NewSpecKey(secp256k1Key).shape(secp256k1Shape);
         final var cryptoTransfer = new HapiCryptoTransfer(
-            tinyBarsFromAccountToAlias(GENESIS, secp256k1Key, 20 * ONE_MILLION_HBARS))
+                        tinyBarsFromAccountToAlias(GENESIS, secp256k1Key, 20 * ONE_MILLION_HBARS))
                 .via(txnName)
                 .payingWith(GENESIS);
         return List.of(newSpecKey, cryptoTransfer);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
@@ -16,7 +16,6 @@
 
 package com.hedera.services.bdd.spec.utilops;
 
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_RECEIVER;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_SENDER;
@@ -26,6 +25,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_RECEIVER_SOURC
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
 
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.assertions.StateChange;
 import com.hedera.services.bdd.spec.assertions.StorageChange;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -71,37 +72,20 @@ public class UtilStateChange {
         return additions;
     }
 
-    public static void initializeEthereumAccountForSpec(final HapiSpec spec) {
-        createEthereumAccount(spec, SECP_256K1_SOURCE_KEY, DEFAULT_CONTRACT_SENDER, "senderCreation");
-        createEthereumAccount(spec, SECP_256K1_RECEIVER_SOURCE_KEY, DEFAULT_CONTRACT_RECEIVER, "receiverCreation");
+    public static List<HapiSpecOperation> createEthereumAccountForSpec(final HapiSpec spec) {
+        final var acc1 = createEthereumAccount(SECP_256K1_SOURCE_KEY, DEFAULT_CONTRACT_SENDER);
+        final var acc2 = createEthereumAccount(SECP_256K1_RECEIVER_SOURCE_KEY, DEFAULT_CONTRACT_RECEIVER);
         specToInitializedEthereumAccount.putIfAbsent(spec.getSuitePrefix() + spec.getName(), true);
+        return Stream.concat(acc1.stream(), acc2.stream()).toList();
     }
 
-    private static void createEthereumAccount(
-            final HapiSpec spec, final String secp256k1Key, final String accountName, final String txnName) {
+    private static List<HapiSpecOperation> createEthereumAccount(final String secp256k1Key, final String txnName) {
         final var newSpecKey = new NewSpecKey(secp256k1Key).shape(secp256k1Shape);
         final var cryptoTransfer = new HapiCryptoTransfer(
-                        tinyBarsFromAccountToAlias(GENESIS, secp256k1Key, 20 * ONE_MILLION_HBARS))
+            tinyBarsFromAccountToAlias(GENESIS, secp256k1Key, 20 * ONE_MILLION_HBARS))
                 .via(txnName)
                 .payingWith(GENESIS);
-        final var idLookup = getTxnRecord(txnName).andAllChildRecords().assertingNothing();
-
-        newSpecKey.execFor(spec);
-        cryptoTransfer.execFor(spec);
-        idLookup.execFor(spec);
-
-        final var children = idLookup.getChildRecords();
-        for (int i = 0, n = children.size(); i < n; i++) {
-            final var childRecord = idLookup.getChildRecord(i);
-            final var autoCreatedId = childRecord.getReceipt().getAccountID();
-            if (autoCreatedId.getAccountNum() > 1000L) {
-                log.info("Auto-created {} 0.0.{}", accountName, autoCreatedId.getAccountNum());
-                final var registry = spec.registry();
-                registry.saveAccountId(accountName, autoCreatedId);
-                registry.saveKey(accountName, registry.getKey(secp256k1Key));
-                break;
-            }
-        }
+        return List.of(newSpecKey, cryptoTransfer);
     }
 
     public static boolean isEthereumAccountCreatedForSpec(final HapiSpec spec) {


### PR DESCRIPTION
**Description**:
Fixing `MAX_CHILD_RECORDS_EXCEEDED` exception when executing tests that are converted to Ethereum.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/12012

**Notes for reviewer**:
The bug was not caused by https://github.com/hashgraph/hedera-services/pull/10944 - it was revealed by it. Till now we were short-circuiting `GenesisRecordsConsensusHook.process` but after https://github.com/hashgraph/hedera-services/pull/10944 was merged we started actually executing the method.

The tests that were converted to Ethereum were throwing `MAX_CHILD_RECORDS_EXCEEDED`. The reason for that is the 
`UtilStateChange.initializeEthereumAccountForSpec`(now `createEthereumAccountForSpec`) method with a combination of `GenesisRecordsConsensusHook.process`.

The `process` method is creating a lot of system accounts. We are marking all the records created from that with `UNLIMITED_CHILD_RECORDS` which bypass the `MAX_CHILD_RECORDS_EXCEEDED` check. The problem is that when we execute the `GenesisRecordsConsensusHook.process` it's executed together, I assume, with the system accounts creation. And since the `GenesisRecordsConsensusHook.process` is not a special process it's not marked as `UNLIMITED_CHILD_RECORDS` we are checking for `MAX_CHILD_RECORDS_EXCEEDED`. The counter is not skipping the `UNLIMITED_CHILD_RECORDS` and we are exceeding the limit and throwing the error.

I was thinking about changing the counting logic so we can skip all the `UNLIMITED_CHILD_RECORDS` records but I think it would be easier and simpler if we don't execute directly the accounts from`GenesisRecordsConsensusHook.process` and we just return them and add them as part of the test's operations.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
