### PR TITLE
perf: warm up more entities

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/RecordFinalizerBase.java
@@ -206,13 +206,17 @@ public class RecordFinalizerBase {
 
             // The NFT may not have existed before, in which case we'll use a null sender account ID
             AccountID senderAccountId;
-            final var tokenId = nftId.tokenId();
-            requireNonNull(tokenId);
-            final var token = writableTokenStore.get(tokenId);
-            requireNonNull(token);
             if (persistedNft != null) {
                 // If the NFT did not have an owner before set it to the treasury account
-                senderAccountId = persistedNft.hasOwnerId() ? persistedNft.ownerId() : token.treasuryAccountIdOrThrow();
+                if (persistedNft.hasOwnerId()) {
+                    senderAccountId = persistedNft.ownerId();
+                } else {
+                    final var tokenId = nftId.tokenId();
+                    requireNonNull(tokenId);
+                    final var token = writableTokenStore.get(tokenId);
+                    requireNonNull(token);
+                    senderAccountId = token.treasuryAccountIdOrThrow();
+                }
             } else {
                 senderAccountId = ZERO_ACCOUNT_ID;
             }
@@ -224,6 +228,10 @@ public class RecordFinalizerBase {
                 if (modifiedNft.hasOwnerId()) {
                     receiverAccountId = modifiedNft.ownerId();
                 } else {
+                    final var tokenId = nftId.tokenId();
+                    requireNonNull(tokenId);
+                    final var token = writableTokenStore.get(tokenId);
+                    requireNonNull(token);
                     receiverAccountId = token.treasuryAccountIdOrThrow();
                 }
             } else {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -171,13 +171,14 @@ public class CryptoTransferHandler implements TransactionHandler {
             }
             final List<NftTransfer> nftTransfers = tokenTransferList.nftTransfers();
             for (final NftTransfer nftTransfer : nftTransfers) {
-                warmNftTransfer(accountStore, nftStore, tokenRelationStore, tokenID, nftTransfer);
+                warmNftTransfer(accountStore, tokenStore, nftStore, tokenRelationStore, tokenID, nftTransfer);
             }
         });
     }
 
     private void warmNftTransfer(
             @NonNull final ReadableAccountStore accountStore,
+            @NonNull final ReadableTokenStore tokenStore,
             @NonNull final ReadableNftStore nftStore,
             @NonNull final ReadableTokenRelationStore tokenRelationStore,
             @NonNull final TokenID tokenID,
@@ -195,7 +196,10 @@ public class CryptoTransferHandler implements TransactionHandler {
         nftTransfer.ifReceiverAccountID(receiverAccountID -> {
             final Account receiver = accountStore.getAliasedAccountById(receiverAccountID);
             if (receiver != null) {
-                receiver.ifHeadTokenId(headTokenID -> tokenRelationStore.warm(receiverAccountID, headTokenID));
+                receiver.ifHeadTokenId(headTokenID -> {
+                    tokenRelationStore.warm(receiverAccountID, headTokenID);
+                    tokenStore.warm(headTokenID);
+                });
                 receiver.ifHeadNftId(nftStore::warm);
             }
             tokenRelationStore.warm(receiverAccountID, tokenID);


### PR DESCRIPTION
**Description**:
* for the NFT receiver account, warm up its `headToken`
* `nftChangesFrom()`: don't read the token unless it's needed

**Related issue(s)**:

Fixes #12976

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
