### PR TITLE
fix: 13674: Backport the fix for 13531 to release 0.51

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBaseBench.java
@@ -331,7 +331,7 @@ public abstract class VirtualMapBaseBench extends BaseBench {
     protected VirtualMap<BenchmarkKey, BenchmarkValue> restoreMap(final String label) {
         Path savedDir = null;
         for (int i = 0; ; i++) {
-            final Path nextSavedDir = getBenchDir().resolve(SAVED + i);
+            final Path nextSavedDir = getBenchDir().resolve(SAVED + i).resolve(label);
             if (!Files.exists(nextSavedDir.resolve(label + SERDE_SUFFIX))) {
                 break;
             }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -955,6 +955,13 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
                 } else {
                     // We removed the second to last leaf, so the first & last leaf paths are now the same.
                     state.setLastLeafPath(FIRST_LEFT_PATH);
+                    // One of the two remaining leaves is removed. When this virtual root copy is hashed,
+                    // the root hash will be a product of the remaining leaf hash and a null hash at
+                    // path 2. However, rehashing is only triggered, if there is at least one dirty leaf,
+                    // while leaf 1 is not marked as such: neither its contents nor its path are changed.
+                    // To fix it, mark it as dirty explicitly
+                    final VirtualLeafRecord<K, V> leaf = records.findLeafRecord(1, true);
+                    cache.putLeaf(leaf);
                 }
             } else {
                 final long lastLeafSibling = getSiblingPath(lastLeafPath);

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapHashingTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapHashingTest.java
@@ -363,6 +363,74 @@ class VirtualMapHashingTest {
         map.getRoot().fullLeafRehashIfNecessary();
     }
 
+    @Test
+    @DisplayName("Remove all but one elements and rehash")
+    void removeLeafTwo() {
+        VirtualMap<TestKey, TestValue> map = createMap();
+
+        try {
+            map.put(new TestKey(1), new TestValue("a"));
+            map.put(new TestKey(2), new TestValue("b"));
+
+            VirtualMap<TestKey, TestValue> copy = map.copy();
+            final Hash hash1 = map.getRight().getHash(); // virtual root node hash
+            map.release();
+            map = copy;
+
+            // Remove the second leaf, it must affect the root hash
+            map.remove(new TestKey(2));
+
+            copy = map.copy();
+            final Hash hash2 = map.getRight().getHash(); // virtual root node hash
+            map.release();
+            map = copy;
+
+            assertNotEquals(hash1, hash2, "Hash must be changed");
+
+            // Remove the last leaf, it must also change the hash
+            map.remove(new TestKey(1));
+
+            copy = map.copy();
+            final Hash hash3 = map.getRight().getHash(); // virtual root node hash
+            map.release();
+            map = copy;
+
+            assertNotEquals(hash2, hash3, "Hash must be changed");
+
+            // Now check the other order: remove leaf 1 first, then leaf 2
+
+            map.put(new TestKey(1), new TestValue("a"));
+            map.put(new TestKey(2), new TestValue("b"));
+
+            copy = map.copy();
+            final Hash hash4 = map.getRight().getHash(); // virtual root node hash
+            map.release();
+            map = copy;
+
+            // Remove the first leaf, it must affect the root hash
+            map.remove(new TestKey(1));
+
+            copy = map.copy();
+            final Hash hash5 = map.getRight().getHash(); // virtual root node hash
+            map.release();
+            map = copy;
+
+            assertNotEquals(hash4, hash5, "Hash must be changed");
+
+            // Remove the last leaf, it must also change the hash
+            map.remove(new TestKey(2));
+
+            copy = map.copy();
+            final Hash hash6 = map.getRight().getHash(); // virtual root node hash
+            map.release();
+            map = copy;
+
+            assertNotEquals(hash5, hash6, "Hash must be changed");
+        } finally {
+            map.release();
+        }
+    }
+
     private static void doFullRehash(VirtualRootNode<TestKey, TestValue> root) {
         root.setImmutable(true);
         root.getCache().seal();


### PR DESCRIPTION
Fix summary: direct backport of https://github.com/hashgraph/hedera-services/pull/13664 to `release/0.51`

Fixes: https://github.com/hashgraph/hedera-services/issues/13674
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
