### PR TITLE
fix: Fix NPE in `QueryWorkflowImpl` (#13541)

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -196,7 +196,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                 TransactionBody txBody;
                 AccountID payerID = null;
                 if (paymentRequired) {
-                    allegedPayment = queryHeader.paymentOrThrow();
+                    allegedPayment = queryHeader.paymentOrElse(Transaction.DEFAULT);
                     final var configuration = configProvider.getConfiguration();
 
                     // 3.i Ingest checks


### PR DESCRIPTION
Cherry-pick #13541 

Fixes https://github.com/hashgraph/hedera-services/issues/13515

Fixes NPE in `QueryWorkflowImpl` by use OrElse pattern instead of throw to correctly return a response code instead of NPE