### PR TITLE
fix: consensus writes marker before exception

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
@@ -651,6 +651,9 @@ public class ConsensusImpl extends ThreadSafeConsensusInfo implements Consensus 
         final List<EventImpl> judges = roundElections.findAllJudges();
         final long decidedRoundNumber = rounds.getElectionRoundNumber();
 
+        // Check for no judges or super majority conditions.
+        checkJudges(judges, decidedRoundNumber);
+
         // update the round and generation values since fame has been decided for a new round
         rounds.currentElectionDecided();
 
@@ -690,9 +693,6 @@ public class ConsensusImpl extends ThreadSafeConsensusInfo implements Consensus 
         final long nonExpiredThreshold = ancientMode.selectIndicator(
                 getMinRoundGeneration(),
                 Math.max(previousRoundNonExpired, decidedRoundNumber - config.roundsExpired() + 1));
-
-        // Check for no judges or super majority conditions.
-        checkJudges(judges, decidedRoundNumber);
 
         return new ConsensusRound(
                 addressBook,


### PR DESCRIPTION
**Description**:
This PR moves the checking of judges and writing of marker files before the exception thrown in the issue.   The whole marker file writing endeavor was necessitated by this issue.  This completes the story arc on the platform side.  The next time this exception occurs we will have written a marker file and then it is up to JRS to respond to the presence of the marker file. 

Fixes #11633 
