### PR TITLE
fix: midnight rate management on restart

### DIFF
--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -4,7 +4,7 @@ ledger.autoRenewPeriod.maxDuration=1000000000
 upgrade.artifacts.path=data/upgrade
 contracts.chainId=298
 # Needed for end-end tests running on mod-service code
-staking.periodMins=1
+staking.periodMins=1440
 staking.fees.nodeRewardPercentage=10
 staking.fees.stakingRewardPercentage=10
 # Needed for Restart and Reconnect HapiTests that run many transactions of each type

--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -4,7 +4,7 @@ ledger.autoRenewPeriod.maxDuration=1000000000
 upgrade.artifacts.path=data/upgrade
 contracts.chainId=298
 # Needed for end-end tests running on mod-service code
-staking.periodMins=1440
+staking.periodMins=1
 staking.fees.nodeRewardPercentage=10
 staking.fees.stakingRewardPercentage=10
 # Needed for Restart and Reconnect HapiTests that run many transactions of each type

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
@@ -34,7 +34,6 @@ import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.RatesConfig;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.UncheckedParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -43,6 +42,8 @@ import java.time.Instant;
 import java.util.stream.LongStream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Parses the exchange rate information and makes it available to the workflows.
@@ -63,6 +64,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 public final class ExchangeRateManager {
+    private static final Logger log = LogManager.getLogger(ExchangeRateManager.class);
 
     private static final BigInteger ONE_HUNDRED = BigInteger.valueOf(100);
 
@@ -80,31 +82,29 @@ public final class ExchangeRateManager {
         requireNonNull(state, "state must not be null");
         requireNonNull(bytes, "bytes must not be null");
 
-        // First we try to read midnightRates from state
+        // Re-use the same code path to set the active rates as does the SystemFileUpdateFacility
+        // IMPORTANT - if we first initialized the midnight rates, we couldn't reuse this code path
+        // because it overwrites the midnight rates with the current rates
+        systemUpdate(bytes);
+
+        // Now fix the midnight rates to what is in state (note that all post-initialization
+        // Services states must have a non-null midnight rates set, even at genesis, as
+        // FeeService schema migrate() creates them in that case)
         midnightRates = state.getReadableStates(FeeService.NAME)
                 .<ExchangeRateSet>getSingleton(FeeService.MIDNIGHT_RATES_STATE_KEY)
                 .get();
-        if (midnightRates != ExchangeRateSet.DEFAULT) {
-            // midnightRates were found in state, a regular update is sufficient
-            //
-            systemUpdate(bytes);
-        }
-
-        // If midnightRates were not found in state, we initialize them from the file
-        try {
-            midnightRates = ExchangeRateSet.PROTOBUF.parse(bytes.toReadableSequentialData());
-        } catch (ParseException e) {
-            // an error here is fatal and needs to be handled by the general initialization code
-            throw new UncheckedParseException(e);
-        }
-        this.currentExchangeRateInfo = new ExchangeRateInfoImpl(midnightRates);
+        requireNonNull(midnightRates, "an initialized state must have a midnight rates set");
+        log.info(
+                "Initializing exchange rates with midnight rates {} and active rates {}",
+                midnightRates,
+                currentExchangeRateInfo.exchangeRates());
     }
 
     /**
      * Updates the exchange rate information. MUST BE CALLED on the handle thread!
      *
-     * @param bytes   The protobuf encoded {@link ExchangeRateSet}.
-     * @param payerId   The payer of the transaction that triggered this update.
+     * @param bytes The protobuf encoded {@link ExchangeRateSet}.
+     * @param payerId The payer of the transaction that triggered this update.
      */
     public void update(@NonNull final Bytes bytes, @NonNull AccountID payerId) {
         requireNonNull(payerId, "payerId must not be null");
@@ -147,7 +147,6 @@ public final class ExchangeRateManager {
 
         // Update the current ExchangeRateInfo and eventually the midnightRates
         this.currentExchangeRateInfo = new ExchangeRateInfoImpl(proposedRates);
-        // TODO: save the mignightRates in state only
         if (isAdminUser(payerId, accountsConfig)) {
             midnightRates = proposedRates;
         }
@@ -167,15 +166,22 @@ public final class ExchangeRateManager {
         return num == accountsConfig.systemAdmin();
     }
 
+    /**
+     * Updates the midnight rates to the current exchange rates, both internally and in the given state.
+     *
+     * @param state the {@link HederaState} to update the midnight rates in
+     */
     public void updateMidnightRates(@NonNull final HederaState state) {
         midnightRates = currentExchangeRateInfo.exchangeRates();
         final var singleton = state.getWritableStates(FeeService.NAME)
                 .<ExchangeRateSet>getSingleton(FeeService.MIDNIGHT_RATES_STATE_KEY);
         singleton.put(midnightRates);
+        log.info("Updated midnight rates to {}", midnightRates);
     }
 
     /**
      * Gets the current {@link ExchangeRateSet}. MUST BE CALLED ON THE HANDLE THREAD!!
+     *
      * @return The current {@link ExchangeRateSet}.
      */
     @NonNull
@@ -188,7 +194,7 @@ public final class ExchangeRateManager {
      * THREAD!!
      *
      * @param consensusTime The consensus time. If after the expiration time of the current rate, the next rate will
-     *                      be returned. Otherwise, the current rate will be returned.
+     * be returned. Otherwise, the current rate will be returned.
      * @return The {@link ExchangeRate} that should be used as of the given consensus time.
      */
     @NonNull


### PR DESCRIPTION
**Description**:
 - Closes #13069 
 - Simply initialize the `ExchangeRateManager`'s midnight rates to what is in state.
     * The existing code was probably a vestige of a time when the `FeeService` schema's `migrate()` method did not initialize a genesis state.