### PR TITLE
fix: 13336: :swirlds-virtualmap:timingSensitive sizeBasedFlushes is flaky

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -624,7 +624,7 @@ public class VirtualPipeline {
      * @param runnable
      * 		The runnable. Cannot be null.
      */
-    private void pausePipelineAndExecute(final String label, final Runnable runnable) {
+    void pausePipelineAndExecute(final String label, final Runnable runnable) {
         Objects.requireNonNull(runnable);
         final CountDownLatch waitForBackgroundThreadToStart = new CountDownLatch(1);
         final CountDownLatch waitForRunnableToFinish = new CountDownLatch(1);

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
@@ -51,7 +51,7 @@ class DummyVirtualRoot extends PartialMerkleLeaf implements VirtualRoot, MerkleL
 
     private int copyIndex;
 
-    private long estimatedSize = 0;
+    private volatile long estimatedSize = 0;
 
     /**
      * If set, automatically cause a copy to be flushable based on copy index. Only applies to copies made


### PR DESCRIPTION
Fix summary: eliminated a thread race in the test, between "main" and virtual pipeline threads. With the race, the pipeline thread can check if a root node copy needs to be flushed before the copy is released. It results in that copy to be merged rather than flushed, which in turn fails the assertion in the end of the test.

Fixes: https://github.com/hashgraph/hedera-services/issues/13336
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
