### PR TITLE
chore: Added unit tests for FileSignatureWaiversImpl

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSignatureWaiversImplTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSignatureWaiversImplTest.java
@@ -16,8 +16,7 @@
 
 package com.hedera.node.app.service.file.impl.test.handlers;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -60,7 +59,8 @@ public class FileSignatureWaiversImplTest {
         when(authorizer.hasPrivilegedAuthorization(payer, HederaFunctionality.FILE_UPDATE, fileUpdateTxn))
                 .thenReturn(SystemPrivilege.AUTHORIZED);
 
-        assertTrue(fileSignatureWaivers.areFileUpdateSignaturesWaived(fileUpdateTxn, payer));
+        assertThat(fileSignatureWaivers.areFileUpdateSignaturesWaived(fileUpdateTxn, payer))
+                .isTrue();
     }
 
     @Test
@@ -69,6 +69,7 @@ public class FileSignatureWaiversImplTest {
         when(authorizer.hasPrivilegedAuthorization(payer, HederaFunctionality.FILE_UPDATE, fileUpdateTxn))
                 .thenReturn(SystemPrivilege.UNAUTHORIZED);
 
-        assertFalse(fileSignatureWaivers.areFileUpdateSignaturesWaived(fileUpdateTxn, payer));
+        assertThat(fileSignatureWaivers.areFileUpdateSignaturesWaived(fileUpdateTxn, payer))
+                .isFalse();
     }
 }

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSignatureWaiversImplTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileSignatureWaiversImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.file.impl.test.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.file.impl.handlers.FileSignatureWaiversImpl;
+import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.authorization.SystemPrivilege;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FileSignatureWaiversImplTest {
+
+    @Mock
+    private Authorizer authorizer;
+
+    @Mock
+    private TransactionBody fileUpdateTxn;
+
+    @Mock
+    private AccountID payer;
+
+    private FileSignatureWaiversImpl fileSignatureWaivers;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        fileSignatureWaivers = new FileSignatureWaiversImpl(authorizer);
+    }
+
+    @Test
+    @DisplayName("Signatures are waived when payer has privileged authorization")
+    public void signaturesAreWaivedWhenPayerHasPrivilegedAuthorization() {
+        when(authorizer.hasPrivilegedAuthorization(payer, HederaFunctionality.FILE_UPDATE, fileUpdateTxn))
+                .thenReturn(SystemPrivilege.AUTHORIZED);
+
+        assertTrue(fileSignatureWaivers.areFileUpdateSignaturesWaived(fileUpdateTxn, payer));
+    }
+
+    @Test
+    @DisplayName("Signatures are not waived when payer does not have privileged authorization")
+    public void signaturesAreNotWaivedWhenPayerDoesNotHavePrivilegedAuthorization() {
+        when(authorizer.hasPrivilegedAuthorization(payer, HederaFunctionality.FILE_UPDATE, fileUpdateTxn))
+                .thenReturn(SystemPrivilege.UNAUTHORIZED);
+
+        assertFalse(fileSignatureWaivers.areFileUpdateSignaturesWaived(fileUpdateTxn, payer));
+    }
+}


### PR DESCRIPTION
**Description**:
Adds unit tests for FileSignatureWaiversImpl. Brings coverage to 100%.

**Related issue(s)**:
#13191 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
