### PR TITLE
fix: invalid package name for HapiUtils

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/version/HederaSoftwareVersionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/version/HederaSoftwareVersionTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.node.app.spi.HapiUtils;
+import com.hedera.hapi.util.HapiUtils;
 import com.hedera.node.config.converter.SemanticVersionConverter;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;


### PR DESCRIPTION
closes #13460