### PR TITLE
fix: add migrations to repair storage links

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/Service.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/Service.java
@@ -30,6 +30,23 @@ import java.util.Set;
  */
 public interface Service {
     /**
+     * A sort value for the service, used to determine the order in which service
+     * schemas are migrated.
+     *
+     * <p><b>(FUTURE)</b> This order should actually depend on the migration
+     * software version, because nothing prevents service {@code A} from needing
+     * to precede service {@code B} in version {@code N}; while at the same time
+     * {@code B} needing to precede {@code A} in version {@code N+1}. But this
+     * will require a significant restructuring in {@code hedera-app} and does
+     * not provide any current value, so we defer that work.
+     *
+     * @return the migrationOrder value
+     */
+    default int migrationOrder() {
+        return 0;
+    }
+
+    /**
      * Returns the name of the service. This name must be unique for each service deployed on the
      * application.
      *

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/MigrationContext.java
@@ -22,6 +22,7 @@ import com.hedera.node.app.spi.workflows.record.GenesisRecordsBuilder;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
 
 /**
  * Provides the context for a migration of state from one {@link Schema} version to another.
@@ -97,4 +98,12 @@ public interface MigrationContext {
      */
     @Nullable
     SemanticVersion previousVersion();
+
+    /**
+     * Returns a mutable "scratchpad" that can be used to share values between different services
+     * during a migration.
+     *
+     * @return the shared values map
+     */
+    Map<String, Object> sharedValues();
 }

--- a/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
+++ b/hedera-node/hedera-app/src/itest/java/grpc/GrpcTestBase.java
@@ -26,6 +26,7 @@ import com.hedera.node.app.spi.Service;
 import com.hedera.node.app.spi.fixtures.TestBase;
 import com.hedera.node.app.spi.fixtures.state.NoOpGenesisRecordsBuilder;
 import com.hedera.node.app.state.merkle.MerkleSchemaRegistry;
+import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.hedera.node.app.workflows.ingest.IngestWorkflow;
 import com.hedera.node.app.workflows.query.QueryWorkflow;
 import com.hedera.node.config.VersionedConfigImpl;
@@ -177,7 +178,8 @@ abstract class GrpcTestBase extends TestBase {
         };
 
         final var cr = ConstructableRegistry.getInstance();
-        final var registry = new MerkleSchemaRegistry(cr, "TestService", new NoOpGenesisRecordsBuilder());
+        final var registry =
+                new MerkleSchemaRegistry(cr, "TestService", new NoOpGenesisRecordsBuilder(), new SchemaApplications());
         final var registration = new ServicesRegistry.Registration(testService, registry);
         final var config = createConfig(new TestSource());
         this.grpcServer = new NettyGrpcServerManager(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -36,7 +36,7 @@ import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MOD_P
 import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.MONO_PRE_MIGRATION;
 import static com.hedera.node.app.service.mono.statedumpers.DumpCheckpoint.selectedDumpCheckpoints;
 import static com.hedera.node.app.service.mono.statedumpers.StateDumper.dumpMonoChildrenFrom;
-import static com.hedera.node.app.state.merkle.MerkleSchemaRegistry.isSoOrdered;
+import static com.hedera.node.app.state.merkle.VersionUtils.isSoOrdered;
 import static com.hedera.node.app.statedumpers.StateDumper.dumpModChildrenFrom;
 import static com.hedera.node.app.util.FileUtilities.observePropertiesAndPermissions;
 import static com.hedera.node.app.util.HederaAsciiArt.HEDERA;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/OrderedServiceMigrator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/OrderedServiceMigrator.java
@@ -31,7 +31,8 @@ import com.hedera.node.config.VersionedConfiguration;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -71,6 +72,7 @@ public class OrderedServiceMigrator {
         requireNonNull(networkInfo);
         requireNonNull(metrics);
 
+        final Map<String, Object> sharedValues = new HashMap<>();
         logger.info("Migrating Entity ID Service as pre-requisite for other services");
         final var entityIdRegistration = servicesRegistry.registrations().stream()
                 .filter(service -> EntityIdService.NAME.equals(service.service().getServiceName()))
@@ -85,7 +87,8 @@ public class OrderedServiceMigrator {
                 networkInfo,
                 metrics,
                 // We call with null here because we're migrating the entity ID service itself
-                null);
+                null,
+                sharedValues);
 
         // The token service has a dependency on the entity ID service during genesis migrations, so we
         // CAREFULLY create a different WritableStates specific to the entity ID service. The different
@@ -100,12 +103,11 @@ public class OrderedServiceMigrator {
         final var entityIdWritableStates = state.getWritableStates(EntityIdService.NAME);
         final var entityIdStore = new WritableEntityIdStore(entityIdWritableStates);
 
-        // Now that the Entity ID Service is migrated, migrate the remaining services in name order. Note: the name
-        // ordering itself isn't important, just that the ordering is deterministic
+        // Now that the Entity ID Service is migrated, migrate the remaining services in the order
+        // determined by the service registry (this ordering can be critical for migrations with
+        // inter-service dependencies)
         servicesRegistry.registrations().stream()
                 .filter(r -> !Objects.equals(entityIdRegistration, r))
-                .sorted(Comparator.comparing(
-                        (ServicesRegistry.Registration r) -> r.service().getServiceName()))
                 .forEach(registration -> {
                     // FUTURE We should have metrics here to keep track of how long it takes to
                     // migrate each service
@@ -124,7 +126,8 @@ public class OrderedServiceMigrator {
                             // If we have reached this point in the code, entityIdStore should not be null because the
                             // EntityIdService should have been migrated already. We enforce with requireNonNull in case
                             // there are scenarios we haven't considered.
-                            requireNonNull(entityIdStore));
+                            requireNonNull(entityIdStore),
+                            sharedValues);
                     // Now commit any changes that were made to the entity ID state (since other service entities could
                     // depend on newly-generated entity IDs)
                     if (entityIdWritableStates instanceof MerkleHederaState.MerkleWritableStates mws) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistry.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.node.app.spi.Service;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Comparator;
 import java.util.Set;
 import javax.inject.Singleton;
 
@@ -35,10 +36,20 @@ public interface ServicesRegistry {
      * @param service The service that was registered
      * @param registry The schema registry for the service
      */
-    record Registration(@NonNull Service service, @NonNull SchemaRegistry registry) {
+    record Registration(@NonNull Service service, @NonNull SchemaRegistry registry)
+            implements Comparable<Registration> {
+        private static final Comparator<Registration> COMPARATOR = Comparator.<Registration>comparingInt(
+                        r -> r.service().migrationOrder())
+                .thenComparing(r -> r.service().getServiceName());
+
         public Registration {
             requireNonNull(service);
             requireNonNull(registry);
+        }
+
+        @Override
+        public int compareTo(@NonNull final Registration that) {
+            return COMPARATOR.compare(this, that);
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServicesRegistryImpl.java
@@ -22,6 +22,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.spi.Service;
 import com.hedera.node.app.spi.workflows.record.GenesisRecordsBuilder;
 import com.hedera.node.app.state.merkle.MerkleSchemaRegistry;
+import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.hedera.node.app.version.HederaSoftwareVersion;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -73,7 +74,8 @@ public final class ServicesRegistryImpl implements ServicesRegistry {
         final var serviceName = service.getServiceName();
 
         logger.debug("Registering schemas for service {}", serviceName);
-        final var registry = new MerkleSchemaRegistry(constructableRegistry, serviceName, genesisRecords);
+        final var registry =
+                new MerkleSchemaRegistry(constructableRegistry, serviceName, genesisRecords, new SchemaApplications());
         service.registerSchemas(registry, VERSION);
 
         entries.add(new Registration(service, registry));

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -16,7 +16,10 @@
 
 package com.hedera.node.app.state.merkle;
 
-import static com.hedera.node.app.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.MIGRATION;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.RESTART;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.STATE_DEFINITIONS;
+import static com.hedera.node.app.state.merkle.VersionUtils.isSoOrdered;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -27,10 +30,10 @@ import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.state.FilteredReadableStates;
 import com.hedera.node.app.spi.state.FilteredWritableStates;
 import com.hedera.node.app.spi.state.MigrationContext;
-import com.hedera.node.app.spi.state.ReadableStates;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
+import com.hedera.node.app.spi.state.WritableStates;
 import com.hedera.node.app.spi.workflows.record.GenesisRecordsBuilder;
 import com.hedera.node.app.state.merkle.disk.OnDiskKey;
 import com.hedera.node.app.state.merkle.disk.OnDiskKeySerializer;
@@ -55,10 +58,9 @@ import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.logging.log4j.LogManager;
@@ -72,7 +74,7 @@ import org.apache.logging.log4j.Logger;
  * then registers each and every {@link Schema} that it has. Each {@link Schema} is associated with
  * a {@link SemanticVersion}.
  *
- * <p>The Hedera application then calls {@link #migrate(MerkleHederaState, SemanticVersion, SemanticVersion, Configuration, NetworkInfo, WritableEntityIdStore)} on each {@link MerkleSchemaRegistry} instance, supplying it the
+ * <p>The Hedera application then calls {@code com.hedera.node.app.Hedera#onMigrate(MerkleHederaState, HederaSoftwareVersion, InitTrigger, Metrics)} on each {@link MerkleSchemaRegistry} instance, supplying it the
  * application version number and the newly created (or deserialized) but not yet hashed copy of the {@link
  * MerkleHederaState}. The registry determines which {@link Schema}s to apply, possibly taking multiple migration steps,
  * to transition the merkle tree from its current version to the final version.
@@ -96,22 +98,29 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      * Stores system entities created during genesis until the node can build synthetic records
      */
     private final GenesisRecordsBuilder genesisRecordsBuilder;
+    /**
+     * The analysis to use when determining how to apply a schema.
+     */
+    private final SchemaApplications schemaApplications;
 
     /**
-     * Create a new instance.
+     * Create a new instance with the default {@link SchemaApplications}.
      *
      * @param constructableRegistry The {@link ConstructableRegistry} to register states with for
      * deserialization
      * @param serviceName The name of the service using this registry.
      * @param genesisRecordsBuilder class used to store entities created at genesis
+     * @param schemaApplications the analysis to use when determining how to apply a schema
      */
     public MerkleSchemaRegistry(
             @NonNull final ConstructableRegistry constructableRegistry,
             @NonNull final String serviceName,
-            @NonNull final GenesisRecordsBuilder genesisRecordsBuilder) {
+            @NonNull final GenesisRecordsBuilder genesisRecordsBuilder,
+            @NonNull final SchemaApplications schemaApplications) {
         this.constructableRegistry = requireNonNull(constructableRegistry);
         this.serviceName = StateUtils.validateStateKey(requireNonNull(serviceName));
         this.genesisRecordsBuilder = requireNonNull(genesisRecordsBuilder);
+        this.schemaApplications = requireNonNull(schemaApplications);
     }
 
     /**
@@ -139,6 +148,14 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
     }
 
     /**
+     * Encapsulates the writable states before and after applying a schema's state definitions.
+     *
+     * @param beforeStates the writable states before applying the schema's state definitions
+     * @param afterStates the writable states after applying the schema's state definitions
+     */
+    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {}
+
+    /**
      * Called by the application after saved states have been loaded to perform the migration. Given
      * the supplied versions, applies all necessary migrations for every {@link Schema} newer than
      * {@code previousVersion} and no newer than {@code currentVersion}.
@@ -154,40 +171,43 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      * previousVersion}.
      * @param config The system configuration to use at the time of migration
      * @param networkInfo The network information to use at the time of migration
+     * @param sharedValues
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void migrate(
-            @NonNull final MerkleHederaState hederaState,
+            @NonNull final MerkleHederaState state,
             @Nullable final SemanticVersion previousVersion,
             @NonNull final SemanticVersion currentVersion,
             @NonNull final Configuration config,
             @NonNull final NetworkInfo networkInfo,
             @NonNull final Metrics metrics,
-            @Nullable final WritableEntityIdStore entityIdStore) {
-        requireNonNull(hederaState);
+            @Nullable final WritableEntityIdStore entityIdStore,
+            @NonNull final Map<String, Object> sharedValues) {
+        requireNonNull(state);
         requireNonNull(currentVersion);
         requireNonNull(config);
         requireNonNull(networkInfo);
         requireNonNull(metrics);
-
-        // Figure out which schemas need to be applied based on the previous and current versions, and then for each
-        // of those schemas, create the new states and remove the old states and migrate the data.
-        final var schemasToApply = computeApplicableSchemas(previousVersion, currentVersion);
-        if (schemasToApply.isEmpty()) {
+        requireNonNull(sharedValues);
+        if (isSoOrdered(currentVersion, previousVersion)) {
+            throw new IllegalArgumentException("The currentVersion must be at least the previousVersion");
+        }
+        if (schemas.isEmpty()) {
             logger.info("Service {} does not use state", serviceName);
             return;
         }
+        final var latestVersion = schemas.getLast().getVersion();
         logger.info(
-                "Migrating {} applicable schemas for service {} from {} to {}",
-                schemasToApply::size,
+                "Applying {} schemas for service {} with state version {}, "
+                        + "software version {}, and latest service schema version {}",
+                schemas::size,
                 () -> serviceName,
                 () -> HapiUtils.toString(previousVersion),
-                () -> HapiUtils.toString(currentVersion));
-        final var latestVersion = schemasToApply.getLast().getVersion();
-        for (final var schema : schemasToApply) {
-            final var applicationType = checkApplicationType(previousVersion, latestVersion, schema);
-            logger.info("Applying {} schema {} ({})", serviceName, schema.getVersion(), applicationType);
-
+                () -> HapiUtils.toString(currentVersion),
+                () -> HapiUtils.toString(latestVersion));
+        for (final var schema : schemas) {
+            final var applications = schemaApplications.computeApplications(previousVersion, latestVersion, schema);
+            logger.info("Applying {} schema {} ({})", serviceName, schema.getVersion(), applications);
             // Now we can migrate the schema and then commit all the changes
             // We just have one merkle tree -- the just-loaded working tree -- to work from.
             // We get a ReadableStates for everything in the current tree, but then wrap
@@ -195,221 +215,44 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             // available at this moment in time. This is done to make sure that even after we
             // add new states into the tree, it doesn't increase the number of states that can
             // be seen by the schema migration code
-            ReadableStates previousStatesIfNeeded = null;
-            if (applicationType != SchemaApplicationType.ONLY_STATE_MANAGEMENT) {
-                final var readableStates = hederaState.getReadableStates(serviceName);
-                previousStatesIfNeeded = new FilteredReadableStates(readableStates, readableStates.stateKeys());
+            final var readableStates = state.getReadableStates(serviceName);
+            final var previousStates = new FilteredReadableStates(readableStates, readableStates.stateKeys());
+            // Similarly, we distinguish between the writable states before and after
+            // applying the schema's state definitions. This is done to ensure that we
+            // commit all state changes made by applying this schema's state definitions;
+            // but also prevent its migrate() and restart() hooks from accidentally using
+            // states that were actually removed by this schema
+            final WritableStates writableStates;
+            final WritableStates newStates;
+            if (applications.contains(STATE_DEFINITIONS)) {
+                final var redefinedWritableStates = applyStateDefinitions(schema, metrics, state);
+                writableStates = redefinedWritableStates.beforeStates();
+                newStates = redefinedWritableStates.afterStates();
+            } else {
+                newStates = writableStates = state.getWritableStates(serviceName);
             }
-
-            // Create the new states (based on the schema) which, thanks to the above, does not
-            // expand the set of states that the migration code will see
-            schema.statesToCreate().stream()
-                    .sorted(Comparator.comparing(StateDefinition::stateKey))
-                    .forEach(def -> {
-                        final var stateKey = def.stateKey();
-                        logger.info("  Ensuring {} has state {}", serviceName, stateKey);
-                        final var md = new StateMetadata<>(serviceName, schema, def);
-                        if (def.singleton()) {
-                            hederaState.putServiceStateIfAbsent(md, () -> new SingletonNode<>(md, null));
-                        } else if (def.queue()) {
-                            hederaState.putServiceStateIfAbsent(md, () -> new QueueNode<>(md));
-                        } else if (!def.onDisk()) {
-                            hederaState.putServiceStateIfAbsent(md, () -> {
-                                final var map = new MerkleMap<>();
-                                map.setLabel(StateUtils.computeLabel(serviceName, stateKey));
-                                return map;
-                            });
-                        } else {
-                            hederaState.putServiceStateIfAbsent(md, () -> {
-                                // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
-                                // PREFER_DISK_BASED_INDICES = false
-                                final var tableConfig = new MerkleDbTableConfig<>(
-                                                (short) 1,
-                                                DigestType.SHA_384,
-                                                (short) 1,
-                                                new OnDiskKeySerializer<>(md),
-                                                (short) 1,
-                                                new OnDiskValueSerializer<>(md))
-                                        .maxNumberOfKeys(def.maxKeysHint());
-                                final var label = StateUtils.computeLabel(serviceName, stateKey);
-                                final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
-                                final var virtualMap = new VirtualMap<>(label, dsBuilder);
-                                virtualMap.registerMetrics(metrics);
-                                return virtualMap;
-                            });
-                        }
-                    });
-
-            // Create the writable states. We won't commit anything from these states
-            // until we have completed migration.
-            final var writableStates = hederaState.getWritableStates(serviceName);
-            final var statesToRemove = schema.statesToRemove();
-            final var remainingStates = new HashSet<>(writableStates.stateKeys());
-            remainingStates.removeAll(statesToRemove);
-            final var newStates = new FilteredWritableStates(writableStates, remainingStates);
-
-            if (applicationType != SchemaApplicationType.ONLY_STATE_MANAGEMENT) {
-                // For any changes to state that depend on other services outside the current
-                // service, we need a reference to the overall state that we can pass into the
-                // context. This reference to overall state will be strictly controlled via the
-                // MigrationContext API so that only changes explicitly specified in the
-                // interface can be made (instead of allowing any arbitrary state change).
-                final var migrationContext = new MigrationContextImpl(
-                        requireNonNull(previousStatesIfNeeded),
-                        newStates,
-                        config,
-                        networkInfo,
-                        genesisRecordsBuilder,
-                        entityIdStore,
-                        previousVersion);
-                if (applicationType != SchemaApplicationType.RESTART_ONLY) {
-                    schema.migrate(migrationContext);
-                }
-                if (applicationType != SchemaApplicationType.MIGRATE_ONLY) {
-                    schema.restart(migrationContext);
-                }
+            final var migrationContext = new MigrationContextImpl(
+                    previousStates,
+                    newStates,
+                    config,
+                    networkInfo,
+                    genesisRecordsBuilder,
+                    entityIdStore,
+                    previousVersion,
+                    sharedValues);
+            if (applications.contains(MIGRATION)) {
+                schema.migrate(migrationContext);
             }
-
+            if (applications.contains(RESTART)) {
+                schema.restart(migrationContext);
+            }
             // Now commit all the service-specific changes made during this service's update or migration
             if (writableStates instanceof MerkleHederaState.MerkleWritableStates mws) {
                 mws.commit();
             }
             // And finally we can remove any states we need to remove
-            statesToRemove.forEach(stateKey -> hederaState.removeServiceState(serviceName, stateKey));
+            schema.statesToRemove().forEach(stateKey -> state.removeServiceState(serviceName, stateKey));
         }
-    }
-
-    private SchemaApplicationType checkApplicationType(
-            @Nullable final SemanticVersion previousVersionFromState,
-            @NonNull final SemanticVersion latestRegisteredSchemaVersion,
-            @NonNull final Schema schema) {
-        // If the previous version is the same as the latest version, then we only need to restart
-        // If this schema is the last registered schema, but is before the current version,
-        // then we only need to restart. Since we apply atleast one schema(last registered schema)
-        // if there are no schemas reported to migrate.
-        if (previousVersionFromState != null
-                && (isSameVersion(previousVersionFromState, latestRegisteredSchemaVersion)
-                        || isSoOrdered(latestRegisteredSchemaVersion, previousVersionFromState))) {
-            return SchemaApplicationType.RESTART_ONLY;
-        } else if (isSameVersion(schema.getVersion(), latestRegisteredSchemaVersion)) {
-            return SchemaApplicationType.MIGRATE_THEN_RESTART;
-        } else if (!isSameVersion(schema.getVersion(), previousVersionFromState)) {
-            return SchemaApplicationType.MIGRATE_ONLY;
-        } else {
-            return SchemaApplicationType.ONLY_STATE_MANAGEMENT;
-        }
-    }
-
-    private enum SchemaApplicationType {
-        /**
-         * A schema whose version is the same as the version of the saved state,
-         * but is not the latest version, has no migration work to do, and also
-         * does not have priority for managing the service's restart logic.
-         */
-        ONLY_STATE_MANAGEMENT,
-        /**
-         * A schema whose version is after the version of the saved state, but
-         * is not the latest version, has migration work to do, but also does
-         * not have priority for managing the service's restart logic.
-         */
-        MIGRATE_ONLY,
-        /**
-         * A schema whose version is both the previous and latest version has
-         * no migration work to do, but does have priority for managing the
-         * service's restart logic.
-         */
-        RESTART_ONLY,
-        /**
-         * A schema whose version is after the version of the saved state, and
-         * is also the latest version, has migration work to do, and also has
-         * priority for managing the service's restart logic.
-         */
-        MIGRATE_THEN_RESTART
-    }
-
-    /**
-     * Given two versions, gets the ordered list of all schemas that must be applied to transition
-     * the merkle tree from some previousVersion to the currentVersion. If {@code previousVersion}
-     * and {@code currentVersion} are the same, then an empty set is returned. In all other cases,
-     * every registered {@link Schema} newer than {@code previousVersion} and less than or equal to
-     * {@code currentVersion} will be returned.
-     *
-     * @param previousVersion The previous version of the merkle tree. May be null for genesis. Must
-     * be less than or equal to {@code currentVersion}.
-     * @param currentVersion The current version of the application. May NOT be null under any
-     * condition. Must be greater than or equal to the {@code previousVersion}.
-     * @return An ordered list of {@link Schema}s which, when applied in order, will transition the
-     * merkle tree from {@code previousVersion} to {@code currentVersion}.
-     */
-    @NonNull
-    private List<Schema> computeApplicableSchemas(
-            @Nullable final SemanticVersion previousVersion, @NonNull final SemanticVersion currentVersion) {
-        // The previous version MUST be strictly less than or equal to the current version
-        if (!isSameVersion(previousVersion, currentVersion) && !isSoOrdered(previousVersion, currentVersion)) {
-            throw new IllegalArgumentException("The currentVersion must be strictly greater than the previousVersion");
-        }
-
-        // Evaluate each of the schemas (which are in ascending order by version, thanks
-        // to the tree-set nature of our set) and select the subset that are newer than
-        // the "previousVersion" and no newer than the currentVersion.
-        final var applicableSchemas = new ArrayList<Schema>();
-        for (Schema schema : schemas) {
-            final var ver = schema.getVersion();
-            if (isSameVersion(ver, currentVersion) || isBetween(previousVersion, ver, currentVersion)) {
-                applicableSchemas.add(schema);
-            }
-        }
-        final List<Schema> registeredSchemas = schemas.isEmpty() ? List.of() : List.of(schemas.getLast());
-        return applicableSchemas.isEmpty() ? registeredSchemas : applicableSchemas;
-    }
-
-    /**
-     * Determines whether these two version are equal to each other. Both are equal if they are both
-     * null, or have the same version number.
-     *
-     * @param a The first arg
-     * @param b The second arg
-     * @return true if both are null, or if both have the same version number
-     */
-    public static boolean isSameVersion(@Nullable final SemanticVersion a, @Nullable final SemanticVersion b) {
-        return (a == null && b == null) || (a != null && b != null && SEMANTIC_VERSION_COMPARATOR.compare(a, b) == 0);
-    }
-
-    private boolean isBetween(
-            @Nullable final SemanticVersion maybeFirst,
-            @NonNull final SemanticVersion maybeSecond,
-            @NonNull final SemanticVersion maybeThird) {
-        return isSoOrdered(maybeFirst, maybeSecond) && isSoOrdered(maybeSecond, maybeThird);
-    }
-
-    /**
-     * Determines if the two arguments are in the proper order, such that the first argument is
-     * strictly lower than the second argument. If they are the same, we return false.
-     *
-     * @param maybeBefore The version we hope comes before {@code maybeAfter}
-     * @param maybeAfter The version we hope comes after {@code maybeBefore}
-     * @return True if, and only if, {@code maybeBefore} is a lower version number than {@code
-     * maybeAfter}.
-     */
-    public static boolean isSoOrdered(
-            @Nullable final SemanticVersion maybeBefore, @NonNull final SemanticVersion maybeAfter) {
-
-        // If they are the same version, then we must fail.
-        if (isSameVersion(maybeBefore, maybeAfter)) {
-            return false;
-        }
-
-        // If the first argument is null, then the second argument always
-        // comes later (since it must be non-null, or else isSameVersion
-        // would have caught it).
-        if (maybeBefore == null) {
-            return true;
-        }
-
-        // If the comparison yields the first argument as being before
-        // or matching the second argument, then we return true because
-        // the condition we're testing for holds.
-        return SEMANTIC_VERSION_COMPARATOR.compare(maybeBefore, maybeAfter) < 0;
     }
 
     /**
@@ -457,5 +300,58 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                             + "'",
                     e);
         }
+    }
+
+    private RedefinedWritableStates applyStateDefinitions(
+            @NonNull final Schema schema,
+            @NonNull final Metrics metrics,
+            @NonNull final MerkleHederaState hederaState) {
+        // Create the new states (based on the schema) which, thanks to the above, does not
+        // expand the set of states that the migration code will see
+        schema.statesToCreate().stream()
+                .sorted(Comparator.comparing(StateDefinition::stateKey))
+                .forEach(def -> {
+                    final var stateKey = def.stateKey();
+                    logger.info("  Ensuring {} has state {}", serviceName, stateKey);
+                    final var md = new StateMetadata<>(serviceName, schema, def);
+                    if (def.singleton()) {
+                        hederaState.putServiceStateIfAbsent(md, () -> new SingletonNode<>(md, null));
+                    } else if (def.queue()) {
+                        hederaState.putServiceStateIfAbsent(md, () -> new QueueNode<>(md));
+                    } else if (!def.onDisk()) {
+                        hederaState.putServiceStateIfAbsent(md, () -> {
+                            final var map = new MerkleMap<>();
+                            map.setLabel(StateUtils.computeLabel(serviceName, stateKey));
+                            return map;
+                        });
+                    } else {
+                        hederaState.putServiceStateIfAbsent(md, () -> {
+                            // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
+                            // PREFER_DISK_BASED_INDICES = false
+                            final var tableConfig = new MerkleDbTableConfig<>(
+                                            (short) 1,
+                                            DigestType.SHA_384,
+                                            (short) 1,
+                                            new OnDiskKeySerializer<>(md),
+                                            (short) 1,
+                                            new OnDiskValueSerializer<>(md))
+                                    .maxNumberOfKeys(def.maxKeysHint());
+                            final var label = StateUtils.computeLabel(serviceName, stateKey);
+                            final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
+                            final var virtualMap = new VirtualMap<>(label, dsBuilder);
+                            virtualMap.registerMetrics(metrics);
+                            return virtualMap;
+                        });
+                    }
+                });
+
+        // Create the "before" and "after" writable states (we won't commit anything
+        // from these states until we have completed migration for this schema)
+        final var statesToRemove = schema.statesToRemove();
+        final var writableStates = hederaState.getWritableStates(serviceName);
+        final var remainingStates = new HashSet<>(writableStates.stateKeys());
+        remainingStates.removeAll(statesToRemove);
+        final var newStates = new FilteredWritableStates(writableStates, remainingStates);
+        return new RedefinedWritableStates(writableStates, newStates);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/SchemaApplicationType.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/SchemaApplicationType.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state.merkle;
+
+import com.hedera.node.app.spi.state.Schema;
+
+/**
+ * Enumerates the ways the {@link MerkleSchemaRegistry} may apply a {@link Schema}
+ * to the {@link MerkleHederaState}.
+ */
+public enum SchemaApplicationType {
+    /**
+     * A schema may contribute state definitions to the {@link MerkleHederaState}
+     * no matter if it was first registered before or after the version of the
+     * deserialized state. The only two conditions under which a schema {@code X}
+     * need not be used for state definitions are:
+     * <ol>
+     *     <li>It is for a service that did not create or remove any state at
+     *     all in the version at which {@code X} was registered; or,</li>
+     *     <li>All its state definitions were removed by schemas
+     *     registered in subsequent versions, <b>and</b> the deserialized
+     *     state is missing or is no earlier than the subsequent version
+     *     that removed the last of {@code X}'s states.</li>
+     * </ol>
+     * <b>Important:</b> In the current system there is no practical benefit to
+     * doing the work to detect the second condition; so we don't.
+     */
+    STATE_DEFINITIONS,
+    /**
+     * A schema may perform migration logic from the state of an earlier
+     * version; this applies at genesis or whenever the deserialized state version
+     * is strictly before the version of the schema.
+     */
+    MIGRATION,
+    /**
+     * A schema may provide restart logic when it is the latest schema
+     * available for a service, and hence able to target any final steps the
+     * current software version needs in the startup phase of the node.
+     */
+    RESTART,
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/SchemaApplications.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/SchemaApplications.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state.merkle;
+
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.MIGRATION;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.RESTART;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.STATE_DEFINITIONS;
+import static com.hedera.node.app.state.merkle.VersionUtils.isSameVersion;
+import static com.hedera.node.app.state.merkle.VersionUtils.isSoOrdered;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.node.app.spi.state.Schema;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Analyzes the ways in which the {@link MerkleSchemaRegistry} should apply a {@link Schema}
+ * to the {@link MerkleHederaState}.
+ *
+ * @see SchemaApplicationType
+ */
+public class SchemaApplications {
+    /**
+     * Computes the {@link SchemaApplicationType}s for the given {@link Schema}.
+     *
+     * @param deserializedVersion the version of the deserialized state
+     * @param latestVersion the latest schema version of the relevant service
+     * @param schema the schema to analyze
+     * @return the ways the schema should be applied
+     */
+    public Set<SchemaApplicationType> computeApplications(
+            @Nullable final SemanticVersion deserializedVersion,
+            @NonNull final SemanticVersion latestVersion,
+            @NonNull final Schema schema) {
+        requireNonNull(schema);
+        requireNonNull(latestVersion);
+        final var uses = EnumSet.noneOf(SchemaApplicationType.class);
+        // Always add state definitions, even if later schemas will remove them all
+        if (hasStateDefinitions(schema)) {
+            uses.add(STATE_DEFINITIONS);
+        }
+        // We only skip migration if the deserialized version is at least as new as the schema
+        // version (which implies the deserialized state already went through this migration)
+        if (deserializedVersion == null || isSoOrdered(deserializedVersion, schema.getVersion())) {
+            uses.add(MIGRATION);
+        }
+        // We only do restart if the schema is the latest one available
+        if (isSameVersion(latestVersion, schema.getVersion())) {
+            uses.add(RESTART);
+        }
+        return uses;
+    }
+
+    private boolean hasStateDefinitions(@NonNull final Schema schema) {
+        return !schema.statesToCreate().isEmpty() || !schema.statesToRemove().isEmpty();
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/VersionUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/VersionUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state.merkle;
+
+import static com.hedera.node.app.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A utility class for version comparisons.
+ */
+public class VersionUtils {
+    private VersionUtils() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
+
+    /**
+     * Determines whether these two version are equal to each other. Both are equal if they are both
+     * null, or have the same version number.
+     *
+     * @param a The first arg
+     * @param b The second arg
+     * @return true if both are null, or if both have the same version number
+     */
+    public static boolean isSameVersion(@Nullable final SemanticVersion a, @Nullable final SemanticVersion b) {
+        return (a == null && b == null) || (a != null && b != null && SEMANTIC_VERSION_COMPARATOR.compare(a, b) == 0);
+    }
+
+    /**
+     * Determines if the two arguments are in the proper order, such that the first argument is
+     * strictly lower than the second argument. If they are the same, we return false.
+     *
+     * @param maybeBefore The version we hope comes before {@code maybeAfter}
+     * @param maybeAfter The version we hope comes after {@code maybeBefore}
+     * @return True if, and only if, {@code maybeBefore} is a lower version number than {@code
+     * maybeAfter}.
+     */
+    public static boolean isSoOrdered(
+            @Nullable final SemanticVersion maybeBefore, @Nullable final SemanticVersion maybeAfter) {
+        if (maybeAfter == null) {
+            return false;
+        }
+
+        // If they are the same version, then we must fail.
+        if (isSameVersion(maybeBefore, maybeAfter)) {
+            return false;
+        }
+
+        // If the first argument is null, then the second argument always
+        // comes later (since it must be non-null, or else isSameVersion
+        // would have caught it).
+        if (maybeBefore == null) {
+            return true;
+        }
+
+        // If the comparison yields the first argument as being before
+        // or matching the second argument, then we return true because
+        // the condition we're testing for holds.
+        return SEMANTIC_VERSION_COMPARATOR.compare(maybeBefore, maybeAfter) < 0;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/MigrationContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/MigrationContextImpl.java
@@ -30,18 +30,20 @@ import com.hedera.node.app.state.merkle.MerkleHederaState;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
 
 /**
  * An implementation of {@link MigrationContext}.
  *
- * @param previousStates        The previous states.
- * @param newStates             The new states, preloaded with any new state definitions.
- * @param configuration         The configuration to use
+ * @param previousStates The previous states.
+ * @param newStates The new states, preloaded with any new state definitions.
+ * @param configuration The configuration to use
  * @param genesisRecordsBuilder The instance responsible for genesis records
  * @param writableEntityIdStore The instance responsible for generating new entity IDs (ONLY during
- *                              migrations). Note that this is nullable only because it cannot exist
- *                              when the entity ID service itself is being migrated
+ * migrations). Note that this is nullable only because it cannot exist
+ * when the entity ID service itself is being migrated
  * @param previousVersion
+ * @param sharedValues
  */
 public record MigrationContextImpl(
         @NonNull ReadableStates previousStates,
@@ -50,7 +52,8 @@ public record MigrationContextImpl(
         @NonNull NetworkInfo networkInfo,
         @NonNull GenesisRecordsBuilder genesisRecordsBuilder,
         @Nullable WritableEntityIdStore writableEntityIdStore,
-        @Nullable SemanticVersion previousVersion)
+        @Nullable SemanticVersion previousVersion,
+        @NonNull Map<String, Object> sharedValues)
         implements MigrationContext {
 
     public MigrationContextImpl {
@@ -59,6 +62,7 @@ public record MigrationContextImpl(
         requireNonNull(configuration);
         requireNonNull(networkInfo);
         requireNonNull(genesisRecordsBuilder);
+        requireNonNull(sharedValues);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.state.merkle;
 
-import static com.hedera.node.app.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
@@ -42,6 +41,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,8 +50,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -74,7 +72,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         // We don't need a real registry, and the unit tests are much
         // faster if we use a mocked one
         registry = mock(ConstructableRegistry.class);
-        schemaRegistry = new MerkleSchemaRegistry(registry, FIRST_SERVICE, new NoOpGenesisRecordsBuilder());
+        schemaRegistry = new MerkleSchemaRegistry(
+                registry, FIRST_SERVICE, new NoOpGenesisRecordsBuilder(), new SchemaApplications());
         config = mock(Configuration.class);
         networkInfo = mock(NetworkInfo.class);
         final var hederaConfig = mock(HederaConfig.class);
@@ -88,7 +87,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("A null ConstructableRegistry throws")
         void nullRegistryThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> new MerkleSchemaRegistry(null, FIRST_SERVICE, mock(GenesisRecordsBuilder.class)))
+            assertThatThrownBy(() -> new MerkleSchemaRegistry(
+                            null, FIRST_SERVICE, mock(GenesisRecordsBuilder.class), new SchemaApplications()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -96,7 +96,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("A null serviceName throws")
         void nullServiceNameThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> new MerkleSchemaRegistry(registry, null, mock(GenesisRecordsBuilder.class)))
+            assertThatThrownBy(() -> new MerkleSchemaRegistry(
+                            registry, null, mock(GenesisRecordsBuilder.class), new SchemaApplications()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -104,7 +105,16 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
         @DisplayName("A null genesisRecordsBuilder throws")
         void nullGenesisRecordsBuilderThrows() {
             //noinspection ConstantConditions
-            assertThatThrownBy(() -> new MerkleSchemaRegistry(registry, FIRST_SERVICE, null))
+            assertThatThrownBy(() -> new MerkleSchemaRegistry(registry, FIRST_SERVICE, null, new SchemaApplications()))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("A null schemaApplications throws")
+        void nullSchemaApplicationsThrows() {
+            //noinspection ConstantConditions
+            assertThatThrownBy(() ->
+                            new MerkleSchemaRegistry(registry, FIRST_SERVICE, mock(GenesisRecordsBuilder.class), null))
                     .isInstanceOf(NullPointerException.class);
         }
     }
@@ -174,7 +184,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     config,
                     networkInfo,
                     mock(Metrics.class),
-                    mock(WritableEntityIdStore.class));
+                    mock(WritableEntityIdStore.class),
+                    new HashMap<>());
         }
     }
 
@@ -206,7 +217,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             config,
                             networkInfo,
                             mock(Metrics.class),
-                            mock(WritableEntityIdStore.class)))
+                            mock(WritableEntityIdStore.class),
+                            new HashMap<>()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -221,7 +233,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             config,
                             networkInfo,
                             mock(Metrics.class),
-                            mock(WritableEntityIdStore.class)))
+                            mock(WritableEntityIdStore.class),
+                            new HashMap<>()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -236,7 +249,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             null,
                             networkInfo,
                             mock(Metrics.class),
-                            mock(WritableEntityIdStore.class)))
+                            mock(WritableEntityIdStore.class),
+                            new HashMap<>()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -251,7 +265,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             config,
                             null,
                             mock(Metrics.class),
-                            mock(WritableEntityIdStore.class)))
+                            mock(WritableEntityIdStore.class),
+                            new HashMap<>()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -266,7 +281,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             config,
                             networkInfo,
                             null,
-                            mock(WritableEntityIdStore.class)))
+                            mock(WritableEntityIdStore.class),
+                            new HashMap<>()))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -281,7 +297,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             config,
                             networkInfo,
                             mock(Metrics.class),
-                            mock(WritableEntityIdStore.class)))
+                            mock(WritableEntityIdStore.class),
+                            new HashMap<>()))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -300,7 +317,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     config,
                     networkInfo,
                     mock(Metrics.class),
-                    mock(WritableEntityIdStore.class));
+                    mock(WritableEntityIdStore.class),
+                    new HashMap<>());
 
             // Then nothing happens
             Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
@@ -321,7 +339,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     config,
                     networkInfo,
                     mock(Metrics.class),
-                    mock(WritableEntityIdStore.class));
+                    mock(WritableEntityIdStore.class),
+                    new HashMap<>());
 
             // Then migration doesn't happen but restart is called
             Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
@@ -343,79 +362,12 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     config,
                     networkInfo,
                     mock(Metrics.class),
-                    mock(WritableEntityIdStore.class));
+                    mock(WritableEntityIdStore.class),
+                    new HashMap<>());
 
             // Then migration doesn't happen but restart is called
             Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any());
             Mockito.verify(schema, Mockito.times(1)).restart(Mockito.any());
-        }
-
-        @ParameterizedTest(name = "From ({0}, {1}]")
-        @CsvSource(
-                textBlock =
-                        """
-                    0, 1
-                    0, 2
-                    0, 3
-                    0, 4
-                    1, 2
-                    1, 3
-                    1, 4
-                    2, 3
-                    2, 4
-                    3, 4
-                    0, 9
-                    """)
-        @DisplayName("Migration applies to all versions up to and including the currentVersion")
-        void migrate(int firstVersion, int lastVersion) {
-            // We will place into this list each schema as it is called
-            final var called = new LinkedList<SemanticVersion>();
-
-            // Given a schema for each version
-            // versions = [null, 1, 2, 3, 4, ... ]
-            // schemas = [null, 1, 2, 3, 4, ... ]
-            final var schemas = new Schema[versions.length];
-            for (int i = 1; i < schemas.length; i++) {
-                final var ver = versions[i];
-                final var schema = Mockito.spy(new TestSchema(ver, () -> called.add(ver)));
-                schemas[i] = schema;
-                schemaRegistry.register(schema);
-            }
-
-            // When we migrate
-            schemaRegistry.migrate(
-                    merkleTree,
-                    versions[firstVersion],
-                    versions[lastVersion],
-                    config,
-                    networkInfo,
-                    mock(Metrics.class),
-                    mock(WritableEntityIdStore.class));
-
-            // Then each schema less than or equal to firstVersion are not called
-            for (int i = 1; i <= firstVersion; i++) {
-                Mockito.verify(schemas[i], Mockito.times(0)).migrate(Mockito.any());
-            }
-
-            // And each schema greater than firstVersion and less than or equal to lastVersion are
-            // called
-            for (int i = firstVersion + 1; i <= lastVersion; i++) {
-                Mockito.verify(schemas[i], Mockito.times(1)).migrate(Mockito.any());
-            }
-
-            // And each schema greater than lastVersion are not called
-            for (int i = lastVersion + 1; i < versions.length; i++) {
-                Mockito.verify(schemas[i], Mockito.times(0)).migrate(Mockito.any());
-            }
-
-            // And each called schema was called in order
-            final var itr = called.iterator();
-            var prev = itr.next();
-            while (itr.hasNext()) {
-                final var ver = itr.next();
-                assertThat(SEMANTIC_VERSION_COMPARATOR.compare(ver, prev)).isPositive();
-                prev = ver;
-            }
         }
 
         @Test
@@ -441,7 +393,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     config,
                     networkInfo,
                     mock(Metrics.class),
-                    mock(WritableEntityIdStore.class));
+                    mock(WritableEntityIdStore.class),
+                    new HashMap<>());
 
             // Then each of v1, v4, and v6 are called
             assertThat(called).hasSize(3);
@@ -607,7 +560,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                         config,
                         networkInfo,
                         mock(Metrics.class),
-                        mock(WritableEntityIdStore.class));
+                        mock(WritableEntityIdStore.class),
+                        new HashMap<>());
 
                 // Then we see that the values for A, B, and C are available
                 final var readableStates = merkleTree.getReadableStates(FIRST_SERVICE);
@@ -633,7 +587,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                         config,
                         networkInfo,
                         mock(Metrics.class),
-                        mock(WritableEntityIdStore.class));
+                        mock(WritableEntityIdStore.class),
+                        new HashMap<>());
 
                 // We should see the v2 state (the delta from v2 after applied atop v1)
                 final var readableStates = merkleTree.getReadableStates(FIRST_SERVICE);
@@ -670,7 +625,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                         config,
                         networkInfo,
                         mock(Metrics.class),
-                        mock(WritableEntityIdStore.class));
+                        mock(WritableEntityIdStore.class),
+                        new HashMap<>());
 
                 // We should see the v3 state (the delta from v3 after applied atop v2 and v1)
                 final var readableStates = merkleTree.getReadableStates(FIRST_SERVICE);
@@ -712,7 +668,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                                 config,
                                 networkInfo,
                                 mock(Metrics.class),
-                                mock(WritableEntityIdStore.class)))
+                                mock(WritableEntityIdStore.class),
+                                new HashMap<>()))
                         .isInstanceOf(RuntimeException.class)
                         .hasMessage("Bad");
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SchemaApplicationsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SchemaApplicationsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state.merkle;
+
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.MIGRATION;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.RESTART;
+import static com.hedera.node.app.state.merkle.SchemaApplicationType.STATE_DEFINITIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.common.EntityNumber;
+import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.spi.state.StateDefinition;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SchemaApplicationsTest {
+    @SuppressWarnings("rawtypes")
+    private static final StateDefinition STATE_DEFINITION = StateDefinition.singleton("NUMBER", EntityNumber.PROTOBUF);
+
+    private static final SemanticVersion LATEST_VERSION =
+            SemanticVersion.newBuilder().major(3).build();
+    private static final SemanticVersion PRECEDING_VERSION =
+            SemanticVersion.newBuilder().major(2).build();
+    private static final SemanticVersion FIRST_VERSION =
+            SemanticVersion.newBuilder().major(1).build();
+
+    @Mock
+    private Schema schema;
+
+    private final SchemaApplications subject = new SchemaApplications();
+
+    @Test
+    void genesisUseWithNoCreatedOrRemovedStatesIsMigrateOnlyIfNotCurrent() {
+        given(schema.getVersion()).willReturn(PRECEDING_VERSION);
+        assertThat(subject.computeApplications(null, LATEST_VERSION, schema)).containsExactly(MIGRATION);
+    }
+
+    @Test
+    void genesisUseWithCreatedStatesIsStateDefsAndMigrateIfNotCurrent() {
+        given(schema.getVersion()).willReturn(PRECEDING_VERSION);
+        given(schema.statesToCreate()).willReturn(Set.of(STATE_DEFINITION));
+        assertThat(subject.computeApplications(null, LATEST_VERSION, schema))
+                .containsExactly(STATE_DEFINITIONS, MIGRATION);
+    }
+
+    @Test
+    void genesisUseWithRemovedStatesIsStateDefsAndMigrateIfNotCurrent() {
+        given(schema.getVersion()).willReturn(PRECEDING_VERSION);
+        given(schema.statesToRemove()).willReturn(Set.of(STATE_DEFINITION.stateKey()));
+        assertThat(subject.computeApplications(null, LATEST_VERSION, schema))
+                .containsExactly(STATE_DEFINITIONS, MIGRATION);
+    }
+
+    @Test
+    void genesisUseWithNoCreatedOrRemovedStatesIsMigrateAndRestartIfCurrent() {
+        given(schema.getVersion()).willReturn(LATEST_VERSION);
+        assertThat(subject.computeApplications(null, LATEST_VERSION, schema)).containsExactly(MIGRATION, RESTART);
+    }
+
+    @Test
+    void restartUseWithEarlierStateDoesMigrate() {
+        given(schema.getVersion()).willReturn(PRECEDING_VERSION);
+        assertThat(subject.computeApplications(FIRST_VERSION, LATEST_VERSION, schema))
+                .containsExactly(MIGRATION);
+    }
+
+    @Test
+    void restartUseWithSameStateDoesNotMigrate() {
+        given(schema.getVersion()).willReturn(PRECEDING_VERSION);
+        assertThat(subject.computeApplications(PRECEDING_VERSION, LATEST_VERSION, schema))
+                .isEmpty();
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -43,6 +43,7 @@ import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -129,18 +130,26 @@ class SerializationTest extends MerkleTestBase {
         // Given a merkle tree with some fruit and animals and country
         final var v1 = version(1, 0, 0);
         final var originalTree = new MerkleHederaState(lifecycles);
-        final var originalRegistry =
-                new MerkleSchemaRegistry(registry, FIRST_SERVICE, mock(GenesisRecordsBuilder.class));
+        final var originalRegistry = new MerkleSchemaRegistry(
+                registry, FIRST_SERVICE, mock(GenesisRecordsBuilder.class), new SchemaApplications());
         final var schemaV1 = createV1Schema();
         originalRegistry.register(schemaV1);
         originalRegistry.migrate(
-                originalTree, null, v1, config, networkInfo, mock(Metrics.class), mock(WritableEntityIdStore.class));
+                originalTree,
+                null,
+                v1,
+                config,
+                networkInfo,
+                mock(Metrics.class),
+                mock(WritableEntityIdStore.class),
+                new HashMap<>());
 
         // When we serialize it to bytes and deserialize it back into a tree
         originalTree.copy(); // make a fast copy because we can only write to disk an immutable copy
         CRYPTO.digestTreeSync(originalTree);
         final var serializedBytes = writeTree(originalTree, dir);
-        final var newRegistry = new MerkleSchemaRegistry(registry, FIRST_SERVICE, mock(GenesisRecordsBuilder.class));
+        final var newRegistry = new MerkleSchemaRegistry(
+                registry, FIRST_SERVICE, mock(GenesisRecordsBuilder.class), new SchemaApplications());
         newRegistry.register(schemaV1);
 
         // Register the MerkleHederaState so, when found in serialized bytes, it will register with
@@ -157,7 +166,8 @@ class SerializationTest extends MerkleTestBase {
                 config,
                 networkInfo,
                 mock(Metrics.class),
-                mock(WritableEntityIdStore.class));
+                mock(WritableEntityIdStore.class),
+                new HashMap<>());
         loadedTree.migrate(1);
 
         // Then, we should be able to see all our original states again

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
@@ -27,6 +27,7 @@ import com.hedera.node.app.spi.state.StateDefinition;
 import com.hedera.node.app.spi.workflows.record.GenesisRecordsBuilder;
 import com.hedera.node.app.state.merkle.MerkleSchemaRegistry;
 import com.hedera.node.app.state.merkle.MerkleTestBase;
+import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.hedera.node.app.state.merkle.StateMetadata;
 import com.hedera.node.app.state.merkle.StateUtils;
 import com.hedera.node.config.data.HederaConfig;
@@ -149,7 +150,8 @@ class OnDiskTest extends MerkleTestBase {
 
         // Before we can read the data back, we need to register the data types
         // I plan to deserialize.
-        final var r = new MerkleSchemaRegistry(registry, SERVICE_NAME, mock(GenesisRecordsBuilder.class));
+        final var r = new MerkleSchemaRegistry(
+                registry, SERVICE_NAME, mock(GenesisRecordsBuilder.class), new SchemaApplications());
         r.register(schema);
 
         // read it back now as our map and validate the data come back fine

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -38,6 +38,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class FakeSchemaRegistry implements SchemaRegistry {
@@ -78,6 +79,13 @@ public class FakeSchemaRegistry implements SchemaRegistry {
             final var previousStates = new EmptyReadableStates();
             final var writableStates = new MapWritableStates(writables);
             schema.migrate(new MigrationContext() {
+                private final Map<String, Object> sharedValues = new HashMap<>();
+
+                @Override
+                public Map<String, Object> sharedValues() {
+                    return sharedValues;
+                }
+
                 @Override
                 public void copyAndReleaseOnDiskState(String stateKey) {
                     // No-op

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/schemas/FileSchemaTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/schemas/FileSchemaTest.java
@@ -39,6 +39,7 @@ import com.hedera.node.app.workflows.handle.record.MigrationContextImpl;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,7 +82,8 @@ final class FileSchemaTest {
                 networkInfo,
                 new GenesisRecordsConsensusHook(),
                 mock(WritableEntityIdStore.class),
-                null));
+                null,
+                new HashMap<>()));
 
         // Then the new state has empty bytes for files 151-158 and proper values
         final var files = newStates.<FileID, File>get(FileServiceImpl.BLOBS_KEY);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.node.app.service.contract.impl.handlers.ContractHandlers;
 import com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema;
+import com.hedera.node.app.service.contract.impl.state.V0500ContractSchema;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
@@ -58,6 +59,7 @@ public enum ContractServiceImpl implements ContractService {
     public void registerSchemas(@NonNull final SchemaRegistry registry, @NonNull final SemanticVersion version) {
         initialContractSchema = new InitialModServiceContractSchema(version);
         registry.register(initialContractSchema);
+        registry.register(new V0500ContractSchema());
     }
 
     public ContractHandlers handlers() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/V0500ContractSchema.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/V0500ContractSchema.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.state;
+
+import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.STORAGE_KEY;
+import static com.hedera.node.app.spi.HapiUtils.CONTRACT_ID_COMPARATOR;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.node.app.spi.state.ReadableKVState;
+import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A schema that analyzes the storage mappings in state and does two things:
+ * <ol>
+ *     <li>For any contract with broken links, repairs the links by relinking its
+ *     storage mappings in sorted key order.</li>
+ *     <li>For every contract, publishes its correct first key in the shared
+ *     migration context in a {@link SortedMap} at key {@code "V0500_FIRST_STORAGE_KEYS"}.</li>
+ * </ol>
+ */
+public class V0500ContractSchema extends Schema {
+    private static final Logger log = LogManager.getLogger(V0500ContractSchema.class);
+
+    private static final long MAX_SUPPORTED_STORAGE_SIZE = 4_000_000L;
+
+    private static final String SHARED_VALUES_KEY = "V0500_FIRST_STORAGE_KEYS";
+
+    private static final SemanticVersion VERSION =
+            SemanticVersion.newBuilder().major(0).minor(50).patch(0).build();
+
+    public V0500ContractSchema() {
+        super(VERSION);
+    }
+
+    private record StorageMapping(@NonNull SlotKey slotKey, @NonNull SlotValue slotValue)
+            implements Comparable<StorageMapping> {
+        @Override
+        public int compareTo(@NonNull final StorageMapping that) {
+            return this.slotKey().key().compareTo(that.slotKey().key());
+        }
+    }
+
+    private record MappingSummary(@NonNull Bytes firstKey, @Nullable List<StorageMapping> fixedMappings) {}
+
+    @Override
+    public void migrate(@NonNull final MigrationContext ctx) {
+        requireNonNull(ctx);
+        final ReadableKVState<SlotKey, SlotValue> storage = ctx.previousStates().get(STORAGE_KEY);
+        if (storage.size() > MAX_SUPPORTED_STORAGE_SIZE) {
+            log.warn("  -> Link repair is impractical with {} slots in state, skipping migration", storage.size());
+            return;
+        }
+        final var begin = Instant.now();
+        final Map<ContractID, List<StorageMapping>> mappings = new HashMap<>();
+        final SortedMap<ContractID, Bytes> firstKeys = new TreeMap<>(CONTRACT_ID_COMPARATOR);
+        // Collect all storage mappings from the previous state
+        storage.keys()
+                .forEachRemaining(key -> mappings.computeIfAbsent(key.contractIDOrThrow(), ignore -> new ArrayList<>())
+                        .add(new StorageMapping(key, requireNonNull(storage.get(key)))));
+
+        // Relink any broken storage mappings, while removing any that were already intact
+        new ArrayList<>(mappings.keySet()).forEach(contractId -> {
+            final var summary = summarizeWithRequiredFixes(mappings.get(contractId));
+            firstKeys.put(contractId, summary.firstKey());
+            if (summary.fixedMappings() != null) {
+                mappings.put(contractId, summary.fixedMappings());
+            } else {
+                mappings.remove(contractId);
+            }
+        });
+
+        final List<ContractID> contractIdsToMigrate = new ArrayList<>(mappings.keySet());
+        log.info(
+                "Previous state with {} slots had {} contracts with broken storage links",
+                storage.size(),
+                contractIdsToMigrate.size());
+        if (!contractIdsToMigrate.isEmpty()) {
+            contractIdsToMigrate.sort(CONTRACT_ID_COMPARATOR);
+            final WritableKVState<SlotKey, SlotValue> writableStorage =
+                    ctx.newStates().get(STORAGE_KEY);
+            // And finally update the new state with the fixed mappings
+            contractIdsToMigrate.forEach(contractId -> mappings.get(contractId)
+                    .forEach(mapping -> writableStorage.put(mapping.slotKey(), mapping.slotValue())));
+        }
+
+        // Expose the first keys of all contracts in the migration context for the token service
+        ctx.sharedValues().put(SHARED_VALUES_KEY, firstKeys);
+        final var end = Instant.now();
+        log.info("Completed link repair in {}", Duration.between(begin, end));
+    }
+
+    private MappingSummary summarizeWithRequiredFixes(@NonNull final List<StorageMapping> mappings) {
+        requireNonNull(mappings);
+        // Identify the first and last mappings and build a key-to-index map
+        StorageMapping first = null;
+        StorageMapping last = null;
+        final Map<Bytes, Integer> locations = HashMap.newHashMap(mappings.size());
+        int location = 0;
+        for (final var mapping : mappings) {
+            if (Bytes.EMPTY.equals(mapping.slotValue().previousKey())) {
+                first = mapping;
+            }
+            if (Bytes.EMPTY.equals(mapping.slotValue().nextKey())) {
+                last = mapping;
+            }
+            locations.put(mapping.slotKey().key(), location++);
+        }
+        if (hasIntactLinks(first, last, locations, mappings)) {
+            return new MappingSummary(first.slotKey().key(), null);
+        } else {
+            final var fixedMappings = fixBrokenLinks(mappings);
+            return new MappingSummary(fixedMappings.getFirst().slotKey().key(), fixedMappings);
+        }
+    }
+
+    private @NonNull List<StorageMapping> fixBrokenLinks(@NonNull final List<StorageMapping> mappings) {
+        mappings.sort(naturalOrder());
+        final List<StorageMapping> relinked = new ArrayList<>(mappings.size());
+        for (int i = 0, n = mappings.size(); i < n; i++) {
+            final var previousKey =
+                    i == 0 ? Bytes.EMPTY : mappings.get(i - 1).slotKey().key();
+            final var nextKey =
+                    i == n - 1 ? Bytes.EMPTY : mappings.get(i + 1).slotKey().key();
+            final var mapping = mappings.get(i);
+            relinked.add(new StorageMapping(
+                    mapping.slotKey(), new SlotValue(mapping.slotValue().value(), previousKey, nextKey)));
+        }
+        return relinked;
+    }
+
+    private boolean hasIntactLinks(
+            @Nullable final StorageMapping first,
+            @Nullable final StorageMapping last,
+            @NonNull final Map<Bytes, Integer> locations,
+            @NonNull final List<StorageMapping> mappings) {
+        if (first != null && last != null) {
+            // Given a first and last mapping, we can check if the chain is intact; that is, if...
+            //   (1) Each mapping points to a next mapping whose previous key is that mapping's key; and,
+            //   (2) Following the chain from the first mapping leads to the last mapping; and,
+            //   (3) Every mapping in the chain is seen exactly once.
+            int seen = 1;
+            StorageMapping current = first;
+            for (int i = 0, n = mappings.size() - 1; i < n; i++, seen++) {
+                final var next = locations.get(current.slotValue().nextKey());
+                if (next == null
+                        || !current.slotKey()
+                                .key()
+                                .equals(mappings.get(next).slotValue().previousKey())) {
+                    break;
+                } else {
+                    current = mappings.get(next);
+                }
+            }
+            return seen == mappings.size() && current == last;
+        }
+        return false;
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -570,16 +570,22 @@ public class ConversionUtils {
      * @return its 20-byte EVM address
      */
     public static byte[] asEvmAddress(final long num) {
-        final byte[] evmAddress = new byte[20];
-        copyToLeftPaddedByteArray(num, evmAddress);
-        return evmAddress;
+        return copyToLeftPaddedByteArray(num, new byte[20]);
     }
 
-    private static void copyToLeftPaddedByteArray(long value, final byte[] dest) {
+    /**
+     * Given a value and a destination byte array, copies the value to the destination array, left-padded.
+     *
+     * @param value the value
+     * @param dest the destination byte array
+     * @return the destination byte array
+     */
+    public static byte[] copyToLeftPaddedByteArray(long value, final byte[] dest) {
         for (int i = 7, j = dest.length - 1; i >= 0; i--, j--) {
             dest[j] = (byte) (value & 0xffL);
             value >>= 8;
         }
+        return dest;
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
@@ -21,9 +21,11 @@ import static com.hedera.node.app.spi.fixtures.state.TestSchema.CURRENT_VERSION;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema;
+import com.hedera.node.app.service.contract.impl.state.V0500ContractSchema;
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import org.junit.jupiter.api.Test;
@@ -40,7 +42,9 @@ class ContractServiceImplTest {
         final var captor = ArgumentCaptor.forClass(Schema.class);
         final var mockRegistry = mock(SchemaRegistry.class);
         CONTRACT_SERVICE.registerSchemas(mockRegistry, CURRENT_VERSION);
-        verify(mockRegistry).register(captor.capture());
-        assertInstanceOf(InitialModServiceContractSchema.class, captor.getValue());
+        verify(mockRegistry, times(2)).register(captor.capture());
+        final var schemas = captor.getAllValues();
+        assertInstanceOf(InitialModServiceContractSchema.class, schemas.getFirst());
+        assertInstanceOf(V0500ContractSchema.class, schemas.getLast());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/V0500ContractSchemaTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/V0500ContractSchemaTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.test.state;
+
+import static com.hedera.node.app.service.contract.impl.state.InitialModServiceContractSchema.STORAGE_KEY;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.copyToLeftPaddedByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
+import com.hedera.node.app.service.contract.impl.state.V0500ContractSchema;
+import com.hedera.node.app.spi.fixtures.state.MapReadableKVState;
+import com.hedera.node.app.spi.fixtures.state.MapReadableStates;
+import com.hedera.node.app.spi.fixtures.state.MapWritableKVState;
+import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("V050 storage links repair")
+@ExtendWith(MockitoExtension.class)
+class V0500ContractSchemaTest {
+    private static final int N = 3;
+    private static final String SHARED_VALUES_KEY = "V0500_FIRST_STORAGE_KEYS";
+    private static final Bytes[] TEST_KEYS = LongStream.range(1, 1 + N)
+            .mapToObj(i -> copyToLeftPaddedByteArray(i, new byte[32]))
+            .map(Bytes::wrap)
+            .sorted()
+            .toArray(Bytes[]::new);
+    private final Map<String, Object> sharedValues = new HashMap<>();
+    private final Map<SlotKey, SlotValue> storage = new HashMap<>();
+    private final MapWritableKVState<SlotKey, SlotValue> writableStorage =
+            new MapWritableKVState<>(STORAGE_KEY, storage);
+    private final MapReadableKVState<SlotKey, SlotValue> readableStorage =
+            new MapReadableKVState<>(STORAGE_KEY, storage);
+    private final MapReadableStates readableStates =
+            MapReadableStates.builder().state(readableStorage).build();
+    private final MapWritableStates writableStates =
+            MapWritableStates.builder().state(writableStorage).build();
+
+    @Mock
+    private MigrationContext ctx;
+
+    private final V0500ContractSchema subject = new V0500ContractSchema();
+
+    @BeforeEach
+    void setUp() {
+        given(ctx.previousStates()).willReturn(readableStates);
+        given(ctx.sharedValues()).willReturn(sharedValues);
+    }
+
+    @Test
+    @DisplayName("preserves intact links as-is")
+    void noChangeToIntactLinks() {
+        for (int i = N - 1; i >= 0; i--) {
+            addMapping(
+                    TEST_KEYS[i], i == N - 1 ? Bytes.EMPTY : TEST_KEYS[i + 1], i == 0 ? Bytes.EMPTY : TEST_KEYS[i - 1]);
+        }
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        assertThat(firstKeys()).containsEntry(CALLED_CONTRACT_ID, TEST_KEYS[N - 1]);
+        assertIntactLinksInOrder(
+                Arrays.stream(TEST_KEYS).sorted(Comparator.reverseOrder()).toArray(Bytes[]::new));
+    }
+
+    @Test
+    @DisplayName("fixes no first mapping")
+    void fixedMissingFirstMapping() {
+        given(ctx.newStates()).willReturn(writableStates);
+        for (int i = N - 1; i >= 0; i--) {
+            addMapping(TEST_KEYS[i], TEST_KEYS[0], i == 0 ? Bytes.EMPTY : TEST_KEYS[i - 1]);
+        }
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        assertFixedInLexicographicOrder();
+    }
+
+    @Test
+    @DisplayName("fixes no last mapping")
+    void fixedMissingLastMapping() {
+        given(ctx.newStates()).willReturn(writableStates);
+        for (int i = 0; i < N; i++) {
+            addMapping(TEST_KEYS[i], i == 0 ? Bytes.EMPTY : TEST_KEYS[i - 1], TEST_KEYS[N - 1]);
+        }
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        assertFixedInLexicographicOrder();
+    }
+
+    @Test
+    @DisplayName("fixes wrong prev pointer")
+    void fixedWrongPrevPointer() {
+        given(ctx.newStates()).willReturn(writableStates);
+        for (int i = 0; i < N; i++) {
+            if (i == 1) {
+                addMapping(TEST_KEYS[i], TEST_KEYS[N - 1], TEST_KEYS[N - 1]);
+            } else {
+                addMapping(
+                        TEST_KEYS[i],
+                        i == 0 ? Bytes.EMPTY : TEST_KEYS[i - 1],
+                        i == N - 1 ? Bytes.EMPTY : TEST_KEYS[i + 1]);
+            }
+        }
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        assertFixedInLexicographicOrder();
+    }
+
+    @Test
+    @DisplayName("fixes unreachable mapping")
+    void fixedUnreachableMapping() {
+        given(ctx.newStates()).willReturn(writableStates);
+        for (int i = 0; i < N; i++) {
+            if (i == 1) {
+                addMapping(TEST_KEYS[i], TEST_KEYS[0], Bytes.EMPTY);
+            } else {
+                addMapping(
+                        TEST_KEYS[i],
+                        i == 0 ? Bytes.EMPTY : TEST_KEYS[i - 1],
+                        i == N - 1 ? Bytes.EMPTY : TEST_KEYS[i + 1]);
+            }
+        }
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        assertFixedInLexicographicOrder();
+    }
+
+    @Test
+    @DisplayName("fixes loop")
+    void fixedLoop() {
+        given(ctx.newStates()).willReturn(writableStates);
+        for (int i = 0; i < N; i++) {
+            if (i == 1) {
+                addMapping(TEST_KEYS[i], TEST_KEYS[0], TEST_KEYS[1]);
+            } else {
+                addMapping(
+                        TEST_KEYS[i],
+                        i == 0 ? Bytes.EMPTY : TEST_KEYS[i - 1],
+                        i == N - 1 ? Bytes.EMPTY : TEST_KEYS[i + 1]);
+            }
+        }
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        assertFixedInLexicographicOrder();
+    }
+
+    private void assertFixedInLexicographicOrder() {
+        assertThat(firstKeys()).containsEntry(CALLED_CONTRACT_ID, TEST_KEYS[0]);
+        assertIntactLinksInOrder(TEST_KEYS);
+    }
+
+    private void assertIntactLinksInOrder(@NonNull final Bytes... keys) {
+        for (int i = 0; i < keys.length; i++) {
+            final var key = keys[i];
+            final var prevKey = i == 0 ? Bytes.EMPTY : keys[i - 1];
+            final var nextKey = i == keys.length - 1 ? Bytes.EMPTY : keys[i + 1];
+            assertThat(storage)
+                    .containsEntry(new SlotKey(CALLED_CONTRACT_ID, key), new SlotValue(key, prevKey, nextKey));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<ContractID, Bytes> firstKeys() {
+        return (Map<ContractID, Bytes>) sharedValues.get(SHARED_VALUES_KEY);
+    }
+
+    private void addMapping(@NonNull final Bytes key, @NonNull final Bytes prevKey, @NonNull final Bytes nextKey) {
+        final var slotKey = new SlotKey(CALLED_CONTRACT_ID, key);
+        final var slotValue = new SlotValue(key, prevKey, nextKey);
+        storage.put(slotKey, slotValue);
+    }
+}

--- a/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/ContractService.java
+++ b/hedera-node/hedera-smart-contract-service/src/main/java/com/hedera/node/app/service/contract/ContractService.java
@@ -29,6 +29,20 @@ import java.util.Set;
 public interface ContractService extends Service {
     String NAME = "ContractService";
 
+    /**
+     * {@inheritDoc}
+     *
+     * Ensure the contract service schemas are migrated before the {@code TokenService} schemas, since
+     * the {@code TokenService} depends on the {@code ContractService} to know the updated first storage
+     * keys for contracts with broken storage links.
+     *
+     * @return {@code Integer.MIN_VALUE}
+     */
+    @Override
+    default int migrationOrder() {
+        return Integer.MIN_VALUE;
+    }
+
     @NonNull
     @Override
     default String getServiceName() {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/TokenServiceImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/TokenServiceImpl.java
@@ -32,6 +32,7 @@ import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.service.token.impl.schemas.InitialModServiceTokenSchema;
 import com.hedera.node.app.service.token.impl.schemas.SyntheticRecordsGenerator;
+import com.hedera.node.app.service.token.impl.schemas.V0500TokenSchema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
@@ -98,6 +99,7 @@ public class TokenServiceImpl implements TokenService {
         modTokenSchema = new InitialModServiceTokenSchema(
                 sysAccts, stakingAccts, treasuryAccts, miscAccts, blocklistAccts, version);
         registry.register(modTokenSchema);
+        registry.register(new V0500TokenSchema());
     }
 
     public void setNftsFromState(@Nullable final VirtualMap<UniqueTokenKey, UniqueTokenValue> fs) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/V0500TokenSchema.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/schemas/V0500TokenSchema.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token.impl.schemas;
+
+import static com.hedera.node.app.service.token.impl.TokenServiceImpl.ACCOUNTS_KEY;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.node.app.spi.state.Schema;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.SortedMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A schema that ensures the first contract storage key of each account matches what
+ * is set in the shared migration context at key {@code "V0500_FIRST_STORAGE_KEYS"}.
+ */
+public class V0500TokenSchema extends Schema {
+    private static final Logger log = LogManager.getLogger(V0500TokenSchema.class);
+    private static final String SHARED_VALUES_KEY = "V0500_FIRST_STORAGE_KEYS";
+
+    private static final SemanticVersion VERSION =
+            SemanticVersion.newBuilder().major(0).minor(50).patch(0).build();
+
+    public V0500TokenSchema() {
+        super(VERSION);
+    }
+
+    @Override
+    public void migrate(@NonNull final MigrationContext ctx) {
+        requireNonNull(ctx);
+        @SuppressWarnings("unchecked")
+        final SortedMap<ContractID, Bytes> migratedFirstKeys =
+                (SortedMap<ContractID, Bytes>) ctx.sharedValues().get(SHARED_VALUES_KEY);
+        if (migratedFirstKeys == null) {
+            log.warn("  -> No first contract keys were published, skipping migration");
+            return;
+        }
+        final WritableKVState<AccountID, Account> writableAccounts =
+                ctx.newStates().get(ACCOUNTS_KEY);
+        migratedFirstKeys.forEach((contractId, firstKey) -> {
+            final var accountId = AccountID.newBuilder()
+                    .accountNum(contractId.contractNumOrThrow())
+                    .build();
+            final var account = writableAccounts.get(accountId);
+            if (account == null) {
+                log.error("Contract account {} not found in the new state", accountId);
+            } else if (!firstKey.equals(account.firstContractStorageKey())) {
+                if (!account.smartContract()) {
+                    log.error("Non-contract account {} has storage slots", accountId);
+                }
+                writableAccounts.put(
+                        accountId,
+                        account.copyBuilder().firstContractStorageKey(firstKey).build());
+            }
+        });
+    }
+}

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/schemas/V0500TokenSchemaTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/schemas/V0500TokenSchemaTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token.impl.schemas;
+
+import static com.hedera.node.app.service.token.impl.TokenServiceImpl.ACCOUNTS_KEY;
+import static com.hedera.node.app.spi.HapiUtils.CONTRACT_ID_COMPARATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.node.app.spi.fixtures.state.MapWritableKVState;
+import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
+import com.hedera.node.app.spi.state.MigrationContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("V050 first storage keys repair")
+@ExtendWith(MockitoExtension.class)
+class V0500TokenSchemaTest {
+    private static final int N = 3;
+    private static final String SHARED_VALUES_KEY = "V0500_FIRST_STORAGE_KEYS";
+    private static final SortedMap<ContractID, Bytes> FIRST_KEYS = new TreeMap<>(CONTRACT_ID_COMPARATOR) {
+        {
+            for (long i = 1; i <= N; i++) {
+                put(contractIdWith(i), Bytes.wrap(copyToLeftPaddedByteArray(i, new byte[32])));
+            }
+        }
+    };
+    private final Map<String, Object> sharedValues = new HashMap<>();
+    private final Map<AccountID, Account> accounts = new HashMap<>();
+    private final MapWritableKVState<AccountID, Account> writableAccounts =
+            new MapWritableKVState<>(ACCOUNTS_KEY, accounts);
+    private final MapWritableStates writableStates =
+            MapWritableStates.builder().state(writableAccounts).build();
+
+    @Mock
+    private MigrationContext ctx;
+
+    private final V0500TokenSchema subject = new V0500TokenSchema();
+
+    @Test
+    @DisplayName("skips migration without shared values")
+    void throwsWithoutSharedValues() {
+        given(ctx.sharedValues()).willReturn(sharedValues);
+        assertDoesNotThrow(() -> subject.migrate(ctx));
+    }
+
+    @Test
+    @DisplayName("works around missing account")
+    void worksAroundMissing() {
+        givenValidCtx();
+        assertDoesNotThrow(() -> subject.migrate(ctx));
+    }
+
+    @Test
+    @DisplayName("fixes first storage keys")
+    void fixesFirstKeys() {
+        givenValidCtx();
+        accounts.put(
+                accountIdWith(1),
+                Account.newBuilder()
+                        .smartContract(true)
+                        .firstContractStorageKey(Bytes.EMPTY)
+                        .build());
+        accounts.put(
+                accountIdWith(2),
+                Account.newBuilder()
+                        .firstContractStorageKey(FIRST_KEYS.get(contractIdWith(2)))
+                        .build());
+        accounts.put(
+                accountIdWith(3),
+                Account.newBuilder()
+                        .firstContractStorageKey(FIRST_KEYS.get(contractIdWith(4)))
+                        .build());
+
+        subject.migrate(ctx);
+        writableStates.commit();
+
+        FIRST_KEYS.forEach((contractId, firstKey) -> assertThat(accounts)
+                .hasEntrySatisfying(
+                        accountIdWith(contractId.contractNumOrThrow()),
+                        account -> assertThat(account.firstContractStorageKey()).isEqualTo(firstKey)));
+    }
+
+    private void givenValidCtx() {
+        given(ctx.newStates()).willReturn(writableStates);
+        given(ctx.sharedValues()).willReturn(sharedValues);
+        sharedValues.put(SHARED_VALUES_KEY, FIRST_KEYS);
+    }
+
+    private static ContractID contractIdWith(final long num) {
+        return ContractID.newBuilder().contractNum(num).build();
+    }
+
+    private static AccountID accountIdWith(final long num) {
+        return AccountID.newBuilder().accountNum(num).build();
+    }
+
+    private static byte[] copyToLeftPaddedByteArray(long value, final byte[] dest) {
+        for (int i = 7, j = dest.length - 1; i >= 0; i--, j--) {
+            dest[j] = (byte) (value & 0xffL);
+            value >>= 8;
+        }
+        return dest;
+    }
+}

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/InitialModServiceTokenSchemaTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/schemas/InitialModServiceTokenSchemaTest.java
@@ -180,7 +180,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                CURRENT_VERSION);
+                CURRENT_VERSION,
+                new HashMap<>());
 
         schema.migrate(migrationContext);
 
@@ -202,7 +203,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null);
+                null,
+                new HashMap<>());
 
         schema.migrate(migrationContext);
 
@@ -222,7 +224,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null);
+                null,
+                new HashMap<>());
 
         schema.migrate(migrationContext);
 
@@ -337,7 +340,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null);
+                null,
+                new HashMap<>());
 
         schema.migrate(migrationContext);
 
@@ -463,7 +467,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                CURRENT_VERSION);
+                CURRENT_VERSION,
+                new HashMap<>());
 
         schema.migrate(migrationContext);
 
@@ -508,7 +513,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                CURRENT_VERSION);
+                CURRENT_VERSION,
+                new HashMap<>());
 
         schema.migrate(migrationContext);
 
@@ -539,7 +545,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null));
+                null,
+                new HashMap<>()));
 
         final var acctsStateResult = newStates.<AccountID, Account>get(ACCOUNTS_KEY);
         for (int i = 1; i < DEFAULT_NUM_SYSTEM_ACCOUNTS; i++) {
@@ -569,7 +576,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null));
+                null,
+                new HashMap<>()));
 
         final var acctsStateResult = newStates.<AccountID, Account>get(ACCOUNTS_KEY);
         final var stakingRewardAccount = acctsStateResult.get(ACCT_IDS[800]);
@@ -601,7 +609,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null));
+                null,
+                new HashMap<>()));
 
         final var acctsStateResult = newStates.<AccountID, Account>get(ACCOUNTS_KEY);
         for (final long reservedNum : NON_CONTRACT_RESERVED_NUMS) {
@@ -631,7 +640,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null));
+                null,
+                new HashMap<>()));
 
         final var acctsStateResult = newStates.<AccountID, Account>get(ACCOUNTS_KEY);
 
@@ -660,7 +670,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null));
+                null,
+                new HashMap<>()));
 
         // Verify that the assigned account ID matches the expected entity IDs
         for (int i = 0; i < EVM_ADDRESSES.length; i++) {
@@ -679,7 +690,8 @@ final class InitialModServiceTokenSchemaTest {
                 networkInfo,
                 genesisRecordsBuilder,
                 entityIdStore,
-                null));
+                null,
+                new HashMap<>()));
 
         // Verify contract entity IDs aren't used
         for (int i = 350; i < 400; i++) {
@@ -725,7 +737,14 @@ final class InitialModServiceTokenSchemaTest {
         final var schema = newSubjectWithAllExpected();
         // When we call restart, the state will be updated to mark node 1 and 3 as deleted
         schema.restart(new MigrationContextImpl(
-                previousStates, newStates, config, networkInfo, genesisRecordsBuilder, entityIdStore, null));
+                previousStates,
+                newStates,
+                config,
+                networkInfo,
+                genesisRecordsBuilder,
+                entityIdStore,
+                null,
+                new HashMap<>()));
         final var updatedStates = newStates.get(STAKING_INFO_KEY);
         // marks nodes 1, 2 as deleted
         assertThat(((StakingNodeInfo) updatedStates.get(NODE_NUM_1)).deleted()).isTrue();


### PR DESCRIPTION
**Description**:
 - Cherry-pick necessary parts of #13535 
    * The extra cleanup to make all `Schema`s top-level classes, remove the `version` argument from `Service.registerSchemas()`, and extract mono migration from `Hedera`---while important tech debt to pay down---does not need to be in `release/0.50`.