### PR TITLE
fix: disable broken consensusTests::nodeRemoveTest

### DIFF
--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestDefinitions.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTestDefinitions.java
@@ -558,6 +558,13 @@ public final class ConsensusTestDefinitions {
                             .getLatestRound()
                             .getSnapshot());
             final int fi = i;
+            // The following lines of code to move the events from a 4 node network to a 3 node network causes the
+            // 3 node network to reach divergent rounds of consensus from the 4 node network.
+            // On random seed 2836910334346903534L, the snapshot ends on round 315, but the 3 node network
+            // goes past the snapshot round.  round 317 has a single judge, which is how this problem was discovered.
+            // The implementation of this test needs to be redone to properly remove a node from the first orchestrator
+            // instead of trying to bootstrap a second orchestrator in the proper state.  Replaying the previously
+            // events is going to be wrong because the weight distribution by % in the 3 node network is different.
             orchestrator1.getNodes().get(i).getOutput().getAddedEvents().forEach(e -> {
                 orchestrator2.getNodes().get(fi).getIntake().addEvent(e);
             });

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/ConsensusTests.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -296,6 +297,7 @@ class ConsensusTests extends PlatformTest {
     @Tag(TestComponentTags.PLATFORM)
     @Tag(TestComponentTags.CONSENSUS)
     @DisplayName("Remove a node from the address book at restart")
+    @Disabled("Disabled until the implementation of the test properly simulates removing a node.")
     void nodeRemoveTest(final ConsensusTestParams params) {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::removeNode)


### PR DESCRIPTION
**Description**:
disables `ConsensusTests::nodeRemoveTest` which is not implemented correctly.  

This new issue was created to implement the test correctly: https://github.com/hashgraph/hedera-services/issues/13556

**Related issue(s)**:

Fixes #13201 