### PR TITLE
chore: 12862 Added null checks to `Hash.serialize` and `Hash.deserialize`

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
@@ -18,6 +18,7 @@ package com.swirlds.common.crypto;
 
 import static com.swirlds.common.utility.CommonUtils.hex;
 import static com.swirlds.common.utility.Mnemonics.generateMnemonic;
+import static java.util.Objects.requireNonNull;
 
 import com.swirlds.common.io.SerializableWithKnownLength;
 import com.swirlds.common.io.exceptions.BadIOException;
@@ -183,6 +184,8 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
      */
     @Override
     public void serialize(final SerializableDataOutputStream out) throws IOException {
+        requireNonNull(digestType, "digestType");
+        requireNonNull(value, "value");
         out.writeInt(digestType.id());
         out.writeByteArray(value);
     }
@@ -205,6 +208,10 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
 
         this.digestType = digestType;
         this.value = in.readByteArray(digestType.digestLength());
+
+        if (value == null) {
+            throw new BadIOException("Invalid hash value read from the stream");
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleInternalDigestProvider.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleInternalDigestProvider.java
@@ -65,7 +65,7 @@ public class MerkleInternalDigestProvider
         for (int index = 0; index < childHashes.size(); index++) {
             final Hash childHash = childHashes.get(index);
 
-            if (childHash == null) {
+            if (childHash == null || childHash.getValue() == null) {
                 final MerkleNode childNode = node.getChild(index);
                 final String msg = String.format(
                         "Child has an unexpected null hash "


### PR DESCRIPTION
**Description**:

Added null checks to  Hash.serialize and Hash.deserialize. Added null check for hash.value to `MerkleInternalDigestProvider.handleItem`

**Related issue(s)**:

Fixes #12862  
