### PR TITLE
build: make annotation library dependencies transitive

### DIFF
--- a/platform-sdk/swirlds-base/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-base/src/main/java/module-info.java
@@ -33,5 +33,5 @@ module com.swirlds.base {
             com.swirlds.logging.test.fixtures,
             com.swirlds.metrics.api;
 
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-base/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/module-info.java
@@ -7,7 +7,7 @@ open module com.swirlds.base.test.fixtures {
 
     requires transitive com.swirlds.base;
     requires transitive org.junit.jupiter.api;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
     requires jakarta.inject;
     requires org.assertj.core;
 }

--- a/platform-sdk/swirlds-cli/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-cli/src/main/java/module-info.java
@@ -18,5 +18,5 @@ module com.swirlds.cli {
     requires transitive org.apache.logging.log4j;
     requires com.swirlds.logging;
     requires io.github.classgraph;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-common/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-common/src/main/java/module-info.java
@@ -162,5 +162,5 @@ module com.swirlds.common {
     requires org.apache.logging.log4j.core;
     requires org.bouncycastle.provider;
     requires org.hyperledger.besu.nativelib.secp256k1;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-common/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/module-info.java
@@ -24,5 +24,5 @@ open module com.swirlds.common.test.fixtures {
     requires org.apache.logging.log4j.core;
     requires org.apache.logging.log4j;
     requires org.junit.jupiter.api;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-config-api/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/module-info.java
@@ -10,5 +10,5 @@ module com.swirlds.config.api {
 
     uses ConfigurationBuilderFactory;
 
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-config-api/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-config-api/src/testFixtures/java/module-info.java
@@ -1,3 +1,3 @@
 module com.swirlds.config.api.test.fixtures {
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-config-extensions/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/module-info.java
@@ -7,5 +7,5 @@ module com.swirlds.config.extensions {
     requires transitive com.swirlds.config.api;
     requires com.swirlds.base;
     requires org.apache.logging.log4j;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-config-extensions/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-config-extensions/src/testFixtures/java/module-info.java
@@ -5,5 +5,5 @@ open module com.swirlds.config.extensions.test.fixtures {
     requires com.swirlds.common;
     requires com.swirlds.config.extensions;
     requires io.github.classgraph;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-config-impl/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/module-info.java
@@ -9,8 +9,8 @@ module com.swirlds.config.impl {
     requires transitive com.swirlds.config.api;
     requires com.swirlds.base;
     requires com.swirlds.config.extensions;
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.auto.service;
+    requires static transitive com.github.spotbugs.annotations;
+    requires static transitive com.google.auto.service;
 
     uses ConfigurationExtension;
 

--- a/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataAnnotationProcessor.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/com/swirlds/config/processor/ConfigDataAnnotationProcessor.java
@@ -45,7 +45,7 @@ import javax.tools.StandardLocation;
  * An annotation processor that creates documentation and constants for config data records.
  */
 @SupportedAnnotationTypes(ConfigProcessorConstants.CONFIG_DATA_ANNOTATION)
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 @AutoService(Processor.class)
 public final class ConfigDataAnnotationProcessor extends AbstractProcessor {
 

--- a/platform-sdk/swirlds-config-processor/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-config-processor/src/main/java/module-info.java
@@ -6,6 +6,6 @@ module com.swirlds.config.processor {
     requires com.squareup.javapoet;
     requires java.compiler;
     requires transitive org.antlr.antlr4.runtime;
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.auto.service;
+    requires static transitive com.github.spotbugs.annotations;
+    requires static transitive com.google.auto.service;
 }

--- a/platform-sdk/swirlds-fchashmap/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-fchashmap/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module com.swirlds.fchashmap {
     requires transitive com.swirlds.common;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 
     exports com.swirlds.fchashmap;
 }

--- a/platform-sdk/swirlds-fcqueue/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-fcqueue/src/main/java/module-info.java
@@ -3,5 +3,5 @@ module com.swirlds.fcqueue {
 
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.metrics.api;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/module-info.java
@@ -42,5 +42,5 @@ open module com.swirlds.merkledb {
     requires org.apache.logging.log4j;
     requires org.eclipse.collections.api;
     requires org.eclipse.collections.impl;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-logging-log4j-appender/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-logging-log4j-appender/src/main/java/module-info.java
@@ -4,8 +4,8 @@ import com.swirlds.logging.log4j.factory.Log4JProviderFactory;
 import org.apache.logging.log4j.spi.Provider;
 
 module com.swirlds.logging.log4j.appender {
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.auto.service;
+    requires static transitive com.github.spotbugs.annotations;
+    requires static transitive com.google.auto.service;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.logging;
     requires transitive org.apache.logging.log4j;

--- a/platform-sdk/swirlds-logging/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-logging/src/main/java/module-info.java
@@ -29,8 +29,8 @@ module com.swirlds.logging {
     requires com.swirlds.config.extensions;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.datatype.jsr310;
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.auto.service;
+    requires static transitive com.github.spotbugs.annotations;
+    requires static transitive com.google.auto.service;
 
     uses LogHandlerFactory;
     uses LogProviderFactory;

--- a/platform-sdk/swirlds-logging/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-logging/src/testFixtures/java/module-info.java
@@ -5,5 +5,5 @@ open module com.swirlds.logging.test.fixtures {
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.logging;
     requires transitive org.junit.jupiter.api;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-merkle/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-merkle/src/main/java/module-info.java
@@ -11,5 +11,5 @@ open module com.swirlds.merkle {
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.fchashmap;
     requires transitive com.swirlds.metrics.api;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/module-info.java
@@ -3,5 +3,5 @@ module com.swirlds.metrics.api {
     exports com.swirlds.metrics.api.snapshot;
 
     requires transitive com.swirlds.base;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/module-info.java
@@ -3,5 +3,5 @@ module com.swirlds.metrics.impl {
 
     requires transitive com.swirlds.metrics.api;
     requires com.swirlds.base;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
@@ -157,8 +157,8 @@ module com.swirlds.platform.core {
     requires jdk.net;
     requires org.bouncycastle.pkix;
     requires org.bouncycastle.provider;
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.auto.service;
+    requires static transitive com.github.spotbugs.annotations;
+    requires static transitive com.google.auto.service;
 
     provides ConfigurationExtension with
             PlatformConfigurationExtension;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/module-info.java
@@ -13,7 +13,7 @@ open module com.swirlds.platform.core.test.fixtures {
     requires org.apache.logging.log4j;
     requires org.junit.jupiter.api;
     requires org.mockito;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 
     exports com.swirlds.platform.test.fixtures;
     exports com.swirlds.platform.test.fixtures.stream;

--- a/platform-sdk/swirlds-state-api/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/module-info.java
@@ -4,5 +4,5 @@ module com.swirlds.state.api {
     exports com.swirlds.state.spi.metrics;
 
     requires com.hedera.pbj.runtime;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/module-info.java
@@ -9,5 +9,5 @@ open module com.swirlds.platform.test {
     requires com.hedera.node.hapi;
     requires java.desktop;
     requires org.junit.jupiter.api;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/module-info.java
@@ -23,5 +23,5 @@ open module com.swirlds.virtualmap {
     requires com.hedera.pbj.runtime;
     requires java.management; // Test dependency
     requires org.apache.logging.log4j;
-    requires static com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 }


### PR DESCRIPTION
**Description**:
- Annotation library dependencies should be transitive as they are annotations on public interfaces. This is not checked by the dependency analysis, but will be by `javac` itself once #11838 is integrated.
- Correct the Java version in our own `ConfigDataAnnotationProcessor`

**Related issue(s)**:

#11569

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
