### PR TITLE
build: support 'tags' in 'cloneHederaProtobufs'

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -25,9 +25,8 @@ description = "Hedera API"
 
 // Add downloaded HAPI repo protobuf files into build directory and add to sources to build them
 tasks.cloneHederaProtobufs {
-    branchOrTag = "v0.50.0-release"
-    // As long as the 'branchOrTag' above is not stable, run always:
-    outputs.upToDateWhen { false }
+    tag = "v0.50.0-release"
+    // branch = "main"
 }
 
 sourceSets {


### PR DESCRIPTION


**Description**:
This allows not to explicitly define a 'branch' OR a 'tag'. If a 'tag' is defined, we assume that it is stable and the task can be up-to-date.

**Related issue(s)**:

Fixes #13023

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
