### PR TITLE
chore: 12862 Added null checks to  Hash.serialize and Hash.deserializ…

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
@@ -183,6 +183,8 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
      */
     @Override
     public void serialize(final SerializableDataOutputStream out) throws IOException {
+        assert digestType != null;
+        assert value != null;
         out.writeInt(digestType.id());
         out.writeByteArray(value);
     }
@@ -205,6 +207,10 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
 
         this.digestType = digestType;
         this.value = in.readByteArray(digestType.digestLength());
+
+        if (value == null) {
+            throw new BadIOException("Invalid hash value read from the stream");
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleInternalDigestProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleInternalDigestProvider.java
@@ -65,7 +65,7 @@ public class MerkleInternalDigestProvider
         for (int index = 0; index < childHashes.size(); index++) {
             final Hash childHash = childHashes.get(index);
 
-            if (childHash == null) {
+            if (childHash == null || childHash.getValue() == null) {
                 final MerkleNode childNode = node.getChild(index);
                 final String msg = String.format(
                         "Child has an unexpected null hash "


### PR DESCRIPTION
Added null checks to Hash.serialize and Hash.deserialize
Added null check for hash.value to MerkleInternalDigestProvider.handleItem.

(this is a cherry-pick of https://github.com/hashgraph/hedera-services/pull/12863)

Fixes #12862 
