### PR TITLE
chore: 11772 Refactored `AddressBook` - it's no longer a `MerkleLeaf`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateChildIndices.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateChildIndices.java
@@ -28,7 +28,6 @@ public final class StateChildIndices {
     public static final int SPECIAL_FILES = 7;
     public static final int SCHEDULE_TXS = 8;
     public static final int RECORD_STREAM_RUNNING_HASH = 9;
-    public static final int LEGACY_ADDRESS_BOOK = 10;
     public static final int CONTRACT_STORAGE = 11;
     public static final int STAKING_INFO = 12;
     public static final int PAYER_RECORDS_OR_CONSOLIDATED_FCQ = 13;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -901,7 +901,6 @@ class ServicesStateTest extends ResponsibleVMapUser {
         subject.setMetadata(metadata);
         subject.setDeserializedStateVersion(10);
         subject.setPlatform(platform);
-        given(platform.getAddressBook()).willReturn(addressBook);
 
         given(networkContext.copy()).willReturn(networkContext);
         given(specialFiles.copy()).willReturn(specialFiles);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -330,7 +330,6 @@ class ServicesStateTest extends ResponsibleVMapUser {
     @Test
     void getsAccountIdAsExpected() {
         // setup:
-        subject.setChild(StateChildIndices.LEGACY_ADDRESS_BOOK, addressBook);
         subject.setPlatform(platform);
         given(platform.getAddressBook()).willReturn(addressBook);
 
@@ -896,7 +895,6 @@ class ServicesStateTest extends ResponsibleVMapUser {
 
     @Test
     void copiesNonNullChildren() {
-        subject.setChild(StateChildIndices.LEGACY_ADDRESS_BOOK, addressBook);
         subject.setChild(StateChildIndices.NETWORK_CTX, networkContext);
         subject.setChild(StateChildIndices.SPECIAL_FILES, specialFiles);
         // and:
@@ -905,7 +903,6 @@ class ServicesStateTest extends ResponsibleVMapUser {
         subject.setPlatform(platform);
         given(platform.getAddressBook()).willReturn(addressBook);
 
-        given(addressBook.copy()).willReturn(addressBook);
         given(networkContext.copy()).willReturn(networkContext);
         given(specialFiles.copy()).willReturn(specialFiles);
         given(metadata.copy()).willReturn(metadata);
@@ -920,7 +917,6 @@ class ServicesStateTest extends ResponsibleVMapUser {
         assertSame(metadata, copy.getMetadata());
         verify(metadata).copy();
         // and:
-        assertSame(addressBook, copy.addressBook());
         assertSame(networkContext, copy.networkCtx());
         assertSame(specialFiles, copy.specialFiles());
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBook.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBook.java
@@ -17,10 +17,11 @@
 package com.swirlds.platform.system.address;
 
 import com.swirlds.base.state.MutabilityException;
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.crypto.Hashable;
+import com.swirlds.common.io.SelfSerializable;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
-import com.swirlds.common.merkle.MerkleLeaf;
-import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.system.address.internal.AddressBookIterator;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -40,7 +41,7 @@ import java.util.Set;
  * The Address of every known member of the swirld. The getters are public and the setters aren't, so it is read-only
  * for apps. When enableEventStreaming is set to be true, the memo field is required and should be unique.
  */
-public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>, MerkleLeaf {
+public class AddressBook implements Iterable<Address>, SelfSerializable, Hashable {
 
     /**
      * The index of a node ID that does not exist in the address book.
@@ -129,6 +130,11 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     private int numberWithWeight;
 
     /**
+     * The hash of this address book.
+     */
+    private Hash hash;
+
+    /**
      * Create an empty address book.
      */
     public AddressBook() {
@@ -140,7 +146,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      */
     @SuppressWarnings("CopyConstructorMissesField")
     private AddressBook(@NonNull final AddressBook that) {
-        super(that);
         Objects.requireNonNull(that, "AddressBook must not be null");
 
         for (final Address address : that) {
@@ -195,7 +200,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      * @return this object
      */
     public AddressBook setRound(final long round) {
-        throwIfImmutable();
         this.round = round;
         return this;
     }
@@ -304,7 +308,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      */
     @NonNull
     public AddressBook setNextNodeId(@NonNull final NodeId newNextNodeId) {
-        throwIfImmutable();
         Objects.requireNonNull(newNextNodeId);
         if (newNextNodeId.compareTo(this.nextNodeId) < 0) {
             throw new IllegalArgumentException("The provided nextNodeId %s is less than the current nextNodeId %s"
@@ -386,7 +389,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      */
     public void updateWeight(@NonNull final NodeId id, final long weight) {
         Objects.requireNonNull(id, "NodeId is null");
-        throwIfImmutable();
         final Address address = getAddress(id);
         if (weight < 0) {
             throw new IllegalArgumentException("weight must be nonnegative");
@@ -459,7 +461,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      */
     @NonNull
     public AddressBook add(@NonNull final Address address) {
-        throwIfImmutable();
         Objects.requireNonNull(address, "address must not be null");
 
         if (addresses.containsKey(address.getNodeId())) {
@@ -481,7 +482,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     @NonNull
     public AddressBook remove(@NonNull final NodeId id) {
         Objects.requireNonNull(id, "NodeId is null");
-        throwIfImmutable();
 
         final Address address = addresses.remove(id);
 
@@ -505,8 +505,6 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      * Remove all addresses from the address book.
      */
     public void clear() {
-        throwIfImmutable();
-
         addresses.clear();
         publicKeyToId.clear();
         nodeIndices.clear();
@@ -521,21 +519,10 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      * Create a copy of this address book. The copy is always mutable, and the original maintains its original
      * mutability status.
      */
-    @Override
+    // @Override
     @NonNull
     public AddressBook copy() {
         return new AddressBook(this);
-    }
-
-    /**
-     * Seal this address book, making it irreversibly immutable. Immutable address books may still be copied.
-     *
-     * @return this object
-     */
-    @NonNull
-    public AddressBook seal() {
-        setImmutable(true);
-        return this;
     }
 
     /**
@@ -619,6 +606,22 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
         return Objects.equals(addresses, that.addresses)
                 && getRound() == that.getRound()
                 && Objects.equals(getNextNodeId(), that.getNextNodeId());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Hash getHash() {
+        return hash;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setHash(final Hash hash) {
+        this.hash = hash;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterDiffGeneratorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterDiffGeneratorTests.java
@@ -53,7 +53,7 @@ class RosterDiffGeneratorTests {
         final RosterDiffGenerator generator = new RosterDiffGenerator(platformContext);
 
         final AddressBook roster = new RandomAddressBookGenerator(random).build();
-        platformContext.getCryptography().digestSync(roster);
+        roster.setHash(platformContext.getCryptography().digestSync(roster));
 
         // First round added should yield a null diff
         assertNull(generator.generateDiff(new UpdatedRoster(0, roster)));
@@ -85,7 +85,7 @@ class RosterDiffGeneratorTests {
 
         AddressBook previousRoster =
                 new RandomAddressBookGenerator(random).setSize(8).build();
-        platformContext.getCryptography().digestSync(previousRoster);
+        previousRoster.setHash(platformContext.getCryptography().digestSync(previousRoster));
         assertNull(generator.generateDiff(new UpdatedRoster(0, previousRoster)));
 
         for (int round = 1; round < 1000; round++) {
@@ -160,7 +160,7 @@ class RosterDiffGeneratorTests {
                     membershipChanged || (modifiedNodeCount != 0 && modifyConsensusWeight);
             final boolean rosterIsIdentical = !membershipChanged && !consensusWeightChanged && modifiedNodeCount == 0;
 
-            platformContext.getCryptography().digestSync(newRoster);
+            newRoster.setHash(platformContext.getCryptography().digestSync(newRoster));
 
             final UpdatedRoster updatedRoster = new UpdatedRoster(round, newRoster);
             final RosterDiff diff = generator.generateDiff(updatedRoster);


### PR DESCRIPTION
**Description**:

This is a clean up. `AddressBook` objects are no longer used as `MerkleLeaf` objects, because `AddressBook` is now a part of `PlatformState` object which, in it's turn, is a  `MerkleLeaf`. 

So, `AddressBook` should no longer implement this interface. It only needs to be  `Iterable`, `SelfSerializable`, and Hashable.

**Related issue(s)**:

Fixes #11772  

