### PR TITLE
chore: Unit test coverage for NetworkTransactionGetRecordHandler 

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -49,6 +49,7 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenRelationStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
+import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fixtures.state.TestSchema;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.state.DeduplicationCache;
@@ -182,6 +183,9 @@ public class NetworkAdminHandlerTestBase {
 
     @Mock
     private NetworkInfo networkInfo;
+
+    @Mock
+    FeeCalculator feeCalculator;
 
     @BeforeEach
     void commonSetUp() {

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetRecordHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetRecordHandlerTest.java
@@ -19,13 +19,11 @@ package com.hedera.node.app.service.networkadmin.impl.test.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.QueryHeader;
@@ -39,10 +37,13 @@ import com.hedera.hapi.node.transaction.TransactionGetRecordQuery;
 import com.hedera.hapi.node.transaction.TransactionGetRecordResponse;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
+import com.hedera.node.app.spi.fees.FeeCalculator;
+import com.hedera.node.app.spi.fixtures.fees.FakeFeeCalculator;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -67,7 +68,7 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
         final var query = createGetTransactionRecordQuery(transactionID, false, false);
         final var header = networkTransactionGetRecordHandler.extractHeader(query);
         final var op = query.transactionGetRecordOrThrow();
-        assertEquals(op.header(), header);
+        assertThat(op.header()).isEqualTo(header);
     }
 
     @Test
@@ -79,23 +80,31 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
         final var expectedResponse = Response.newBuilder()
                 .transactionGetRecord(TransactionGetRecordResponse.newBuilder().header(responseHeader))
                 .build();
-        assertEquals(expectedResponse, response);
+        assertThat(expectedResponse).isEqualTo(response);
     }
 
     @Test
     void requiresPayment() {
-        assertTrue(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.ANSWER_ONLY));
-        assertTrue(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.ANSWER_STATE_PROOF));
-        assertFalse(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.COST_ANSWER));
-        assertFalse(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.COST_ANSWER_STATE_PROOF));
+        assertThat(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.ANSWER_ONLY))
+                .isTrue();
+        assertThat(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.ANSWER_STATE_PROOF))
+                .isTrue();
+        assertThat(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.COST_ANSWER))
+                .isFalse();
+        assertThat(networkTransactionGetRecordHandler.requiresNodePayment(ResponseType.COST_ANSWER_STATE_PROOF))
+                .isFalse();
     }
 
     @Test
     void needsAnswerOnlyCostForCostAnswer() {
-        assertFalse(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.ANSWER_ONLY));
-        assertFalse(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.ANSWER_STATE_PROOF));
-        assertTrue(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.COST_ANSWER));
-        assertFalse(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.COST_ANSWER_STATE_PROOF));
+        assertThat(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.ANSWER_ONLY))
+                .isFalse();
+        assertThat(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.ANSWER_STATE_PROOF))
+                .isFalse();
+        assertThat(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.COST_ANSWER))
+                .isTrue();
+        assertThat(networkTransactionGetRecordHandler.needsAnswerOnlyCost(ResponseType.COST_ANSWER_STATE_PROOF))
+                .isFalse();
     }
 
     @Test
@@ -137,8 +146,9 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
 
         final var response = networkTransactionGetRecordHandler.findResponse(context, responseHeader);
         final var op = response.transactionGetRecordOrThrow();
-        assertEquals(ResponseCodeEnum.FAIL_FEE, op.header().nodeTransactionPrecheckCode());
-        assertNull(op.transactionRecord());
+        assertThat(op.header()).isNotNull();
+        assertThat(op.header().nodeTransactionPrecheckCode()).isEqualTo(ResponseCodeEnum.FAIL_FEE);
+        assertThat(op.transactionRecord()).isNull();
     }
 
     @Test
@@ -153,8 +163,9 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
 
         final var response = networkTransactionGetRecordHandler.findResponse(context, responseHeader);
         final var op = response.transactionGetRecordOrThrow();
-        assertEquals(ResponseCodeEnum.RECORD_NOT_FOUND, op.header().nodeTransactionPrecheckCode());
-        assertNull(op.transactionRecord());
+        assertThat(op.header()).isNotNull();
+        assertThat(op.header().nodeTransactionPrecheckCode()).isEqualTo(ResponseCodeEnum.RECORD_NOT_FOUND);
+        assertThat(op.transactionRecord()).isNull();
     }
 
     @Test
@@ -170,8 +181,9 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
 
         final var response = networkTransactionGetRecordHandler.findResponse(context, responseHeader);
         final var op = response.transactionGetRecordOrThrow();
-        assertEquals(ResponseCodeEnum.OK, op.header().nodeTransactionPrecheckCode());
-        assertEquals(expectedRecord, op.transactionRecord());
+        assertThat(op.header()).isNotNull();
+        assertThat(op.header().nodeTransactionPrecheckCode()).isEqualTo(ResponseCodeEnum.OK);
+        assertThat(op.transactionRecord()).isEqualTo(expectedRecord);
     }
 
     @Test
@@ -188,12 +200,11 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
 
         final var response = networkTransactionGetRecordHandler.findResponse(context, responseHeader);
         final var op = response.transactionGetRecordOrThrow();
-        assertEquals(ResponseCodeEnum.OK, op.header().nodeTransactionPrecheckCode());
-        assertEquals(expectedRecord, op.transactionRecord());
-        assertEquals(expectedDuplicateRecords, op.duplicateTransactionRecords());
-        assertEquals(
-                expectedDuplicateRecords.size(),
-                op.duplicateTransactionRecords().size());
+        assertThat(op.header()).isNotNull();
+        assertThat(op.header().nodeTransactionPrecheckCode()).isEqualTo(ResponseCodeEnum.OK);
+        assertThat(op.transactionRecord()).isEqualTo(expectedRecord);
+        assertThat(op.duplicateTransactionRecords()).isEqualTo(expectedDuplicateRecords);
+        assertThat(op.duplicateTransactionRecords().size()).isEqualTo(expectedDuplicateRecords.size());
     }
 
     @Test
@@ -210,11 +221,40 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
 
         final var response = networkTransactionGetRecordHandler.findResponse(context, responseHeader);
         final var op = response.transactionGetRecordOrThrow();
-        assertEquals(ResponseCodeEnum.OK, op.header().nodeTransactionPrecheckCode());
-        assertEquals(expectedRecord, op.transactionRecord());
-        assertEquals(expectedChildRecordList, op.childTransactionRecords());
-        assertEquals(
-                expectedChildRecordList.size(), op.childTransactionRecords().size());
+        assertThat(op.header()).isNotNull();
+        assertThat(op.header().nodeTransactionPrecheckCode()).isEqualTo(ResponseCodeEnum.OK);
+        assertThat(op.transactionRecord()).isEqualTo(expectedRecord);
+        assertThat(op.childTransactionRecords()).isEqualTo(expectedChildRecordList);
+        assertThat(op.childTransactionRecords().size()).isEqualTo(expectedChildRecordList.size());
+    }
+
+    @Test
+    @DisplayName("test computeFees When Free")
+    void testComputeFees() throws Throwable {
+        final var query = createGetTransactionRecordQuery(transactionID, false, false);
+        given(context.query()).willReturn(query);
+        given(context.recordCache()).willReturn(cache);
+        given(context.feeCalculator()).willReturn(feeCalculator);
+        feeCalculator.addNetworkRamByteSeconds(6);
+        assertThatCode(() -> networkTransactionGetRecordHandler.computeFees(context))
+                .doesNotThrowAnyException();
+        verify(feeCalculator).addNetworkRamByteSeconds(6);
+    }
+
+    @Test
+    @DisplayName("test computeFees with duplicates and children")
+    void testComputeFeesWithDuplicatesAndChildRecords() throws Throwable {
+        final var query = createGetTransactionRecordQuery(transactionID, true, true);
+        given(context.query()).willReturn(query);
+        given(context.recordCache()).willReturn(cache);
+        FeeCalculator feeCalc = new FakeFeeCalculator();
+        feeCalc.addBytesPerTransaction(1000L);
+        feeCalc.addNetworkRamByteSeconds(6);
+        given(context.feeCalculator()).willReturn(feeCalc);
+        assertThatCode(() -> networkTransactionGetRecordHandler.computeFees(context))
+                .doesNotThrowAnyException();
+        var networkFee = networkTransactionGetRecordHandler.computeFees(context).networkFee();
+        assertThat(networkFee).isZero();
     }
 
     private TransactionRecord getExpectedRecord(TransactionID transactionID) {


### PR DESCRIPTION
**Description**:

Adds Unit test coverage > 93% for computeFees and removes all use of junit assertions in NetworkTransactionGetRecordHandler

**Related issue(s)**:

Fixes #13271 

