### PR TITLE
feat: Update hapi version in use by services to 0.50

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -25,7 +25,7 @@ description = "Hedera API"
 
 // Add downloaded HAPI repo protobuf files into build directory and add to sources to build them
 tasks.cloneHederaProtobufs {
-    branchOrTag = "main"
+    branchOrTag = "v0.50.0-release"
     // As long as the 'branchOrTag' above is not stable, run always:
     outputs.upToDateWhen { false }
 }


### PR DESCRIPTION
**Description**:
Bump the hapi version in use by services to that in `hedera-protobufs` branch `v0.50.0-release`

**Related issue(s)**:

Fixes #13021
