### PR TITLE
chore: Disable DeterministicThrottleTest.throttlesWithinPermissibleTolerance()

### DIFF
--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class DeterministicThrottleTest {
@@ -142,6 +143,7 @@ class DeterministicThrottleTest {
     }
 
     @Test
+    @Disabled("Test is flaky. See https://github.com/hashgraph/hedera-services/issues/13667")
     void throttlesWithinPermissibleTolerance() throws InterruptedException {
         final long mtps = 123_456L;
         final var subject = DeterministicThrottle.withMtps(mtps);


### PR DESCRIPTION
**Description**:

Disables `DeterministicThrottleTest.throttlesWithinPermissibleTolerance()` because it is flaky. The test should be enabled again once it has been redesigned (see #13667).

**Related issue(s)**:

Fixes #13666 
