### PR TITLE
fix: hapi test expectations

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/mod/BodyIdClearingStrategy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/mod/BodyIdClearingStrategy.java
@@ -94,10 +94,10 @@ public class BodyIdClearingStrategy extends IdClearingStrategy<TxnModification> 
             entry("proto.ConsensusCreateTopicTransactionBody.autoRenewAccount", ExpectedResponse.atConsensus(SUCCESS)),
             entry("proto.ConsensusUpdateTopicTransactionBody.topicID", ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
             entry("proto.ConsensusUpdateTopicTransactionBody.autoRenewAccount", ExpectedResponse.atConsensus(SUCCESS)),
-            entry("proto.ConsensusDeleteTopicTransactionBody.topicID", ExpectedResponse.atConsensus(INVALID_TOPIC_ID)),
+            entry("proto.ConsensusDeleteTopicTransactionBody.topicID", ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
             entry(
                     "proto.ConsensusSubmitMessageTransactionBody.topicID",
-                    ExpectedResponse.atConsensus(INVALID_TOPIC_ID)),
+                    ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
             entry(
                     "proto.TokenCreateTransactionBody.treasury",
                     ExpectedResponse.atIngest(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/mod/BodyIdClearingStrategy.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/mod/BodyIdClearingStrategy.java
@@ -95,9 +95,7 @@ public class BodyIdClearingStrategy extends IdClearingStrategy<TxnModification> 
             entry("proto.ConsensusUpdateTopicTransactionBody.topicID", ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
             entry("proto.ConsensusUpdateTopicTransactionBody.autoRenewAccount", ExpectedResponse.atConsensus(SUCCESS)),
             entry("proto.ConsensusDeleteTopicTransactionBody.topicID", ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
-            entry(
-                    "proto.ConsensusSubmitMessageTransactionBody.topicID",
-                    ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
+            entry("proto.ConsensusSubmitMessageTransactionBody.topicID", ExpectedResponse.atIngest(INVALID_TOPIC_ID)),
             entry(
                     "proto.TokenCreateTransactionBody.treasury",
                     ExpectedResponse.atIngest(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)),


### PR DESCRIPTION
**Description**:
Fix the following failing EETs:
SubmitMessageSuite » idVariantsTreatedAsExpected
TopicDeleteSuite » idVariantsTreatedAsExpected

**Related issue(s)**:

Fixes #12985 
