### PR TITLE
fix: keep staking account creation and initial wait in the same staking period

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -36,6 +36,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRAN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.swirlds.common.stream.LinkedObjectStreamUtilities.getPeriod;
 import static java.lang.System.arraycopy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -663,5 +664,19 @@ public class TxnUtils {
         } catch (UnsupportedEncodingException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Calculates the duration until the start of the next staking period.
+     *
+     * @param now the current time
+     * @param stakePeriodMins the duration of a staking period in minutes
+     * @return the duration until the start of the next staking period
+     */
+    public static java.time.Duration timeUntilNextPeriod(@NonNull final Instant now, final long stakePeriodMins) {
+        final var stakePeriodMillis = stakePeriodMins * 60 * 1000L;
+        final var currentPeriod = getPeriod(now, stakePeriodMillis);
+        final var nextPeriod = currentPeriod + 1;
+        return java.time.Duration.between(now, Instant.ofEpochMilli(nextPeriod * stakePeriodMillis));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsRestartTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsRestartTest.java
@@ -42,8 +42,8 @@ public class MixedOpsRestartTest {
     private static final int MIXED_OPS_BURST_TPS = 50;
     private static final long PORT_UNBINDING_TIMEOUT_MS = 180_000L;
     private static final Duration MIXED_OPS_BURST_DURATION = Duration.ofSeconds(10);
-    private static final Duration FREEZE_TIMEOUT = Duration.ofSeconds(75);
-    private static final Duration RESTART_TIMEOUT = Duration.ofSeconds(120);
+    private static final Duration FREEZE_TIMEOUT = Duration.ofSeconds(90);
+    private static final Duration RESTART_TIMEOUT = Duration.ofSeconds(180);
     private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(60);
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Use a new `ifNextStakePeriodStartsWithin()` utility verb to sleep for an extra staking period in tests that assume a `cryptoCreate` and `waitUntilStartOfNextStakingPeriod` will occur in the same period.
 - Increase the network restart timeout from 2min to 3min in `MixedOpsRestartTest` (one node in a recent run took 2min4s to go `ACTIVE` after restart).