### PR TITLE
fix: revert recycle-bin store location

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/PlatformContext.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/PlatformContext.java
@@ -24,6 +24,7 @@ import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.filesystem.FileSystemManagerFactory;
+import com.swirlds.common.io.utility.NoOpRecycleBin;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
@@ -42,9 +43,11 @@ public interface PlatformContext {
 
     /**
      * Creates a new instance of the platform context. The instance uses a {@link NoOpMetrics} implementation for
-     * metrics. The instance uses the static {@link CryptographyHolder#get()} call to get the cryptography. The instance
+     * metrics and a {@link com.swirlds.common.io.utility.NoOpRecycleBin}.
+     * The instance uses the static {@link CryptographyHolder#get()} call to get the cryptography. The instance
      * uses the static {@link Time#getCurrent()} call to get the time.
      *
+     * @apiNote This method is meant for utilities and testing and not for a node's production operation
      * @param configuration the configuration
      * @return the platform context
      * @deprecated since we need to remove the static {@link CryptographyHolder#get()} call in future.
@@ -54,11 +57,8 @@ public interface PlatformContext {
     static PlatformContext create(@NonNull final Configuration configuration) {
         final Metrics metrics = new NoOpMetrics();
         final Cryptography cryptography = CryptographyHolder.get();
-        // This new method is used by commands that have no access to nodeId,
-        // we temporary assigning node 0 until we remove recycle bin from the fsManager,
-        // then we can set a dummy impl of the recycle bin
         final FileSystemManager fileSystemManager =
-                FileSystemManagerFactory.getInstance().createFileSystemManager(configuration, metrics);
+                FileSystemManagerFactory.getInstance().createFileSystemManager(configuration, new NoOpRecycleBin());
 
         return create(configuration, metrics, cryptography, fileSystemManager);
     }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/internal/DefaultPlatformContext.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/internal/DefaultPlatformContext.java
@@ -21,7 +21,6 @@ import com.swirlds.common.concurrent.ExecutorFactory;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.io.filesystem.FileSystemManager;
-import com.swirlds.common.io.filesystem.FileSystemManagerFactory;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -45,27 +44,13 @@ public final class DefaultPlatformContext implements PlatformContext {
     /**
      * Constructor.
      *
-     * @param configuration the configuration
-     * @param metrics       the metrics
-     * @param cryptography  the cryptography
-     * @param time          the time
-     * @param executorFactory the executor factory
+     * @param configuration     the configuration
+     * @param metrics           the metrics
+     * @param cryptography      the cryptography
+     * @param time              the time
+     * @param executorFactory   the executor factory
+     * @param fileSystemManager the fileSystemManager
      */
-    public DefaultPlatformContext(
-            @NonNull final Configuration configuration,
-            @NonNull final Metrics metrics,
-            @NonNull final Cryptography cryptography,
-            @NonNull final Time time,
-            @NonNull final ExecutorFactory executorFactory) {
-        this(
-                configuration,
-                metrics,
-                cryptography,
-                time,
-                executorFactory,
-                FileSystemManagerFactory.getInstance().createFileSystemManager(configuration, metrics));
-    }
-
     public DefaultPlatformContext(
             @NonNull final Configuration configuration,
             @NonNull final Metrics metrics,

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/FileSystemManagerConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/config/FileSystemManagerConfig.java
@@ -40,5 +40,5 @@ public record FileSystemManagerConfig(
 
     public static final String DEFAULT_TMP_DIR_NAME = "tmp";
     public static final String DEFAULT_DATA_DIR_NAME = "saved";
-    public static final String DEFAULT_RECYCLE_BIN_DIR_NAME = "recycle-bin";
+    public static final String DEFAULT_RECYCLE_BIN_DIR_NAME = "saved/swirlds-recycle-bin";
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/filesystem/FileSystemManagerFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/filesystem/FileSystemManagerFactory.java
@@ -17,6 +17,7 @@
 package com.swirlds.common.io.filesystem;
 
 import com.swirlds.common.io.filesystem.internal.FileSystemManagerFactoryImpl;
+import com.swirlds.common.platform.NodeId;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -30,12 +31,25 @@ public interface FileSystemManagerFactory {
      * Creates a {@link FileSystemManager} by searching {@code root} path in the {@link Configuration} class under a
      * property name indicated in {@code rootLocationPropertyName}
      *
-     * @param configuration            the configuration instance to retrieve properties from
+     * @param configuration the configuration instance to retrieve properties from
+     * @param metrics       metrics instance of the platform
+     * @return a new instance of {@link FileSystemManager}
+     */
+    @NonNull
+    FileSystemManager createFileSystemManager(@NonNull Configuration configuration, @NonNull Metrics metrics);
+
+    /**
+     * Creates a {@link FileSystemManager} by searching {@code root} path in the {@link Configuration} class under a
+     * property name indicated in {@code rootLocationPropertyName}
+     *
+     * @param configuration the configuration instance to retrieve properties from
+     * @param metrics       metrics instance of the platform
+     * @param nodeId        id of the ode configuring this instance
      * @return a new instance of {@link FileSystemManager}
      */
     @NonNull
     FileSystemManager createFileSystemManager(
-            @NonNull final Configuration configuration, @NonNull final Metrics metrics);
+            @NonNull Configuration configuration, @NonNull Metrics metrics, @NonNull NodeId nodeId);
 
     /**
      * Retrieves the default FileSystemManagerFactory instance

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/filesystem/FileSystemManagerFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/filesystem/FileSystemManagerFactory.java
@@ -17,6 +17,7 @@
 package com.swirlds.common.io.filesystem;
 
 import com.swirlds.common.io.filesystem.internal.FileSystemManagerFactoryImpl;
+import com.swirlds.common.io.utility.RecycleBin;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
@@ -32,11 +33,11 @@ public interface FileSystemManagerFactory {
      * property name indicated in {@code rootLocationPropertyName}
      *
      * @param configuration the configuration instance to retrieve properties from
-     * @param metrics       metrics instance of the platform
+     * @param recycleBin    the recycleBin instance to use
      * @return a new instance of {@link FileSystemManager}
      */
     @NonNull
-    FileSystemManager createFileSystemManager(@NonNull Configuration configuration, @NonNull Metrics metrics);
+    FileSystemManager createFileSystemManager(@NonNull Configuration configuration, @NonNull RecycleBin recycleBin);
 
     /**
      * Creates a {@link FileSystemManager} by searching {@code root} path in the {@link Configuration} class under a

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/filesystem/internal/FileSystemManagerFactoryImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/filesystem/internal/FileSystemManagerFactoryImpl.java
@@ -22,7 +22,7 @@ import com.swirlds.base.time.Time;
 import com.swirlds.common.io.config.FileSystemManagerConfig;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.filesystem.FileSystemManagerFactory;
-import com.swirlds.common.io.utility.NoOpRecycleBin;
+import com.swirlds.common.io.utility.RecycleBin;
 import com.swirlds.common.io.utility.RecycleBinImpl;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.config.api.Configuration;
@@ -43,17 +43,16 @@ public class FileSystemManagerFactoryImpl implements FileSystemManagerFactory {
      * {@code FileSystemManagerConfig} record
      *
      * @param configuration the configuration instance to retrieve properties from
-     * @param metrics       metrics instance
+     * @param recycleBin    the recycle-bin instance to use in the fileSystemManager
      * @return a new instance of {@link FileSystemManager}
      * @throws UncheckedIOException if the dir structure to rootLocation cannot be created
      */
     @NonNull
     @Override
     public FileSystemManager createFileSystemManager(
-            @NonNull final Configuration configuration, @NonNull final Metrics metrics) {
+            @NonNull final Configuration configuration, @NonNull final RecycleBin recycleBin) {
         final FileSystemManagerConfig fsmConfig = configuration.getConfigData(FileSystemManagerConfig.class);
-        return new FileSystemManagerImpl(
-                fsmConfig.rootPath(), fsmConfig.userDataDir(), fsmConfig.tmpDir(), new NoOpRecycleBin());
+        return new FileSystemManagerImpl(fsmConfig.rootPath(), fsmConfig.userDataDir(), fsmConfig.tmpDir(), recycleBin);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/NoOpRecycleBin.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/NoOpRecycleBin.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 
 /**
  * A no-op {@link RecycleBin} implementation.
- *
  */
 public class NoOpRecycleBin implements RecycleBin {
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/NoOpRecycleBin.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/NoOpRecycleBin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.io.utility;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A no-op {@link RecycleBin} implementation.
+ *
+ */
+public class NoOpRecycleBin implements RecycleBin {
+
+    @Override
+    public void recycle(@NonNull Path path) throws IOException {}
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+}

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/filesystem/internal/FileSystemManagerImplTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/filesystem/internal/FileSystemManagerImplTest.java
@@ -58,8 +58,7 @@ public class FileSystemManagerImplTest {
                 getTestRootPath(),
                 FileSystemManagerConfig.DEFAULT_DATA_DIR_NAME,
                 FileSystemManagerConfig.DEFAULT_TMP_DIR_NAME,
-                FileSystemManagerConfig.DEFAULT_RECYCLE_BIN_DIR_NAME,
-                p -> mockRecycleBin);
+                mockRecycleBin);
     }
 
     private String getTestRootPath() {
@@ -86,8 +85,7 @@ public class FileSystemManagerImplTest {
                 largeRootLocation,
                 FileSystemManagerConfig.DEFAULT_DATA_DIR_NAME,
                 FileSystemManagerConfig.DEFAULT_TMP_DIR_NAME,
-                FileSystemManagerConfig.DEFAULT_RECYCLE_BIN_DIR_NAME,
-                p -> mockRecycleBin);
+                mockRecycleBin);
         // then
         assertThat(Path.of(largeRootLocation)).isDirectory().isNotEmptyDirectory();
     }
@@ -110,8 +108,7 @@ public class FileSystemManagerImplTest {
         assertThat(dir)
                 .isNotEmptyDirectory()
                 .isDirectoryContaining("glob:**" + FileSystemManagerConfig.DEFAULT_TMP_DIR_NAME)
-                .isDirectoryContaining("glob:**" + FileSystemManagerConfig.DEFAULT_DATA_DIR_NAME)
-                .isDirectoryContaining("glob:**" + FileSystemManagerConfig.DEFAULT_RECYCLE_BIN_DIR_NAME);
+                .isDirectoryContaining("glob:**" + FileSystemManagerConfig.DEFAULT_DATA_DIR_NAME);
         assertThat(tmpDir).isDirectoryNotContaining("glob:{" + String.join(",", tmpFileNames) + "}");
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -34,6 +34,8 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.crypto.CryptographyFactory;
 import com.swirlds.common.crypto.CryptographyHolder;
+import com.swirlds.common.io.filesystem.FileSystemManager;
+import com.swirlds.common.io.filesystem.FileSystemManagerFactory;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
 import com.swirlds.common.merkle.crypto.MerkleCryptographyFactory;
@@ -388,7 +390,9 @@ public final class PlatformBuilder {
         setupGlobalMetrics(configuration);
         final Metrics metrics = getMetricsProvider().createPlatformMetrics(selfId);
 
-        return PlatformContext.create(configuration, metrics, cryptography);
+        final FileSystemManager fileSystemManager =
+                FileSystemManagerFactory.getInstance().createFileSystemManager(configuration, metrics, selfId);
+        return PlatformContext.create(configuration, metrics, cryptography, fileSystemManager);
     }
 
     /**


### PR DESCRIPTION
**Description**:
This Pr revers the storage location of the recycle bin back to `saved/swirlds-recycle-bin/nodeId`

**Related issue(s)**:

Fixes #13334 

**Notes for reviewer**:
A recent refactor of the context unified how the PlatformContext is created for commands when no NodeId is needed.
Given the necessity of introducing the nodeId in the factory is limited to cases where we have that information,  I had to create a NoOpRecycleBin that doesn't requiere the nodeId to function.
This introduction brought the opportunity to modify the signature of the factory to support both cases, and thus simplify the factory building patterns
