### PR TITLE
fix: 13300 Added special handling for `com.swirlds.platform.state.merkle.logging.StateLogger`

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -74,6 +74,17 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- State logs -->
+    <RollingFile name="StateLogs"
+                 fileName="output/state/state-changes.log"
+                 filePattern="output/state/state-changes-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -205,6 +216,11 @@
     <!-- Send transaction state logs to their own appender   -->
     <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
+    </Logger>
+
+    <!-- Send state logs to their own appender   -->
+    <Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+      <AppenderRef ref="StateLogs"/>
     </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -74,6 +74,16 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <RollingFile name="StateLogs"
+                 fileName="output/state/state-changes.log"
+                 filePattern="output/state/state-changes-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -205,6 +215,11 @@
     <!-- Send transaction state logs to their own appender   -->
     <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
+    </Logger>
+
+    <!-- Send state logs to their own appender   -->
+    <Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+      <AppenderRef ref="StateLogs"/>
     </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -74,6 +74,16 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <RollingFile name="StateLogs"
+                 fileName="output/state/state-changes.log"
+                 filePattern="output/state/state-changes-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -206,6 +216,12 @@
     <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
+
+    <!-- Send state logs to their own appender   -->
+    <Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+      <AppenderRef ref="StateLogs"/>
+    </Logger>
+
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -74,6 +74,16 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <RollingFile name="StateLogs"
+                 fileName="output/state/state-changes.log"
+                 filePattern="output/state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -205,6 +215,11 @@
     <!-- Send transaction state logs to their own appender   -->
     <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
+    </Logger>
+
+    <!-- Send state logs to their own appender   -->
+    <Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+      <AppenderRef ref="StateLogs"/>
     </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -74,6 +74,17 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- State logs -->
+    <RollingFile name="StateLogs"
+      fileName="output/state/state-changes.log"
+      filePattern="output/state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -206,6 +217,12 @@
     <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
     </Logger>
+
+    <!-- Send state logs to their own appender   -->
+    <Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+      <AppenderRef ref="StateLogs"/>
+    </Logger>
+
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -74,6 +74,17 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- State logs -->
+    <RollingFile name="StateLogs"
+      fileName="output/state/state-changes.log"
+      filePattern="output/state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -205,6 +216,11 @@
     <!-- Send transaction state logs to their own appender   -->
     <Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
       <AppenderRef ref="TransactionStateLogs"/>
+    </Logger>
+
+    <!-- Send state logs to their own appender   -->
+    <Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+      <AppenderRef ref="StateLogs"/>
     </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">

--- a/hedera-node/log4j2.xml
+++ b/hedera-node/log4j2.xml
@@ -62,6 +62,16 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- State logs -->
+    <RollingFile name="StateLogs" fileName="output/state/state-changes.log"
+                 filePattern="output/state/state-changes-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <SizeBasedTriggeringPolicy size="50 MB" />
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">

--- a/hedera-node/test-clients/src/main/resource/log4j2.xml
+++ b/hedera-node/test-clients/src/main/resource/log4j2.xml
@@ -18,7 +18,7 @@
 		<!-- Transaction state logs -->
 		<RollingFile name="TransactionStateLogs"
 								 fileName="output/transaction-state/state-changes.log"
-								 filePattern="output/transaction-state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log.gz">
+								 filePattern="output/transaction-state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log">
 			<PatternLayout>
 				<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
 			</PatternLayout>
@@ -29,7 +29,7 @@
 		<!-- State logs -->
 		<RollingFile name="StateLogs"
 								 fileName="output/state/state-changes.log"
-								 filePattern="output/state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log.gz">
+								 filePattern="output/state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log">
 			<PatternLayout>
 				<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
 			</PatternLayout>

--- a/hedera-node/test-clients/src/main/resource/log4j2.xml
+++ b/hedera-node/test-clients/src/main/resource/log4j2.xml
@@ -25,12 +25,28 @@
 			<SizeBasedTriggeringPolicy size="50 MB" />
 			<DefaultRolloverStrategy max="10"/>
 		</RollingFile>
+
+		<!-- State logs -->
+		<RollingFile name="StateLogs"
+								 fileName="output/state/state-changes.log"
+								 filePattern="output/state/state-changes-%d{yyyy-MM-dd--HH-mm-ss}-%i.log.gz">
+			<PatternLayout>
+				<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %m{nolookups}%n</pattern>
+			</PatternLayout>
+			<SizeBasedTriggeringPolicy size="50 MB" />
+			<DefaultRolloverStrategy max="10"/>
+		</RollingFile>
 	</Appenders>
 	<Loggers>
 
 		<!-- Send transaction state logs to their own appender   -->
 		<Logger name="com.hedera.node.app.state.logging.TransactionStateLogger" level="info" additivity="false">
 			<AppenderRef ref="TransactionStateLogs"/>
+		</Logger>
+
+		<!-- Send state logs to their own appender   -->
+		<Logger name="com.swirlds.platform.state.merkle.logging.StateLogger" level="info" additivity="false">
+			<AppenderRef ref="StateLogs"/>
 		</Logger>
 
 		<Root level="INFO">


### PR DESCRIPTION
**Description**:

This PR addresses performance regression introduced by https://github.com/hashgraph/hedera-services/pull/12570

Now `StateLogger` has its own appenders.

Fixes #13300 

