### PR TITLE
Too large transactions should not trigger possibly catastrophic failure

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -109,17 +109,17 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
     @Override
     public void invoke(
             @NonNull final BufferedData requestBuffer, @NonNull final StreamObserver<BufferedData> responseObserver) {
+        // Track the number of times this method has been called
+        callsReceivedCounter.increment();
+        callsReceivedSpeedometer.cycle();
+
+        // Fail-fast if the request is too large (Note that the request buffer is sized to allow exactly
+        // 1 more byte than MAX_MESSAGE_SIZE, so we can detect this case).
+        if (requestBuffer.length() > MAX_MESSAGE_SIZE) {
+            throw new RuntimeException("More than " + MAX_MESSAGE_SIZE + " received");
+        }
+
         try {
-            // Track the number of times this method has been called
-            callsReceivedCounter.increment();
-            callsReceivedSpeedometer.cycle();
-
-            // Fail-fast if the request is too large (Note that the request buffer is sized to allow exactly
-            // 1 more byte than MAX_MESSAGE_SIZE, so we can detect this case).
-            if (requestBuffer.length() > MAX_MESSAGE_SIZE) {
-                throw new RuntimeException("More than " + MAX_MESSAGE_SIZE + " received");
-            }
-
             // Prepare the response buffer
             final var responseBuffer = BUFFER_THREAD_LOCAL.get();
             responseBuffer.reset();


### PR DESCRIPTION
**Description**:

This PR excludes the check if a message is too large from the catch-all branch.

**Related issue(s)**:

Fixes #13004 