### PR TITLE
feat: Direct call w/o value to system accounts [0.0.361-0.0.750] change output

### DIFF
--- a/hedera-node/docs/system-accounts-operations.md
+++ b/hedera-node/docs/system-accounts-operations.md
@@ -134,7 +134,7 @@ _Please note that the expected behavior described in this section is valid if th
      - success, if the address is a contract, and we are using the correct ABI;
      - success with no op, if there is no contract;
      - fail, if the address is a contract, and we are **not** using the correct ABI.
-   - **Hedera:** success with no op.
+   - **Hedera:** success with no op. (with all gas consumed)
 
 | Address                            | Calls in Ethereum (ABI)                                                                                                                                                            | Calls in Hedera (ABI)                                                                                        |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -171,6 +171,7 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
     private void handleNonExtantSystemAccount(
             @NonNull final MessageFrame frame, @NonNull final OperationTracer tracer) {
         final PrecompileContractResult result = PrecompileContractResult.success(Bytes.EMPTY);
+        frame.decrementRemainingGas(frame.getRemainingGas());
         finishPrecompileExecution(frame, result, PRECOMPILE, (ActionSidecarContentTracer) tracer);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -171,7 +171,7 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
     private void handleNonExtantSystemAccount(
             @NonNull final MessageFrame frame, @NonNull final OperationTracer tracer) {
         final PrecompileContractResult result = PrecompileContractResult.success(Bytes.EMPTY);
-        frame.decrementRemainingGas(frame.getRemainingGas());
+        frame.clearGasRemaining();
         finishPrecompileExecution(frame, result, PRECOMPILE, (ActionSidecarContentTracer) tracer);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -112,6 +112,7 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
     @Override
     public void start(@NonNull final MessageFrame frame, @NonNull final OperationTracer tracer) {
         final var codeAddress = frame.getContractAddress();
+        final var evmPrecompile = precompiles.get(codeAddress);
         // This must be done first as the system contract address range overlaps with system
         // accounts. Note that unlike EVM precompiles, we do allow sending value "to" Hedera
         // system contracts because they sometimes require fees greater than be reasonably
@@ -130,12 +131,14 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
                 return;
             }
 
-            handleNonExtantSystemAccount(frame, tracer);
-            return;
+            if (evmPrecompile == null) {
+                handleNonExtantSystemAccount(frame, tracer);
+
+                return;
+            }
         }
 
         // Handle evm precompiles
-        final var evmPrecompile = precompiles.get(codeAddress);
         if (evmPrecompile != null) {
             doExecutePrecompile(evmPrecompile, frame, tracer);
             return;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -265,9 +265,6 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
             @NonNull final MessageFrame frame, @NonNull final OperationTracer operationTracer) {
         if (transfersValue(frame)) {
             doHalt(frame, INVALID_FEE_SUBMITTED, operationTracer);
-        } else if (precompiles.get(codeAddress) == null) {
-            final PrecompileContractResult result = PrecompileContractResult.success(Bytes.EMPTY);
-            finishPrecompileExecution(frame, result, PRECOMPILE, (ActionSidecarContentTracer) operationTracer);
         }
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -112,7 +112,6 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
     @Override
     public void start(@NonNull final MessageFrame frame, @NonNull final OperationTracer tracer) {
         final var codeAddress = frame.getContractAddress();
-        final var evmPrecompile = precompiles.get(codeAddress);
         // This must be done first as the system contract address range overlaps with system
         // accounts. Note that unlike EVM precompiles, we do allow sending value "to" Hedera
         // system contracts because they sometimes require fees greater than be reasonably
@@ -124,9 +123,10 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
             return;
         }
 
+        final var evmPrecompile = precompiles.get(codeAddress);
         // Check to see if the code address is a system account and possibly halt
         if (addressChecks.isSystemAccount(codeAddress)) {
-            doHaltIfInvalidSystemCall(codeAddress, frame, tracer);
+            doHaltIfInvalidSystemCall(frame, tracer);
             if (alreadyHalted(frame)) {
                 return;
             }
@@ -262,9 +262,7 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
     }
 
     private void doHaltIfInvalidSystemCall(
-            @NonNull final Address codeAddress,
-            @NonNull final MessageFrame frame,
-            @NonNull final OperationTracer operationTracer) {
+            @NonNull final MessageFrame frame, @NonNull final OperationTracer operationTracer) {
         if (transfersValue(frame)) {
             doHalt(frame, INVALID_FEE_SUBMITTED, operationTracer);
         } else if (precompiles.get(codeAddress) == null) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
@@ -58,7 +58,6 @@ import static com.hedera.services.bdd.suites.contract.Utils.nonMirrorAddrWith;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.utils.contracts.ErrorMessageResult.errorMessageResult;
 import static com.hedera.services.bdd.suites.utils.contracts.SimpleBytesResult.bigIntResult;
-
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
@@ -66,7 +65,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FEE_SU
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
@@ -554,8 +554,7 @@ public class Evm46ValidationSuite extends HapiSuite {
                 .then(getTxnRecord("callToSystemAddress")
                         .hasPriority(recordWith()
                                 .status(SUCCESS)
-                                .contractCallResult(
-                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))));
+                                .contractCallResult(resultWith().gasUsed(GAS_LIMIT_FOR_CALL))));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4263,8 +4263,11 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                             .setCallingContract(
                                                                     spec.registry()
                                                                             .getContractId(contract))
-                                                            .setGas(3870552)
-                                                            .setRecipientContract(childId)
+                                                            .setGas(3870609)
+                                                            .setTargetedAddress(
+                                                                    ByteString.fromHex(
+                                                                            String.valueOf(expectedCreate2Address)
+                                                                                    .substring(2)))
                                                             .setGasUsed(44936)
                                                             .setValue(tcValue)
                                                             .setOutput(EMPTY)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4587,7 +4587,7 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                 .setCallOperationType(CallOperationType.OP_CALL)
                                                 .setGas(978936)
-                                                .setGasUsed(3172)
+                                                .setGasUsed(963748)
                                                 .setOutput(EMPTY)
                                                 /*
                                                    For EVM v0.34 use this code block instead:
@@ -4609,6 +4609,7 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                                 .encodeCallWithArgs(BigInteger.valueOf(234))
                                                                 .array()))
                                                 .setGas(960576)
+                                                .setGasUsed(960576)
                                                 .setRecipientContract(ContractID.newBuilder()
                                                         .setContractNum(0)
                                                         .build())

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4263,11 +4263,8 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                             .setCallingContract(
                                                                     spec.registry()
                                                                             .getContractId(contract))
-                                                            .setGas(3870609)
-                                                            .setTargetedAddress(
-                                                                    ByteString.fromHex(
-                                                                            String.valueOf(expectedCreate2Address)
-                                                                                    .substring(2)))
+                                                            .setGas(3870552)
+                                                            .setRecipientContract(childId)
                                                             .setGasUsed(44936)
                                                             .setValue(tcValue)
                                                             .setOutput(EMPTY)
@@ -4590,7 +4587,7 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                 .setCallingAccount(TxnUtils.asId(GENESIS, spec))
                                                 .setCallOperationType(CallOperationType.OP_CALL)
                                                 .setGas(978936)
-                                                .setGasUsed(18360)
+                                                .setGasUsed(3172)
                                                 .setOutput(EMPTY)
                                                 /*
                                                    For EVM v0.34 use this code block instead:
@@ -5111,7 +5108,7 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                             .setRecipientContract(
                                                                     spec.registry()
                                                                             .getContractId(create2Factory))
-                                                            .setGasUsed(80135)
+                                                            .setGasUsed(80193)
                                                             .setOutput(EMPTY)
                                                             .setInput(
                                                                     encodeFunctionCall(
@@ -5126,7 +5123,7 @@ public class TraceabilitySuite extends SidecarAwareHapiSuite {
                                                             .setCallingContract(
                                                                     spec.registry()
                                                                             .getContractId(create2Factory))
-                                                            .setGas(3870609)
+                                                            .setGas(3870552)
                                                             // recipient should be the
                                                             // original hollow account id as
                                                             // a contract


### PR DESCRIPTION
Direct call w/o value to system accounts [0.0.361-0.0.750] result in precompile error

### **Description**:
Executing a ContractCall w/o value to system account in the range[0.0.361-0.0.750) result in PRECOMPILE_ERROR
`Expected result:` The call should `succeed` with `no-op`.

### **Steps to reproduce**

1. Create an account
2. Execute ContractCall to 0.0.629 using the account from step1.
3. `Expected` result: The call should succeed with no-op.
4. `Actual` result: The call fails with PRECOMPILE_ERROR

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/11033
Fixes #
https://github.com/hashgraph/hedera-services/issues/11033

Fixes #

### **Notes for reviewer**
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This is achieved by adding a new function called `handleNonExtantSystemAccount`. It will: 

>  //    Create an empty/successful result object
> `PrecompileContractResult result = PrecompileContractResult.success(Bytes.EMPTY);`
> //    Pass it to the existing **finishPrecompileExecution** function that mutates the **frame** object with the required values.
> `finishPrecompileExecution(frame, result, PRECOMPILE, (ActionSidecarContentTracer) tracer);`

We call this new function in `CustomMessageCallProcessor.java` -> `start`, when: 

> - We don't have a Hedera system contract (precompile) with this input address **codeAddress** -> `systemContracts.containsKey(codeAddress)` returns `false`
> - the input **codeAddress** for the frame is from the reserved system accounts rage [0.0.0-0.0.750) -> `addressChecks.isSystemAccount` returns `true`
> - we don't have a holt event
> - we don't have a EVM precompile with this input address
> 