### PR TITLE
fix: ignore token expiry status in `TokenDissociate`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Account.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/models/Account.java
@@ -252,7 +252,7 @@ public class Account extends HederaEvmAccount {
     public void dissociateUsing(final List<Dissociation> dissociations, final OptionValidator validator) {
         for (final var dissociation : dissociations) {
             validateTrue(id.equals(dissociation.dissociatingAccountId()), FAIL_INVALID);
-            dissociation.updateModelRelsSubjectTo(validator);
+            dissociation.updateModelRelsSubjectTo();
             final var pastRel = dissociation.dissociatingAccountRel();
             if (pastRel.isAutomaticAssociation()) {
                 decrementUsedAutomaticAssociations();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/AccountTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/AccountTest.java
@@ -224,7 +224,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numPositiveBalances - 1, subject.getNumPositiveBalances());
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -251,7 +251,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -279,7 +279,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -308,7 +308,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(numAssociations - 1, subject.getNumAssociations());
         assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
@@ -333,7 +333,7 @@ class AccountTest {
         subject.dissociateUsing(List.of(dissociationRel), validator);
 
         // then:
-        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        verify(dissociationRel).updateModelRelsSubjectTo();
         assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
@@ -50,12 +50,12 @@ import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -147,20 +147,10 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
                 validateFalse(tokenRel.frozen(), ACCOUNT_FROZEN_FOR_TOKEN);
 
                 if (tokenRelBalance > 0) {
-                    validateFalse(token.tokenType() == NON_FUNGIBLE_UNIQUE, ACCOUNT_STILL_OWNS_NFTS);
-
-                    final var tokenIsExpired = tokenIsExpired(token, context.consensusNow());
-                    validateTrue(tokenIsExpired, TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
-
-                    // If the fungible common token is expired, we automatically transfer the
-                    // dissociating account's balance back to the token's treasury
-                    final var treasuryTokenRel = dissociation.treasuryTokenRel();
-                    if (treasuryTokenRel != null) {
-                        final var updatedTreasuryBalanceTokenRel = treasuryTokenRel.balance() + tokenRelBalance;
-                        treasuryBalancesToUpdate.add(treasuryTokenRel
-                                .copyBuilder()
-                                .balance(updatedTreasuryBalanceTokenRel)
-                                .build());
+                    if (token.tokenType() == NON_FUNGIBLE_UNIQUE) {
+                        throw new HandleException(ACCOUNT_STILL_OWNS_NFTS);
+                    } else {
+                        throw new HandleException(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
                     }
                 }
             }
@@ -260,10 +250,6 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
         }
 
         return new ValidatedResult(acct, dissociations);
-    }
-
-    private boolean tokenIsExpired(final Token token, final Instant consensusNow) {
-        return token.expirationSecond() <= consensusNow.getEpochSecond();
     }
 
     private record ValidatedResult(@NonNull Account account, @NonNull List<Dissociation> dissociations) {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyCryptoTestsSuite.java
@@ -221,7 +221,7 @@ public class LeakyCryptoTestsSuite extends HapiSuite {
     public List<HapiSpec> getSpecsInSuite() {
         return List.of(
                 maxAutoAssociationSpec(),
-                canDissociateFromMultipleExpiredTokens(),
+                cannotDissociateFromExpiredTokenWithNonZeroBalance(),
                 cannotExceedAccountAllowanceLimit(),
                 cannotExceedAllowancesTransactionLimit(),
                 createAnAccountWithEVMAddressAliasAndECKey(),
@@ -500,7 +500,7 @@ public class LeakyCryptoTestsSuite extends HapiSuite {
 
     @Order(1)
     @HapiTest
-    public HapiSpec canDissociateFromMultipleExpiredTokens() {
+    public HapiSpec cannotDissociateFromExpiredTokenWithNonZeroBalance() {
         final var civilian = "civilian";
         final long initialSupply = 100L;
         final long nonZeroXfer = 10L;


### PR DESCRIPTION
**Description**:
 - Cherry-pick #13104 