### PR TITLE
perf: cherry-pick: HapiUtils.parsedIntOrZero() throws too many exceptions

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/HapiUtils.java
@@ -339,7 +339,7 @@ public class HapiUtils {
     }
 
     private static int parsedIntOrZero(@Nullable final String s) {
-        if (s == null) {
+        if (s == null || s.isBlank()) {
             return 0;
         } else {
             try {


### PR DESCRIPTION
**Description**:
Call isBlank() in parsedIntOrZero() to avoid NumberFormatException for empty/blank strings.

**Related issue(s)**:

Fixes #13587

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
