### PR TITLE
fix(reconnect): use AtomicLong for anticipatedMessages counter

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/streams/AsyncInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/streams/AsyncInputStream.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,7 +60,7 @@ public class AsyncInputStream<T extends SelfSerializable> implements AutoCloseab
 
     private final SerializableDataInputStream inputStream;
 
-    private final AtomicInteger anticipatedMessages;
+    private final AtomicLong anticipatedMessages;
     private final BlockingQueue<SelfSerializable> receivedMessages;
 
     /**
@@ -99,7 +99,7 @@ public class AsyncInputStream<T extends SelfSerializable> implements AutoCloseab
         this.workGroup = Objects.requireNonNull(workGroup, "workGroup must not be null");
         this.messageFactory = Objects.requireNonNull(messageFactory, "messageFactory must not be null");
         this.pollTimeout = config.asyncStreamTimeout();
-        this.anticipatedMessages = new AtomicInteger(0);
+        this.anticipatedMessages = new AtomicLong(0L);
         this.receivedMessages = new LinkedBlockingQueue<>(config.asyncStreamBufferSize());
         this.finishedLatch = new CountDownLatch(1);
         this.alive = true;
@@ -136,10 +136,10 @@ public class AsyncInputStream<T extends SelfSerializable> implements AutoCloseab
         T message = null;
         try {
             while (isAlive() && !Thread.currentThread().isInterrupted()) {
-                final int previous =
-                        anticipatedMessages.getAndUpdate((final int value) -> value == 0 ? 0 : (value - 1));
+                final long previous =
+                        anticipatedMessages.getAndUpdate((final long value) -> value == 0L ? 0L : (value - 1L));
 
-                if (previous == 0) {
+                if (previous == 0L) {
                     MILLISECONDS.sleep(1);
                     continue;
                 }


### PR DESCRIPTION
**Description**:
Using `AtomicLong`, instead of `AtomicInteger`, for the `anticipatedMessages` counter in `AsyncInputStream`.

While investigating https://github.com/hashgraph/hedera-services/issues/13064 , I've noticed that the `LearnerPushVirtualTreeView` maintains the list of expected lessons in a queue that natively supports more than 2G items. In fact, it supports at least the `Long.MAX_VALUE` items (barring physical memory limitations.) This was implemented on purpose because the size of the trees being synchronized may be very large.

However, a counter of anticipated messages in the `AsyncInputStream` was an `AtomicInteger` for some reason, which clearly may produce incorrect results should the number of anticipated messages exceed the 2G or 4G limit.

While I'm unsure if the test failure described in the issue is caused by this discrepancy, it needs to be fixed nevertheless.

**Related issue(s)**:

Might contribute to #13064

**Notes for reviewer**:
`gr test` passes in `swirlds-common`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
