### PR TITLE
feat: move checks from `IngestChecker` to `pureChecks` methods

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -16,30 +16,21 @@
 
 package com.hedera.node.app.workflows.ingest;
 
-import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CALL;
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_ADD_LIVE_HASH;
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_DELETE_LIVE_HASH;
-import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.HederaFunctionality.FREEZE;
 import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_DELETE;
 import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_UNDELETE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BUSY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PLATFORM_NOT_ACTIVE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNAUTHORIZED;
 import static com.hedera.hapi.util.HapiUtils.isHollow;
-import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.populateEthTxData;
-import static com.hedera.node.app.service.contract.impl.ContractServiceImpl.INTRINSIC_GAS_LOWER_BOUND;
-import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static com.swirlds.platform.system.status.PlatformStatus.ACTIVE;
-import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -74,9 +65,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.HederaState;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.math.BigInteger;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -177,31 +166,6 @@ public final class IngestChecker {
         final var txInfo = transactionChecker.check(tx);
         final var txBody = txInfo.txBody();
         final var functionality = txInfo.functionality();
-
-        // Temporary ingest checks needed for specifically ContractCall and EthereumTransaction
-        // as long as it is being charged exclusively in gas
-        // We cannot submit transactions that offer no gas or the work done gossiping
-        // and reaching consensus on the transaction will be completely uncompensated; the
-        // minimum threshold here is chosen for mono-service compatibility
-        if (functionality == CONTRACT_CALL) {
-            validateTruePreCheck(txBody.contractCallOrThrow().gas() >= INTRINSIC_GAS_LOWER_BOUND, INSUFFICIENT_GAS);
-
-            // If the fee offered does not cover the gas cost of the transaction, then
-            // we would again end up with uncompensated work
-            // final var gasCost = solvencyPreCheck.estimateAdditionalCosts(txBody, CONTRACT_CALL, consensusTime)
-            //         - txBody.contractCallOrThrow().amount();
-            // validateTruePreCheck(txBody.transactionFee() >= gasCost, INSUFFICIENT_TX_FEE);
-        } else if (functionality == ETHEREUM_TRANSACTION) {
-            final var ethTxData = populateEthTxData(
-                    requireNonNull(txBody.ethereumTransactionOrThrow().ethereumData())
-                            .toByteArray());
-            validateTruePreCheck(nonNull(ethTxData), INVALID_ETHEREUM_TRANSACTION);
-            validateTruePreCheck(ethTxData.gasLimit() >= INTRINSIC_GAS_LOWER_BOUND, INSUFFICIENT_GAS);
-            // Do not allow sending HBars to Burn Address
-            if (ethTxData.value().compareTo(BigInteger.ZERO) > 0) {
-                validateFalsePreCheck(Arrays.equals(ethTxData.to(), new byte[20]), INVALID_SOLIDITY_ADDRESS);
-            }
-        }
 
         // 1a. Verify the transaction has been sent to *this* node
         if (!nodeAccount.equals(txBody.nodeAccountID())) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -17,10 +17,14 @@
 package com.hedera.node.app.service.contract.impl.handlers;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CALL;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.throwIfUnsuccessful;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -42,6 +46,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
  * This class contains all workflow-related functionality regarding {@link HederaFunctionality#CONTRACT_CALL}.
@@ -49,10 +55,14 @@ import javax.inject.Singleton;
 @Singleton
 public class ContractCallHandler implements TransactionHandler {
     private final Provider<TransactionComponent.Factory> provider;
+    private final GasCalculator gasCalculator;
 
     @Inject
-    public ContractCallHandler(@NonNull final Provider<TransactionComponent.Factory> provider) {
+    public ContractCallHandler(
+            @NonNull final Provider<TransactionComponent.Factory> provider,
+            @NonNull final GasCalculator gasCalculator) {
         this.provider = requireNonNull(provider);
+        this.gasCalculator = requireNonNull(gasCalculator);
     }
 
     @Override
@@ -66,7 +76,7 @@ public class ContractCallHandler implements TransactionHandler {
         // Assemble the appropriate top-level record for the result
         // (FUTURE) Remove ExternalizeAbortResult.NO, this is only
         // for mono-service fidelity during differential testing
-        outcome.addCallDetailsTo(context.recordBuilder(ContractCallRecordBuilder.class), ExternalizeAbortResult.NO);
+        outcome.addCallDetailsTo(context.recordBuilder(ContractCallRecordBuilder.class), ExternalizeAbortResult.YES);
 
         throwIfUnsuccessful(outcome.status());
     }
@@ -80,6 +90,11 @@ public class ContractCallHandler implements TransactionHandler {
     public void pureChecks(@NonNull TransactionBody txn) throws PreCheckException {
         final var op = txn.contractCallOrThrow();
         mustExist(op.contractID(), INVALID_CONTRACT_ID);
+
+        validateTruePreCheck(op.gas() <= MAX_GAS_LIMIT, MAX_GAS_LIMIT_EXCEEDED);
+        final var intrinsicGas = gasCalculator.transactionIntrinsicGasCost(
+                Bytes.wrap(op.functionParameters().toByteArray()), false);
+        validateTruePreCheck(op.gas() >= intrinsicGas, INSUFFICIENT_GAS);
     }
 
     @NonNull

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -76,7 +76,7 @@ public class ContractCallHandler implements TransactionHandler {
         // Assemble the appropriate top-level record for the result
         // (FUTURE) Remove ExternalizeAbortResult.NO, this is only
         // for mono-service fidelity during differential testing
-        outcome.addCallDetailsTo(context.recordBuilder(ContractCallRecordBuilder.class), ExternalizeAbortResult.YES);
+        outcome.addCallDetailsTo(context.recordBuilder(ContractCallRecordBuilder.class), ExternalizeAbortResult.NO);
 
         throwIfUnsuccessful(outcome.status());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
@@ -17,9 +17,13 @@
 package com.hedera.node.app.service.contract.impl.handlers;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CREATE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.throwIfUnsuccessful;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -42,6 +46,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
  * This class contains all workflow-related functionality regarding {@link HederaFunctionality#CONTRACT_CREATE}.
@@ -51,10 +57,14 @@ public class ContractCreateHandler implements TransactionHandler {
     private static final AccountID REMOVE_AUTO_RENEW_ACCOUNT_SENTINEL =
             AccountID.newBuilder().shardNum(0).realmNum(0).accountNum(0).build();
     private final Provider<TransactionComponent.Factory> provider;
+    private final GasCalculator gasCalculator;
 
     @Inject
-    public ContractCreateHandler(@NonNull final Provider<TransactionComponent.Factory> provider) {
+    public ContractCreateHandler(
+            @NonNull final Provider<TransactionComponent.Factory> provider,
+            @NonNull final GasCalculator gasCalculator) {
         this.provider = requireNonNull(provider);
+        this.gasCalculator = requireNonNull(gasCalculator);
     }
 
     @Override
@@ -73,7 +83,12 @@ public class ContractCreateHandler implements TransactionHandler {
 
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+        final var op = txn.contractCreateInstanceOrThrow();
+
+        validateTruePreCheck(op.gas() <= MAX_GAS_LIMIT, MAX_GAS_LIMIT_EXCEEDED);
+        // FUTURE:Consider reading the init code from a file but this may be too much to do for pure checks
+        final var intrinsicGas = gasCalculator.transactionIntrinsicGasCost(Bytes.wrap(new byte[0]), true);
+        validateTruePreCheck(op.gas() >= intrinsicGas, INSUFFICIENT_GAS);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractHandlers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractHandlers.java
@@ -49,6 +49,7 @@ public class ContractHandlers {
 
     private final EthereumTransactionHandler ethereumTransactionHandler;
 
+    // Approximate gas limit for contract transactions.  Used for pure checks.
     public static final long MAX_GAS_LIMIT = 15_000_000L;
 
     @Inject

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractHandlers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractHandlers.java
@@ -49,6 +49,8 @@ public class ContractHandlers {
 
     private final EthereumTransactionHandler ethereumTransactionHandler;
 
+    public static final long MAX_GAS_LIMIT = 15_000_000L;
+
     @Inject
     public ContractHandlers(
             @NonNull final ContractCallHandler contractCallHandler,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -17,11 +17,18 @@
 package com.hedera.node.app.service.contract.impl.handlers;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
+import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.populateEthTxData;
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.throwIfUnsuccessful;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
+import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -51,9 +58,12 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.math.BigInteger;
+import java.util.Arrays;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
  * This class contains all workflow-related functionality regarding {@link
@@ -64,15 +74,18 @@ public class EthereumTransactionHandler implements TransactionHandler {
     private final EthTxSigsCache ethereumSignatures;
     private final EthereumCallDataHydration callDataHydration;
     private final Provider<TransactionComponent.Factory> provider;
+    private final GasCalculator gasCalculator;
 
     @Inject
     public EthereumTransactionHandler(
             @NonNull final EthTxSigsCache ethereumSignatures,
             @NonNull final EthereumCallDataHydration callDataHydration,
-            @NonNull final Provider<TransactionComponent.Factory> provider) {
+            @NonNull final Provider<TransactionComponent.Factory> provider,
+            @NonNull final GasCalculator gasCalculator) {
         this.ethereumSignatures = requireNonNull(ethereumSignatures);
         this.callDataHydration = requireNonNull(callDataHydration);
         this.provider = requireNonNull(provider);
+        this.gasCalculator = requireNonNull(gasCalculator);
     }
 
     @Override
@@ -87,7 +100,19 @@ public class EthereumTransactionHandler implements TransactionHandler {
 
     @Override
     public void pureChecks(@NonNull final TransactionBody txn) throws PreCheckException {
-        // nothing to do
+        final var ethTxData = populateEthTxData(
+                requireNonNull(txn.ethereumTransactionOrThrow().ethereumData()).toByteArray());
+        validateTruePreCheck(nonNull(ethTxData), INVALID_ETHEREUM_TRANSACTION);
+        validateTruePreCheck(ethTxData.gasLimit() <= MAX_GAS_LIMIT, MAX_GAS_LIMIT_EXCEEDED);
+        final byte[] callData = ethTxData.hasCallData() ? ethTxData.callData() : new byte[0];
+        final var intrinsicGas =
+                gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(callData), false);
+        validateTruePreCheck(ethTxData.gasLimit() >= intrinsicGas, INSUFFICIENT_GAS);
+        // FUTURE: This was copied over from IngestChecker.  Investigate if it's still needed.
+        // Do not allow sending HBars to Burn Address
+        if (ethTxData.value().compareTo(BigInteger.ZERO) > 0) {
+            validateFalsePreCheck(Arrays.equals(ethTxData.to(), new byte[20]), INVALID_SOLIDITY_ADDRESS);
+        }
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
@@ -17,12 +17,14 @@
 package com.hedera.node.app.service.contract.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.HALT_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertFailsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -38,6 +40,8 @@ import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +50,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ContractCallHandlerTest extends ContractHandlerTestBase {
+    public static final long INTRINSIC_GAS = 21064L;
+
     @Mock
     private TransactionComponent component;
 
@@ -64,7 +70,15 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
     @Mock
     private RootProxyWorldUpdater baseProxyWorldUpdater;
 
-    private final ContractCallHandler subject = new ContractCallHandler(() -> factory);
+    @Mock
+    private GasCalculator gasCalculator;
+
+    private ContractCallHandler subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new ContractCallHandler(() -> factory, gasCalculator);
+    }
 
     @Test
     void delegatesToCreatedComponentAndExposesSuccess() {
@@ -115,6 +129,23 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
         assertThat(context.payerKey()).isEqualTo(payerKey);
     }
 
+    @Test
+    void validatePureChecks() {
+        // check null contact id
+        final var txn1 = contractCallTransactionWithNoContractId();
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(txn1));
+
+        // check at least intrinsic gas
+        final var txn2 = contractCallTransactionWithInsufficientGas();
+        given(gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(new byte[0]), false))
+                .willReturn(INTRINSIC_GAS);
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(txn2));
+
+        // check does not exceed max gas
+        final var txn3 = contractCallTransactionWithAboveMaxGas();
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(txn3));
+    }
+
     private TransactionBody contractCallTransaction() {
         final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
         return TransactionBody.newBuilder()
@@ -122,6 +153,34 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
                 .contractCall(ContractCallTransactionBody.newBuilder()
                         .gas(1_234)
                         .amount(1_234L)
+                        .contractID(targetContract))
+                .build();
+    }
+
+    private TransactionBody contractCallTransactionWithNoContractId() {
+        final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
+        return TransactionBody.newBuilder()
+                .transactionID(transactionID)
+                .contractCall(ContractCallTransactionBody.newBuilder())
+                .build();
+    }
+
+    private TransactionBody contractCallTransactionWithInsufficientGas() {
+        final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
+        return TransactionBody.newBuilder()
+                .transactionID(transactionID)
+                .contractCall(ContractCallTransactionBody.newBuilder()
+                        .gas(INTRINSIC_GAS - 1)
+                        .contractID(targetContract))
+                .build();
+    }
+
+    private TransactionBody contractCallTransactionWithAboveMaxGas() {
+        final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
+        return TransactionBody.newBuilder()
+                .transactionID(transactionID)
+                .contractCall(ContractCallTransactionBody.newBuilder()
+                        .gas(MAX_GAS_LIMIT + 1)
                         .contractID(targetContract))
                 .build();
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
@@ -50,7 +50,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ContractCallHandlerTest extends ContractHandlerTestBase {
-    public static final long INTRINSIC_GAS = 21064L;
+    public static final long INTRINSIC_GAS_FOR_0_ARG_METHOD = 21064L;
 
     @Mock
     private TransactionComponent component;
@@ -138,7 +138,7 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
         // check at least intrinsic gas
         final var txn2 = contractCallTransactionWithInsufficientGas();
         given(gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(new byte[0]), false))
-                .willReturn(INTRINSIC_GAS);
+                .willReturn(INTRINSIC_GAS_FOR_0_ARG_METHOD);
         assertThrows(PreCheckException.class, () -> subject.pureChecks(txn2));
 
         // check does not exceed max gas
@@ -170,7 +170,7 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
         return TransactionBody.newBuilder()
                 .transactionID(transactionID)
                 .contractCall(ContractCallTransactionBody.newBuilder()
-                        .gas(INTRINSIC_GAS - 1)
+                        .gas(INTRINSIC_GAS_FOR_0_ARG_METHOD - 1)
                         .contractID(targetContract))
                 .build();
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
@@ -16,8 +16,10 @@
 
 package com.hedera.node.app.service.contract.impl.test.handlers;
 
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONTRACTS_CONFIG;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.INTRINSIC_GAS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,8 +51,11 @@ import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import java.util.function.Function;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -103,7 +108,15 @@ class ContractCallLocalHandlerTest {
     @Mock
     private FeeCalculator feeCalculator;
 
-    private final ContractCallLocalHandler subject = new ContractCallLocalHandler(() -> factory);
+    @Mock
+    private GasCalculator gasCalculator;
+
+    private ContractCallLocalHandler subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new ContractCallLocalHandler(() -> factory, gasCalculator);
+    }
 
     @Test
     void extractHeaderTest() {
@@ -133,6 +146,7 @@ class ContractCallLocalHandlerTest {
         given(context.query()).willReturn(query);
         given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
         given(contractCallLocalQuery.contractID()).willReturn(contractID);
+        given(contractCallLocalQuery.functionParameters()).willReturn(Bytes.EMPTY);
         given(context.createStore(ReadableAccountStore.class)).willReturn(store);
         given(store.getContractById(contractID)).willReturn(contract);
         givenAllowCallsToNonContractAccountOffConfig();
@@ -170,6 +184,7 @@ class ContractCallLocalHandlerTest {
         given(context.query()).willReturn(query);
         given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
         given(contractCallLocalQuery.contractID()).willReturn(null);
+        given(contractCallLocalQuery.functionParameters()).willReturn(Bytes.EMPTY);
         givenDefaultConfig();
 
         // when:
@@ -182,10 +197,35 @@ class ContractCallLocalHandlerTest {
         given(context.query()).willReturn(query);
         given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
         given(contractCallLocalQuery.contractID()).willReturn(contractID);
+        given(contractCallLocalQuery.functionParameters()).willReturn(Bytes.EMPTY);
         given(context.createStore(ReadableAccountStore.class)).willReturn(store);
         given(store.getContractById(contractID)).willReturn(null);
         given(context.createStore(ReadableTokenStore.class)).willReturn(tokenStore);
         given(tokenStore.get(any())).willReturn(null);
+        givenAllowCallsToNonContractAccountOffConfig();
+
+        // when:
+        assertThatThrownBy(() -> subject.validate(context)).isInstanceOf(PreCheckException.class);
+    }
+
+    @Test
+    void validateFailsIfGasIsLessThanIntrinsic() {
+        // given
+        given(context.query()).willReturn(query);
+        given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
+        given(contractCallLocalQuery.gas()).willReturn(INTRINSIC_GAS - 1);
+        givenAllowCallsToNonContractAccountOffConfig();
+
+        // when:
+        assertThatThrownBy(() -> subject.validate(context)).isInstanceOf(PreCheckException.class);
+    }
+
+    @Test
+    void validateFailsIfGasIsMoreThanMax() {
+        // given
+        given(context.query()).willReturn(query);
+        given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
+        given(contractCallLocalQuery.gas()).willReturn(MAX_GAS_LIMIT + 1);
         givenAllowCallsToNonContractAccountOffConfig();
 
         // when:
@@ -198,6 +238,7 @@ class ContractCallLocalHandlerTest {
         given(context.query()).willReturn(query);
         given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
         given(contractCallLocalQuery.contractID()).willReturn(contractID);
+        given(contractCallLocalQuery.functionParameters()).willReturn(Bytes.EMPTY);
         given(context.createStore(ReadableAccountStore.class)).willReturn(store);
         given(store.getContractById(contractID)).willReturn(contract);
         givenAllowCallsToNonContractAccountOffConfig();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
@@ -19,8 +19,8 @@ package com.hedera.node.app.service.contract.impl.test.handlers;
 import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONTRACTS_CONFIG;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.INTRINSIC_GAS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT;
+import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS_FOR_0_ARG_METHOD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
@@ -213,7 +213,7 @@ class ContractCallLocalHandlerTest {
         // given
         given(context.query()).willReturn(query);
         given(query.contractCallLocalOrThrow()).willReturn(contractCallLocalQuery);
-        given(contractCallLocalQuery.gas()).willReturn(INTRINSIC_GAS - 1);
+        given(contractCallLocalQuery.gas()).willReturn(INTRINSIC_GAS_FOR_0_ARG_METHOD - 1);
         givenAllowCallsToNonContractAccountOffConfig();
 
         // when:

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerParityTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerParityTest.java
@@ -35,6 +35,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import java.util.Set;
 import javax.inject.Provider;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,12 +49,15 @@ class ContractCreateHandlerParityTest {
     @Mock
     private Provider<TransactionComponent.Factory> provider;
 
+    @Mock
+    private GasCalculator gasCalculator;
+
     private ContractCreateHandler subject;
 
     @BeforeEach
     void setUp() {
         accountStore = AdapterUtils.wellKnownKeyLookupAt();
-        subject = new ContractCreateHandler(provider);
+        subject = new ContractCreateHandler(provider, gasCalculator);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
@@ -21,8 +21,10 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.HALT_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertFailsWith;
+import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -43,6 +45,7 @@ import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import java.util.List;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -67,11 +70,14 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
     @Mock
     private ContractCreateRecordBuilder recordBuilder;
 
+    @Mock
+    private GasCalculator gasCalculator;
+
     private ContractCreateHandler subject;
 
     @BeforeEach
     void setUp() {
-        subject = new ContractCreateHandler(() -> factory);
+        subject = new ContractCreateHandler(() -> factory, gasCalculator);
     }
 
     @Test
@@ -173,6 +179,20 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
         // meta.requiredNonPayerKeys());
     }
 
+    @Test
+    @DisplayName("validate checks in pureChecks()")
+    void validatePureChecks() {
+        // check at least intrinsic gas
+        final var txn1 = contractCreateTransactionWithInsufficientGas();
+        given(gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(new byte[0]), true))
+                .willReturn(INTRINSIC_GAS);
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(txn1));
+
+        // check does not exceed max gas
+        final var txn2 = contractCreateTransactionWithInsufficientGas();
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(txn2));
+    }
+
     private TransactionBody contractCreateTransaction(final Key adminKey, final AccountID autoRenewId) {
         final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
         final var createTxnBody = ContractCreateTransactionBody.newBuilder().memo("Create Contract");
@@ -192,6 +212,24 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
         return TransactionBody.newBuilder()
                 .transactionID(transactionID)
                 .contractCreateInstance(createTxnBody)
+                .build();
+    }
+
+    private TransactionBody contractCreateTransactionWithInsufficientGas() {
+        final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
+        return TransactionBody.newBuilder()
+                .transactionID(transactionID)
+                .contractCreateInstance(
+                        ContractCreateTransactionBody.newBuilder().gas(INTRINSIC_GAS - 1))
+                .build();
+    }
+
+    private TransactionBody contractCreateTransactionWithAboveMaxGas() {
+        final var transactionID = TransactionID.newBuilder().accountID(payer).transactionValidStart(consensusTimestamp);
+        return TransactionBody.newBuilder()
+                .transactionID(transactionID)
+                .contractCreateInstance(
+                        ContractCreateTransactionBody.newBuilder().gas(INTRINSIC_GAS - 1))
                 .build();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
@@ -17,11 +17,12 @@
 package com.hedera.node.app.service.contract.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.HALT_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertFailsWith;
-import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS;
+import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS_FOR_0_ARG_METHOD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -185,11 +186,11 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
         // check at least intrinsic gas
         final var txn1 = contractCreateTransactionWithInsufficientGas();
         given(gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(new byte[0]), true))
-                .willReturn(INTRINSIC_GAS);
+                .willReturn(INTRINSIC_GAS_FOR_0_ARG_METHOD);
         assertThrows(PreCheckException.class, () -> subject.pureChecks(txn1));
 
         // check does not exceed max gas
-        final var txn2 = contractCreateTransactionWithInsufficientGas();
+        final var txn2 = contractCreateTransactionWithAboveMaxGas();
         assertThrows(PreCheckException.class, () -> subject.pureChecks(txn2));
     }
 
@@ -220,7 +221,7 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
         return TransactionBody.newBuilder()
                 .transactionID(transactionID)
                 .contractCreateInstance(
-                        ContractCreateTransactionBody.newBuilder().gas(INTRINSIC_GAS - 1))
+                        ContractCreateTransactionBody.newBuilder().gas(INTRINSIC_GAS_FOR_0_ARG_METHOD - 1))
                 .build();
     }
 
@@ -229,7 +230,7 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
         return TransactionBody.newBuilder()
                 .transactionID(transactionID)
                 .contractCreateInstance(
-                        ContractCreateTransactionBody.newBuilder().gas(INTRINSIC_GAS - 1))
+                        ContractCreateTransactionBody.newBuilder().gas(MAX_GAS_LIMIT + 1))
                 .build();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.contract.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
+import static com.hedera.node.app.service.contract.impl.handlers.ContractHandlers.MAX_GAS_LIMIT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.ETH_DATA_WITHOUT_TO_ADDRESS;
@@ -25,14 +26,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.ETH_DAT
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.HEVM_CREATION;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT_WITH_SIGNER_NONCE;
+import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.node.contract.EthereumTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
@@ -60,10 +65,13 @@ import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.List;
 import java.util.function.Supplier;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -124,9 +132,15 @@ class EthereumTransactionHandlerTest {
     @Mock
     private HederaEvmAccount senderAccount;
 
+    @Mock
+    private GasCalculator gasCalculator;
+
+    @Mock
+    private EthTxData ethTxDataReturned;
+
     @BeforeEach
     void setUp() {
-        subject = new EthereumTransactionHandler(ethereumSignatures, callDataHydration, () -> factory);
+        subject = new EthereumTransactionHandler(ethereumSignatures, callDataHydration, () -> factory, gasCalculator);
     }
 
     void setUpTransactionProcessing() {
@@ -260,6 +274,43 @@ class EthereumTransactionHandlerTest {
                 .willReturn(HydratedEthTxData.failureFrom(INVALID_ETHEREUM_TRANSACTION));
         assertThrowsPreCheck(() -> subject.preHandle(preHandleContext), INVALID_ETHEREUM_TRANSACTION);
         verifyNoInteractions(ethereumSignatures);
+    }
+
+    @Test
+    void validatePureChecks() throws PreCheckException {
+        // check bad eth txn body
+        final var txn1 = ethTxWithNoTx();
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(txn1));
+
+        // check at least intrinsic gas
+        try (MockedStatic<EthTxData> ethTxData = Mockito.mockStatic(EthTxData.class)) {
+            ethTxData.when(() -> EthTxData.populateEthTxData(any())).thenReturn(ethTxDataReturned);
+            given(ethTxDataReturned.gasLimit()).willReturn(INTRINSIC_GAS - 1);
+            given(gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(new byte[0]), false))
+                    .willReturn(INTRINSIC_GAS);
+            assertThrows(PreCheckException.class, () -> subject.pureChecks(ethTxWithTx()));
+        }
+
+        // check less than max gas
+        try (MockedStatic<EthTxData> ethTxData = Mockito.mockStatic(EthTxData.class)) {
+            ethTxData.when(() -> EthTxData.populateEthTxData(any())).thenReturn(ethTxDataReturned);
+            given(ethTxDataReturned.gasLimit()).willReturn(MAX_GAS_LIMIT + 1);
+            assertThrows(PreCheckException.class, () -> subject.pureChecks(ethTxWithTx()));
+        }
+    }
+
+    private TransactionBody ethTxWithNoTx() {
+        return TransactionBody.newBuilder()
+                .ethereumTransaction(EthereumTransactionBody.newBuilder().build())
+                .build();
+    }
+
+    private TransactionBody ethTxWithTx() {
+        return TransactionBody.newBuilder()
+                .ethereumTransaction(EthereumTransactionBody.newBuilder()
+                        .ethereumData(Bytes.EMPTY)
+                        .build())
+                .build();
     }
 
     void givenSenderAccount() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -26,7 +26,7 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.ETH_DAT
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.HEVM_CREATION;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SUCCESS_RESULT_WITH_SIGNER_NONCE;
-import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS;
+import static com.hedera.node.app.service.contract.impl.test.handlers.ContractCallHandlerTest.INTRINSIC_GAS_FOR_0_ARG_METHOD;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -285,9 +285,9 @@ class EthereumTransactionHandlerTest {
         // check at least intrinsic gas
         try (MockedStatic<EthTxData> ethTxData = Mockito.mockStatic(EthTxData.class)) {
             ethTxData.when(() -> EthTxData.populateEthTxData(any())).thenReturn(ethTxDataReturned);
-            given(ethTxDataReturned.gasLimit()).willReturn(INTRINSIC_GAS - 1);
+            given(ethTxDataReturned.gasLimit()).willReturn(INTRINSIC_GAS_FOR_0_ARG_METHOD - 1);
             given(gasCalculator.transactionIntrinsicGasCost(org.apache.tuweni.bytes.Bytes.wrap(new byte[0]), false))
-                    .willReturn(INTRINSIC_GAS);
+                    .willReturn(INTRINSIC_GAS_FOR_0_ARG_METHOD);
             assertThrows(PreCheckException.class, () -> subject.pureChecks(ethTxWithTx()));
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -227,6 +227,7 @@ public class ContractCallSuite {
     private static final String RECEIVER_2_INFO = "receiver2Info";
     private static final String RECEIVER_3_INFO = "receiver3Info";
     public static final String DELEGATE_CALL_SPECIFIC = "delegateCallSpecific";
+    private static final long INTRINSIC_GAS_FOR_0_ARG_METHOD = 21_064L;
 
     @HapiTest
     final Stream<DynamicTest> canHandleInvalidContractCallTransactions() {
@@ -2637,7 +2638,7 @@ public class ContractCallSuite {
                 .when(withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         contractCallWithFunctionAbi(CONTRACT, getABIFor(FUNCTION, functionName, contractName))
-                                .gas(21_063L)
+                                .gas(INTRINSIC_GAS_FOR_0_ARG_METHOD - 1)
                                 .signingWith(ACCOUNT)
                                 .hasPrecheck(INSUFFICIENT_GAS))))
                 .then();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -17,6 +17,7 @@
 package com.hedera.services.bdd.suites.contract.hapi;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asContract;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asContractString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.contractIdFromHexedMirrorAddress;
@@ -101,6 +102,7 @@ import static com.hedera.services.bdd.suites.contract.Utils.captureChildCreate2M
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIForContract;
 import static com.hedera.services.bdd.suites.contract.opcodes.Create2OperationSuite.SALT;
+import static com.hedera.services.bdd.suites.regression.factories.HollowAccountCompletedFuzzingFactory.CONTRACT;
 import static com.hedera.services.bdd.suites.utils.ECDSAKeysUtils.randomHeadlongAddress;
 import static com.hedera.services.bdd.suites.utils.contracts.SimpleBytesResult.bigIntResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
@@ -2622,6 +2624,23 @@ public class ContractCallSuite {
                 .when()
                 .then(contractCall(
                         contract, "callRequested", nonExtantEvmAddress, new byte[0], BigInteger.valueOf(88_888L)));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> failsWithLessThanIntrinsicGas() {
+        final String randomContract = "0.0.1051";
+        final String functionName = "name";
+        final String contractName = "ERC721ABI";
+        return defaultHapiSpec("failsWithLessThanIntrinsicGas")
+                .given(cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS), withOpContext((spec, opLog) -> spec.registry()
+                        .saveContractId(CONTRACT, asContract(randomContract))))
+                .when(withOpContext((spec, ctxLog) -> allRunFor(
+                        spec,
+                        contractCallWithFunctionAbi(CONTRACT, getABIFor(FUNCTION, functionName, contractName))
+                                .gas(21_063L)
+                                .signingWith(ACCOUNT)
+                                .hasPrecheck(INSUFFICIENT_GAS))))
+                .then();
     }
 
     private String getNestedContractAddress(final String contract, final HapiSpec spec) {


### PR DESCRIPTION
**Description**:
There were several checks performed in `IngestChecker` that should be relocated to relevant `pureChecks()` methods in handlers.

Fixes: #13521 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
