### PR TITLE
fix: always migrate token default KYC granted as `false`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenStateTranslator.java
@@ -72,7 +72,11 @@ public final class TokenStateTranslator {
                 .maxSupply(token.maxSupply())
                 .paused(token.isPaused())
                 .accountsFrozenByDefault(token.accountsAreFrozenByDefault())
-                .accountsKycGrantedByDefault(token.accountsKycGrantedByDefault())
+                // KYC is never granted by default as that would defeat the purpose;
+                // but for tokens without a KYC key, mono-service would leave this
+                // as true for convenience. There's no reason to do that in mod-service,
+                // so just set every migrated token to false.
+                .accountsKycGrantedByDefault(false)
                 .customFees(convertMonoCustomFees(token.customFeeSchedule()));
         if (token.hasAdminKey()) {
             builder.adminKey(PbjConverter.asPbjKey(token.getAdminKey()));

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenStateTranslator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/TokenStateTranslator.java
@@ -72,11 +72,7 @@ public final class TokenStateTranslator {
                 .maxSupply(token.maxSupply())
                 .paused(token.isPaused())
                 .accountsFrozenByDefault(token.accountsAreFrozenByDefault())
-                // KYC is never granted by default as that would defeat the purpose;
-                // but for tokens without a KYC key, mono-service would leave this
-                // as true for convenience. There's no reason to do that in mod-service,
-                // so just set every migrated token to false.
-                .accountsKycGrantedByDefault(false)
+                .accountsKycGrantedByDefault(token.accountsKycGrantedByDefault())
                 .customFees(convertMonoCustomFees(token.customFeeSchedule()));
         if (token.hasAdminKey()) {
             builder.adminKey(PbjConverter.asPbjKey(token.getAdminKey()));

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/InitialModServiceTokenSchema.java
@@ -425,7 +425,14 @@ public class InitialModServiceTokenSchema extends Schema {
             log.info("BBM: starting tokens (both fungible and non-fungible)");
             var tokensToState = ctx.newStates().<TokenID, Token>get(TOKENS_KEY);
             MerkleMapLike.from(tFs).forEachNode((entityNum, merkleToken) -> {
-                var toToken = TokenStateTranslator.tokenFromMerkle(merkleToken);
+                var toToken = TokenStateTranslator.tokenFromMerkle(merkleToken)
+                        .copyBuilder()
+                        // KYC is never granted by default as that would defeat the purpose;
+                        // but for tokens without a KYC key, mono-service would leave this
+                        // as true for convenience. There's no reason to do that in mod-service,
+                        // so just set every migrated token to false.
+                        .accountsKycGrantedByDefault(false)
+                        .build();
                 tokensToState.put(
                         TokenID.newBuilder().tokenNum(entityNum.longValue()).build(), toToken);
             });


### PR DESCRIPTION
**Description**:
 - For tokens with a KYC key, mono-service would set their default KCY granted as `true`; but mod-service uses `false` in every case.
 - Update migration code to always set KYC granted as `false`.