### PR TITLE
fix: 13610: Backport the fix for 13584 to 0.50

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -1316,13 +1316,15 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
             virtualHash = (rootHash != null) ? rootHash : hasher.emptyRootHash();
         }
 
+        // There are no remaining changes to be made to the cache, so we can seal it.
+        cache.seal();
+
+        // Make sure the copy is marked as hashed after the cache is sealed, otherwise the chances
+        // are an attempt to merge the cache will fail because the cache hasn't been sealed yet
         setHashPrivate(virtualHash);
 
         final long end = System.currentTimeMillis();
         statistics.recordHash(end - start);
-
-        // There are no remaining changes to be made to the cache, so we can seal it.
-        cache.seal();
     }
 
     /*


### PR DESCRIPTION
Fix summary: direct backport of https://github.com/hashgraph/hedera-services/pull/13586 to `release/0.50` branch.

Fixes: https://github.com/hashgraph/hedera-services/issues/13610
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
