### PR TITLE
perf: HapiUtils.parsedIntOrZero() throws too many exceptions

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -28,8 +28,7 @@ tasks.cloneHederaProtobufs {
     // uncomment below to use a specific tag
     //    tag = "v0.50.0-release"
     // uncomment below to use a specific branch
-    //    branch = "main"
-    branch = "13265-backout-dab-change"
+    branch = "main"
 }
 
 sourceSets {

--- a/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
+++ b/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
@@ -339,7 +339,7 @@ public class HapiUtils {
     }
 
     private static int parsedIntOrZero(@Nullable final String s) {
-        if (s == null) {
+        if (s == null || s.isBlank()) {
             return 0;
         } else {
             try {


### PR DESCRIPTION
Call `isBlank()` in `parsedIntOrZero()` to avoid `NumberFormatException` for empty/blank strings.

**Related issue(s)**:

Fixes #13587

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
