### PR TITLE
fix: ignore token expiry status in `TokenDissociate`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Account.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Account.java
@@ -252,7 +252,7 @@ public class Account extends HederaEvmAccount {
     public void dissociateUsing(final List<Dissociation> dissociations, final OptionValidator validator) {
         for (final var dissociation : dissociations) {
             validateTrue(id.equals(dissociation.dissociatingAccountId()), FAIL_INVALID);
-            dissociation.updateModelRelsSubjectTo(validator);
+            dissociation.updateModelRelsSubjectTo();
             final var pastRel = dissociation.dissociatingAccountRel();
             if (pastRel.isAutomaticAssociation()) {
                 decrementUsedAutomaticAssociations();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/AccountTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/AccountTest.java
@@ -224,7 +224,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numPositiveBalances - 1, subject.getNumPositiveBalances());
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -251,7 +251,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -279,7 +279,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -308,7 +308,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -333,7 +333,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
@@ -50,12 +50,12 @@ import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -147,20 +147,10 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
                 validateFalse(tokenRel.frozen(), ACCOUNT_FROZEN_FOR_TOKEN);
 
                 if (tokenRelBalance > 0) {
-                    validateFalse(token.tokenType() == NON_FUNGIBLE_UNIQUE, ACCOUNT_STILL_OWNS_NFTS);
-
-                    final var tokenIsExpired = tokenIsExpired(token, context.consensusNow());
-                    validateTrue(tokenIsExpired, TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
-
-                    // If the fungible common token is expired, we automatically transfer the
-                    // dissociating account's balance back to the token's treasury
-                    final var treasuryTokenRel = dissociation.treasuryTokenRel();
-                    if (treasuryTokenRel != null) {
-                        final var updatedTreasuryBalanceTokenRel = treasuryTokenRel.balance() + tokenRelBalance;
-                        treasuryBalancesToUpdate.add(treasuryTokenRel
-                                .copyBuilder()
-                                .balance(updatedTreasuryBalanceTokenRel)
-                                .build());
+                    if (token.tokenType() == NON_FUNGIBLE_UNIQUE) {
+                        throw new HandleException(ACCOUNT_STILL_OWNS_NFTS);
+                    } else {
+                        throw new HandleException(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
                     }
                 }
             }
@@ -259,10 +249,6 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
         }
 
         return new ValidatedResult(acct, dissociations);
-    }
-
-    private boolean tokenIsExpired(final Token token, final Instant consensusNow) {
-        return token.expirationSecond() <= consensusNow.getEpochSecond();
     }
 
     private record ValidatedResult(@NonNull Account account, @NonNull List<Dissociation> dissociations) {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
@@ -124,9 +124,7 @@ import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.ED_25519_K
 import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.LAZY_CREATION_ENABLED;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hedera.services.bdd.suites.leaky.LeakyContractTestsSuite.RECEIVER;
-import static com.hedera.services.bdd.suites.token.TokenPauseSpecs.DEFAULT_MIN_AUTO_RENEW_PERIOD;
 import static com.hedera.services.bdd.suites.token.TokenPauseSpecs.LEDGER_AUTO_RENEW_PERIOD_MIN_DURATION;
-import static com.hedera.services.bdd.suites.token.TokenPauseSpecs.TokenIdOrderingAsserts.withOrderedTokenIds;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.SUPPLY_KEY;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.TRANSFER_TXN;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.UNIQUE;
@@ -152,6 +150,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_A
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.hederahashgraph.api.proto.java.SubType.DEFAULT;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
@@ -506,13 +505,12 @@ public class LeakyCryptoTestsSuite extends SidecarAwareHapiSuite {
                         overriding("tokens.maxPerAccount", "" + ADVENTUROUS_NETWORK));
     }
 
-    @BddMethodIsNotATest
     @Order(1)
+    @HapiTest
     public HapiSpec canDissociateFromMultipleExpiredTokens() {
         final var civilian = "civilian";
         final long initialSupply = 100L;
         final long nonZeroXfer = 10L;
-        final var dissociateTxn = "dissociateTxn";
         final var numTokens = 10;
         final IntFunction<String> tokenNameFn = i -> "fungible" + i;
         final String[] assocOrder = new String[numTokens];
@@ -520,7 +518,8 @@ public class LeakyCryptoTestsSuite extends SidecarAwareHapiSuite {
         final String[] dissocOrder = new String[numTokens];
         Arrays.setAll(dissocOrder, i -> tokenNameFn.apply(numTokens - 1 - i));
 
-        return defaultHapiSpec("CanDissociateFromMultipleExpiredTokens")
+        return propertyPreservingHapiSpec("CanDissociateFromMultipleExpiredTokens")
+                .preserving(LEDGER_AUTO_RENEW_PERIOD_MIN_DURATION)
                 .given(
                         overriding(LEDGER_AUTO_RENEW_PERIOD_MIN_DURATION, "1"),
                         cryptoCreate(TOKEN_TREASURY),
@@ -537,11 +536,8 @@ public class LeakyCryptoTestsSuite extends SidecarAwareHapiSuite {
                                 .mapToObj(i -> cryptoTransfer(moving(nonZeroXfer, tokenNameFn.apply(i))
                                         .between(TOKEN_TREASURY, civilian)))
                                 .toArray(HapiSpecOperation[]::new)))
-                .when(sleepFor(1_000L), tokenDissociate(civilian, dissocOrder).via(dissociateTxn))
-                .then(
-                        getTxnRecord(dissociateTxn)
-                                .hasPriority(recordWith().tokenTransfers(withOrderedTokenIds(assocOrder))),
-                        overriding(LEDGER_AUTO_RENEW_PERIOD_MIN_DURATION, DEFAULT_MIN_AUTO_RENEW_PERIOD));
+                .when(sleepFor(2_000L))
+                .then(tokenDissociate(civilian, dissocOrder).hasKnownStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
@@ -228,7 +228,7 @@ public class LeakyCryptoTestsSuite extends SidecarAwareHapiSuite {
     public List<HapiSpec> getSpecsInSuite() {
         return List.of(
                 maxAutoAssociationSpec(),
-                canDissociateFromMultipleExpiredTokens(),
+                cannotDissociateFromExpiredTokenWithNonZeroBalance(),
                 cannotExceedAccountAllowanceLimit(),
                 cannotExceedAllowancesTransactionLimit(),
                 createAnAccountWithEVMAddressAliasAndECKey(),
@@ -507,7 +507,7 @@ public class LeakyCryptoTestsSuite extends SidecarAwareHapiSuite {
 
     @Order(1)
     @HapiTest
-    public HapiSpec canDissociateFromMultipleExpiredTokens() {
+    public HapiSpec cannotDissociateFromExpiredTokenWithNonZeroBalance() {
         final var civilian = "civilian";
         final long initialSupply = 100L;
         final long nonZeroXfer = 10L;


### PR DESCRIPTION
**Description**:
 - Closes #13102 
 - Remove behavior of allowing dissociation and doing treasury return when a token is expired.
     * This is expected when expiry and rent are enabled, but incorrect without them.
 - Rename and enable spec `cannotDissociateFromExpiredTokenWithNonZeroBalance()` as a `@HapiTest` to validate new behavior.