### PR TITLE
fix: 12853: Memory leak from MerkleDbDataSource.copyStatisticsFrom()

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -283,11 +283,11 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
             hashStoreRam = null;
         }
 
-        statisticsUpdater = new MerkleDbStatisticsUpdater(this);
+        statisticsUpdater = new MerkleDbStatisticsUpdater(database.getConfig(), tableName);
 
         final Runnable updateTotalStatsFunction = () -> {
-            statisticsUpdater.updateStoreFileStats();
-            statisticsUpdater.updateOffHeapStats();
+            statisticsUpdater.updateStoreFileStats(this);
+            statisticsUpdater.updateOffHeapStats(this);
         };
 
         // internal node hashes store, on disk
@@ -539,9 +539,9 @@ public final class MerkleDbDataSource<K extends VirtualKey, V extends VirtualVal
             // Report total size on disk as sum of all store files. All metadata and other helper files
             // are considered small enough to be ignored. If/when we decide to use on-disk long lists
             // for indices, they should be added here
-            statisticsUpdater.updateStoreFileStats();
+            statisticsUpdater.updateStoreFileStats(this);
             // update off-heap stats
-            statisticsUpdater.updateOffHeapStats();
+            statisticsUpdater.updateOffHeapStats(this);
         }
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
@@ -42,6 +42,9 @@ import com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags;
 import com.swirlds.merkledb.serialize.KeyIndexType;
 import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
 import com.swirlds.merkledb.test.fixtures.TestType;
+import com.swirlds.metrics.api.IntegerGauge;
+import com.swirlds.metrics.api.Metric.ValueType;
+import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.VirtualLongKey;
 import com.swirlds.virtualmap.datasource.VirtualHashRecord;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
@@ -644,6 +647,38 @@ class MerkleDbDataSourceTest {
                 assertEquals(i + 5, leaf.getPath(), "Leaf path mismatch at path " + i);
                 assertEquals(keys.get(i), leaf.getKey(), "Wrong key at path " + i);
                 assertEquals(values.get(i), leaf.getValue(), "Wrong value at path " + i);
+            }
+        });
+    }
+
+    @Test
+    void copyStatisticsTest() throws Exception {
+        // This test simulates what happens on reconnect and makes sure that MerkleDb stats are reported
+        // for the copy correctly
+        final String label = "copyStatisticsTest";
+        final TestType testType = TestType.variable_variable;
+        final Metrics metrics = testType.getMetrics();
+        createAndApplyDataSource(testDirectory, label, testType, 1000, dataSource -> {
+            dataSource.registerMetrics(metrics);
+            assertEquals(
+                    1L,
+                    metrics.getMetric(MerkleDbStatistics.STAT_CATEGORY, "merkledb_count")
+                            .get(ValueType.VALUE));
+            dataSource.saveRecords(4, 8, Stream.of(), Stream.of(), Stream.of(), false);
+            final IntegerGauge sourceCounter = (IntegerGauge)
+                    metrics.getMetric(MerkleDbStatistics.STAT_CATEGORY, "ds_files_leavesStoreFileCount_" + label);
+            assertEquals(1L, sourceCounter.get());
+            final var copy = dataSource.getDatabase().copyDataSource(dataSource, true);
+            try {
+                assertEquals(
+                        2L, metrics.getMetric("merkle_db", "merkledb_count").get(ValueType.VALUE));
+                copy.copyStatisticsFrom(dataSource);
+                copy.saveRecords(4, 8, Stream.of(), Stream.of(), Stream.of(), false);
+                final IntegerGauge copyCounter = (IntegerGauge)
+                        metrics.getMetric(MerkleDbStatistics.STAT_CATEGORY, "ds_files_leavesStoreFileCount_" + label);
+                assertEquals(2L, copyCounter.get());
+            } finally {
+                copy.close();
             }
         });
     }

--- a/platform-sdk/swirlds-jasperdb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/TestType.java
+++ b/platform-sdk/swirlds-jasperdb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/TestType.java
@@ -71,6 +71,8 @@ public enum TestType {
 
     public final boolean fixedSize;
 
+    private Metrics metrics = null;
+
     TestType(boolean fixedSize) {
         this.fixedSize = fixedSize;
     }
@@ -79,8 +81,28 @@ public enum TestType {
         return new DataTypeConfig<>(this);
     }
 
+    public Metrics getMetrics() {
+        if (metrics == null) {
+            final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+            MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
+
+            final MetricKeyRegistry registry = mock(MetricKeyRegistry.class);
+            when(registry.register(any(), any(), any())).thenReturn(true);
+            metrics = new DefaultMetrics(
+                    null,
+                    registry,
+                    mock(ScheduledExecutorService.class),
+                    new DefaultMetricsFactory(metricsConfig),
+                    metricsConfig);
+            MerkleDbStatistics statistics =
+                    new MerkleDbStatistics(configuration.getConfigData(MerkleDbConfig.class), "test");
+            statistics.registerMetrics(metrics);
+        }
+        return metrics;
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes", "unused"})
-    public static class DataTypeConfig<K extends VirtualKey, V extends VirtualValue> {
+    public class DataTypeConfig<K extends VirtualKey, V extends VirtualValue> {
 
         private final TestType testType;
         private final KeySerializer<? extends VirtualLongKey> keySerializer;
@@ -191,24 +213,6 @@ public enum TestType {
             return (keySerializer.getSerializedSize() != Long.BYTES);
         }
 
-        private static Metrics createMetrics() {
-            final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
-            MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
-
-            final MetricKeyRegistry registry = mock(MetricKeyRegistry.class);
-            when(registry.register(any(), any(), any())).thenReturn(true);
-            Metrics metrics = new DefaultMetrics(
-                    null,
-                    registry,
-                    mock(ScheduledExecutorService.class),
-                    new DefaultMetricsFactory(metricsConfig),
-                    metricsConfig);
-            MerkleDbStatistics statistics =
-                    new MerkleDbStatistics(configuration.getConfigData(MerkleDbConfig.class), "test");
-            statistics.registerMetrics(metrics);
-            return metrics;
-        }
-
         public MerkleDbDataSource<VirtualLongKey, ExampleByteArrayVirtualValue> createDataSource(
                 final Path dbPath,
                 final String name,
@@ -228,7 +232,7 @@ public enum TestType {
                             .hashesRamToDiskThreshold(hashesRamToDiskThreshold);
             MerkleDbDataSource dataSource =
                     database.createDataSource(name, (MerkleDbTableConfig) tableConfig, enableMerging);
-            dataSource.registerMetrics(createMetrics());
+            dataSource.registerMetrics(getMetrics());
             return dataSource;
         }
 


### PR DESCRIPTION
Fix summary: a reference to `MerkleDbDataSource` is removed from `MerkleDbStatisticsUpdater` class. Instead, a data source instance (to pull stats from) is passed as an arg to all statistics updater methods.

Fixes: https://github.com/hashgraph/hedera-services/issues/12853
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
