### PR TITLE
fix: misc EET expectations

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/mod/BodyIdClearingStrategy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/mod/BodyIdClearingStrategy.java
@@ -75,7 +75,7 @@ public class BodyIdClearingStrategy extends IdClearingStrategy<TxnModification> 
                     ExpectedResponse.atIngest(ACCOUNT_ID_DOES_NOT_EXIST)),
             entry("proto.ContractCreateTransactionBody.fileID", ExpectedResponse.atConsensus(INVALID_FILE_ID)),
             entry("proto.ContractCreateTransactionBody.auto_renew_account_id", ExpectedResponse.atConsensus(SUCCESS)),
-            entry("proto.ContractUpdateTransactionBody.contractID", ExpectedResponse.atConsensus(INVALID_CONTRACT_ID)),
+            entry("proto.ContractUpdateTransactionBody.contractID", ExpectedResponse.atIngest(INVALID_CONTRACT_ID)),
             entry("proto.ContractUpdateTransactionBody.auto_renew_account_id", ExpectedResponse.atConsensus(SUCCESS)),
             entry("proto.ContractUpdateTransactionBody.staked_account_id", ExpectedResponse.atConsensus(SUCCESS)),
             entry("proto.FileAppendTransactionBody.fileID", ExpectedResponse.atIngest(INVALID_FILE_ID)),
@@ -92,7 +92,7 @@ public class BodyIdClearingStrategy extends IdClearingStrategy<TxnModification> 
                     "proto.ContractDeleteTransactionBody.transferContractID",
                     ExpectedResponse.atConsensus(OBTAINER_REQUIRED)),
             entry("proto.ConsensusCreateTopicTransactionBody.autoRenewAccount", ExpectedResponse.atConsensus(SUCCESS)),
-            entry("proto.ConsensusUpdateTopicTransactionBody.topicID", ExpectedResponse.atConsensus(INVALID_TOPIC_ID)),
+            entry("proto.ConsensusUpdateTopicTransactionBody.topicID", ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
             entry("proto.ConsensusUpdateTopicTransactionBody.autoRenewAccount", ExpectedResponse.atConsensus(SUCCESS)),
             entry("proto.ConsensusDeleteTopicTransactionBody.topicID", ExpectedResponse.atConsensus(INVALID_TOPIC_ID)),
             entry(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2051Spec.java
@@ -86,7 +86,7 @@ public class Issue2051Spec extends HapiSuite {
                                 .transfer(TRANSFER)
                                 .hasKnownStatus(ACCOUNT_DELETED),
                         getTxnRecord(DELETE_TXN).logged(),
-                        getAccountBalance(PAYER).hasTinyBars(approxChangeFromSnapshot(SNAPSHOT, -9384399, 1000)));
+                        getAccountBalance(PAYER).hasTinyBars(approxChangeFromSnapshot(SNAPSHOT, -9384399, 10000)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -583,7 +583,7 @@ public class TokenManagementSpecs extends HapiSuite {
 
     @HapiTest
     public HapiSpec wipeIdVariantsTreatedAsExpected() {
-        return defaultHapiSpec("updateIdVariantsTreatedAsExpected")
+        return defaultHapiSpec("wipeIdVariantsTreatedAsExpected")
                 .given(
                         newKeyNamed("wipeKey"),
                         cryptoCreate("holder").maxAutomaticTokenAssociations(2),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -575,9 +575,10 @@ public class TokenManagementSpecs extends HapiSuite {
                         cryptoCreate("autoRenewAccount"),
                         tokenCreate("t").adminKey("adminKey"))
                 .when()
-                .then(submitModified(
-                        withSuccessivelyVariedBodyIds(),
-                        () -> tokenUpdate("t").autoRenewPeriod(7776000L).autoRenewAccount("autoRenewAccount")));
+                .then(submitModified(withSuccessivelyVariedBodyIds(), () -> tokenUpdate("t")
+                        .autoRenewPeriod(7776000L)
+                        .autoRenewAccount("autoRenewAccount")
+                        .signedBy(DEFAULT_PAYER, "adminKey", "autoRenewAccount")));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Update expected responses for several specs using `BodyIdClearingStrategy`.
 - Add explicit admin key signature to `tokenUpdate()` in `updateIdVariantsTreatedAsExpected()` (it was removed from default signers [here](https://github.com/hashgraph/hedera-services/pull/12396) in anticipation of HIP-540). 
 - Increase allowed variation for `CryptoDelete` fee in spec `Issue2051Spec.transferAccountCannotBeDeleted()`.