### PR TITLE
fix: remove balance adjustment limit from record in state, use `0` for initial gas snapshot

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContext.java
@@ -82,7 +82,7 @@ public class MerkleNetworkContext extends PartialMerkleLeaf implements MerkleLea
     public static final long NO_PREPARED_UPDATE_FILE_NUM = -1;
     public static final byte[] NO_PREPARED_UPDATE_FILE_HASH = new byte[0];
     public static final DeterministicThrottle.UsageSnapshot NO_GAS_THROTTLE_SNAPSHOT =
-            new DeterministicThrottle.UsageSnapshot(-1, Instant.EPOCH);
+            new DeterministicThrottle.UsageSnapshot(0L, Instant.EPOCH);
     static final DeterministicThrottle.UsageSnapshot NEVER_USED_SNAPSHOT =
             new DeterministicThrottle.UsageSnapshot(0L, null);
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustments.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustments.java
@@ -38,7 +38,7 @@ public class CurrencyAdjustments implements SelfSerializable {
     static final long RUNTIME_CONSTRUCTABLE_ID = 0xd8b06bd46e12a466L;
 
     private static final long[] NO_ADJUSTMENTS = new long[0];
-    static final int MAX_NUM_ADJUSTMENTS = 25;
+    static final int MAX_NUM_ADJUSTMENTS = Integer.MAX_VALUE;
 
     long[] hbars = NO_ADJUSTMENTS;
     long[] accountNums = NO_ADJUSTMENTS;


### PR DESCRIPTION
**Description**:
 - Cherry-pick #12826 
 - Use `0` for initial gas `UsageSnapshot` to avoid issues migrating a genesis mono-service state.