### PR TITLE
fix: Enable aliases in TokenWipe as per mono service

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -140,7 +140,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
                 tokensConfig);
         final var acct = validated.account();
         final var token = validated.token();
-        final var unaliasedAccountId = acct.accountIdOrThrow();
+        final var unaliasedId = acct.accountIdOrThrow();
 
         final long newTotalSupply;
         final long newAccountBalance;
@@ -168,7 +168,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
                 validateTrue(nft != null, INVALID_NFT_ID);
 
                 final var nftOwner = nft.ownerId();
-                validateTrue(Objects.equals(nftOwner, unaliasedAccountId), ACCOUNT_DOES_NOT_OWN_WIPED_NFT);
+                validateTrue(Objects.equals(nftOwner, unaliasedId), ACCOUNT_DOES_NOT_OWN_WIPED_NFT);
             }
 
             // Check that the new token balance will not be negative
@@ -177,7 +177,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
 
             // Remove the NFTs
             nftSerialNums.forEach(serialNum -> {
-                if (!unaliasedAccountId.equals(token.treasuryAccountId())) {
+                if (!unaliasedId.equals(token.treasuryAccountId())) {
                     removeFromList(
                             NftID.newBuilder()
                                     .serialNumber(serialNum)
@@ -191,9 +191,8 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
             });
         }
 
-        final Account.Builder updatedAcctBuilder = requireNonNull(
-                        accountStore.getAliasedAccountById(unaliasedAccountId))
-                .copyBuilder();
+        final Account.Builder updatedAcctBuilder =
+                requireNonNull(accountStore.getAccountById(unaliasedId)).copyBuilder();
         // Update the NFT count for the account
         updatedAcctBuilder.numberOwnedNfts(acct.numberOwnedNfts() - nftSerialNums.size());
         // Finally, record all the changes

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -140,6 +140,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
                 tokensConfig);
         final var acct = validated.account();
         final var token = validated.token();
+        final var unaliasedAccountId = acct.accountIdOrThrow();
 
         final long newTotalSupply;
         final long newAccountBalance;
@@ -167,7 +168,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
                 validateTrue(nft != null, INVALID_NFT_ID);
 
                 final var nftOwner = nft.ownerId();
-                validateTrue(Objects.equals(nftOwner, accountId), ACCOUNT_DOES_NOT_OWN_WIPED_NFT);
+                validateTrue(Objects.equals(nftOwner, unaliasedAccountId), ACCOUNT_DOES_NOT_OWN_WIPED_NFT);
             }
 
             // Check that the new token balance will not be negative
@@ -176,7 +177,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
 
             // Remove the NFTs
             nftSerialNums.forEach(serialNum -> {
-                if (!accountId.equals(token.treasuryAccountId())) {
+                if (!unaliasedAccountId.equals(token.treasuryAccountId())) {
                     removeFromList(
                             NftID.newBuilder()
                                     .serialNumber(serialNum)
@@ -190,8 +191,9 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
             });
         }
 
-        final Account.Builder updatedAcctBuilder =
-                requireNonNull(accountStore.get(accountId)).copyBuilder();
+        final Account.Builder updatedAcctBuilder = requireNonNull(
+                        accountStore.getAliasedAccountById(unaliasedAccountId))
+                .copyBuilder();
         // Update the NFT count for the account
         updatedAcctBuilder.numberOwnedNfts(acct.numberOwnedNfts() - nftSerialNums.size());
         // Finally, record all the changes
@@ -245,15 +247,15 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
             @NonNull final TokensConfig tokensConfig) {
         validateTrue(fungibleWipeCount > -1, INVALID_WIPING_AMOUNT);
 
-        final var account =
-                TokenHandlerHelper.getIfUsable(accountId, accountStore, expiryValidator, INVALID_ACCOUNT_ID);
+        final var account = TokenHandlerHelper.getIfUsableForAliasedId(
+                accountId, accountStore, expiryValidator, INVALID_ACCOUNT_ID);
 
         validator.validateWipe(fungibleWipeCount, nftSerialNums, tokensConfig);
 
         final var token = TokenHandlerHelper.getIfUsable(tokenId, tokenStore);
         validateTrue(token.wipeKey() != null, ResponseCodeEnum.TOKEN_HAS_NO_WIPE_KEY);
 
-        final var accountRel = TokenHandlerHelper.getIfUsable(accountId, tokenId, tokenRelStore);
+        final var accountRel = TokenHandlerHelper.getIfUsable(account.accountIdOrThrow(), tokenId, tokenRelStore);
         if (token.hasKycKey()) {
             validateTrue(accountRel.kycGranted(), ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractLogAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractLogAsserts.java
@@ -55,7 +55,7 @@ public class ContractLogAsserts extends BaseErroringAssertsProvider<ContractLogi
     public ContractLogAsserts ecdsaAliasStartingAt(String aliasKey, int start) {
         registerProvider((spec, o) -> {
             byte[] data = dataFrom(o);
-            ByteString alias = spec.registry().aliasIdFor(aliasKey).getAlias();
+            ByteString alias = spec.registry().keyAliasIdFor(aliasKey).getAlias();
             byte[] expected = recoverAddressFromPubKey(alias.substring(2).toByteArray());
             byte[] actual = Arrays.copyOfRange(data, start, start + 20);
             Assertions.assertArrayEquals(expected, actual, "Bad alias in log data, starting at byte " + start);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -671,7 +671,7 @@ public class HapiSpecRegistry {
         return get(name, AccountID.class);
     }
 
-    public AccountID aliasIdFor(String keyName) {
+    public AccountID keyAliasIdFor(String keyName) {
         final var key = get(keyName, Key.class);
         return AccountID.newBuilder().setAlias(key.toByteString()).build();
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -336,7 +336,7 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
             } else if (referenceType == ReferenceType.LITERAL_ACCOUNT_ALIAS) {
                 id = AccountID.newBuilder().setAlias(rawAlias).build();
             } else {
-                id = spec.registry().aliasIdFor(aliasKeySource);
+                id = spec.registry().keyAliasIdFor(aliasKeySource);
             }
             config = b -> b.setAccountID(id);
             accountID = Optional.of(id);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -192,6 +192,14 @@ public class TxnUtils {
                         : lookUpAccount(lookupSpec, s));
     }
 
+    public static AccountID aliase(final String s, final HapiSpec lookupSpec) {
+        return isIdLiteral(s)
+                ? asAccount(s)
+                : (lookupSpec.registry().hasAccountId(s)
+                        ? lookupSpec.registry().getAccountID(s)
+                        : lookUpAccount(lookupSpec, s));
+    }
+
     private static AccountID lookUpAccount(final HapiSpec spec, final String alias) {
         final var key = spec.registry().getKey(alias);
         final var lookedUpKey = spec.registry().getKey(alias).toByteString().toStringUtf8();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -192,14 +192,6 @@ public class TxnUtils {
                         : lookUpAccount(lookupSpec, s));
     }
 
-    public static AccountID aliase(final String s, final HapiSpec lookupSpec) {
-        return isIdLiteral(s)
-                ? asAccount(s)
-                : (lookupSpec.registry().hasAccountId(s)
-                        ? lookupSpec.registry().getAccountID(s)
-                        : lookUpAccount(lookupSpec, s));
-    }
-
     private static AccountID lookUpAccount(final HapiSpec spec, final String alias) {
         final var key = spec.registry().getKey(alias);
         final var lookedUpKey = spec.registry().getKey(alias).toByteString().toStringUtf8();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -17,6 +17,9 @@
 package com.hedera.services.bdd.spec.transactions;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.explicitBytesOf;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.randomUppercase;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate.WELL_KNOWN_INITIAL_SUPPLY;
 import static com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate.WELL_KNOWN_NFT_SUPPLY_KEY;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
@@ -25,7 +28,9 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.CONSTRUCTOR;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
@@ -37,6 +42,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
@@ -85,6 +91,7 @@ import com.hedera.services.bdd.spec.transactions.token.HapiTokenUpdateNfts;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenWipe;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.spec.transactions.util.HapiUtilPrng;
+import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.EthereumTransactionBody;
@@ -126,6 +133,23 @@ public class TxnVerbs {
     @SafeVarargs
     public static HapiCryptoTransfer cryptoTransfer(Function<HapiSpec, TransferList>... providers) {
         return new HapiCryptoTransfer(providers);
+    }
+
+    public static HapiSpecOperation newAliasedAccount(@NonNull final String account) {
+        final var creationTxn = "transfer" + randomUppercase(5);
+        final var aliasKey = "receiverKey" + randomUppercase(5);
+        return withOpContext((spec, opLog) -> {
+            CustomSpecAssert.allRunFor(
+                    spec,
+                    newKeyNamed(aliasKey),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(DEFAULT_PAYER, aliasKey, ONE_HUNDRED_HBARS))
+                            .via(creationTxn),
+                    getTxnRecord(creationTxn).andAllChildRecords().exposingCreationsTo(creations -> {
+                        final var createdId = HapiPropertySource.asAccount(creations.getFirst());
+                        spec.registry().saveAccountId(account, createdId);
+                        spec.registry().saveKey(account, spec.registry().getKey(aliasKey));
+                    }));
+        });
     }
 
     public static HapiCryptoTransfer cryptoTransfer(BiConsumer<HapiSpec, CryptoTransferTransactionBody.Builder> def) {
@@ -246,7 +270,7 @@ public class TxnVerbs {
                 mintToken(
                         token,
                         IntStream.range(0, initialMint)
-                                .mapToObj(i -> ByteString.copyFromUtf8(TxnUtils.randomUppercase(i + 1)))
+                                .mapToObj(i -> ByteString.copyFromUtf8(randomUppercase(i + 1)))
                                 .toList()));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoTransfer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoTransfer.java
@@ -349,7 +349,7 @@ public class HapiCryptoTransfer extends HapiTxnOp<HapiCryptoTransfer> {
             final String from, final String to, final long amount) {
         return spec -> {
             final var fromId = asId(from, spec);
-            final var toId = spec.registry().aliasIdFor(to);
+            final var toId = spec.registry().keyAliasIdFor(to);
             return xFromTo(fromId, toId, amount);
         };
     }
@@ -368,7 +368,7 @@ public class HapiCryptoTransfer extends HapiTxnOp<HapiCryptoTransfer> {
                         .build();
                 return xFromTo(fromId, toAccId, amount);
             }
-            final var toId = spec.registry().aliasIdFor(to);
+            final var toId = spec.registry().keyAliasIdFor(to);
             return xFromTo(fromId, toId, amount);
         };
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenAssociate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenAssociate.java
@@ -20,7 +20,6 @@ import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMA
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
@@ -164,7 +163,7 @@ public class HapiTokenAssociate extends HapiTxnOp<HapiTokenAssociate> {
         if (account != null && referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else if (account != null) {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         TokenAssociateTransactionBody opBody = spec.txns()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDissociate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDissociate.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static java.util.stream.Collectors.toList;
 
@@ -95,7 +94,7 @@ public class HapiTokenDissociate extends HapiTxnOp<HapiTokenDissociate> {
         if (referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         final TokenDissociateTransactionBody opBody = spec.txns()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 
 import com.google.common.base.MoreObjects;
@@ -95,7 +94,7 @@ public class HapiTokenFreeze extends HapiTxnOp<HapiTokenFreeze> {
         if (referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         final var tId = TxnUtils.asTokenId(token, spec);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
@@ -65,6 +65,7 @@ public class HapiTokenKycGrant extends HapiTxnOp<HapiTokenKycGrant> {
         this.referenceType = referenceType;
         if (referenceType == ReferenceType.ALIAS_KEY_NAME) {
             this.alias = reference;
+            this.account = null;
         } else {
             this.account = reference;
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 
 import com.google.common.base.MoreObjects;
@@ -65,7 +64,6 @@ public class HapiTokenKycGrant extends HapiTxnOp<HapiTokenKycGrant> {
         this.referenceType = referenceType;
         if (referenceType == ReferenceType.ALIAS_KEY_NAME) {
             this.alias = reference;
-            this.account = null;
         } else {
             this.account = reference;
         }
@@ -93,7 +91,7 @@ public class HapiTokenKycGrant extends HapiTxnOp<HapiTokenKycGrant> {
         if (referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         final var tId = TxnUtils.asTokenId(token, spec);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 
 import com.google.common.base.MoreObjects;
@@ -93,7 +92,7 @@ public class HapiTokenKycRevoke extends HapiTxnOp<HapiTokenKycRevoke> {
         if (referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         final var tId = TxnUtils.asTokenId(token, spec);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 
 import com.google.common.base.MoreObjects;
@@ -95,7 +94,7 @@ public class HapiTokenUnfreeze extends HapiTxnOp<HapiTokenUnfreeze> {
         if (referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         final var tId = TxnUtils.asTokenId(token, spec);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 
 import com.google.common.base.MoreObjects;
@@ -130,7 +129,7 @@ public class HapiTokenWipe extends HapiTxnOp<HapiTokenWipe> {
         if (referenceType == ReferenceType.REGISTRY_NAME) {
             aId = TxnUtils.asId(account, spec);
         } else {
-            aId = asIdForKeyLookUp(alias, spec);
+            aId = spec.registry().keyAliasIdFor(alias);
             account = asAccountString(aId);
         }
         final TokenWipeAccountTransactionBody opBody = spec.txns()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -264,7 +264,7 @@ public class EthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8())))
                                                 .ethereumHash(ByteString.copyFrom(
@@ -597,7 +597,7 @@ public class EthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8())))
                                                 .ethereumHash(ByteString.copyFrom(
@@ -698,7 +698,7 @@ public class EthereumSuite extends HapiSuite {
                                                                         eventSignatureOf("Info(address,address)")))))
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8())))
                                                 .ethereumHash(ByteString.copyFrom(
@@ -912,7 +912,7 @@ public class EthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8())))
                                                 .ethereumHash(ByteString.copyFrom(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumV1SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumV1SecurityModelSuite.java
@@ -358,7 +358,7 @@ public class EthereumV1SecurityModelSuite extends HapiSuite {
                                                 .logs(inOrder())
                                                 .senderId(spec.registry()
                                                         .getAccountID(spec.registry()
-                                                                .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                 .getAlias()
                                                                 .toStringUtf8())))
                                         .ethereumHash(ByteString.copyFrom(
@@ -416,7 +416,7 @@ public class EthereumV1SecurityModelSuite extends HapiSuite {
                                                 .logs(inOrder())
                                                 .senderId(spec.registry()
                                                         .getAccountID(spec.registry()
-                                                                .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                 .getAlias()
                                                                 .toStringUtf8())))
                                         .ethereumHash(ByteString.copyFrom(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -250,7 +250,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8())))
                                                 .ethereumHash(ByteString.copyFrom(
@@ -289,7 +289,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                                                         List.of(eventSignatureOf("Info(uint256)")))))
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8())))
                                                 .ethereumHash(ByteString.copyFrom(
@@ -356,7 +356,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8()))
                                                         .create1EvmAddress(
@@ -402,7 +402,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8()))
                                                         .create1EvmAddress(
@@ -454,7 +454,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
                                                         .logs(inOrder())
                                                         .senderId(spec.registry()
                                                                 .getAccountID(spec.registry()
-                                                                        .aliasIdFor(SECP_256K1_SOURCE_KEY)
+                                                                        .keyAliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias()
                                                                         .toStringUtf8()))
                                                         .create1EvmAddress(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -19,6 +19,8 @@ package com.hedera.services.bdd.suites.token;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.ED25519;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
@@ -48,12 +50,18 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccoun
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccountWithAlias;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromToWithAlias;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.HIGHLY_NON_DETERMINISTIC_FEES;
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.A_TOKEN;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.TOKEN_A_CREATE;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.VALID_ALIAS;
+import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.CIVILIAN;
+import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.TRANSFER_TXN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
@@ -75,6 +83,7 @@ import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.Frozen;
 import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.Unfrozen;
 import static com.hederahashgraph.api.proto.java.TokenKycStatus.Granted;
 import static com.hederahashgraph.api.proto.java.TokenKycStatus.Revoked;
+import static com.hederahashgraph.api.proto.java.TokenSupplyType.FINITE;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
@@ -83,6 +92,7 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
@@ -120,6 +130,7 @@ public class TokenManagementSpecs extends HapiSuite {
                 supplyMgmtSuccessCasesWork(),
                 wipeAccountFailureCasesWork(),
                 wipeAccountSuccessCasesWork(),
+                wipeAccountWithAliasesWork(),
                 supplyMgmtFailureCasesWork(),
                 burnTokenFailsDueToInsufficientTreasuryBalance(),
                 frozenTreasuryCannotBeMintedOrBurned(),
@@ -188,8 +199,18 @@ public class TokenManagementSpecs extends HapiSuite {
                         tokenUnfreezeWithAlias(PRIMARY, partyAlias).hasPrecheck(INVALID_ACCOUNT_ID),
 
                         // wipe won't happen if the kyc key exists and kyc not granted
-                        grantTokenKycWithAlias(PRIMARY, partyAlias).hasPrecheck(INVALID_ACCOUNT_ID),
-                        wipeTokenAccountWithAlias(PRIMARY, partyAlias, 1).hasPrecheck(INVALID_ACCOUNT_ID))
+                        grantTokenKycWithAlias(PRIMARY, partyAlias).hasPrecheck(INVALID_ACCOUNT_ID).logged(),
+                        withOpContext((spec, opLog) -> {
+                                    final var aliasAccount = spec.registry()
+                                            .getAccountID(spec.registry()
+                                                    .getKey(partyAlias)
+                                                    .toByteString()
+                                                    .toStringUtf8());
+                                    final var op1 = tokenAssociate(asAccountString(aliasAccount), PRIMARY);
+                                    // Only wipe works with alias. But because it is not associated it fails here
+                                    final var op2 = wipeTokenAccountWithAlias(PRIMARY, partyAlias, 1);
+                                    allRunFor(spec, op1, op2);
+                        }))
                 .then();
     }
 
@@ -458,6 +479,52 @@ public class TokenManagementSpecs extends HapiSuite {
                         getTokenInfo(wipeableToken).hasTotalSupply(500),
                         getAccountBalance(TOKEN_TREASURY).hasTokenBalance(wipeableToken, 500),
                         getTxnRecord(WIPE_TXN).logged());
+    }
+
+    @HapiTest
+    public HapiSpec wipeAccountWithAliasesWork() {
+        final var initialTokenSupply = 1000;
+        return defaultHapiSpec("wipeAccountWithAliasesWork")
+                .given(
+                        newKeyNamed(VALID_ALIAS),
+                        newKeyNamed("wipeKey"),
+                        cryptoCreate(TOKEN_TREASURY).balance(10 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(CIVILIAN).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(2),
+                        tokenCreate(A_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .supplyType(FINITE)
+                                .initialSupply(initialTokenSupply)
+                                .maxSupply(10L * initialTokenSupply)
+                                .wipeKey("wipeKey")
+                                .treasury(TOKEN_TREASURY)
+                                .via(TOKEN_A_CREATE),
+                        getTxnRecord(TOKEN_A_CREATE).hasNewTokenAssociation(A_TOKEN, TOKEN_TREASURY),
+                        tokenAssociate(CIVILIAN, A_TOKEN),
+                        cryptoTransfer(moving(10, A_TOKEN).between(TOKEN_TREASURY, CIVILIAN)),
+                        getAccountInfo(CIVILIAN)
+                                .hasToken(relationshipWith(A_TOKEN).balance(10)))
+                .when(
+                        cryptoTransfer(
+                                        movingHbar(10L).between(CIVILIAN, VALID_ALIAS),
+                                        moving(5, A_TOKEN).between(CIVILIAN, VALID_ALIAS))
+                                .signedBy(DEFAULT_PAYER, CIVILIAN)
+                                .via(TRANSFER_TXN),
+                        getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged(),
+                        getAliasedAccountInfo(VALID_ALIAS)
+                                .has(accountWith().balance(10L))
+                                .hasToken(relationshipWith(A_TOKEN).balance(5L))
+                                .logged())
+                .then(
+                        wipeTokenAccountWithAlias(A_TOKEN, VALID_ALIAS, 4).via(WIPE_TXN),
+                        getAliasedAccountInfo(VALID_ALIAS)
+                                .has(accountWith().balance(10L))
+                                .hasToken(relationshipWith(A_TOKEN).balance(1L))
+                                .logged(),
+                        wipeTokenAccountWithAlias(A_TOKEN, VALID_ALIAS, 0),
+                        getAliasedAccountInfo(VALID_ALIAS)
+                                .has(accountWith().balance(10L))
+                                .hasToken(relationshipWith(A_TOKEN).balance(1L))
+                                .logged());
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -204,7 +204,7 @@ public class TokenManagementSpecs extends HapiSuite {
                         grantTokenKyc(PRIMARY, partyAlias),
                         cryptoTransfer(moving(1, PRIMARY).between(TOKEN_TREASURY, partyAlias))
                                 .signedBy(DEFAULT_PAYER, TOKEN_TREASURY),
-                        // Only wipe works with alias. But because it is not associated it fails here
+                        // Only wipe works with alias apart from CryptoTransfer
                         wipeTokenAccountWithAlias(PRIMARY, partyAlias, 1))
                 .then();
     }


### PR DESCRIPTION
Fixes #12953 

- In mono-service we have aliases enabled for only `TokenWipe` transaction apart from `CryptoTransfer` transaction.
- Enable the same in mod service