### PR TITLE
fix: unit test marker file writing collision

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MarkerFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MarkerFileWriter.java
@@ -107,16 +107,12 @@ public class MarkerFileWriter {
         markerFilesWritten.computeIfAbsent(filename, key -> {
             final Path markerFile = markerFileDirectory.resolve(filename);
             try {
-                // Prevent any other writer for the same string to check and write the file at the same time.
-                // The cost of acquiring the lock is no worse than the file system calls.
-                synchronized (filename) {
-                    if (Files.exists(markerFile)) {
-                        failedToWriteMarkerFileLogger.error(
-                                LogMarker.ERROR.getMarker(), "Marker file already exists: {}", markerFile);
-                        return true;
-                    }
-                    Files.createFile(markerFile);
+                if (Files.exists(markerFile)) {
+                    failedToWriteMarkerFileLogger.error(
+                            LogMarker.ERROR.getMarker(), "Marker file already exists: {}", markerFile);
+                    return true;
                 }
+                Files.createFile(markerFile);
             } catch (final IOException e) {
                 failedToWriteMarkerFileLogger.error(
                         LogMarker.EXCEPTION.getMarker(), "Failed to create marker file: {}", markerFile, e);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MarkerFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MarkerFileWriter.java
@@ -107,12 +107,16 @@ public class MarkerFileWriter {
         markerFilesWritten.computeIfAbsent(filename, key -> {
             final Path markerFile = markerFileDirectory.resolve(filename);
             try {
-                if (Files.exists(markerFile)) {
-                    failedToWriteMarkerFileLogger.error(
-                            LogMarker.ERROR.getMarker(), "Marker file already exists: {}", markerFile);
-                    return true;
+                // Prevent any other writer for the same string to check and write the file at the same time.
+                // The cost of acquiring the lock is no worse than the file system calls.
+                synchronized (filename) {
+                    if (Files.exists(markerFile)) {
+                        failedToWriteMarkerFileLogger.error(
+                                LogMarker.ERROR.getMarker(), "Marker file already exists: {}", markerFile);
+                        return true;
+                    }
+                    Files.createFile(markerFile);
                 }
-                Files.createFile(markerFile);
             } catch (final IOException e) {
                 failedToWriteMarkerFileLogger.error(
                         LogMarker.EXCEPTION.getMarker(), "Failed to create marker file: {}", markerFile, e);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MarkerFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/MarkerFileWriter.java
@@ -107,6 +107,11 @@ public class MarkerFileWriter {
         markerFilesWritten.computeIfAbsent(filename, key -> {
             final Path markerFile = markerFileDirectory.resolve(filename);
             try {
+                if (Files.exists(markerFile)) {
+                    failedToWriteMarkerFileLogger.error(
+                            LogMarker.ERROR.getMarker(), "Marker file already exists: {}", markerFile);
+                    return true;
+                }
                 Files.createFile(markerFile);
             } catch (final IOException e) {
                 failedToWriteMarkerFileLogger.error(

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformTest.java
@@ -38,6 +38,8 @@ public abstract class PlatformTest {
 
     /**
      * Temporary directory provided by JUnit
+     * <p>
+     * Do not make this value static, otherwise all test methods will share the same temp directory.
      */
     @TempDir
     protected Path tempDir;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
@@ -26,7 +26,6 @@ import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.eventhandling.EventConfig_;
 import com.swirlds.platform.test.PlatformTest;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,9 +44,9 @@ class ConsensusTests extends PlatformTest {
      */
     private final int NUM_ITER = 1;
 
-    private AtomicBoolean ignoreNoSuperMajorityMarkerFile = new AtomicBoolean(false);
-    private AtomicBoolean ignoreNoJudgesMarkerFile = new AtomicBoolean(false);
-    private AtomicBoolean ignoreCoinRoundMarkerFile = new AtomicBoolean(false);
+    private boolean ignoreNoSuperMajorityMarkerFile = false;
+    private boolean ignoreNoJudgesMarkerFile = false;
+    private boolean ignoreCoinRoundMarkerFile = false;
 
     @BeforeAll
     public static void initConfig() {
@@ -56,13 +55,13 @@ class ConsensusTests extends PlatformTest {
 
     @AfterEach
     void checkForMarkerFiles() {
-        if (!ignoreNoSuperMajorityMarkerFile.getAndSet(false)) {
+        if (!ignoreNoSuperMajorityMarkerFile) {
             assertMarkerFile(ConsensusImpl.NO_SUPER_MAJORITY_MARKER_FILE, false);
         }
-        if (!ignoreNoJudgesMarkerFile.getAndSet(false)) {
+        if (!ignoreNoJudgesMarkerFile) {
             assertMarkerFile(ConsensusImpl.NO_JUDGES_MARKER_FILE, false);
         }
-        if (!ignoreCoinRoundMarkerFile.getAndSet(false)) {
+        if (!ignoreCoinRoundMarkerFile) {
             assertMarkerFile(ConsensusImpl.COIN_ROUND_MARKER_FILE, false);
         }
     }
@@ -142,9 +141,10 @@ class ConsensusTests extends PlatformTest {
                 .setParams(modifyParams(params))
                 .setIterations(NUM_ITER)
                 .run();
-        // Some forking tests make too many forkers.  When there is  > 1/3 nodes forking, no super majority can result.
-        // This is expected, so ignore the marker file generated for these tests.
-        ignoreNoSuperMajorityMarkerFile.set(true);
+        // Some forking tests make too many forkers.  When there is  > 1/3 nodes forking, both no super majority and
+        // possibly no judges can result. This is expected, so ignore the marker file generated for these tests.
+        ignoreNoSuperMajorityMarkerFile = true;
+        ignoreNoJudgesMarkerFile = true;
     }
 
     @ParameterizedTest


### PR DESCRIPTION
**Description**:
* added file system test for existence of marker file before writing.  
* added atomic boolean flags for when to ignore marker file checks at the end of consensus tests.  


Fixes #12857 
