### PR TITLE
fix: remove gas cost check

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -26,7 +26,6 @@ import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_UNDELETE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BUSY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -186,9 +185,9 @@ public final class IngestChecker {
 
             // If the fee offered does not cover the gas cost of the transaction, then
             // we would again end up with uncompensated work
-            final var gasCost = solvencyPreCheck.estimateAdditionalCosts(txBody, CONTRACT_CALL, consensusTime)
-                    - txBody.contractCallOrThrow().amount();
-            validateTruePreCheck(txBody.transactionFee() >= gasCost, INSUFFICIENT_TX_FEE);
+            // final var gasCost = solvencyPreCheck.estimateAdditionalCosts(txBody, CONTRACT_CALL, consensusTime)
+            //         - txBody.contractCallOrThrow().amount();
+            // validateTruePreCheck(txBody.transactionFee() >= gasCost, INSUFFICIENT_TX_FEE);
         } else if (functionality == ETHEREUM_TRANSACTION) {
             final var ethTxData = populateEthTxData(
                     requireNonNull(txBody.ethereumTransactionOrThrow().ethereumData())

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -1618,13 +1618,15 @@ public class ContractCallSuite extends HapiSuite {
     HapiSpec insufficientFee() {
         final var contract = CREATE_TRIVIAL;
 
+        // FUTURE: Once we add the check again that compares the estimated gas with the maximum transaction fee,
+        // this test will need to be updated and expect INSUFFICIENT_TX_FEE.
         return defaultHapiSpec("InsufficientFee", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(cryptoCreate("accountToPay"), uploadInitCode(contract), contractCreate(contract))
                 .when()
                 .then(contractCall(contract, "create")
                         .fee(0L)
                         .payingWith("accountToPay")
-                        .hasPrecheck(INSUFFICIENT_TX_FEE));
+                        .hasPrecheck(OK));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:

This PR removes the check that failed transactions when the estimated gas cost was higher than the maximum transaction fee.

**Related issue(s)**:

Fixes #13030 