### PR TITLE
fix: Revert pureChecks exception thrown in unchecked submit

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
@@ -50,21 +50,19 @@ public class NetworkUncheckedSubmitHandler implements TransactionHandler {
 
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
-        // this will never actually get called
-        // because pureChecks will always throw
         requireNonNull(context);
         throw new PreCheckException(NOT_SUPPORTED);
     }
 
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        throw new PreCheckException(NOT_SUPPORTED);
+        // nothing to do
     }
 
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // this will never actually get called
-        // because pureChecks will always throw
+        // because preHandle will always throw
         requireNonNull(context);
         throw new HandleException(NOT_SUPPORTED);
     }


### PR DESCRIPTION
The exception newly added to the unchecked submit's `pureChecks` method is causing some hapi tests to fail. Until we can get the tests updated, or perhaps permanently, this commit returns the handler behavior to its previous state.

For reference, the exception was added in PR #12748 