### PR TITLE
fix: 12901: Backport the fix for 11966 to release 0.49

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbTableConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbTableConfig.java
@@ -57,13 +57,6 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
         public static final int ORIGINAL = 1;
     }
 
-    /**
-     * Since {@code com.swirlds.platform.Browser} populates settings, and it is loaded before any
-     * application classes that might instantiate a data source, the {@link ConfigurationHolder}
-     * holder will have been configured by the time this static initializer runs.
-     */
-    private static final MerkleDbConfig config = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
-
     private static final FieldDefinition FIELD_TABLECONFIG_HASHVERSION =
             new FieldDefinition("hashVersion", FieldType.UINT32, false, true, false, 1);
     private static final FieldDefinition FIELD_TABLECONFIG_DIGESTTYPEID =
@@ -116,7 +109,7 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
     /**
      * Max number of keys that can be stored in a table.
      */
-    private long maxNumberOfKeys = config.maxNumOfKeys();
+    private long maxNumberOfKeys = 0;
 
     /**
      * Threshold where we switch from storing internal hashes in ram to storing them on disk. If it is 0 then everything
@@ -124,7 +117,7 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
      * we swap from ram to disk. This allows a tree where the lower levels of the tree nodes hashes are in ram and the
      * upper larger less changing layers are on disk.
      */
-    private long hashesRamToDiskThreshold = config.hashesRamToDiskThreshold();
+    private long hashesRamToDiskThreshold = 0;
 
     /**
      * Indicates whether to store indexes on disk or in Java heap/off-heap memory.
@@ -162,6 +155,7 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
             @NonNull final KeySerializer<K> keySerializer,
             final short valueVersion,
             @NonNull final ValueSerializer<V> valueSerializer) {
+        // Mandatory fields
         this.hashVersion = hashVersion;
         this.hashType = hashType;
         this.keyVersion = keyVersion;
@@ -170,14 +164,27 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
         this.valueVersion = valueVersion;
         Objects.requireNonNull(valueSerializer, "Null value serializer");
         this.valueSerializer = valueSerializer;
+
+        // Optional hints, may be set explicitly using setters later. Defaults are loaded from
+        // MerkleDb configuration
+        final MerkleDbConfig dbConfig = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
+        maxNumberOfKeys = dbConfig.maxNumOfKeys();
+        hashesRamToDiskThreshold = dbConfig.hashesRamToDiskThreshold();
     }
 
     public MerkleDbTableConfig(final ReadableSequentialData in) {
-        // Defaults
+        // Defaults. If a field is missing in the input, a default protobuf value is used
+        // (zero, false, null, etc.) rather than a default value from MerkleDb config. The
+        // config is used for defaults when a new table config is created, but when an
+        // existing config is loaded, only values from the input must be used (even if some
+        // of them are protobuf default and aren't present)
         hashVersion = 0;
         hashType = DigestType.SHA_384;
         keyVersion = 0;
         valueVersion = 0;
+        preferDiskBasedIndices = false;
+        maxNumberOfKeys = 0;
+        hashesRamToDiskThreshold = 0;
 
         while (in.hasRemaining()) {
             final int tag = in.readVarInt(false);
@@ -211,6 +218,9 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
         Objects.requireNonNull(hashType, "Null or wrong hash type");
         Objects.requireNonNull(keySerializer, "Null or unknown key serializer");
         Objects.requireNonNull(valueSerializer, "Null or unknown value serializer");
+        if (maxNumberOfKeys <= 0) {
+            throw new IllegalArgumentException("Missing or wrong max number of keys");
+        }
     }
 
     public int pbjSizeInBytes() {
@@ -359,7 +369,7 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
     }
 
     /**
-     * Specifies the max number of keys that can be stored in the table.
+     * Specifies the max number of keys that can be stored in the table. Must be greater than zero.
      *
      * @param maxNumberOfKeys
      *      Max number of keys
@@ -367,6 +377,9 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
      *      This table config object
      */
     public MerkleDbTableConfig<K, V> maxNumberOfKeys(final long maxNumberOfKeys) {
+        if (maxNumberOfKeys <= 0) {
+            throw new IllegalArgumentException("Max number of keys must be greater than 0");
+        }
         this.maxNumberOfKeys = maxNumberOfKeys;
         return this;
     }
@@ -383,7 +396,7 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
     }
 
     /**
-     * Specifies internal hashes RAM/disk threshold.
+     * Specifies internal hashes RAM/disk threshold. Must be greater or equal to zero.
      *
      * @param hashesRamToDiskThreshold
      *      Internal hashes RAM/disk threshold
@@ -391,6 +404,9 @@ public final class MerkleDbTableConfig<K extends VirtualKey, V extends VirtualVa
      *      This table config object
      */
     public MerkleDbTableConfig<K, V> hashesRamToDiskThreshold(final long hashesRamToDiskThreshold) {
+        if (hashesRamToDiskThreshold < 0) {
+            throw new IllegalArgumentException("Hashes RAM/disk threshold must be greater or equal to 0");
+        }
         this.hashesRamToDiskThreshold = hashesRamToDiskThreshold;
         return this;
     }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -74,7 +74,7 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
         @Positive @ConfigProperty(defaultValue = "500000000") long maxNumOfKeys,
-        @Min(0) @ConfigProperty(defaultValue = "0") long hashesRamToDiskThreshold,
+        @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,
         @Min(1) @ConfigProperty(defaultValue = "3") int compactionThreads,
         @ConstraintMethod("minNumberOfFilesInCompactionValidation") @ConfigProperty(defaultValue = "8")
                 int minNumberOfFilesInCompaction,

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTableConfigTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTableConfigTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.merkledb;
+
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import com.swirlds.common.config.singleton.ConfigurationHolder;
+import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.common.crypto.DigestType;
+import com.swirlds.merkledb.config.MerkleDbConfig;
+import com.swirlds.merkledb.test.fixtures.ExampleFixedSizeVirtualValue;
+import com.swirlds.merkledb.test.fixtures.ExampleFixedSizeVirtualValueSerializer;
+import com.swirlds.merkledb.test.fixtures.ExampleLongKeyFixedSize;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class MerkleDbTableConfigTest {
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
+    }
+
+    @Test
+    void deserializeDefaultsTest() throws IOException {
+        final MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> tableConfig =
+                new MerkleDbTableConfig<>(
+                        (short) 1, DigestType.SHA_384,
+                        (short) 1, new ExampleLongKeyFixedSize.Serializer(),
+                        (short) 1, new ExampleFixedSizeVirtualValueSerializer());
+
+        final MerkleDbConfig dbConfig = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
+        Assertions.assertEquals(dbConfig.maxNumOfKeys(), tableConfig.getMaxNumberOfKeys());
+        Assertions.assertEquals(dbConfig.hashesRamToDiskThreshold(), tableConfig.getHashesRamToDiskThreshold());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> tableConfig.maxNumberOfKeys(0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> tableConfig.maxNumberOfKeys(-1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> tableConfig.hashesRamToDiskThreshold(-1));
+
+        // Default protobuf value, will not be serialized
+        tableConfig.hashesRamToDiskThreshold(0);
+
+        final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        try (final WritableStreamingData out = new WritableStreamingData(bout)) {
+            tableConfig.writeTo(out);
+        }
+
+        final byte[] arr = bout.toByteArray();
+        final MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> restored;
+        try (final ReadableStreamingData in = new ReadableStreamingData(arr)) {
+            restored = new MerkleDbTableConfig<>(in);
+        }
+
+        Assertions.assertEquals(dbConfig.maxNumOfKeys(), restored.getMaxNumberOfKeys());
+        // Fields that aren't deserialized should have default protobuf values (e.g. zero), not
+        // default MerkleDbConfig values
+        Assertions.assertEquals(0, restored.getHashesRamToDiskThreshold());
+    }
+}


### PR DESCRIPTION
Fix summary: simplified version of the original fix https://github.com/hashgraph/hedera-services/pull/11973, only changes for `MerkleDbTableConfig` and `MerkleDbConfig` are backported.

Fixes: https://github.com/hashgraph/hedera-services/issues/12901
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
