### PR TITLE
fix: allow default `ContractID`s

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -735,7 +735,6 @@ public class ConversionUtils {
         } else {
             // OrElse(0) is needed, as an UNSET contract OneOf has null number
             return asLongZeroAddress(contractId.contractNumOrElse(0L));
-            //            return asLongZeroAddress(contractId.contractNumOrThrow());
         }
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -726,14 +726,16 @@ public class ConversionUtils {
      * Given a {@link ContractID} return the corresponding Besu {@link Address}
      * Importantly, this method does NOT check for the existence of the contract in the ledger
      *
-     * @param contractId
+     * @param contractId the contract id
      * @return the equivalent Besu address
      */
     public static @NonNull Address contractIDToBesuAddress(final ContractID contractId) {
         if (contractId.hasEvmAddress()) {
-            return pbjToBesuAddress(contractId.evmAddress());
+            return pbjToBesuAddress(contractId.evmAddressOrThrow());
         } else {
-            return asLongZeroAddress(contractId.contractNumOrThrow());
+            // OrElse(0) is needed, as an UNSET contract OneOf has null number
+            return asLongZeroAddress(contractId.contractNumOrElse(0L));
+            //            return asLongZeroAddress(contractId.contractNumOrThrow());
         }
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -37,6 +37,7 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.as
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asLongZeroAddress;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asNumberedAccountId;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asNumberedContractId;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.contractIDToBesuAddress;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.numberOfLongZero;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjLogFrom;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjLogsFrom;
@@ -79,6 +80,11 @@ class ConversionUtilsTest {
                 0L, asExactLongValueOrZero(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE)));
         assertEquals(
                 0L, asExactLongValueOrZero(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE)));
+    }
+
+    @Test
+    void besuAddressIsZeroForDefaultContractId() {
+        assertEquals(Address.ZERO, contractIDToBesuAddress(ContractID.DEFAULT));
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
@@ -31,6 +31,7 @@ import com.hedera.services.bdd.spec.infrastructure.meta.ActionableContractCall;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
+import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -54,6 +55,8 @@ import java.util.function.ObjLongConsumer;
 import java.util.function.Supplier;
 
 public class HapiContractCall extends HapiBaseCall<HapiContractCall> {
+    public static final String DEFAULT_ID_SENTINEL = "<DEFAULT_ID>";
+
     protected List<String> otherSigs = Collections.emptyList();
     private Optional<String> details = Optional.empty();
     private Optional<Function<HapiSpec, Object[]>> paramsFn = Optional.empty();
@@ -302,7 +305,9 @@ public class HapiContractCall extends HapiBaseCall<HapiContractCall> {
                 .<ContractCallTransactionBody, ContractCallTransactionBody.Builder>body(
                         ContractCallTransactionBody.class, builder -> {
                             if (contract != null) {
-                                if (!tryAsHexedAddressIfLenMatches) {
+                                if (DEFAULT_ID_SENTINEL.equals(contract)) {
+                                    builder.setContractID(ContractID.getDefaultInstance());
+                                } else if (!tryAsHexedAddressIfLenMatches) {
                                     builder.setContractID(spec.registry().getContractId(contract));
                                 } else {
                                     builder.setContractID(TxnUtils.asContractId(contract, spec));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -55,6 +55,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiContractCall.DEFAULT_ID_SENTINEL;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
@@ -145,7 +146,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestSuite(fuzzyMatch = true)
+@HapiTestSuite(fuzzyMatch = false)
 @Tag(SMART_CONTRACT)
 public class ContractCallSuite extends HapiSuite {
 
@@ -1597,7 +1598,11 @@ public class ContractCallSuite extends HapiSuite {
         return defaultHapiSpec("idVariantsTreatedAsExpected")
                 .given(uploadInitCode(PAY_RECEIVABLE_CONTRACT), contractCreate(PAY_RECEIVABLE_CONTRACT))
                 .when()
-                .then(submitModified(withSuccessivelyVariedBodyIds(), () -> contractCall(PAY_RECEIVABLE_CONTRACT)));
+                .then(
+                        submitModified(withSuccessivelyVariedBodyIds(), () -> contractCall(PAY_RECEIVABLE_CONTRACT)),
+                        // It's also ok to use a default PBJ ContractID (i.e. an id with
+                        // UNSET contract oneof) to make a no-op call to address 0x00...00
+                        contractCall(DEFAULT_ID_SENTINEL));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Permits use of `ContractID.DEFAULT` as an implied no-op call to the zero address.