### PR TITLE
fix: resolve release pipeline failures due to job dependencies

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -858,8 +858,7 @@ jobs:
       - validate
       - local-node-images
       - validate-production-image
-      - evm-mc-publish
-      - sdk-publish
+      - publish
     if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}
     steps:
       - name: Determine Notification Parameters


### PR DESCRIPTION
## Description

This pull request changes the following:

- Removes non-existent jobs referenced by the `needs` clause of the `send-notifications` job in the `node-zxc-build-release-artifact.yaml` workflow definition.

### Related Issues

- Closes #13420 