### PR TITLE
fix: use default KYC status `false` for token w/o key

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EvmTokenUtil.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/EvmTokenUtil.java
@@ -87,7 +87,7 @@ public class EvmTokenUtil {
                 },
                 () -> {
                     info.setKycKey(new EvmKey());
-                    info.setDefaultKycStatus(true);
+                    info.setDefaultKycStatus(false);
                 });
 
         final var supplyCandidate = token.supplyKey();


### PR DESCRIPTION
**Description**:
 - Closes #12505 