### PR TITLE
fix(PBJ): upgrade to PBJ v0.8.7 to address bugs

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -58,7 +58,7 @@ moduleInfo {
     version("com.google.jimfs", "1.2")
     version("com.google.protobuf", protobufVersion)
     version("com.google.protobuf.util", protobufVersion)
-    version("com.hedera.pbj.runtime", "0.8.5")
+    version("com.hedera.pbj.runtime", "0.8.7")
     version("com.squareup.javapoet", "1.13.0")
     version("com.sun.jna", "5.12.1")
     version("dagger", daggerVersion)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -157,6 +157,6 @@ dependencyResolutionManagement {
         version("grpc-proto", "1.45.1")
         version("hapi-proto", hapiProtoVersion)
 
-        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.5")
+        plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.8.7")
     }
 }


### PR DESCRIPTION
**Description**:
Upgrading PBJ to address the following two bugs:
* https://github.com/hashgraph/pbj/issues/236 - `Bytes` ignored the `start`/`length` of a wrapped sub-array.
* https://github.com/hashgraph/pbj/issues/246 - `ReadableSequentialDataInputStream.read()` violated the `InputStream.read()` contract.

Both the bugs are fixed in PBJ v0.8.7.

**Related issue(s)**:

Fixes https://github.com/hashgraph/pbj/issues/246

**Notes for reviewer**:
PBJ v0.8.7 is released: https://central.sonatype.com/artifact/com.hedera.pbj/pbj-runtime/versions

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
