### PR TITLE
feat(reconnect): introduce ReconnectMapStats interface

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
@@ -28,34 +28,48 @@ package com.swirlds.common.merkle.synchronization.stats;
  */
 public interface ReconnectMapStats {
     /**
-     * Increment a transfers counter.
+     * Increment a transfers from teacher counter.
      * <p>
-     * Different reconnect algorithms may define the term "transfer" differently. Examples of a transfer: <br>
+     * Different reconnect algorithms may define the term "transfer" differently. Examples of a transfer from teacher: <br>
      * * a lesson from the teacher, <br>
-     * * a query response to the teacher, <br>
-     * * a request from the learner, <br>
-     * * a response from the teacher.
-     *
-     * @param fromTeacher a transfer of data from a teacher to the learner (e.g. a lesson, or a response)
-     * @param fromLearner a transfer of data from the learner to its teacher (e.g. a query response, or a request)
+     * * a response from the teacher per a prior request from the learner.
      */
-    default void incrementTransfers(int fromTeacher, int fromLearner) {}
+    default void incrementTransfersFromTeacher() {}
 
     /**
-     * Gather stats about internal nodes transfers.
+     * Increment a transfers from learner counter.
+     * <p>
+     * Different reconnect algorithms may define the term "transfer" differently. Examples of a transfer from learner: <br>
+     * * a query response to the teacher for a single hash, <br>
+     * * a request from the learner.
+     */
+    default void incrementTransfersFromLearner() {}
+
+    /**
+     * Gather stats about internal nodes hashes transfers.
      * @param hashNum the number of hashes of internal nodes transferred
      * @param cleanHashNum the number of hashes transferred unnecessarily because they were clean
+     */
+    default void incrementInternalHashes(int hashNum, int cleanHashNum) {}
+
+    /**
+     * Gather stats about internal nodes data transfers.
      * @param dataNum the number of data payloads of internal nodes transferred (for non-VirtualMap trees)
      * @param cleanDataNum the number of data payloads transferred unnecessarily because they were clean
      */
-    default void incrementInternalNodes(int hashNum, int cleanHashNum, int dataNum, int cleanDataNum) {}
+    default void incrementInternalData(int dataNum, int cleanDataNum) {}
 
     /**
-     * Gather stats about leaf nodes transfers.
+     * Gather stats about leaf nodes hashes transfers.
      * @param hashNum the number of hashes of leaf nodes transferred
      * @param cleanHashNum the number of hashes transferred unnecessarily because they were clean
+     */
+    default void incrementLeafHashes(int hashNum, int cleanHashNum) {}
+
+    /**
+     * Gather stats about leaf nodes data transfers.
      * @param dataNum the number of data payloads of leaf nodes transferred
      * @param cleanDataNum the number of data payloads transferred unnecessarily because they were clean
      */
-    default void incrementLeafNodes(int hashNum, int cleanHashNum, int dataNum, int cleanDataNum) {}
+    default void incrementLeafData(int dataNum, int cleanDataNum) {}
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
@@ -35,21 +35,27 @@ public interface ReconnectMapStats {
      * * a query response to the teacher, <br>
      * * a request from the learner, <br>
      * * a response from the teacher.
+     *
+     * @param fromTeacher a transfer of data from a teacher to the learner (e.g. a lesson, or a response)
+     * @param fromLearner a transfer of data from the learner to its teacher (e.g. a query response, or a request)
      */
-    default void incrementTransfers() {}
+    default void incrementTransfers(int fromTeacher, int fromLearner) {}
 
     /**
      * Gather stats about internal nodes transfers.
-     * @param num the number of hashes of internal nodes transferred
-     * @param cleanNum the number of hashes of internal nodes transferred unnecessarily because they were clean
+     * @param hashNum the number of hashes of internal nodes transferred
+     * @param cleanHashNum the number of hashes transferred unnecessarily because they were clean
+     * @param dataNum the number of data payloads of internal nodes transferred (for non-VirtualMap trees)
+     * @param cleanDataNum the number of data payloads transferred unnecessarily because they were clean
      */
-    default void incrementInternalNodes(int num, int cleanNum) {}
+    default void incrementInternalNodes(int hashNum, int cleanHashNum, int dataNum, int cleanDataNum) {}
 
     /**
      * Gather stats about leaf nodes transfers.
      * @param hashNum the number of hashes of leaf nodes transferred
+     * @param cleanHashNum the number of hashes transferred unnecessarily because they were clean
      * @param dataNum the number of data payloads of leaf nodes transferred
      * @param cleanDataNum the number of data payloads transferred unnecessarily because they were clean
      */
-    default void incrementLeafNodes(int hashNum, int dataNum, int cleanDataNum) {}
+    default void incrementLeafNodes(int hashNum, int cleanHashNum, int dataNum, int cleanDataNum) {}
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.merkle.synchronization.stats;
+
+/**
+ * An interface that helps gather statistics about the reconnect of tree-like data structures, such as VirtualMaps.
+ * <p>
+ * An implementation could gather aggregate statistics for all maps, or it could gather the counters for a specific
+ * map and then also optionally delegate to another instance of the interface that would compute aggregate stats
+ * for all maps.
+ * <p>
+ * All the methods have default no-op implementations to help with stubbing of the instances until an implementation
+ * is ready, or in tests.
+ */
+public interface ReconnectMapStats {
+    /**
+     * Increment a transfers counter.
+     * <p>
+     * Different reconnect algorithms may define the term "transfer" differently. Examples of a transfer: <br>
+     * * a lesson from the teacher, <br>
+     * * a query response to the teacher, <br>
+     * * a request from the learner, <br>
+     * * a response from the teacher.
+     */
+    default void incrementTransfers() {}
+
+    /**
+     * Gather stats about internal nodes transfers.
+     * @param num the number of hashes of internal nodes transferred
+     * @param cleanNum the number of hashes of internal nodes transferred unnecessarily because they were clean
+     */
+    default void incrementInternalNodes(int num, int cleanNum) {}
+
+    /**
+     * Gather stats about leaf nodes transfers.
+     * @param hashNum the number of hashes of leaf nodes transferred
+     * @param dataNum the number of data payloads of leaf nodes transferred
+     * @param cleanDataNum the number of data payloads transferred unnecessarily because they were clean
+     */
+    default void incrementLeafNodes(int hashNum, int dataNum, int cleanDataNum) {}
+}


### PR DESCRIPTION
**Description**:
Introducing an interface to help gather reconnect-related statistics for maps per a proposal at https://github.com/hashgraph/hedera-services/issues/12412#issuecomment-2076062254

It is out of scope of this particular PR to implement this interface, or start using it.

**Related issue(s)**:

Contributes to #12412

**Notes for reviewer**:
`gr assemble` passes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
