### PR TITLE
fix: explicitly set ledger.id=0x00

### DIFF
--- a/hedera-node/configuration/mainnet/application.properties
+++ b/hedera-node/configuration/mainnet/application.properties
@@ -3,3 +3,4 @@
 # hedera-config), this requirement will no longer be valid.
 # It's used by modular code for property overrides, taking hedera-config/ as the base, 
 # with overrides from this file (configuration/mainnet/application.properties).
+ledger.id=0x00


### PR DESCRIPTION
**Description**:
 - Explicitly set the mainnet ledger id in _application.properties_ to simplify transaction tooling that doesn't expect an empty `0.0.121` file.