### PR TITLE
chore: Add validations for `CryptoTransfer`

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/Validations.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/Validations.java
@@ -16,8 +16,12 @@
 
 package com.hedera.node.app.spi.validation;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.TokenID;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -71,6 +75,16 @@ public final class Validations {
                     responseCodeEnum == null ? ResponseCodeEnum.INVALID_ACCOUNT_ID : responseCodeEnum);
         }
         return result;
+    }
+
+    /**
+     * Performs a "pure" check for a given token ID. If the token ID is not in the body, is null, or is invalid, a {@link PreCheckException} is thrown.
+     */
+    public static void validateTokenId(@Nullable final TokenID tokenID) throws PreCheckException {
+        validateTruePreCheck(tokenID != null, INVALID_TOKEN_ID);
+        validateTruePreCheck(tokenID.shardNum() >= 0, INVALID_TOKEN_ID);
+        validateTruePreCheck(tokenID.realmNum() >= 0, INVALID_TOKEN_ID);
+        validateTruePreCheck(tokenID.tokenNum() > 0, INVALID_TOKEN_ID);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -39,6 +39,7 @@ import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.spi.key.KeyUtils.isValid;
 import static com.hedera.node.app.spi.validation.AttributeValidator.isKeyRemoval;
+import static com.hedera.node.app.spi.validation.Validations.validateTokenId;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
@@ -92,6 +93,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         requireNonNull(txn);
         final var op = txn.tokenUpdateOrThrow();
         validateTruePreCheck(op.hasToken(), INVALID_TOKEN_ID);
+        validateTokenId(op.tokenOrThrow());
         if (op.hasFeeScheduleKey()) {
             validateTruePreCheck(isValid(op.feeScheduleKey()), INVALID_CUSTOM_FEE_SCHEDULE_KEY);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -670,7 +670,7 @@ public class TokenTransactSpecs extends HapiSuite {
                 .then(
                         cryptoTransfer(moving(1L, "some").between(DEFAULT_PAYER, SENTINEL_ACCOUNT))
                                 .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                                .hasPrecheck(INVALID_ACCOUNT_ID),
                         cryptoTransfer(moving(100_000_000_000_000L, SENTINEL_ACCOUNT)
                                         .between(DEFAULT_PAYER, FUNDING))
                                 .signedBy(DEFAULT_PAYER)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -243,7 +243,7 @@ public class TokenUpdateSpecs extends HapiSuite {
                                 .fee(ONE_HBAR)
                                 .payingWith(PAYER)
                                 .signedBy(PAYER)
-                                .hasKnownStatus(INVALID_TOKEN_ID),
+                                .hasPrecheck(INVALID_TOKEN_ID),
                         tokenUpdate("1.2.3")
                                 .fee(ONE_HBAR)
                                 .payingWith(PAYER)


### PR DESCRIPTION
Fixes #12817 
- Updated validations for tokenID and accountID
- Testing will be done with the [PR](https://github.com/hashgraph/hedera-services/pull/12811) changes to allow submitting invalid IDs