### PR TITLE
chore: Switch to Transaction.getApplicationPayload()

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/CacheWarmer.java
@@ -107,7 +107,7 @@ public class CacheWarmer {
         // We can potentially optimize this by limiting the code to the bare minimum needed
         // or keeping the result for later.
         try {
-            final Bytes buffer = Bytes.wrap(platformTransaction.getContents());
+            final Bytes buffer = platformTransaction.getApplicationPayload();
             return checker.parseAndCheck(buffer).txBody();
         } catch (PreCheckException ex) {
             return null;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -610,7 +610,7 @@ public class HandleWorkflow {
         } catch (final Exception e) {
             logger.error("Possibly CATASTROPHIC failure while handling a user transaction", e);
             if (transactionInfo == null) {
-                final var baseData = extractTransactionBaseData(platformTxn.getContents());
+                final var baseData = extractTransactionBaseData(platformTxn.getApplicationPayload());
                 if (baseData.transaction() == null) {
                     // FUTURE: Charge node generic penalty, set values in record builder, and remove log statement
                     logger.error("Failed to parse transaction from creator: {}", creator);
@@ -1034,15 +1034,15 @@ public class HandleWorkflow {
             @Nullable TransactionBody txBody,
             @Nullable AccountID payer) {}
 
-    private TransactionBaseData extractTransactionBaseData(@Nullable final byte[] contents) {
+    private TransactionBaseData extractTransactionBaseData(@NonNull final Bytes content) {
         // This method is only called if something fatal happened. We do a best effort approach to extract the
         // type of the transaction, the TransactionBody and the payer if not known.
-        if (contents == null || contents.length == 0) {
+        if (content.length() == 0) {
             return new TransactionBaseData(NONE, Bytes.EMPTY, null, null, null);
         }
 
         HederaFunctionality function = NONE;
-        Bytes transactionBytes = Bytes.wrap(contents);
+        Bytes transactionBytes = content;
         Transaction transaction = null;
         TransactionBody txBody = null;
         AccountID payer = null;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansion.java
@@ -63,7 +63,8 @@ public class AdaptedMonoEventExpansion {
         final List<Transaction> forWorkflows = new ArrayList<>();
         event.forEachTransaction(txn -> {
             try {
-                final var accessor = SignedTxnAccessor.from(txn.getApplicationPayload().toByteArray());
+                final var accessor =
+                        SignedTxnAccessor.from(txn.getApplicationPayload().toByteArray());
                 if (typesForWorkflows.contains(accessor.getFunction())) {
                     forWorkflows.add(txn);
                 } else {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansion.java
@@ -63,7 +63,7 @@ public class AdaptedMonoEventExpansion {
         final List<Transaction> forWorkflows = new ArrayList<>();
         event.forEachTransaction(txn -> {
             try {
-                final var accessor = SignedTxnAccessor.from(txn.getContents());
+                final var accessor = SignedTxnAccessor.from(txn.getApplicationPayload().toByteArray());
                 if (typesForWorkflows.contains(accessor.getFunction())) {
                     forWorkflows.add(txn);
                 } else {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -47,7 +47,6 @@ import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfiguration;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.system.transaction.Transaction;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -176,7 +175,7 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
             // Transaction info is a pure function of the transaction, so we can
             // always reuse it from a prior result
             txInfo = previousResult == null
-                    ? transactionChecker.parseAndCheck(Bytes.wrap(platformTx.getContents()))
+                    ? transactionChecker.parseAndCheck(platformTx.getApplicationPayload())
                     : previousResult.txInfo();
             if (txInfo == null) {
                 // In particular, a null transaction info means we already know the transaction's final failure status

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -1163,7 +1163,7 @@ class HandleWorkflowTest extends AppTestBase {
         void testPreHandleCausesUnexpectedException() {
             final var transactionBytes = Transaction.PROTOBUF.toBytes(
                     new TransactionScenarioBuilder().txInfo().transaction());
-            when(platformTxn.getContents()).thenReturn(transactionBytes.toByteArray());
+            when(platformTxn.getApplicationPayload()).thenReturn(transactionBytes);
             when(platformTxn.getMetadata()).thenReturn(null);
             when(preHandleWorkflow.preHandleTransaction(any(), any(), any(), eq(platformTxn), eq(null)))
                     .thenThrow(NullPointerException.class);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/AdaptedMonoEventExpansionTest.java
@@ -28,6 +28,7 @@ import com.hedera.node.app.service.mono.context.properties.GlobalStaticPropertie
 import com.hedera.node.app.service.mono.sigs.EventExpansion;
 import com.hedera.node.app.service.mono.sigs.order.SigReqsManager;
 import com.hedera.node.app.state.merkle.MerkleHederaState;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.system.transaction.ConsensusTransactionImpl;
 import com.swirlds.platform.system.transaction.Transaction;
@@ -108,7 +109,7 @@ class AdaptedMonoEventExpansionTest extends AppTestBase {
     void worksAroundUnparseableTxn() {
         final var workflows = Set.of(ConsensusCreateTopic);
         given(staticProperties.workflowsEnabled()).willReturn(workflows);
-        given(nonsenseTxn.getContents()).willReturn("NONSENSE".getBytes());
+        given(nonsenseTxn.getApplicationPayload()).willReturn(Bytes.wrap("NONSENSE"));
         willAnswer(invocation -> {
                     final Consumer<Transaction> consumer = invocation.getArgument(0);
                     consumer.accept(nonsenseTxn);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
@@ -220,7 +220,8 @@ public class EntityMapWarmer {
                 final PlatformTxnAccessor txnAccess;
                 final TransactionBody txnBody;
                 try {
-                    txnAccess = PlatformTxnAccessor.from(txn.getApplicationPayload().toByteArray());
+                    txnAccess =
+                            PlatformTxnAccessor.from(txn.getApplicationPayload().toByteArray());
                     txnBody = txnAccess.getTxn();
                 } catch (InvalidProtocolBufferException e) {
                     log.error(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/cache/EntityMapWarmer.java
@@ -220,13 +220,13 @@ public class EntityMapWarmer {
                 final PlatformTxnAccessor txnAccess;
                 final TransactionBody txnBody;
                 try {
-                    txnAccess = PlatformTxnAccessor.from(txn.getContents());
+                    txnAccess = PlatformTxnAccessor.from(txn.getApplicationPayload().toByteArray());
                     txnBody = txnAccess.getTxn();
                 } catch (InvalidProtocolBufferException e) {
                     log.error(
                             "Unable to parse transaction: {} \nErrant Txn: [{}]",
                             e.getMessage(),
-                            Hex.toHexString(txn.getContents()));
+                            Hex.toHexString(txn.getApplicationPayload().toByteArray()));
                     return;
                 }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpan.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/span/ExpandHandleSpan.java
@@ -58,7 +58,7 @@ public class ExpandHandleSpan {
     }
 
     public SwirldsTxnAccessor track(final Transaction transaction) throws InvalidProtocolBufferException {
-        final var accessor = spanAccessorFor(transaction.getContents());
+        final var accessor = spanAccessorFor(transaction.getApplicationPayload().toByteArray());
         transaction.setMetadata(accessor);
         return accessor;
     }
@@ -70,7 +70,7 @@ public class ExpandHandleSpan {
             transaction.setMetadata(null);
             return cachedAccessor;
         } else {
-            return spanAccessorFor(transaction.getContents());
+            return spanAccessorFor(transaction.getApplicationPayload().toByteArray());
         }
     }
 


### PR DESCRIPTION
**Description**:

Switch to `Transaction.getApplicationPayload()` instead of the deprecated method `Transaction.getContents()`

**Related issue(s)**:

Fixes #12885 
