### PR TITLE
build: activate more Javadoc lint checks and fail on problems

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
@@ -214,6 +214,7 @@ tasks.withType<Javadoc>().configureEach {
         )
         options.windowTitle = "Hedera Consensus Node"
         options.memberLevel = JavadocMemberLevel.PACKAGE
+        addStringOption("Xdoclint:all,-missing", "-Xwerror")
     }
 }
 
@@ -337,6 +338,7 @@ testlogger {
 tasks.assemble {
     // 'assemble' compiles all sources, including all test sources
     dependsOn(tasks.testClasses)
+    dependsOn(tasks.javadoc)
     dependsOn(tasks.named("hammerClasses"))
     dependsOn(tasks.named("timeConsumingClasses"))
     dependsOn(tasks.named("itestClasses"))

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-modules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-modules.gradle.kts
@@ -67,7 +67,8 @@ jvmDependencyConflicts.patch {
     module("com.google.guava:guava") {
         (annotationLibraries -
                 "com.google.code.findbugs:jsr305" -
-                "com.google.errorprone:error_prone_annotations")
+                "com.google.errorprone:error_prone_annotations" -
+                "org.checkerframework:checker-qual")
             .forEach { removeDependency(it) }
     }
     module("com.google.protobuf:protobuf-java-util") {
@@ -136,6 +137,7 @@ extraJavaModuleInfo {
     module("org.apache.commons:commons-math3", "org.apache.commons.math3")
     module("org.apache.commons:commons-collections4", "org.apache.commons.collections4")
     module("com.esaulpaugh:headlong", "headlong")
+    module("org.checkerframework:checker-qual", "org.checkerframework.checker.qual")
     module("org.connid:framework", "org.connid.framework")
     module("org.connid:framework-internal", "org.connid.framework.internal") {
         exportAllPackages()

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.protobuf.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.protobuf.gradle.kts
@@ -57,6 +57,14 @@ sourceSets.all {
     }
 }
 
+tasks.javadoc {
+    options {
+        this as StandardJavadocDocletOptions
+        // There are violations in the generated protobuf code
+        addStringOption("Xdoclint:-reference,-html", "-quiet")
+    }
+}
+
 // Give JUnit more ram and make it execute tests in parallel
 tasks.test {
     // We are running a lot of tests 10s of thousands, so they need to run in parallel. Make each


### PR DESCRIPTION
**Description**:

- Activates Javadoc lint checks (except _missing_) and fail on problems as part of `qualityGate`

Related:
- #14337 
- #14338
- #14339

**Related issue(s)**:

#11569

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
