### PR TITLE
Use mainnet `throttles.json` for testnet 

### DIFF
--- a/hedera-node/configuration/testnet/upgrade/throttles.json
+++ b/hedera-node/configuration/testnet/upgrade/throttles.json
@@ -61,7 +61,7 @@
         },
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 1250000,
+          "milliOpsPerSec": 125000,
           "operations": [
             "TokenMint"
           ]
@@ -140,14 +140,14 @@
       "throttleGroups": [
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 200000,
+          "milliOpsPerSec": 2000,
           "operations": [
             "CryptoCreate"
           ]
         },
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 50000,
+          "milliOpsPerSec": 5000,
           "operations": [
             "ConsensusCreateTopic"
           ]


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/13296
Use mainnet throttles.json for testnet also