### PR TITLE
feat: enable loading keys from PEM files

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/config/CryptoConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/config/CryptoConfig.java
@@ -40,7 +40,7 @@ public record CryptoConfig(
         @ConfigProperty(defaultValue = "0.5") double cpuVerifierThreadRatio,
         @ConfigProperty(defaultValue = "0.5") double cpuDigestThreadRatio,
         @ConfigProperty(defaultValue = "password") String keystorePassword,
-        @ConfigProperty(defaultValue = "false") boolean enableNewKeyStoreModel) {
+        @ConfigProperty(defaultValue = "true") boolean enableNewKeyStoreModel) {
 
     /**
      * Calculates the number of threads needed to achieve the CPU core ratio given by {@link


### PR DESCRIPTION
**Description**:
This change of configuration enables loading signing and agreement keys from PEM files in addition to PFX files. 

**Related issue(s)**:

Fixes #13488 
