### PR TITLE
feat: Write tests for burn operations #12726

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
@@ -20,7 +20,6 @@ import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.logWith;
@@ -36,8 +35,6 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
 import static com.hedera.services.bdd.suites.contract.Utils.*;
-import static com.hedera.services.bdd.suites.contract.precompile.V1SecurityModelOverrides.CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS;
-import static com.hedera.services.bdd.suites.contract.precompile.V1SecurityModelOverrides.CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
@@ -702,8 +702,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
         final var amount = 99L;
         final AtomicLong fungibleNum = new AtomicLong();
 
-        return propertyPreservingHapiSpec("burnTokenWithFullPrefixAndPartialPrefixKeys")
-                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+        return defaultHapiSpec("burnTokenWithFullPrefixAndPartialPrefixKeys")
                 .given(
                         newKeyNamed(SIGNER),
                         uploadInitCode(ORDINARY_CALLS_CONTRACT),
@@ -784,8 +783,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
         final var SUPPLY_KEY = "SUPPLY_KEY";
         final var ADMIN_KEY = "ADMIN_KEY";
 
-        return propertyPreservingHapiSpec("hscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer")
-                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+        return defaultHapiSpec("hscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         cryptoCreate(ADMIN_KEY).balance(ONE_HUNDRED_HBARS),
@@ -867,8 +865,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
         final var CREATION_TX = "CREATION_TX";
         final var MULTI_KEY = "MULTI_KEY";
 
-        return propertyPreservingHapiSpec("V2SecurityHscsPrec004TokenBurnOfFungibleTokenUnits")
-                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+        return defaultHapiSpec("V2SecurityHscsPrec004TokenBurnOfFungibleTokenUnits")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(ADMIN_KEY),
@@ -955,8 +952,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
         final var CREATION_TX = "CREATION_TX";
         final var BURN_AFTER_NESTED_MINT_TX = "burnAfterNestedMint";
 
-        return propertyPreservingHapiSpec("V2SecurityHscsPrec011BurnAfterNestedMint")
-                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+        return defaultHapiSpec("V2SecurityHscsPrec011BurnAfterNestedMint")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(ADMIN_KEY),
@@ -1031,8 +1027,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
     final HapiSpec V2SecurityHscsPrec005TokenBurnOfNft() {
         final var gasUsed = 14085;
         final var CREATION_TX = "CREATION_TX";
-        return propertyPreservingHapiSpec("V2SecurityHscsPrec005TokenBurnOfNft")
-                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+        return defaultHapiSpec("V2SecurityHscsPrec005TokenBurnOfNft")
                 .given(
                         newKeyNamed(ADMIN_KEY),
                         newKeyNamed(SUPPLY_KEY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
@@ -17,21 +17,34 @@
 package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.logWith;
+import static com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers.changingFungibleBalances;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.*;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.*;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.*;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
-import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.*;
+import static com.hedera.services.bdd.suites.contract.precompile.V1SecurityModelOverrides.*;
+import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 
+import com.hedera.node.app.hapi.utils.contracts.ParsingConstants;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestSuite;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.assertions.AccountInfoAsserts;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -39,6 +52,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenType;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,7 +65,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
 
     private static final long GAS_TO_OFFER = 4_000_000L;
     private static final String TOKEN_TREASURY = "treasury";
-    private static final KeyShape TRESHOLD_KEY_SHAPE = KeyShape.threshOf(1, ED25519, CONTRACT);
+    private static final KeyShape THRESHOLD_KEY_SHAPE = KeyShape.threshOf(1, ED25519, CONTRACT);
     private static final String CONTRACT_KEY = "ContractKey";
     public static final String MINT_CONTRACT = "MintContract";
     private static final String DELEGATE_CONTRACT_KEY_NAME = "contractKey";
@@ -67,6 +81,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
     private static final String SIGNER = "anybody";
     private static final String SIGNER2 = "anybody";
     private static final String FUNGIBLE_TOKEN = "fungibleToken";
+    private static final String FUNGIBLE_TOKEN_2 = "fungibleToken2";
     private static final String SIGNER_AND_TOKEN_HAVE_NO_UPDATED_KEYS = "signerAndTokenHaveNoUpdatedKeys";
     private static final String SIGNER_BURNS_WITH_CONTRACT_ID =
             "signerBurnsAndTokenSupplyKeyHasTheIntermediaryContractId";
@@ -78,6 +93,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
     private static final String NON_FUNGIBLE_TOKEN = "nonFungibleToken";
     private static final String BURN_TOKEN = "BurnToken";
     private static final String MIXED_BURN_TOKEN = "MixedBurnToken";
+    private static final String BURN_TOKEN_WITH_EVENT = "burnTokenWithEvent";
     private static final String FIRST = "First!";
     private static final String SECOND = "Second!";
     private static final String THIRD = "Third!";
@@ -90,6 +106,10 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
             "NonFungibleTokenHasTheContractIdOnDelegateCall";
     private static final String DELEGATE_CALL_WHEN_FUNGIBLE_TOKEN_HAS_CONTRACT_ID_SIGNER_SIGNS =
             "FungibleTokenHasTheContractIdOnDelegateCall";
+    private static final String ACCOUNT_NAME = "anybody";
+    private static final String ORDINARY_CALLS_CONTRACT = "HTSCalls";
+    private static final String ADMIN_KEY = "ADMIN_KEY";
+    private static final String SUPPLY_KEY = "SUPPLY_KEY";
 
     public static void main(final String... args) {
         new ContractBurnHTSV2SecurityModelSuite().runSuiteAsync();
@@ -113,7 +133,12 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                 V2Security004FungibleTokenBurnNegative(),
                 V2Security004NonFungibleTokenBurnNegative(),
                 V2Security039FungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall(),
-                V2Security039NonFungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall());
+                V2Security039NonFungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall(),
+                V2SecurityBurnTokenWithFullPrefixAndPartialPrefixKeys(),
+                V2SecurityHscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer(),
+                V2SecurityHscsPrec004TokenBurnOfFungibleTokenUnits(),
+                V2SecurityHscsPrec011BurnAfterNestedMint(),
+                V2SecurityHscsPrec005TokenBurnOfNft());
     }
 
     @HapiTest
@@ -183,7 +208,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                         getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(initialAmount - 3 * amountToBurn),
                         // Create a key with thresh 1/2 with sigs: new ed25519 key, contractId of burnToken contract
                         newKeyNamed(TRESHOLD_KEY_CORRECT_CONTRACT_ID)
-                                .shape(TRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
+                                .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
                         // Update the token supply key to with the created key
                         tokenUpdate(FUNGIBLE_TOKEN)
                                 .supplyKey(TRESHOLD_KEY_CORRECT_CONTRACT_ID)
@@ -337,7 +362,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                         // Create a key with thresh 1/2 with sigs:  new ed25519 key, contractId of MINT_CONTRACT
                         // contract. MINT_CONTRACT is used only as a "wrong" contract id
                         newKeyNamed(TRESHOLD_KEY_WITH_SIGNER_KEY)
-                                .shape(TRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MINT_CONTRACT))),
+                                .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MINT_CONTRACT))),
                         // Update the signer of the transaction to have the threshold key with the wrong contract id
                         cryptoUpdate(SIGNER).key(TRESHOLD_KEY_WITH_SIGNER_KEY),
                         // Update the token's supply to have the threshold key with the wrong contract id
@@ -363,7 +388,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                         // Create a key with thresh 1/2 with sigs: new ed25519 key, contractId of MIXED_BURN_TOKEN
                         // contract
                         // Here the key has the contract`id of the correct contract
-                        newKeyNamed(THRESHOLD_KEY).shape(TRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
+                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
                         // Set the token's supply key to the initial one
                         tokenUpdate(FUNGIBLE_TOKEN).supplyKey(TOKEN_TREASURY).signedByPayerAnd(TOKEN_TREASURY),
                         // Update the Signer with the correct threshold key
@@ -441,7 +466,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                         // contract. MINT_CONTRACT is only used as a "wrong" contractId
                         // Here the key has the contract`id of the wrong contract
                         newKeyNamed(TRESHOLD_KEY_WITH_SIGNER_KEY)
-                                .shape(TRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MINT_CONTRACT))),
+                                .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MINT_CONTRACT))),
                         // Update the signer of the transaction to have the threshold key with the wrong contract id
                         cryptoUpdate(SIGNER).key(TRESHOLD_KEY_WITH_SIGNER_KEY),
                         // Update the token's supply to have the threshold key with the wrong contract id
@@ -467,7 +492,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                         // Create a key with thresh 1/2 with sigs: new ed25519 key, contractId of MIXED_BURN_TOKEN
                         // contract
                         // Here the key has the contract`id of the correct contract
-                        newKeyNamed(THRESHOLD_KEY).shape(TRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
+                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
                         // Set the token's supply key to the initial one
                         tokenUpdate(NON_FUNGIBLE_TOKEN)
                                 .supplyKey(TOKEN_TREASURY)
@@ -549,7 +574,7 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                         // Create a key with thresh 1/2 with sigs:  new ed25519 key, contractId of
                         // BURN_TOKEN_VIA_DELEGATE_CALL contract
                         newKeyNamed(TRESHOLD_KEY_CORRECT_CONTRACT_ID)
-                                .shape(TRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
+                                .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
                         // Update the token's supply to have the threshold key wit the wrong contract id
                         tokenUpdate(NON_FUNGIBLE_TOKEN)
                                 .supplyKey(TRESHOLD_KEY_CORRECT_CONTRACT_ID)
@@ -667,6 +692,396 @@ public class ContractBurnHTSV2SecurityModelSuite extends HapiSuite {
                                     DELEGATE_CALL_WHEN_FUNGIBLE_TOKEN_HAS_CONTRACT_ID_SIGNER_SIGNS,
                                     CONTRACT_REVERT_EXECUTED));
                 }));
+    }
+
+    @HapiTest
+    final HapiSpec V2SecurityBurnTokenWithFullPrefixAndPartialPrefixKeys() {
+        final var firstBurnTxn = "firstBurnTxn";
+        final var secondBurnTxn = "secondBurnTxn";
+        final var amount = 99L;
+        final AtomicLong fungibleNum = new AtomicLong();
+
+        return propertyPreservingHapiSpec("burnTokenWithFullPrefixAndPartialPrefixKeys")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+                .given(
+                        newKeyNamed(SIGNER),
+                        uploadInitCode(ORDINARY_CALLS_CONTRACT),
+                        contractCreate(ORDINARY_CALLS_CONTRACT),
+                        newKeyNamed(THRESHOLD_KEY)
+                                .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, ORDINARY_CALLS_CONTRACT))),
+                        cryptoCreate(ACCOUNT_NAME).balance(10 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(100)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(SIGNER)
+                                .supplyKey(THRESHOLD_KEY)
+                                .exposingCreatedIdTo(idLit -> fungibleNum.set(asDotDelimitedLongArray(idLit)[2])),
+                        tokenCreate(FUNGIBLE_TOKEN_2)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(100)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(SIGNER)
+                                .supplyKey(SIGNER)
+                                .exposingCreatedIdTo(idLit -> fungibleNum.set(asDotDelimitedLongArray(idLit)[2])))
+                .when(withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        ORDINARY_CALLS_CONTRACT,
+                                        "burnTokenCall",
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN_2))),
+                                        BigInteger.ONE,
+                                        new long[0])
+                                .via(firstBurnTxn)
+                                .payingWith(ACCOUNT_NAME)
+                                .signedBy(SIGNER)
+                                .hasKnownStatus(SUCCESS),
+                        contractCall(
+                                        ORDINARY_CALLS_CONTRACT,
+                                        "burnTokenCall",
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN))),
+                                        BigInteger.ONE,
+                                        new long[0])
+                                .via(secondBurnTxn)
+                                .payingWith(ACCOUNT_NAME)
+                                .alsoSigningWithFullPrefix(SIGNER, THRESHOLD_KEY, ACCOUNT_NAME)
+                                .hasKnownStatus(SUCCESS))))
+                .then(
+                        childRecordsCheck(
+                                firstBurnTxn,
+                                SUCCESS,
+                                recordWith()
+                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
+                        childRecordsCheck(
+                                secondBurnTxn,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(99)))
+                                        .newTotalSupply(99)),
+                        getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(amount),
+                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, amount));
+    }
+
+    @HapiTest
+    final HapiSpec V2SecurityHscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer() {
+        final var bob = "bob";
+        final var feeCollector = "feeCollector";
+        final var tokenWithHbarFee = "tokenWithHbarFee";
+        final var theContract = "TransferAndBurn";
+        final var SUPPLY_KEY = "SUPPLY_KEY";
+        final var ADMIN_KEY = "ADMIN_KEY";
+
+        return propertyPreservingHapiSpec("hscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(ADMIN_KEY).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(ALICE).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(bob).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(feeCollector).balance(0L),
+                        tokenCreate(tokenWithHbarFee)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .initialSupply(0L)
+                                .treasury(TOKEN_TREASURY)
+                                .withCustom(fixedHbarFee(300 * ONE_HBAR, feeCollector)),
+                        mintToken(tokenWithHbarFee, List.of(copyFromUtf8(FIRST))),
+                        mintToken(tokenWithHbarFee, List.of(copyFromUtf8(SECOND))),
+                        uploadInitCode(theContract),
+                        withOpContext((spec, opLog) -> allRunFor(
+                                spec,
+                                contractCreate(
+                                                theContract,
+                                                asHeadlongAddress(asHexedAddress(
+                                                        spec.registry().getTokenID(tokenWithHbarFee))))
+                                        .payingWith(bob)
+                                        .gas(GAS_TO_OFFER))),
+                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, theContract))),
+                        tokenUpdate(tokenWithHbarFee).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                        tokenAssociate(ALICE, tokenWithHbarFee),
+                        tokenAssociate(bob, tokenWithHbarFee),
+                        tokenAssociate(theContract, tokenWithHbarFee),
+                        cryptoTransfer(movingUnique(tokenWithHbarFee, 2L).between(TOKEN_TREASURY, ALICE))
+                                .payingWith(GENESIS),
+                        getAccountInfo(feeCollector)
+                                .has(AccountInfoAsserts.accountWith().balance(0L)))
+                .when(
+                        withOpContext((spec, opLog) -> {
+                            final var serialNumbers = new long[] {1L};
+                            allRunFor(
+                                    spec,
+                                    contractCall(
+                                                    theContract,
+                                                    "transferBurn",
+                                                    HapiParserUtil.asHeadlongAddress(asAddress(
+                                                            spec.registry().getAccountID(ALICE))),
+                                                    HapiParserUtil.asHeadlongAddress(asAddress(
+                                                            spec.registry().getAccountID(bob))),
+                                                    BigInteger.ZERO,
+                                                    2L,
+                                                    serialNumbers)
+                                            .alsoSigningWithFullPrefix(ALICE, THRESHOLD_KEY)
+                                            .gas(GAS_TO_OFFER)
+                                            .via("contractCallTxn")
+                                            .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
+                        }),
+                        childRecordsCheck(
+                                "contractCallTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(REVERTED_SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(1))),
+                                recordWith()
+                                        .status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .withStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE)))))
+                .then(
+                        getAccountBalance(bob).hasTokenBalance(tokenWithHbarFee, 0),
+                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenWithHbarFee, 1),
+                        getAccountBalance(ALICE).hasTokenBalance(tokenWithHbarFee, 1));
+    }
+
+    @HapiTest
+    final HapiSpec V2SecurityHscsPrec004TokenBurnOfFungibleTokenUnits() {
+        final var gasUsed = 14085L;
+        final var CREATION_TX = "CREATION_TX";
+        final var MULTI_KEY = "MULTI_KEY";
+
+        return propertyPreservingHapiSpec("V2SecurityHscsPrec004TokenBurnOfFungibleTokenUnits")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(50L)
+                                .supplyKey(MULTI_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY),
+                        uploadInitCode(MIXED_BURN_TOKEN),
+                        withOpContext((spec, opLog) -> allRunFor(
+                                spec,
+                                contractCreate(
+                                                MIXED_BURN_TOKEN,
+                                                asHeadlongAddress(asHexedAddress(
+                                                        spec.registry().getTokenID(FUNGIBLE_TOKEN))))
+                                        .payingWith(ALICE)
+                                        .via(CREATION_TX)
+                                        .gas(GAS_TO_OFFER))),
+                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
+                        tokenUpdate(FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                        getTxnRecord(CREATION_TX).logged())
+                .when(
+                        contractCall(MIXED_BURN_TOKEN, BURN_TOKEN_WITH_EVENT, BigInteger.ZERO, new long[0])
+                                .payingWith(ALICE)
+                                .alsoSigningWithFullPrefix(THRESHOLD_KEY)
+                                .gas(GAS_TO_OFFER)
+                                .via("burnZero"),
+                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 50),
+                        contractCall(MIXED_BURN_TOKEN, BURN_TOKEN_WITH_EVENT, BigInteger.ONE, new long[0])
+                                .payingWith(ALICE)
+                                .alsoSigningWithFullPrefix(THRESHOLD_KEY)
+                                .gas(GAS_TO_OFFER)
+                                .via("burn"),
+                        getTxnRecord("burn")
+                                .hasPriority(recordWith()
+                                        .contractCallResult(resultWith()
+                                                .logs(inOrder(logWith()
+                                                        .noData()
+                                                        .withTopicsInOrder(List.of(parsedToByteString(49))))))),
+                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 49),
+                        childRecordsCheck(
+                                "burn",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(49))
+                                                .gasUsed(gasUsed))
+                                        .newTotalSupply(49)
+                                        .tokenTransfers(changingFungibleBalances()
+                                                .including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))
+                                        .newTotalSupply(49)),
+                        contractCall(MIXED_BURN_TOKEN, "burnToken", BigInteger.ONE, new long[0])
+                                .via("burn with contract key")
+                                .gas(GAS_TO_OFFER),
+                        childRecordsCheck(
+                                "burn with contract key",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(48)))
+                                        .newTotalSupply(48)
+                                        .tokenTransfers(changingFungibleBalances()
+                                                .including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))))
+                .then(getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 48));
+    }
+
+    @HapiTest
+    final HapiSpec V2SecurityHscsPrec011BurnAfterNestedMint() {
+        final var innerContract = "MintToken";
+        final var outerContract = "NestedBurn";
+        final var revisedKey = KeyShape.threshOf(1, SIMPLE, DELEGATE_CONTRACT, DELEGATE_CONTRACT);
+        final var SUPPLY_KEY = "SUPPLY_KEY";
+        final var CREATION_TX = "CREATION_TX";
+        final var BURN_AFTER_NESTED_MINT_TX = "burnAfterNestedMint";
+
+        return propertyPreservingHapiSpec("V2SecurityHscsPrec011BurnAfterNestedMint")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(50L)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY),
+                        uploadInitCode(innerContract, outerContract),
+                        contractCreate(innerContract).gas(GAS_TO_OFFER),
+                        withOpContext((spec, opLog) -> allRunFor(
+                                spec,
+                                contractCreate(
+                                                outerContract,
+                                                asHeadlongAddress(getNestedContractAddress(innerContract, spec)))
+                                        .payingWith(ALICE)
+                                        .via(CREATION_TX)
+                                        .gas(GAS_TO_OFFER))),
+                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, outerContract))),
+                        tokenUpdate(FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                        getTxnRecord(CREATION_TX).logged())
+                .when(
+                        withOpContext((spec, opLog) -> allRunFor(
+                                spec,
+                                newKeyNamed(CONTRACT_KEY)
+                                        .shape(revisedKey.signedWith(sigs(ON, innerContract, outerContract))),
+                                tokenUpdate(FUNGIBLE_TOKEN)
+                                        .supplyKey(CONTRACT_KEY)
+                                        .signedByPayerAnd(ADMIN_KEY),
+                                contractCall(
+                                                outerContract,
+                                                BURN_AFTER_NESTED_MINT_TX,
+                                                BigInteger.ONE,
+                                                HapiParserUtil.asHeadlongAddress(asAddress(
+                                                        spec.registry().getTokenID(FUNGIBLE_TOKEN))),
+                                                new long[0])
+                                        .payingWith(ALICE)
+                                        .alsoSigningWithFullPrefix(CONTRACT_KEY)
+                                        .hasKnownStatus(SUCCESS)
+                                        .via(BURN_AFTER_NESTED_MINT_TX))),
+                        childRecordsCheck(
+                                BURN_AFTER_NESTED_MINT_TX,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_MINT)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(51)
+                                                        .withSerialNumbers()))
+                                        .tokenTransfers(
+                                                changingFungibleBalances().including(FUNGIBLE_TOKEN, TOKEN_TREASURY, 1))
+                                        .newTotalSupply(51),
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(50)))
+                                        .tokenTransfers(changingFungibleBalances()
+                                                .including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))
+                                        .newTotalSupply(50)))
+                .then(getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 50));
+    }
+
+    @HapiTest
+    final HapiSpec V2SecurityHscsPrec005TokenBurnOfNft() {
+        final var gasUsed = 14085;
+        final var CREATION_TX = "CREATION_TX";
+        return propertyPreservingHapiSpec("V2SecurityHscsPrec005TokenBurnOfNft")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(SECOND))),
+                        uploadInitCode(BURN_TOKEN),
+                        withOpContext((spec, opLog) -> allRunFor(
+                                spec,
+                                contractCreate(
+                                                BURN_TOKEN,
+                                                asHeadlongAddress(asHexedAddress(
+                                                        spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))))
+                                        .payingWith(ALICE)
+                                        .via(CREATION_TX)
+                                        .gas(GAS_TO_OFFER))),
+                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, BURN_TOKEN))),
+                        tokenUpdate(NON_FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                        getTxnRecord(CREATION_TX).logged())
+                .when(
+                        withOpContext((spec, opLog) -> {
+                            final var serialNumbers = new long[] {1L};
+                            allRunFor(
+                                    spec,
+                                    contractCall(BURN_TOKEN, "burnToken", BigInteger.ZERO, serialNumbers)
+                                            .payingWith(ALICE)
+                                            .alsoSigningWithFullPrefix(THRESHOLD_KEY)
+                                            .gas(GAS_TO_OFFER)
+                                            .via("burn"));
+                        }),
+                        childRecordsCheck(
+                                "burn",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                        .withStatus(SUCCESS)
+                                                        .withTotalSupply(1))
+                                                .gasUsed(gasUsed))
+                                        .newTotalSupply(1)))
+                .then(getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
@@ -36,7 +36,8 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
 import static com.hedera.services.bdd.suites.contract.Utils.*;
-import static com.hedera.services.bdd.suites.contract.precompile.V1SecurityModelOverrides.*;
+import static com.hedera.services.bdd.suites.contract.precompile.V1SecurityModelOverrides.CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS;
+import static com.hedera.services.bdd.suites.contract.precompile.V1SecurityModelOverrides.CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 


### PR DESCRIPTION
Write E2E suites for HSCS operations affected by the security model
Token Burn
-->

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/12726
Fixes #
https://github.com/hashgraph/hedera-services/issues/12726