### PR TITLE
Remove "proto." prefix from metric names

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -170,7 +170,7 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
             @NonNull final Metrics metrics,
             @NonNull final String nameTemplate,
             @NonNull final String descriptionTemplate) {
-        final var baseName = serviceName.replace('.', ':') + ":" + methodName;
+        final String baseName = calculateBaseName();
         final var name = String.format(nameTemplate, baseName);
         final var desc = String.format(descriptionTemplate, baseName);
         return metrics.getOrCreate(new Counter.Config("app", name).withDescription(desc));
@@ -188,9 +188,13 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
             @NonNull final Metrics metrics,
             @NonNull final String nameTemplate,
             @NonNull final String descriptionTemplate) {
-        final var baseName = serviceName.replace('.', ':') + ":" + methodName;
+        final String baseName = calculateBaseName();
         final var name = String.format(nameTemplate, baseName);
         final var desc = String.format(descriptionTemplate, baseName);
         return metrics.getOrCreate(new SpeedometerMetric.Config("app", name).withDescription(desc));
+    }
+
+    private String calculateBaseName() {
+        return serviceName.substring("proto.".length()).replace('.', ':') + ":" + methodName;
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/QueryMethodTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/QueryMethodTest.java
@@ -46,7 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 final class QueryMethodTest {
-    private static final String SERVICE_NAME = "testService";
+    private static final String SERVICE_NAME = "proto.testService";
     private static final String METHOD_NAME = "testMethod";
 
     private final QueryWorkflow queryWorkflow = (requestBuffer, responseBuffer) -> {};
@@ -160,7 +160,8 @@ final class QueryMethodTest {
     }
 
     private Counter counter(String suffix) {
-        return (Counter) metrics.getMetric("app", SERVICE_NAME + ":" + METHOD_NAME + suffix);
+        return (Counter)
+                metrics.getMetric("app", SERVICE_NAME.substring("proto.".length()) + ":" + METHOD_NAME + suffix);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/TransactionMethodTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/grpc/impl/TransactionMethodTest.java
@@ -44,7 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 final class TransactionMethodTest {
-    private static final String SERVICE_NAME = "testService";
+    private static final String SERVICE_NAME = "proto.testService";
     private static final String METHOD_NAME = "testMethod";
 
     private final IngestWorkflow ingestWorkflow = (requestBuffer, responseBuffer) -> {};
@@ -156,7 +156,8 @@ final class TransactionMethodTest {
     }
 
     private Counter counter(String suffix) {
-        return (Counter) metrics.getMetric("app", SERVICE_NAME + ":" + METHOD_NAME + suffix);
+        return (Counter)
+                metrics.getMetric("app", SERVICE_NAME.substring("proto.".length()) + ":" + METHOD_NAME + suffix);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

This PR removes the "proto." prefix from metric names generated for all gRPC endpoints. The prefix is part of the generated `servicesName` but can be confusing when appearing in the metric names.

**Related issue(s)**:

Fixes #13617 
