### PR TITLE
chore: Update default fees to a constant value

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/Fees.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/Fees.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.spi.fees;
 
+import com.hederahashgraph.api.proto.java.FeeComponents;
+import com.hederahashgraph.api.proto.java.FeeData;
+
 /**
  * Represents the combination of node, network, and service fees.
  *
@@ -36,6 +39,15 @@ package com.hedera.node.app.spi.fees;
 public record Fees(long nodeFee, long networkFee, long serviceFee) {
     /** A constant representing zero fees. */
     public static final Fees FREE = new Fees(0, 0, 0);
+    /**
+     * A constant representing fees of 1 tinybar for each of the node, network, and service components.
+     * This is useful when a fee is required, but the entity is not present in state to determine the actual fee.
+     */
+    public static final FeeData CONSTANT_FEE_DATA = FeeData.newBuilder()
+            .setNodedata(FeeComponents.newBuilder().setConstant(1).build())
+            .setNetworkdata(FeeComponents.newBuilder().setConstant(1).build())
+            .setServicedata(FeeComponents.newBuilder().setConstant(1).build())
+            .build();
 
     public Fees {
         // Validate the fee components are never negative.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -726,10 +726,7 @@ public final class Hedera implements SwirldMain {
         final var nextBlockInfo =
                 currentBlockInfo.copyBuilder().migrationRecordsStreamed(false).build();
         blockInfoState.put(nextBlockInfo);
-        logger.info(
-                "Unmarked migration records streamed with block info {} with hash {}",
-                nextBlockInfo,
-                blockInfoState.hashCode());
+        logger.info("Unmarked migration records streamed");
         ((WritableSingletonStateBase<BlockInfo>) blockInfoState).commit();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetTopicInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetTopicInfoResourceUsage.java
@@ -26,6 +26,7 @@ import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.getQueryFeeDataMatri
 import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.getStateProofSize;
 import static com.hedera.node.app.service.mono.utils.EntityNum.fromTopicId;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.asKeyUnchecked;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.node.app.service.mono.context.primitives.StateView;
 import com.hedera.node.app.service.mono.fees.calculation.QueryResourceUsageEstimator;
@@ -66,7 +67,7 @@ public class GetTopicInfoResourceUsage implements QueryResourceUsageEstimator {
 
     public FeeData usageGivenTypeAndTopic(@Nullable final MerkleTopic topic, final ResponseType responseType) {
         if (topic == null) {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
 
         final long bpr = BASIC_QUERY_RES_HEADER

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsage.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.fees.calculation.crypto.queries;
 
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage;
@@ -91,7 +92,7 @@ public final class GetAccountDetailsResourceUsage implements QueryResourceUsageE
      */
     public FeeData usageGiven(final com.hedera.hapi.node.transaction.Query query, final Account account) {
         if (account == null) {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
         final var ctx = ExtantCryptoContext.newBuilder()
                 .setCurrentKey(fromPbj(account.key()))

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.fees.calculation.crypto.queries;
 
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage;
@@ -99,7 +100,7 @@ public final class GetAccountInfoResourceUsage implements QueryResourceUsageEsti
      */
     public FeeData usageGiven(final com.hedera.hapi.node.transaction.Query query, final Account account) {
         if (account == null) {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
         final var ctx = ExtantCryptoContext.newBuilder()
                 .setCurrentKey(fromPbj(account.key()))

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsage.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.mono.fees.calculation.crypto.queries;
 import static com.hedera.node.app.service.mono.queries.meta.GetTxnRecordAnswer.PAYER_RECORDS_CTX_KEY;
 import static com.hedera.node.app.service.mono.utils.EntityNum.fromAccountId;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.putIfNotNull;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionRecord;
@@ -73,7 +74,7 @@ public final class GetAccountRecordsResourceUsage implements QueryResourceUsageE
      */
     public FeeData usageGivenFor(final Account account, List<TransactionRecord> pbjRecords) {
         if (account == null) {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
         final var records =
                 pbjRecords.stream().map(k -> PbjConverter.fromPbj(k)).toList();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.fees.calculation.schedule.queries;
 
 import static com.hedera.node.app.service.mono.queries.schedule.GetScheduleInfoAnswer.SCHEDULE_INFO_CTX_KEY;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.putIfNotNull;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.node.app.hapi.fees.usage.schedule.ExtantScheduleContext;
 import com.hedera.node.app.hapi.fees.usage.schedule.ScheduleOpsUsage;
@@ -82,7 +83,7 @@ public final class GetScheduleInfoResourceUsage implements QueryResourceUsageEst
             }
             return scheduleOpsUsage.scheduleInfoUsage(query, scheduleCtxBuilder.build());
         } else {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsage.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.mono.fees.calculation.token.queries;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.mono.queries.token.GetTokenInfoAnswer.TOKEN_INFO_CTX_KEY;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.putIfNotNull;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.hapi.fees.usage.token.TokenGetInfoUsage;
@@ -106,7 +107,7 @@ public final class GetTokenInfoResourceUsage implements QueryResourceUsageEstima
             }
             return estimate.get();
         } else {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsage.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.mono.fees.calculation.token.queries;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.mono.queries.token.GetTokenNftInfoAnswer.NFT_INFO_CTX_KEY;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.putIfNotNull;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.node.app.hapi.fees.usage.token.TokenGetNftInfoUsage;
@@ -74,7 +75,7 @@ public final class GetTokenNftInfoResourceUsage implements QueryResourceUsageEst
                     factory.apply(fromPbj(query)).givenMetadata(nft.metadata().toString());
             return estimate.get();
         } else {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsage.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.fees.calculation.token.txns;
 
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.node.app.service.mono.utils.EntityNum.fromAccountId;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.hapi.fees.usage.EstimatorFactory;
@@ -72,7 +73,7 @@ public final class TokenAssociateResourceUsage extends AbstractTokenResourceUsag
      */
     public FeeData usageGiven(final TransactionBody txn, final SigValueObj svo, final Account account) {
         if (account == null) {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         } else {
             final var sigUsage =
                     new SigUsage(svo.getTotalSigCount(), svo.getSignatureSize(), svo.getPayerAcctSigCount());

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsage.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.mono.fees.calculation.token.txns;
 
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.node.app.service.mono.utils.EntityNum.fromAccountId;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.hapi.fees.usage.EstimatorFactory;
@@ -72,7 +73,7 @@ public class TokenDissociateResourceUsage extends AbstractTokenResourceUsage imp
      */
     public FeeData usageGiven(final TransactionBody txn, final SigValueObj svo, final Account account) {
         if (account == null) {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         } else {
             final var sigUsage =
                     new SigUsage(svo.getTotalSigCount(), svo.getSignatureSize(), svo.getPayerAcctSigCount());

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsage.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.mono.fees.calculation.token.txns;
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.node.app.service.mono.fees.calculation.token.queries.GetTokenInfoResourceUsage.ifPresent;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.hapi.fees.usage.EstimatorFactory;
@@ -111,7 +112,7 @@ public class TokenUpdateResourceUsage extends AbstractTokenResourceUsage impleme
             }
             return estimate.get();
         } else {
-            return FeeData.getDefaultInstance();
+            return CONSTANT_FEE_DATA;
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.mono.pbj;
 
+import static com.hedera.hapi.node.base.ContractID.ContractOneOfType.UNSET;
 import static com.hedera.node.app.service.mono.Utils.asHederaKey;
 import static com.hedera.node.app.service.mono.Utils.asHederaKeyUnchecked;
 import static java.util.Objects.requireNonNull;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/pbj/PbjConverter.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.pbj;
 
-import static com.hedera.hapi.node.base.ContractID.ContractOneOfType.UNSET;
 import static com.hedera.node.app.service.mono.Utils.asHederaKey;
 import static com.hedera.node.app.service.mono.Utils.asHederaKeyUnchecked;
 import static java.util.Objects.requireNonNull;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.mono.fees.calculation.consensus.queries;
 
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 import static com.hedera.test.utils.IdUtils.asTopic;
 import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
 import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
@@ -79,7 +80,7 @@ class GetMerkleTopicInfoResourceUsageTest {
     void throwsIaeWhenTopicDoesNotExist() {
         final var query = topicInfoQuery(topicId, ANSWER_ONLY);
 
-        assertSame(FeeData.getDefaultInstance(), subject.usageGiven(query, view));
+        assertSame(CONSTANT_FEE_DATA, subject.usageGiven(query, view));
     }
 
     @ParameterizedTest

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsageTest.java
@@ -98,7 +98,7 @@ class ContractUpdateResourceUsageTest {
     @Test
     void returnsDefaultUsageOnException() throws Exception {
         // when:
-        final FeeData actual = subject.usageGiven(contractUpdateTxn, sigUsage, null);
+        final FeeData actual = subject.usageGiven(contractUpdateTxn, sigUsage, (StateView) null);
 
         // then:
         assertEquals(FeeData.getDefaultInstance(), actual);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractGetInfoHandler.java
@@ -23,6 +23,7 @@ import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.hexedEvmAddressOf;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.summarizeStakingInfo;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.tokenRelationshipsOf;
+import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
@@ -50,7 +51,6 @@ import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.StakingConfig;
 import com.hedera.node.config.data.TokensConfig;
-import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
@@ -114,7 +114,7 @@ public class ContractGetInfoHandler extends PaidQueryHandler {
         return context.feeCalculator().legacyCalculate(sigValueObj -> {
             final var contract = contractFrom(context);
             if (contract == null) {
-                return FeeData.getDefaultInstance();
+                return CONSTANT_FEE_DATA;
             } else {
                 return ContractGetInfoUsage.newEstimate(fromPbj(context.query()))
                         .givenCurrentKey(fromPbj(contract.keyOrThrow()))

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -298,8 +298,11 @@ public class ContractUpdateHandler implements TransactionHandler {
     public Fees calculateFees(@NonNull final FeeContext feeContext) {
         requireNonNull(feeContext);
         final var op = feeContext.body();
+        final var contractId = op.contractUpdateInstanceOrThrow().contractIDOrElse(ContractID.DEFAULT);
+        final var accountStore = feeContext.readableStore(ReadableAccountStore.class);
+        final var contract = accountStore.getContractById(contractId);
         return feeContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> new ContractUpdateResourceUsage(
                         new SmartContractFeeBuilder())
-                .usageGiven(fromPbj(op), sigValueObj, null));
+                .usageGiven(fromPbj(op), sigValueObj, contract));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/13043

- Fixes the handlers that are returning `FeeData.getDefaultInstance` when an entity doesn't exist in state to use a FeeData with a constant value set.