### PR TITLE
perf: HapiUtils.parsedIntOrZero() throws too many exceptions

### DIFF
--- a/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
+++ b/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
@@ -339,7 +339,7 @@ public class HapiUtils {
     }
 
     private static int parsedIntOrZero(@Nullable final String s) {
-        if (s == null) {
+        if (s == null || s.isBlank()) {
             return 0;
         } else {
             try {


### PR DESCRIPTION
**Description**:

Call isBlank() in parsedIntOrZero() to avoid NumberFormatException for empty/blank strings.

**Related issue(s)**:

Fixes #13587

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
