### PR TITLE
fix: unbind gRPC server from previous `daggerApp`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -16,36 +16,6 @@
 
 package com.hedera.node.app;
 
-import static com.hedera.node.app.records.impl.BlockRecordManagerImpl.isDefaultConsTimeOfLastHandledTxn;
-import static com.hedera.node.app.service.contract.impl.ContractServiceImpl.CONTRACT_SERVICE;
-import static com.hedera.node.app.service.mono.pbj.PbjConverter.toPbj;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.ACCOUNTS;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.CONTRACT_STORAGE;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.NETWORK_CTX;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.RECORD_STREAM_RUNNING_HASH;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.SCHEDULE_TXS;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.STAKING_INFO;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.STORAGE;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOKENS;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOKEN_ASSOCIATIONS;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOPICS;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.UNIQUE_TOKENS;
-import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MOD_POST_EVENT_STREAM_REPLAY;
-import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MOD_POST_MIGRATION;
-import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MONO_PRE_MIGRATION;
-import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.selectedDumpCheckpoints;
-import static com.hedera.node.app.service.mono.statedumpers.StateDumper.dumpMonoChildrenFrom;
-import static com.hedera.node.app.state.merkle.MerkleSchemaRegistry.isSoOrdered;
-import static com.hedera.node.app.statedumpers.StateDumper.dumpModChildrenFrom;
-import static com.hedera.node.app.util.FileUtilities.observePropertiesAndPermissions;
-import static com.hedera.node.app.util.HederaAsciiArt.HEDERA;
-import static com.swirlds.platform.system.InitTrigger.EVENT_STREAM_RECOVERY;
-import static com.swirlds.platform.system.InitTrigger.GENESIS;
-import static com.swirlds.platform.system.InitTrigger.RECONNECT;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
@@ -131,6 +101,9 @@ import com.swirlds.platform.system.transaction.Transaction;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.nio.charset.Charset;
 import java.security.NoSuchAlgorithmException;
 import java.time.InstantSource;
@@ -139,8 +112,36 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import static com.hedera.node.app.records.impl.BlockRecordManagerImpl.isDefaultConsTimeOfLastHandledTxn;
+import static com.hedera.node.app.service.contract.impl.ContractServiceImpl.CONTRACT_SERVICE;
+import static com.hedera.node.app.service.mono.pbj.PbjConverter.toPbj;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.ACCOUNTS;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.CONTRACT_STORAGE;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.NETWORK_CTX;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.RECORD_STREAM_RUNNING_HASH;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.SCHEDULE_TXS;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.STAKING_INFO;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.STORAGE;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOKENS;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOKEN_ASSOCIATIONS;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOPICS;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.UNIQUE_TOKENS;
+import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MOD_POST_EVENT_STREAM_REPLAY;
+import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MOD_POST_MIGRATION;
+import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MONO_PRE_MIGRATION;
+import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.selectedDumpCheckpoints;
+import static com.hedera.node.app.service.mono.statedumpers.StateDumper.dumpMonoChildrenFrom;
+import static com.hedera.node.app.state.merkle.MerkleSchemaRegistry.isSoOrdered;
+import static com.hedera.node.app.statedumpers.StateDumper.dumpModChildrenFrom;
+import static com.hedera.node.app.util.FileUtilities.observePropertiesAndPermissions;
+import static com.hedera.node.app.util.HederaAsciiArt.HEDERA;
+import static com.swirlds.platform.system.InitTrigger.EVENT_STREAM_RECOVERY;
+import static com.swirlds.platform.system.InitTrigger.GENESIS;
+import static com.swirlds.platform.system.InitTrigger.RECONNECT;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 /*
  ****************        ****************************************************************************************
@@ -1094,8 +1095,13 @@ public final class Hedera implements SwirldMain {
         logger.debug("Initializing dagger");
         final var selfId = platform.getSelfId();
         final var nodeAddress = platform.getAddressBook().getAddress(selfId);
+        // The Dagger component should be constructed every time we reach this point, even if
+        // it exists. This avoids any problems with mutable singleton state by reconstructing
+        // everything. But we must ensure the gRPC server in the old component is fully stopped.
+        if (daggerApp != null) {
+            shutdownGrpcServer();
+        }
         // Fully qualified so as to not confuse javadoc
-        // DaggerApp should be constructed every time we reach this point, even if exists. This is needed for reconnect
         daggerApp = com.hedera.node.app.DaggerHederaInjectionComponent.builder()
                 .initTrigger(trigger)
                 .configProvider(configProvider)


### PR DESCRIPTION
**Description**:
Consider a scenario such as,
```
<<<JVM restarts>>
2024-05-23 14:04:55.913 INFO  430  Hedera - Initializing configuration with trigger RESTART
<<first gRPC server created>>
2024-05-23 14:04:57.140 INFO  809  Hedera - Hederanode#2 is REPLAYING_EVENTS
2024-05-23 14:05:00.017 INFO  809  Hedera - Hederanode#2 is OBSERVING
2024-05-23 14:05:10.031 INFO  809  Hedera - Hederanode#2 is CHECKING
2024-05-23 14:05:10.107 INFO  799  Hedera - Hederanode#2 is ACTIVE
<<first gRPC server started, ports bound>>
2024-05-23 14:05:12.142 INFO  809  Hedera - Hederanode#2 is BEHIND
2024-05-23 14:05:17.035 INFO  430  Hedera - Initializing configuration with trigger RECONNECT
<<second gRPC server created; ⚠️ first should be stopped, ports unbound>>
2024-05-23 14:05:17.324 INFO  809  Hedera - Hederanode#2 is RECONNECT_COMPLETE
2024-05-23 14:05:22.041 INFO  809  Hedera - Hederanode#2 is CHECKING
2024-05-23 14:05:23.259 INFO  799  Hedera - Hederanode#2 is ACTIVE
<<second gRPC server started, same ports bound>>
```

This PR ensures the ⚠️ item is addressed.