### PR TITLE
chore: Added Unit tests to FileSystemDeleteHandler

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemDeleteTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSystemDeleteTest.java
@@ -21,11 +21,10 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNAUTHORIZED;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
 import static com.hedera.test.utils.KeyUtils.A_COMPLEX_KEY;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.BDDMockito.given;
@@ -135,7 +134,7 @@ class FileSystemDeleteTest extends FileTestBase {
         given(transaction.systemDeleteOrThrow()).willReturn(transactionBody);
         given(transactionBody.fileID()).willReturn(null);
 
-        assertThrows(PreCheckException.class, () -> subject.pureChecks(handleContext.body()));
+        assertThatThrownBy(() -> subject.pureChecks(handleContext.body())).isInstanceOf(PreCheckException.class);
     }
 
     @Test
@@ -143,7 +142,7 @@ class FileSystemDeleteTest extends FileTestBase {
     public void testPureChecksDoesNotThrowExceptionWhenFileIdIsNotNull() {
         given(handleContext.body()).willReturn(newFileDeleteTxn());
 
-        assertDoesNotThrow(() -> subject.pureChecks(handleContext.body()));
+        assertThatCode(() -> subject.pureChecks(handleContext.body())).doesNotThrowAnyException();
     }
 
     @Test
@@ -183,8 +182,8 @@ class FileSystemDeleteTest extends FileTestBase {
         writableStore = new WritableFileStore(writableStates, testConfig, storeMetricsService);
         given(handleContext.writableStore(WritableFileStore.class)).willReturn(writableStore);
 
-        final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
-        assertEquals(INVALID_FILE_ID, msg.getStatus());
+        HandleException thrown = (HandleException) catchThrowable(() -> subject.handle(handleContext));
+        assertThat(thrown.getStatus()).isEqualTo(INVALID_FILE_ID);
     }
 
     @Test
@@ -193,13 +192,13 @@ class FileSystemDeleteTest extends FileTestBase {
         given(handleContext.body()).willReturn(newSystemDeleteTxn());
 
         final var existingFile = writableStore.get(fileSystemFileId);
-        assertTrue(existingFile.isPresent());
-        assertFalse(existingFile.get().deleted());
+        assertThat(existingFile.isPresent()).isTrue();
+        assertThat(existingFile.get().deleted()).isFalse();
         given(handleContext.writableStore(WritableFileStore.class)).willReturn(writableStore);
 
-        final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
-        assertEquals(ENTITY_NOT_ALLOWED_TO_DELETE, msg.getStatus());
-        assertFalse(existingFile.get().deleted());
+        HandleException thrown = (HandleException) catchThrowable(() -> subject.handle(handleContext));
+        assertThat(ENTITY_NOT_ALLOWED_TO_DELETE).isEqualTo(thrown.getStatus());
+        assertThat(existingFile.get().deleted()).isFalse();
     }
 
     @Test
@@ -213,9 +212,8 @@ class FileSystemDeleteTest extends FileTestBase {
         writableStore = new WritableFileStore(writableStates, testConfig, storeMetricsService);
         given(handleContext.writableStore(WritableFileStore.class)).willReturn(writableStore);
 
-        final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
-
-        assertEquals(UNAUTHORIZED, msg.getStatus());
+        HandleException thrown = (HandleException) catchThrowable(() -> subject.handle(handleContext));
+        assertThat(thrown.getStatus()).isEqualTo(UNAUTHORIZED);
     }
 
     @Test
@@ -224,8 +222,8 @@ class FileSystemDeleteTest extends FileTestBase {
         given(handleContext.body()).willReturn(newFileDeleteTxn());
 
         final var existingFile = writableStore.get(fileId);
-        assertTrue(existingFile.isPresent());
-        assertFalse(existingFile.get().deleted());
+        assertThat(existingFile.isPresent()).isTrue();
+        assertThat(existingFile.get().deleted()).isFalse();
         given(handleContext.writableStore(WritableFileStore.class)).willReturn(writableStore);
 
         lenient().when(handleContext.consensusNow()).thenReturn(instant);
@@ -234,7 +232,7 @@ class FileSystemDeleteTest extends FileTestBase {
 
         final var changedFile = writableStore.get(fileId);
 
-        assertEquals(changedFile, Optional.empty());
+        assertThat(changedFile).isEqualTo(Optional.empty());
     }
 
     @Test
@@ -243,8 +241,8 @@ class FileSystemDeleteTest extends FileTestBase {
         given(handleContext.body()).willReturn(newFileDeleteTxn());
 
         final var existingFile = writableStore.get(fileId);
-        assertTrue(existingFile.isPresent());
-        assertFalse(existingFile.get().deleted());
+        assertThat(existingFile.isPresent()).isTrue();
+        assertThat(existingFile.get().deleted()).isFalse();
         given(handleContext.writableStore(WritableFileStore.class)).willReturn(writableStore);
 
         lenient().when(handleContext.consensusNow()).thenReturn(instant);
@@ -253,8 +251,8 @@ class FileSystemDeleteTest extends FileTestBase {
 
         final var changedFile = writableStore.get(fileId);
 
-        assertTrue(changedFile.isPresent());
-        assertTrue(changedFile.get().deleted());
+        assertThat(changedFile.isPresent()).isTrue();
+        assertThat(changedFile.get().deleted()).isTrue();
     }
 
     private Key mockPayerLookup() throws PreCheckException {


### PR DESCRIPTION
**Description**:
Adds unit tests to FileSystemDeleteHandler. Brings coverage to 92%.

**Related issue(s)**:
#13192 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
