### PR TITLE
refactor: 13691 Extracted `RootNodeState` interface

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -96,7 +96,8 @@ import org.apache.logging.log4j.Logger;
  * each child must be part of the state proof. It would be better to have a binary tree. We should
  * consider nesting service nodes in a MerkleMap, or some other such approach to get a binary tree.
  */
-public class MerkleHederaState extends PartialNaryMerkleInternal implements MerkleInternal, SwirldState, HederaState, RootNodeState {
+public class MerkleHederaState extends PartialNaryMerkleInternal
+        implements MerkleInternal, SwirldState, HederaState, RootNodeState {
     private static final Logger logger = LogManager.getLogger(MerkleHederaState.class);
 
     /**
@@ -788,7 +789,8 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
         return md.stateDefinition().stateKey();
     }
 
-    // FUTURE USE: the following code will become relevant with https://github.com/hashgraph/hedera-services/issues/11773
+    // FUTURE USE: the following code will become relevant with
+    // https://github.com/hashgraph/hedera-services/issues/11773
     @Override
     public SwirldState getSwirldState() {
         return this;
@@ -796,12 +798,14 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
 
     @Override
     public PlatformState getPlatformState() {
-        throw new UnsupportedOperationException("To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
+        throw new UnsupportedOperationException(
+                "To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
     }
 
     @Override
     public void setPlatformState(PlatformState platformState) {
-        throw new UnsupportedOperationException("To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
+        throw new UnsupportedOperationException(
+                "To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -314,6 +314,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public MerkleHederaState copy() {
         throwIfImmutable();
@@ -791,25 +792,37 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
 
     // FUTURE USE: the following code will become relevant with
     // https://github.com/hashgraph/hedera-services/issues/11773
+    @NonNull
     @Override
     public SwirldState getSwirldState() {
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
     @Override
     public PlatformState getPlatformState() {
         throw new UnsupportedOperationException(
                 "To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void setPlatformState(PlatformState platformState) {
+    public void setPlatformState(@NonNull final PlatformState platformState) {
         throw new UnsupportedOperationException(
                 "To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
     @Override
-    public String getInfoString(int hashDepth) {
+    public String getInfoString(final int hashDepth) {
         return State.createInfoString(hashDepth, getPlatformState(), getHash(), this);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -31,6 +31,8 @@ import com.swirlds.common.utility.Labeled;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.merkle.StateUtils;
 import com.swirlds.platform.state.merkle.disk.OnDiskReadableKVState;
 import com.swirlds.platform.state.merkle.disk.OnDiskWritableKVState;
@@ -94,7 +96,7 @@ import org.apache.logging.log4j.Logger;
  * each child must be part of the state proof. It would be better to have a binary tree. We should
  * consider nesting service nodes in a MerkleMap, or some other such approach to get a binary tree.
  */
-public class MerkleHederaState extends PartialNaryMerkleInternal implements MerkleInternal, SwirldState, HederaState {
+public class MerkleHederaState extends PartialNaryMerkleInternal implements MerkleInternal, SwirldState, HederaState, RootNodeState {
     private static final Logger logger = LogManager.getLogger(MerkleHederaState.class);
 
     /**
@@ -784,5 +786,26 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     @NonNull
     private static String extractStateKey(@NonNull final StateMetadata<?, ?> md) {
         return md.stateDefinition().stateKey();
+    }
+
+    // FUTURE USE: the following code will become relevant with https://github.com/hashgraph/hedera-services/issues/11773
+    @Override
+    public SwirldState getSwirldState() {
+        return this;
+    }
+
+    @Override
+    public PlatformState getPlatformState() {
+        throw new UnsupportedOperationException("To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
+    }
+
+    @Override
+    public void setPlatformState(PlatformState platformState) {
+        throw new UnsupportedOperationException("To be implemented with https://github.com/hashgraph/hedera-services/issues/11773");
+    }
+
+    @Override
+    public String getInfoString(int hashDepth) {
+        return State.createInfoString(hashDepth, getPlatformState(), getHash(), this);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -30,8 +30,8 @@ import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
 import com.swirlds.common.utility.Labeled;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.merkle.StateUtils;
 import com.swirlds.platform.state.merkle.disk.OnDiskReadableKVState;
@@ -97,7 +97,7 @@ import org.apache.logging.log4j.Logger;
  * consider nesting service nodes in a MerkleMap, or some other such approach to get a binary tree.
  */
 public class MerkleHederaState extends PartialNaryMerkleInternal
-        implements MerkleInternal, SwirldState, HederaState, RootNodeState {
+        implements MerkleInternal, SwirldState, HederaState, MerkleRoot {
     private static final Logger logger = LogManager.getLogger(MerkleHederaState.class);
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
@@ -25,8 +25,8 @@ import static com.swirlds.platform.system.SoftwareVersion.NO_VERSION;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.platform.config.StateConfig;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -70,7 +70,7 @@ public final class StateInitializer {
             trigger = RESTART;
         }
 
-        final RootNodeState initialState = signedState.getState();
+        final MerkleRoot initialState = signedState.getState();
 
         // Although the state from disk / genesis state is initially hashed, we are actually dealing with a copy
         // of that state here. That copy should have caused the hash to be cleared.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
@@ -26,7 +26,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -70,7 +70,7 @@ public final class StateInitializer {
             trigger = RESTART;
         }
 
-        final State initialState = signedState.getState();
+        final RootNodeState initialState = signedState.getState();
 
         // Although the state from disk / genesis state is initially hashed, we are actually dealing with a copy
         // of that state here. That copy should have caused the hash to be cleared.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -59,8 +59,8 @@ import com.swirlds.platform.metrics.RuntimeMetrics;
 import com.swirlds.platform.pool.TransactionPoolNexus;
 import com.swirlds.platform.publisher.DefaultPlatformPublisher;
 import com.swirlds.platform.publisher.PlatformPublisher;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.nexus.DefaultLatestCompleteStateNexus;
 import com.swirlds.platform.state.nexus.LatestCompleteStateNexus;
@@ -382,7 +382,7 @@ public class SwirldsPlatform implements Platform {
             return null;
         }
 
-        final RootNodeState state = initialState.getState();
+        final MerkleRoot state = initialState.getState();
         final PlatformState platformState = state.getPlatformState();
 
         return new DefaultBirthRoundMigrationShim(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -60,7 +60,7 @@ import com.swirlds.platform.pool.TransactionPoolNexus;
 import com.swirlds.platform.publisher.DefaultPlatformPublisher;
 import com.swirlds.platform.publisher.PlatformPublisher;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.nexus.DefaultLatestCompleteStateNexus;
 import com.swirlds.platform.state.nexus.LatestCompleteStateNexus;
@@ -382,7 +382,7 @@ public class SwirldsPlatform implements Platform {
             return null;
         }
 
-        final State state = initialState.getState();
+        final RootNodeState state = initialState.getState();
         final PlatformState platformState = state.getPlatformState();
 
         return new DefaultBirthRoundMigrationShim(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -70,7 +70,7 @@ import com.swirlds.platform.gossip.NoOpIntakeEventCounter;
 import com.swirlds.platform.gossip.sync.config.SyncConfig;
 import com.swirlds.platform.pool.TransactionPoolNexus;
 import com.swirlds.platform.scratchpad.Scratchpad;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.address.AddressBookInitializer;
 import com.swirlds.platform.state.iss.IssScratchpad;
@@ -535,7 +535,7 @@ public final class PlatformBuilder {
                 platformContext);
 
         if (addressBookInitializer.hasAddressBookChanged()) {
-            final State state = initialState.get().getState();
+            final RootNodeState state = initialState.get().getState();
             // Update the address book with the current address book read from config.txt.
             // Eventually we will not do this, and only transactions will be capable of
             // modifying the address book.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -70,7 +70,7 @@ import com.swirlds.platform.gossip.NoOpIntakeEventCounter;
 import com.swirlds.platform.gossip.sync.config.SyncConfig;
 import com.swirlds.platform.pool.TransactionPoolNexus;
 import com.swirlds.platform.scratchpad.Scratchpad;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.address.AddressBookInitializer;
 import com.swirlds.platform.state.iss.IssScratchpad;
@@ -535,7 +535,7 @@ public final class PlatformBuilder {
                 platformContext);
 
         if (addressBookInitializer.hasAddressBookChanged()) {
-            final RootNodeState state = initialState.get().getState();
+            final MerkleRoot state = initialState.get().getState();
             // Update the address book with the current address book read from config.txt.
             // Eventually we will not do this, and only transactions will be capable of
             // modifying the address book.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -36,8 +36,8 @@ import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.metrics.RoundHandlingMetrics;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -300,7 +300,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
         }
 
         handlerMetrics.setPhase(GETTING_STATE_TO_SIGN);
-        final RootNodeState immutableStateCons = swirldStateManager.getStateForSigning();
+        final MerkleRoot immutableStateCons = swirldStateManager.getStateForSigning();
 
         handlerMetrics.setPhase(CREATING_SIGNED_STATE);
         final SignedState signedState = new SignedState(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -37,7 +37,7 @@ import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.metrics.RoundHandlingMetrics;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -300,7 +300,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
         }
 
         handlerMetrics.setPhase(GETTING_STATE_TO_SIGN);
-        final State immutableStateCons = swirldStateManager.getStateForSigning();
+        final RootNodeState immutableStateCons = swirldStateManager.getStateForSigning();
 
         handlerMetrics.setPhase(CREATING_SIGNED_STATE);
         final SignedState signedState = new SignedState(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
@@ -25,7 +25,7 @@ import com.swirlds.logging.legacy.payload.ReconnectLoadFailurePayload;
 import com.swirlds.logging.legacy.payload.ReconnectStartPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -51,7 +51,7 @@ public class ReconnectHelper {
     /** clears all data that is no longer needed since we fell behind */
     private final Clearable clearAll;
     /** supplier of the initial signed state against which to perform a delta based reconnect */
-    private final Supplier<RootNodeState> workingStateSupplier;
+    private final Supplier<MerkleRoot> workingStateSupplier;
     /** provides the latest signed state round for which we have a supermajority of signatures */
     private final LongSupplier lastCompleteRoundSupplier;
     /** throttles reconnect learner attempts */
@@ -66,7 +66,7 @@ public class ReconnectHelper {
     public ReconnectHelper(
             final Runnable pauseGossip,
             final Clearable clearAll,
-            final Supplier<RootNodeState> workingStateSupplier,
+            final Supplier<MerkleRoot> workingStateSupplier,
             final LongSupplier lastCompleteRoundSupplier,
             final ReconnectLearnerThrottle reconnectLearnerThrottle,
             final Consumer<SignedState> loadSignedState,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
@@ -25,7 +25,7 @@ import com.swirlds.logging.legacy.payload.ReconnectLoadFailurePayload;
 import com.swirlds.logging.legacy.payload.ReconnectStartPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -51,7 +51,7 @@ public class ReconnectHelper {
     /** clears all data that is no longer needed since we fell behind */
     private final Clearable clearAll;
     /** supplier of the initial signed state against which to perform a delta based reconnect */
-    private final Supplier<State> workingStateSupplier;
+    private final Supplier<RootNodeState> workingStateSupplier;
     /** provides the latest signed state round for which we have a supermajority of signatures */
     private final LongSupplier lastCompleteRoundSupplier;
     /** throttles reconnect learner attempts */
@@ -66,7 +66,7 @@ public class ReconnectHelper {
     public ReconnectHelper(
             final Runnable pauseGossip,
             final Clearable clearAll,
-            final Supplier<State> workingStateSupplier,
+            final Supplier<RootNodeState> workingStateSupplier,
             final LongSupplier lastCompleteRoundSupplier,
             final ReconnectLearnerThrottle reconnectLearnerThrottle,
             final Consumer<SignedState> loadSignedState,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
@@ -29,7 +29,7 @@ import com.swirlds.logging.legacy.payload.ReconnectDataUsagePayload;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
@@ -56,7 +56,7 @@ public class ReconnectLearner {
 
     private final Connection connection;
     private final AddressBook addressBook;
-    private final State currentState;
+    private final RootNodeState currentState;
     private final Duration reconnectSocketTimeout;
     private final ReconnectMetrics statistics;
     private final SignedStateValidationData stateValidationData;
@@ -88,7 +88,7 @@ public class ReconnectLearner {
             @NonNull final ThreadManager threadManager,
             @NonNull final Connection connection,
             @NonNull final AddressBook addressBook,
-            @NonNull final State currentState,
+            @NonNull final RootNodeState currentState,
             @NonNull final Duration reconnectSocketTimeout,
             @NonNull final ReconnectMetrics statistics) {
 
@@ -190,7 +190,7 @@ public class ReconnectLearner {
                 new LearningSynchronizer(threadManager, in, out, currentState, connection::disconnect, reconnectConfig);
         synchronizer.synchronize();
 
-        final State state = (State) synchronizer.getRoot();
+        final RootNodeState state = (RootNodeState) synchronizer.getRoot();
         final SignedState newSignedState = new SignedState(
                 platformContext,
                 CryptoStatic::verifySignature,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
@@ -29,7 +29,7 @@ import com.swirlds.logging.legacy.payload.ReconnectDataUsagePayload;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
@@ -56,7 +56,7 @@ public class ReconnectLearner {
 
     private final Connection connection;
     private final AddressBook addressBook;
-    private final RootNodeState currentState;
+    private final MerkleRoot currentState;
     private final Duration reconnectSocketTimeout;
     private final ReconnectMetrics statistics;
     private final SignedStateValidationData stateValidationData;
@@ -88,7 +88,7 @@ public class ReconnectLearner {
             @NonNull final ThreadManager threadManager,
             @NonNull final Connection connection,
             @NonNull final AddressBook addressBook,
-            @NonNull final RootNodeState currentState,
+            @NonNull final MerkleRoot currentState,
             @NonNull final Duration reconnectSocketTimeout,
             @NonNull final ReconnectMetrics statistics) {
 
@@ -190,7 +190,7 @@ public class ReconnectLearner {
                 new LearningSynchronizer(threadManager, in, out, currentState, connection::disconnect, reconnectConfig);
         synchronizer.synchronize();
 
-        final RootNodeState state = (RootNodeState) synchronizer.getRoot();
+        final MerkleRoot state = (MerkleRoot) synchronizer.getRoot();
         final SignedState newSignedState = new SignedState(
                 platformContext,
                 CryptoStatic::verifySignature,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
@@ -20,7 +20,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
@@ -63,7 +63,7 @@ public class ReconnectLearnerFactory {
      * @param workingState the state to use to perform a delta based reconnect
      * @return a new instance
      */
-    public ReconnectLearner create(final Connection conn, final RootNodeState workingState) {
+    public ReconnectLearner create(final Connection conn, final MerkleRoot workingState) {
         return new ReconnectLearner(
                 platformContext, threadManager, conn, addressBook, workingState, reconnectSocketTimeout, statistics);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
@@ -20,7 +20,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
@@ -63,7 +63,7 @@ public class ReconnectLearnerFactory {
      * @param workingState the state to use to perform a delta based reconnect
      * @return a new instance
      */
-    public ReconnectLearner create(final Connection conn, final State workingState) {
+    public ReconnectLearner create(final Connection conn, final RootNodeState workingState) {
         return new ReconnectLearner(
                 platformContext, threadManager, conn, addressBook, workingState, reconnectSocketTimeout, statistics);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
@@ -21,7 +21,7 @@ import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.logging.legacy.payload.ReconnectFailurePayload;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -60,7 +60,7 @@ public final class ReconnectUtils {
     /**
      * Hash the working state to prepare for reconnect
      */
-    static void hashStateForReconnect(final RootNodeState workingState) {
+    static void hashStateForReconnect(final MerkleRoot workingState) {
         try {
             MerkleCryptoFactory.getInstance().digestTreeAsync(workingState).get();
         } catch (final ExecutionException e) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
@@ -21,7 +21,7 @@ import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.logging.legacy.payload.ReconnectFailurePayload;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -60,7 +60,7 @@ public final class ReconnectUtils {
     /**
      * Hash the working state to prepare for reconnect
      */
-    static void hashStateForReconnect(final State workingState) {
+    static void hashStateForReconnect(final RootNodeState workingState) {
         try {
             MerkleCryptoFactory.getInstance().digestTreeAsync(workingState).get();
         } catch (final ExecutionException e) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -51,8 +51,8 @@ import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
 import com.swirlds.platform.recovery.internal.EventStreamRoundIterator;
 import com.swirlds.platform.recovery.internal.RecoveredState;
 import com.swirlds.platform.recovery.internal.RecoveryPlatform;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileReader;
@@ -182,7 +182,7 @@ public final class EventRecoveryWorkflow {
                     resultingStateDirectory);
 
             // Make one more copy to force the state in recoveredState to be immutable.
-            final RootNodeState mutableStateCopy =
+            final MerkleRoot mutableStateCopy =
                     recoveredState.state().get().getState().copy();
 
             SignedStateFileWriter.writeSignedStateFilesToDirectory(
@@ -374,7 +374,7 @@ public final class EventRecoveryWorkflow {
 
         final Instant currentRoundTimestamp = getRoundTimestamp(round);
         previousState.get().getState().throwIfImmutable();
-        final RootNodeState newState = previousState.get().getState().copy();
+        final MerkleRoot newState = previousState.get().getState().copy();
         final EventImpl lastEvent = (EventImpl) getLastEvent(round);
         new StatefulEventHasher().hashEvent(lastEvent.getBaseEvent());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -52,7 +52,7 @@ import com.swirlds.platform.recovery.internal.EventStreamRoundIterator;
 import com.swirlds.platform.recovery.internal.RecoveredState;
 import com.swirlds.platform.recovery.internal.RecoveryPlatform;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileReader;
@@ -182,7 +182,7 @@ public final class EventRecoveryWorkflow {
                     resultingStateDirectory);
 
             // Make one more copy to force the state in recoveredState to be immutable.
-            final State mutableStateCopy =
+            final RootNodeState mutableStateCopy =
                     recoveredState.state().get().getState().copy();
 
             SignedStateFileWriter.writeSignedStateFilesToDirectory(
@@ -374,7 +374,7 @@ public final class EventRecoveryWorkflow {
 
         final Instant currentRoundTimestamp = getRoundTimestamp(round);
         previousState.get().getState().throwIfImmutable();
-        final State newState = previousState.get().getState().copy();
+        final RootNodeState newState = previousState.get().getState().copy();
         final EventImpl lastEvent = (EventImpl) getLastEvent(round);
         new StatefulEventHasher().hashEvent(lastEvent.getBaseEvent());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
@@ -63,7 +63,7 @@ public final class BirthRoundStateMigration {
             return;
         }
 
-        final State state = initialState.getState();
+        final RootNodeState state = initialState.getState();
         final PlatformState platformState = state.getPlatformState();
 
         final boolean alreadyMigrated = platformState.getFirstVersionInBirthRoundMode() != null;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
@@ -63,7 +63,7 @@ public final class BirthRoundStateMigration {
             return;
         }
 
-        final RootNodeState state = initialState.getState();
+        final MerkleRoot state = initialState.getState();
         final PlatformState platformState = state.getPlatformState();
 
         final boolean alreadyMigrated = platformState.getFirstVersionInBirthRoundMode() != null;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
@@ -22,7 +22,7 @@ import com.swirlds.platform.system.SwirldState;
 /**
  * This interface represents the root node of Hedera Merkle tree.
  */
-public interface RootNodeState extends MerkleInternal {
+public interface MerkleRoot extends MerkleInternal {
     /**
      * Get the application state.
      *
@@ -51,5 +51,5 @@ public interface RootNodeState extends MerkleInternal {
     String getInfoString(int hashDepth);
 
     /** {@inheritDoc} */
-    RootNodeState copy();
+    MerkleRoot copy();
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.state;
 
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.platform.system.SwirldState;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * This interface represents the root node of Hedera Merkle tree.
@@ -28,6 +29,7 @@ public interface MerkleRoot extends MerkleInternal {
      *
      * @return the application state
      */
+    @NonNull
     SwirldState getSwirldState();
 
     /**
@@ -35,21 +37,24 @@ public interface MerkleRoot extends MerkleInternal {
      *
      * @return the platform state
      */
+    @NonNull
     PlatformState getPlatformState();
     /**
      * Set the platform state.
      *
      * @param platformState the platform state
      */
-    void setPlatformState(PlatformState platformState);
+    void setPlatformState(@NonNull final PlatformState platformState);
 
     /**
      * Generate a string that describes this state.
      *
      * @param hashDepth the depth of the tree to visit and print
      */
-    String getInfoString(int hashDepth);
+    @NonNull
+    String getInfoString(final int hashDepth);
 
     /** {@inheritDoc} */
+    @NonNull
     MerkleRoot copy();
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/RootNodeState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/RootNodeState.java
@@ -1,0 +1,39 @@
+package com.swirlds.platform.state;
+
+import com.swirlds.common.merkle.MerkleInternal;
+import com.swirlds.platform.system.SwirldState;
+
+/**
+ * This interface represents the root node of Hedera Merkle tree.
+ */
+public interface RootNodeState extends MerkleInternal {
+    /**
+     * Get the application state.
+     *
+     * @return the application state
+     */
+    SwirldState getSwirldState();
+
+    /**
+     * Get the platform state.
+     *
+     * @return the platform state
+     */
+    PlatformState getPlatformState();
+    /**
+     * Set the platform state.
+     *
+     * @param platformState the platform state
+     */
+    void setPlatformState(PlatformState platformState);
+
+    /**
+     * Generate a string that describes this state.
+     *
+     * @param hashDepth the depth of the tree to visit and print
+     */
+    String getInfoString(int hashDepth);
+
+    /** {@inheritDoc} */
+    RootNodeState copy();
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/RootNodeState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/RootNodeState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.swirlds.platform.state;
 
 import com.swirlds.common.merkle.MerkleInternal;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -26,6 +26,7 @@ import com.swirlds.common.utility.RuntimeObjectRecord;
 import com.swirlds.common.utility.RuntimeObjectRegistry;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.system.SwirldState;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
@@ -114,6 +115,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
      * @return the application state
      */
     @Override
+    @NonNull
     public SwirldState getSwirldState() {
         return getChild(ChildIndices.SWIRLD_STATE);
     }
@@ -132,6 +134,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
      *
      * @return the platform state
      */
+    @NonNull
     @Override
     public PlatformState getPlatformState() {
         return getChild(ChildIndices.PLATFORM_STATE);
@@ -143,7 +146,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
      * @param platformState the platform state
      */
     @Override
-    public void setPlatformState(final PlatformState platformState) {
+    public void setPlatformState(@NonNull final PlatformState platformState) {
         setChild(ChildIndices.PLATFORM_STATE, platformState);
     }
 
@@ -166,6 +169,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public MerkleRoot copy() {
         throwIfImmutable();
@@ -210,12 +214,21 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
      *
      * @param hashDepth the depth of the tree to visit and print
      */
+    @NonNull
     @Override
     public String getInfoString(final int hashDepth) {
         final PlatformState platformState = getPlatformState();
         return createInfoString(hashDepth, platformState, getHash(), this);
     }
 
+    /**
+     * Generate a string that describes this state.
+     *
+     * @param hashDepth the depth of the tree to visit and print
+     * @param platformState current platform state
+     * @param state current root node state
+     *
+     */
     public static String createInfoString(int hashDepth, PlatformState platformState, Hash rootHash, MerkleNode state) {
         final Hash epochHash = platformState.getNextEpochHash();
         final Hash hashEventsCons = platformState.getLegacyRunningEventHash();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.Logger;
  * The root of the merkle tree holding the state of the Swirlds ledger. Contains two children: the state used by the
  * application and the state used by the platform.
  */
-public class State extends PartialNaryMerkleInternal implements RootNodeState {
+public class State extends PartialNaryMerkleInternal implements MerkleRoot {
 
     private static final Logger logger = LogManager.getLogger(State.class);
 
@@ -167,7 +167,7 @@ public class State extends PartialNaryMerkleInternal implements RootNodeState {
      * {@inheritDoc}
      */
     @Override
-    public RootNodeState copy() {
+    public MerkleRoot copy() {
         throwIfImmutable();
         throwIfDestroyed();
         return new State(this);
@@ -192,7 +192,7 @@ public class State extends PartialNaryMerkleInternal implements RootNodeState {
         if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        final RootNodeState state = (RootNodeState) other;
+        final MerkleRoot state = (MerkleRoot) other;
         return Objects.equals(getPlatformState(), state.getPlatformState())
                 && Objects.equals(getSwirldState(), state.getSwirldState());
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -49,12 +49,12 @@ public class SwirldStateManager implements FreezePeriodChecker {
     /**
      * reference to the state that reflects all known consensus transactions
      */
-    private final AtomicReference<State> stateRef = new AtomicReference<>();
+    private final AtomicReference<RootNodeState> stateRef = new AtomicReference<>();
 
     /**
      * The most recent immutable state. No value until the first fast copy is created.
      */
-    private final AtomicReference<State> latestImmutableState = new AtomicReference<>();
+    private final AtomicReference<RootNodeState> latestImmutableState = new AtomicReference<>();
 
     /**
      * Handle transactions by applying them to a state
@@ -104,7 +104,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      *
      * @param state the initial state
      */
-    public void setInitialState(@NonNull final State state) {
+    public void setInitialState(@NonNull final RootNodeState state) {
         Objects.requireNonNull(state);
         state.throwIfDestroyed("state must not be destroyed");
         state.throwIfImmutable("state must be mutable");
@@ -125,7 +125,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param round the round to handle
      */
     public void handleConsensusRound(final ConsensusRound round) {
-        final State state = stateRef.get();
+        final RootNodeState state = stateRef.get();
 
         uptimeTracker.handleRound(
                 round,
@@ -139,7 +139,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * Returns the consensus state. The consensus state could become immutable at any time. Modifications must not be
      * made to the returned state.
      */
-    public State getConsensusState() {
+    public RootNodeState getConsensusState() {
         return stateRef.get();
     }
 
@@ -163,7 +163,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param signedState the signed state to load
      */
     public void loadFromSignedState(@NonNull final SignedState signedState) {
-        final State state = signedState.getState();
+        final RootNodeState state = signedState.getState();
 
         state.throwIfDestroyed("state must not be destroyed");
         state.throwIfImmutable("state must be mutable");
@@ -171,8 +171,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
         fastCopyAndUpdateRefs(state);
     }
 
-    private void fastCopyAndUpdateRefs(final State state) {
-        final State consState = fastCopy(state, stats, softwareVersion);
+    private void fastCopyAndUpdateRefs(final RootNodeState state) {
+        final RootNodeState consState = fastCopy(state, stats, softwareVersion);
 
         // Set latest immutable first to prevent the newly immutable state from being deleted between setting the
         // stateRef and the latestImmutableState
@@ -185,8 +185,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
      *
      * @param state the new mutable state
      */
-    private void setState(final State state) {
-        final State currVal = stateRef.get();
+    private void setState(final RootNodeState state) {
+        final RootNodeState currVal = stateRef.get();
         if (currVal != null) {
             currVal.release();
         }
@@ -195,8 +195,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
         stateRef.set(state);
     }
 
-    private void setLatestImmutableState(final State immutableState) {
-        final State currVal = latestImmutableState.get();
+    private void setLatestImmutableState(final RootNodeState immutableState) {
+        final RootNodeState currVal = latestImmutableState.get();
         if (currVal != null) {
             currVal.release();
         }
@@ -233,7 +233,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @return a copy of the state to use for the next signed state
      * @see State#copy()
      */
-    public State getStateForSigning() {
+    public RootNodeState getStateForSigning() {
         fastCopyAndUpdateRefs(stateRef.get());
         return latestImmutableState.get();
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -49,12 +49,12 @@ public class SwirldStateManager implements FreezePeriodChecker {
     /**
      * reference to the state that reflects all known consensus transactions
      */
-    private final AtomicReference<RootNodeState> stateRef = new AtomicReference<>();
+    private final AtomicReference<MerkleRoot> stateRef = new AtomicReference<>();
 
     /**
      * The most recent immutable state. No value until the first fast copy is created.
      */
-    private final AtomicReference<RootNodeState> latestImmutableState = new AtomicReference<>();
+    private final AtomicReference<MerkleRoot> latestImmutableState = new AtomicReference<>();
 
     /**
      * Handle transactions by applying them to a state
@@ -104,7 +104,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      *
      * @param state the initial state
      */
-    public void setInitialState(@NonNull final RootNodeState state) {
+    public void setInitialState(@NonNull final MerkleRoot state) {
         Objects.requireNonNull(state);
         state.throwIfDestroyed("state must not be destroyed");
         state.throwIfImmutable("state must be mutable");
@@ -125,7 +125,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param round the round to handle
      */
     public void handleConsensusRound(final ConsensusRound round) {
-        final RootNodeState state = stateRef.get();
+        final MerkleRoot state = stateRef.get();
 
         uptimeTracker.handleRound(
                 round,
@@ -139,7 +139,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * Returns the consensus state. The consensus state could become immutable at any time. Modifications must not be
      * made to the returned state.
      */
-    public RootNodeState getConsensusState() {
+    public MerkleRoot getConsensusState() {
         return stateRef.get();
     }
 
@@ -163,7 +163,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param signedState the signed state to load
      */
     public void loadFromSignedState(@NonNull final SignedState signedState) {
-        final RootNodeState state = signedState.getState();
+        final MerkleRoot state = signedState.getState();
 
         state.throwIfDestroyed("state must not be destroyed");
         state.throwIfImmutable("state must be mutable");
@@ -171,8 +171,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
         fastCopyAndUpdateRefs(state);
     }
 
-    private void fastCopyAndUpdateRefs(final RootNodeState state) {
-        final RootNodeState consState = fastCopy(state, stats, softwareVersion);
+    private void fastCopyAndUpdateRefs(final MerkleRoot state) {
+        final MerkleRoot consState = fastCopy(state, stats, softwareVersion);
 
         // Set latest immutable first to prevent the newly immutable state from being deleted between setting the
         // stateRef and the latestImmutableState
@@ -185,8 +185,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
      *
      * @param state the new mutable state
      */
-    private void setState(final RootNodeState state) {
-        final RootNodeState currVal = stateRef.get();
+    private void setState(final MerkleRoot state) {
+        final MerkleRoot currVal = stateRef.get();
         if (currVal != null) {
             currVal.release();
         }
@@ -195,8 +195,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
         stateRef.set(state);
     }
 
-    private void setLatestImmutableState(final RootNodeState immutableState) {
-        final RootNodeState currVal = latestImmutableState.get();
+    private void setLatestImmutableState(final MerkleRoot immutableState) {
+        final MerkleRoot currVal = latestImmutableState.get();
         if (currVal != null) {
             currVal.release();
         }
@@ -233,7 +233,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @return a copy of the state to use for the next signed state
      * @see State#copy()
      */
-    public RootNodeState getStateForSigning() {
+    public MerkleRoot getStateForSigning() {
         fastCopyAndUpdateRefs(stateRef.get());
         return latestImmutableState.get();
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
@@ -41,8 +41,8 @@ public final class SwirldStateManagerUtils {
      * @param softwareVersion the current software version
      * @return the newly created state copy
      */
-    public static State fastCopy(
-            @NonNull final State state,
+    public static RootNodeState fastCopy(
+            @NonNull final RootNodeState state,
             @NonNull final SwirldStateMetrics stats,
             @NonNull final SoftwareVersion softwareVersion) {
 
@@ -51,7 +51,7 @@ public final class SwirldStateManagerUtils {
         final long copyStart = System.nanoTime();
 
         // Create a fast copy
-        final State copy = state.copy();
+        final RootNodeState copy = state.copy();
         state.getPlatformState().setCreationSoftwareVersion(softwareVersion);
 
         // Increment the reference count because this reference becomes the new value

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
@@ -41,8 +41,8 @@ public final class SwirldStateManagerUtils {
      * @param softwareVersion the current software version
      * @return the newly created state copy
      */
-    public static RootNodeState fastCopy(
-            @NonNull final RootNodeState state,
+    public static MerkleRoot fastCopy(
+            @NonNull final MerkleRoot state,
             @NonNull final SwirldStateMetrics stats,
             @NonNull final SoftwareVersion softwareVersion) {
 
@@ -51,7 +51,7 @@ public final class SwirldStateManagerUtils {
         final long copyStart = System.nanoTime();
 
         // Create a fast copy
-        final RootNodeState copy = state.copy();
+        final MerkleRoot copy = state.copy();
         state.getPlatformState().setCreationSoftwareVersion(softwareVersion);
 
         // Increment the reference count because this reference becomes the new value

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
@@ -52,7 +52,7 @@ public class TransactionHandler {
      * @param state
      * 		the state to apply {@code round} to
      */
-    public void handleRound(final ConsensusRound round, final RootNodeState state) {
+    public void handleRound(final ConsensusRound round, final MerkleRoot state) {
         try {
             final Instant timeOfHandle = Instant.now();
             final long startTime = System.nanoTime();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
@@ -52,7 +52,7 @@ public class TransactionHandler {
      * @param state
      * 		the state to apply {@code round} to
      */
-    public void handleRound(final ConsensusRound round, final State state) {
+    public void handleRound(final ConsensusRound round, final RootNodeState state) {
         try {
             final Instant timeOfHandle = Instant.now();
             final long startTime = System.nanoTime();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hashlogger/DefaultHashLogger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hashlogger/DefaultHashLogger.java
@@ -20,7 +20,7 @@ import static com.swirlds.logging.legacy.LogMarker.STATE_HASH;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -107,7 +107,7 @@ public class DefaultHashLogger implements HashLogger {
      */
     @NonNull
     private Message generateLogMessage(@NonNull final SignedState signedState) {
-        final RootNodeState state = signedState.getState();
+        final MerkleRoot state = signedState.getState();
         final String platformInfo = state.getInfoString(depth);
 
         return MESSAGE_FACTORY.newMessage(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hashlogger/DefaultHashLogger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hashlogger/DefaultHashLogger.java
@@ -20,7 +20,7 @@ import static com.swirlds.logging.legacy.LogMarker.STATE_HASH;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -107,7 +107,7 @@ public class DefaultHashLogger implements HashLogger {
      */
     @NonNull
     private Message generateLogMessage(@NonNull final SignedState signedState) {
-        final State state = signedState.getState();
+        final RootNodeState state = signedState.getState();
         final String platformInfo = state.getInfoString(depth);
 
         return MESSAGE_FACTORY.newMessage(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -34,7 +34,7 @@ import com.swirlds.common.utility.RuntimeObjectRegistry;
 import com.swirlds.common.utility.Threshold;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.crypto.SignatureVerifier;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction;
 import com.swirlds.platform.state.snapshot.StateToDiskReason;
 import com.swirlds.platform.system.SwirldState;
@@ -99,7 +99,7 @@ public class SignedState implements SignedStateInfo {
     /**
      * The root of the merkle state.
      */
-    private final State state;
+    private final RootNodeState state;
 
     /**
      * The timestamp of when this object was created.
@@ -181,7 +181,7 @@ public class SignedState implements SignedStateInfo {
     public SignedState(
             @NonNull final PlatformContext platformContext,
             @NonNull final SignatureVerifier signatureVerifier,
-            @NonNull final State state,
+            @NonNull final RootNodeState state,
             @NonNull final String reason,
             final boolean freezeState,
             final boolean deleteOnBackgroundThread,
@@ -268,7 +268,7 @@ public class SignedState implements SignedStateInfo {
      *
      * @return the state contained in the signed state
      */
-    public @NonNull State getState() {
+    public @NonNull RootNodeState getState() {
         return state;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -34,7 +34,7 @@ import com.swirlds.common.utility.RuntimeObjectRegistry;
 import com.swirlds.common.utility.Threshold;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.crypto.SignatureVerifier;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction;
 import com.swirlds.platform.state.snapshot.StateToDiskReason;
 import com.swirlds.platform.system.SwirldState;
@@ -99,7 +99,7 @@ public class SignedState implements SignedStateInfo {
     /**
      * The root of the merkle state.
      */
-    private final RootNodeState state;
+    private final MerkleRoot state;
 
     /**
      * The timestamp of when this object was created.
@@ -181,7 +181,7 @@ public class SignedState implements SignedStateInfo {
     public SignedState(
             @NonNull final PlatformContext platformContext,
             @NonNull final SignatureVerifier signatureVerifier,
-            @NonNull final RootNodeState state,
+            @NonNull final MerkleRoot state,
             @NonNull final String reason,
             final boolean freezeState,
             final boolean deleteOnBackgroundThread,
@@ -268,7 +268,7 @@ public class SignedState implements SignedStateInfo {
      *
      * @return the state contained in the signed state
      */
-    public @NonNull RootNodeState getState() {
+    public @NonNull MerkleRoot getState() {
         return state;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -32,7 +32,7 @@ import com.swirlds.logging.legacy.payload.SavedStateLoadedPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.internal.SignedStateLoadingException;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
 import com.swirlds.platform.state.snapshot.SavedStateInfo;
 import com.swirlds.platform.state.snapshot.SignedStateFilePath;
@@ -162,7 +162,7 @@ public final class StartupStateUtils {
         Objects.requireNonNull(platformContext);
         Objects.requireNonNull(initialSignedState);
 
-        final State stateCopy = initialSignedState.getState().copy();
+        final RootNodeState stateCopy = initialSignedState.getState().copy();
         final SignedState signedStateCopy = new SignedState(
                 platformContext,
                 CryptoStatic::verifySignature,
@@ -254,7 +254,7 @@ public final class StartupStateUtils {
             }
         }
 
-        final State state = deserializedSignedState.reservedSignedState().get().getState();
+        final RootNodeState state = deserializedSignedState.reservedSignedState().get().getState();
 
         final Hash oldHash = deserializedSignedState.originalHash();
         final Hash newHash = rehashTree(state);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -32,7 +32,7 @@ import com.swirlds.logging.legacy.payload.SavedStateLoadedPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.internal.SignedStateLoadingException;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
 import com.swirlds.platform.state.snapshot.SavedStateInfo;
 import com.swirlds.platform.state.snapshot.SignedStateFilePath;
@@ -162,7 +162,7 @@ public final class StartupStateUtils {
         Objects.requireNonNull(platformContext);
         Objects.requireNonNull(initialSignedState);
 
-        final RootNodeState stateCopy = initialSignedState.getState().copy();
+        final MerkleRoot stateCopy = initialSignedState.getState().copy();
         final SignedState signedStateCopy = new SignedState(
                 platformContext,
                 CryptoStatic::verifySignature,
@@ -254,7 +254,7 @@ public final class StartupStateUtils {
             }
         }
 
-        final RootNodeState state =
+        final MerkleRoot state =
                 deserializedSignedState.reservedSignedState().get().getState();
 
         final Hash oldHash = deserializedSignedState.originalHash();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -254,7 +254,8 @@ public final class StartupStateUtils {
             }
         }
 
-        final RootNodeState state = deserializedSignedState.reservedSignedState().get().getState();
+        final RootNodeState state =
+                deserializedSignedState.reservedSignedState().get().getState();
 
         final Hash oldHash = deserializedSignedState.originalHash();
         final Hash newHash = rehashTree(state);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -28,7 +28,7 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.crypto.CryptoStatic;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -83,7 +83,7 @@ public final class SignedStateFileReader {
 
         final DeserializedSignedState returnState;
 
-        record StateFileData(RootNodeState state, Hash hash, SigSet sigSet) {}
+        record StateFileData(MerkleRoot state, Hash hash, SigSet sigSet) {}
 
         final StateFileData data = deserializeAndDebugOnFailure(
                 () -> new BufferedInputStream(new FileInputStream(stateFile.toFile())),
@@ -92,7 +92,7 @@ public final class SignedStateFileReader {
 
                     final Path directory = stateFile.getParent();
 
-                    final RootNodeState state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
+                    final MerkleRoot state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
                     final Hash hash = in.readSerializable();
                     final SigSet sigSet = in.readSerializable();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -28,7 +28,7 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.crypto.CryptoStatic;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -83,7 +83,7 @@ public final class SignedStateFileReader {
 
         final DeserializedSignedState returnState;
 
-        record StateFileData(State state, Hash hash, SigSet sigSet) {}
+        record StateFileData(RootNodeState state, Hash hash, SigSet sigSet) {}
 
         final StateFileData data = deserializeAndDebugOnFailure(
                 () -> new BufferedInputStream(new FileInputStream(stateFile.toFile())),
@@ -92,7 +92,7 @@ public final class SignedStateFileReader {
 
                     final Path directory = stateFile.getParent();
 
-                    final State state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
+                    final RootNodeState state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
                     final Hash hash = in.readSerializable();
                     final SigSet sigSet = in.readSerializable();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
@@ -35,7 +35,7 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.logging.legacy.payload.StateSavedToDiskPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -68,7 +68,7 @@ public final class SignedStateFileWriter {
      * @param directory       the directory where the state is being written
      */
     public static void writeHashInfoFile(
-            @NonNull final PlatformContext platformContext, final Path directory, final State state)
+            @NonNull final PlatformContext platformContext, final Path directory, final RootNodeState state)
             throws IOException {
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
         final String platformInfo = state.getInfoString(stateConfig.debugHashDepth());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
@@ -35,7 +35,7 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.logging.legacy.payload.StateSavedToDiskPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -68,7 +68,7 @@ public final class SignedStateFileWriter {
      * @param directory       the directory where the state is being written
      */
     public static void writeHashInfoFile(
-            @NonNull final PlatformContext platformContext, final Path directory, final RootNodeState state)
+            @NonNull final PlatformContext platformContext, final Path directory, final MerkleRoot state)
             throws IOException {
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
         final String platformInfo = state.getInfoString(stateConfig.debugHashDepth());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -38,8 +38,8 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.AddressBookConfig_;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.address.AddressBookInitializer;
 import com.swirlds.platform.state.signed.SignedState;
@@ -379,7 +379,7 @@ class AddressBookInitializerTest {
         when(platformState.getCreationSoftwareVersion()).thenReturn(softwareVersion);
         when(platformState.getAddressBook()).thenReturn(currentAddressBook);
         when(platformState.getPreviousAddressBook()).thenReturn(previousAddressBook);
-        final RootNodeState state = mock(State.class);
+        final MerkleRoot state = mock(State.class);
         when(state.getPlatformState()).thenReturn(platformState);
         when(signedState.getState()).thenReturn(state);
         when(signedState.isGenesisState()).thenReturn(fromGenesis);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -39,6 +39,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.AddressBookConfig_;
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.address.AddressBookInitializer;
 import com.swirlds.platform.state.signed.SignedState;
@@ -378,7 +379,7 @@ class AddressBookInitializerTest {
         when(platformState.getCreationSoftwareVersion()).thenReturn(softwareVersion);
         when(platformState.getAddressBook()).thenReturn(currentAddressBook);
         when(platformState.getPreviousAddressBook()).thenReturn(previousAddressBook);
-        final State state = mock(State.class);
+        final RootNodeState state = mock(State.class);
         when(state.getPlatformState()).thenReturn(platformState);
         when(signedState.getState()).thenReturn(state);
         when(signedState.isGenesisState()).thenReturn(fromGenesis);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -44,6 +44,7 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.RandomUtils;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
@@ -218,7 +219,7 @@ class SavedStateMetadataTests {
 
         final SignedState signedState = mock(SignedState.class);
         final SigSet sigSet = mock(SigSet.class);
-        final State state = mock(State.class);
+        final RootNodeState state = mock(State.class);
         when(state.getHash()).thenReturn(randomHash(random));
         final PlatformState platformState = mock(PlatformState.class);
         when(platformState.getLegacyRunningEventHash()).thenReturn(randomHash(random));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -43,8 +43,8 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.RandomUtils;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
@@ -219,7 +219,7 @@ class SavedStateMetadataTests {
 
         final SignedState signedState = mock(SignedState.class);
         final SigSet sigSet = mock(SigSet.class);
-        final RootNodeState state = mock(State.class);
+        final MerkleRoot state = mock(State.class);
         when(state.getHash()).thenReturn(randomHash(random));
         final PlatformState platformState = mock(PlatformState.class);
         when(platformState.getLegacyRunningEventHash()).thenReturn(randomHash(random));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -43,8 +43,8 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileUtils;
@@ -81,7 +81,7 @@ class SignedStateFileReadWriteTest {
     @DisplayName("writeHashInfoFile() Test")
     void writeHashInfoFileTest() throws IOException {
 
-        final RootNodeState state = new RandomSignedStateGenerator().build().getState();
+        final MerkleRoot state = new RandomSignedStateGenerator().build().getState();
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
         writeHashInfoFile(platformContext, testDirectory, state);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -44,7 +44,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileUtils;
@@ -81,7 +81,7 @@ class SignedStateFileReadWriteTest {
     @DisplayName("writeHashInfoFile() Test")
     void writeHashInfoFileTest() throws IOException {
 
-        final State state = new RandomSignedStateGenerator().build().getState();
+        final RootNodeState state = new RandomSignedStateGenerator().build().getState();
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
         writeHashInfoFile(platformContext, testDirectory, state);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
@@ -19,6 +19,7 @@ package com.swirlds.platform.consensus;
 import static org.mockito.Mockito.when;
 
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.events.EventConstants;
@@ -69,7 +70,7 @@ class RoundCalculationUtilsTest {
         final Map<Long, Long> map =
                 LongStream.range(1, 50).collect(HashMap::new, (m, l) -> m.put(l, l * 10), HashMap::putAll);
         final SignedState signedState = Mockito.mock(SignedState.class);
-        final State state = Mockito.mock(State.class);
+        final RootNodeState state = Mockito.mock(State.class);
         final PlatformState platformState = Mockito.mock(PlatformState.class);
         when(signedState.getState()).thenReturn(state);
         when(state.getPlatformState()).thenReturn(platformState);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
@@ -18,8 +18,8 @@ package com.swirlds.platform.consensus;
 
 import static org.mockito.Mockito.when;
 
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.events.EventConstants;
@@ -70,7 +70,7 @@ class RoundCalculationUtilsTest {
         final Map<Long, Long> map =
                 LongStream.range(1, 50).collect(HashMap::new, (m, l) -> m.put(l, l * 10), HashMap::putAll);
         final SignedState signedState = Mockito.mock(SignedState.class);
-        final RootNodeState state = Mockito.mock(State.class);
+        final MerkleRoot state = Mockito.mock(State.class);
         final PlatformState platformState = Mockito.mock(PlatformState.class);
         when(signedState.getState()).thenReturn(state);
         when(state.getPlatformState()).thenReturn(platformState);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
@@ -36,8 +36,8 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -94,8 +94,8 @@ class DefaultTransactionHandlerTests {
     }
 
     private static SwirldStateManager mockSwirldStateManager(@NonNull final PlatformState platformState) {
-        final RootNodeState consensusState = mock(State.class);
-        final RootNodeState stateForSigning = mock(State.class);
+        final MerkleRoot consensusState = mock(State.class);
+        final MerkleRoot stateForSigning = mock(State.class);
         when(consensusState.getPlatformState()).thenReturn(platformState);
         final SwirldStateManager swirldStateManager = mock(SwirldStateManager.class);
         when(swirldStateManager.getConsensusState()).thenReturn(consensusState);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
@@ -37,6 +37,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -93,8 +94,8 @@ class DefaultTransactionHandlerTests {
     }
 
     private static SwirldStateManager mockSwirldStateManager(@NonNull final PlatformState platformState) {
-        final State consensusState = mock(State.class);
-        final State stateForSigning = mock(State.class);
+        final RootNodeState consensusState = mock(State.class);
+        final RootNodeState stateForSigning = mock(State.class);
         when(consensusState.getPlatformState()).thenReturn(platformState);
         final SwirldStateManager swirldStateManager = mock(SwirldStateManager.class);
         when(swirldStateManager.getConsensusState()).thenReturn(consensusState);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -47,8 +47,8 @@ import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.protocol.Protocol;
 import com.swirlds.platform.network.protocol.ProtocolFactory;
 import com.swirlds.platform.network.protocol.ReconnectProtocolFactory;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -300,7 +300,7 @@ class ReconnectProtocolTests {
                 Time.getCurrent());
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
-        final RootNodeState state = mock(State.class);
+        final MerkleRoot state = mock(State.class);
         when(signedState.getState()).thenReturn(state);
 
         final ReservedSignedState reservedSignedState = signedState.reserve("test");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -48,6 +48,7 @@ import com.swirlds.platform.network.protocol.Protocol;
 import com.swirlds.platform.network.protocol.ProtocolFactory;
 import com.swirlds.platform.network.protocol.ReconnectProtocolFactory;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -299,7 +300,7 @@ class ReconnectProtocolTests {
                 Time.getCurrent());
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
-        final State state = mock(State.class);
+        final RootNodeState state = mock(State.class);
         when(signedState.getState()).thenReturn(state);
 
         final ReservedSignedState reservedSignedState = signedState.reserve("test");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -38,7 +38,7 @@ import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.SocketConnection;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -187,7 +187,7 @@ final class ReconnectTest {
     }
 
     private ReconnectLearner buildReceiver(
-            final State state, final Connection connection, final ReconnectMetrics reconnectMetrics) {
+            final RootNodeState state, final Connection connection, final ReconnectMetrics reconnectMetrics) {
         final AddressBook addressBook = buildAddressBook(5);
 
         return new ReconnectLearner(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -37,8 +37,8 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.SocketConnection;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -187,7 +187,7 @@ final class ReconnectTest {
     }
 
     private ReconnectLearner buildReceiver(
-            final RootNodeState state, final Connection connection, final ReconnectMetrics reconnectMetrics) {
+            final MerkleRoot state, final Connection connection, final ReconnectMetrics reconnectMetrics) {
         final AddressBook addressBook = buildAddressBook(5);
 
         return new ReconnectLearner(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
@@ -57,8 +57,8 @@ import com.swirlds.platform.reconnect.ReconnectLearnerThrottle;
 import com.swirlds.platform.reconnect.ReconnectThrottle;
 import com.swirlds.platform.recovery.EmergencyRecoveryManager;
 import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.address.AddressBook;
@@ -229,7 +229,7 @@ class EmergencyReconnectTests {
 
     private ReconnectController createReconnectController(
             final AddressBook addressBook,
-            final Supplier<RootNodeState> learnerState,
+            final Supplier<MerkleRoot> learnerState,
             final Consumer<SignedState> receivedStateConsumer) {
 
         final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
@@ -58,7 +58,7 @@ import com.swirlds.platform.reconnect.ReconnectThrottle;
 import com.swirlds.platform.recovery.EmergencyRecoveryManager;
 import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
 import com.swirlds.platform.state.RandomSignedStateGenerator;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.address.AddressBook;
@@ -229,7 +229,7 @@ class EmergencyReconnectTests {
 
     private ReconnectController createReconnectController(
             final AddressBook addressBook,
-            final Supplier<State> learnerState,
+            final Supplier<RootNodeState> learnerState,
             final Consumer<SignedState> receivedStateConsumer) {
 
         final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -207,7 +207,7 @@ class SignedStateTests {
     @Test
     @DisplayName("Alternate Constructor Reservations Test")
     void alternateConstructorReservationsTest() {
-        final State state = spy(new State());
+        final RootNodeState state = spy(new State());
         final PlatformState platformState = mock(PlatformState.class);
         when(state.getPlatformState()).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(0L);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -207,7 +207,7 @@ class SignedStateTests {
     @Test
     @DisplayName("Alternate Constructor Reservations Test")
     void alternateConstructorReservationsTest() {
-        final RootNodeState state = spy(new State());
+        final MerkleRoot state = spy(new State());
         final PlatformState platformState = mock(PlatformState.class);
         when(state.getPlatformState()).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(0L);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
@@ -70,7 +70,7 @@ class StateRegistryTests {
 
         assertEquals(0, RuntimeObjectRegistry.getActiveObjectsCount(State.class), "no states have been created yet");
 
-        final List<State> states = new LinkedList<>();
+        final List<RootNodeState> states = new LinkedList<>();
         // Create a bunch of states
         for (int i = 0; i < 100; i++) {
             states.add(new State());
@@ -81,9 +81,9 @@ class StateRegistryTests {
         }
 
         // Fast copy a state
-        final State stateToCopy = new State();
+        final RootNodeState stateToCopy = new State();
         states.add(stateToCopy);
-        final State copyOfStateToCopy = stateToCopy.copy();
+        final RootNodeState copyOfStateToCopy = stateToCopy.copy();
         states.add(copyOfStateToCopy);
         assertEquals(
                 states.size(),
@@ -100,7 +100,7 @@ class StateRegistryTests {
         final InputOutputStream io = new InputOutputStream();
         io.getOutput().writeMerkleTree(dir, stateToSerialize);
         io.startReading();
-        final State deserializedState = io.getInput().readMerkleTree(dir, 5);
+        final RootNodeState deserializedState = io.getInput().readMerkleTree(dir, 5);
         states.add(deserializedState);
         assertEquals(
                 states.size(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
@@ -70,7 +70,7 @@ class StateRegistryTests {
 
         assertEquals(0, RuntimeObjectRegistry.getActiveObjectsCount(State.class), "no states have been created yet");
 
-        final List<RootNodeState> states = new LinkedList<>();
+        final List<MerkleRoot> states = new LinkedList<>();
         // Create a bunch of states
         for (int i = 0; i < 100; i++) {
             states.add(new State());
@@ -81,9 +81,9 @@ class StateRegistryTests {
         }
 
         // Fast copy a state
-        final RootNodeState stateToCopy = new State();
+        final MerkleRoot stateToCopy = new State();
         states.add(stateToCopy);
-        final RootNodeState copyOfStateToCopy = stateToCopy.copy();
+        final MerkleRoot copyOfStateToCopy = stateToCopy.copy();
         states.add(copyOfStateToCopy);
         assertEquals(
                 states.size(),
@@ -100,7 +100,7 @@ class StateRegistryTests {
         final InputOutputStream io = new InputOutputStream();
         io.getOutput().writeMerkleTree(dir, stateToSerialize);
         io.startReading();
-        final RootNodeState deserializedState = io.getInput().readMerkleTree(dir, 5);
+        final MerkleRoot deserializedState = io.getInput().readMerkleTree(dir, 5);
         states.add(deserializedState);
         assertEquals(
                 states.size(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 class SwirldStateManagerTests {
 
     private SwirldStateManager swirldStateManager;
-    private State initialState;
+    private RootNodeState initialState;
 
     @BeforeEach
     void setup() {
@@ -107,7 +107,7 @@ class SwirldStateManagerTests {
                         + "decremented.");
     }
 
-    private static State newState() {
+    private static RootNodeState newState() {
         final State state = new State();
         state.setSwirldState(new DummySwirldState());
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 class SwirldStateManagerTests {
 
     private SwirldStateManager swirldStateManager;
-    private RootNodeState initialState;
+    private MerkleRoot initialState;
 
     @BeforeEach
     void setup() {
@@ -107,7 +107,7 @@ class SwirldStateManagerTests {
                         + "decremented.");
     }
 
-    private static RootNodeState newState() {
+    private static MerkleRoot newState() {
         final State state = new State();
         state.setSwirldState(new DummySwirldState());
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
@@ -48,7 +48,7 @@ public class SwirldStateManagerUtilsTests {
 
         state.reserve();
         final SwirldStateMetrics stats = mock(SwirldStateMetrics.class);
-        final RootNodeState result = SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1));
+        final MerkleRoot result = SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1));
 
         assertFalse(result.isImmutable(), "The copy state should be mutable.");
         assertEquals(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
@@ -48,7 +48,7 @@ public class SwirldStateManagerUtilsTests {
 
         state.reserve();
         final SwirldStateMetrics stats = mock(SwirldStateMetrics.class);
-        final State result = SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1));
+        final RootNodeState result = SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1));
 
         assertFalse(result.isImmutable(), "The copy state should be mutable.");
         assertEquals(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
@@ -35,8 +35,8 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig_;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -152,7 +152,7 @@ public class HashLoggerTest {
         final MerkleNode merkleNode = MerkleTestUtils.buildLessSimpleTree();
         MerkleCryptoFactory.getInstance().digestTreeSync(merkleNode);
         final SignedState signedState = mock(SignedState.class);
-        final RootNodeState state = mock(State.class);
+        final MerkleRoot state = mock(State.class);
 
         final AddressBook addressBook = new AddressBook();
         addressBook.setHash(merkleNode.getHash());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
@@ -36,6 +36,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig_;
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -151,7 +152,7 @@ public class HashLoggerTest {
         final MerkleNode merkleNode = MerkleTestUtils.buildLessSimpleTree();
         MerkleCryptoFactory.getInstance().digestTreeSync(merkleNode);
         final SignedState signedState = mock(SignedState.class);
-        final State state = mock(State.class);
+        final RootNodeState state = mock(State.class);
 
         final AddressBook addressBook = new AddressBook();
         addressBook.setHash(merkleNode.getHash());

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,8 +37,8 @@ class StateTest {
     @DisplayName("Test Copy")
     void testCopy() {
 
-        final RootNodeState state = SignedStateUtils.randomSignedState(0).getState();
-        final RootNodeState copy = state.copy();
+        final MerkleRoot state = SignedStateUtils.randomSignedState(0).getState();
+        final MerkleRoot copy = state.copy();
 
         assertNotSame(state, copy, "copy should not return the same object");
 
@@ -59,7 +59,7 @@ class StateTest {
     @Tag(TestComponentTags.MERKLE)
     @DisplayName("Test Try Reserve")
     void tryReserveTest() {
-        final RootNodeState state = SignedStateUtils.randomSignedState(0).getState();
+        final MerkleRoot state = SignedStateUtils.randomSignedState(0).getState();
         assertEquals(
                 1,
                 state.getReservationCount(),

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
-import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.RootNodeState;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,8 +37,8 @@ class StateTest {
     @DisplayName("Test Copy")
     void testCopy() {
 
-        final State state = SignedStateUtils.randomSignedState(0).getState();
-        final State copy = state.copy();
+        final RootNodeState state = SignedStateUtils.randomSignedState(0).getState();
+        final RootNodeState copy = state.copy();
 
         assertNotSame(state, copy, "copy should not return the same object");
 
@@ -59,7 +59,7 @@ class StateTest {
     @Tag(TestComponentTags.MERKLE)
     @DisplayName("Test Try Reserve")
     void tryReserveTest() {
-        final State state = SignedStateUtils.randomSignedState(0).getState();
+        final RootNodeState state = SignedStateUtils.randomSignedState(0).getState();
         assertEquals(
                 1,
                 state.getReservationCount(),

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
@@ -27,7 +27,7 @@ import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.test.fixtures.io.InputOutputStream;
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.test.fixtures.state.DummySwirldState;
 import java.io.IOException;
@@ -73,7 +73,7 @@ class StateTests {
 
         io.startReading();
 
-        final RootNodeState decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
+        final MerkleRoot decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
         MerkleCryptoFactory.getInstance().digestTreeSync(decodedState);
 
         assertEquals(state.getHash(), decodedState.getHash(), "expected trees to be equal");
@@ -84,7 +84,7 @@ class StateTests {
     @Tag(TestComponentTags.PLATFORM)
     @DisplayName("State Copy Test")
     void stateCopyTest() {
-        final RootNodeState copiedState = state.copy();
+        final MerkleRoot copiedState = state.copy();
         MerkleCryptoFactory.getInstance().digestTreeSync(copiedState);
 
         assertEquals(state.getHash(), copiedState.getHash(), "expected trees to be equal");

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
@@ -27,6 +27,7 @@ import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.test.fixtures.io.InputOutputStream;
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.test.fixtures.state.DummySwirldState;
 import java.io.IOException;
@@ -72,7 +73,7 @@ class StateTests {
 
         io.startReading();
 
-        final State decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
+        final RootNodeState decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
         MerkleCryptoFactory.getInstance().digestTreeSync(decodedState);
 
         assertEquals(state.getHash(), decodedState.getHash(), "expected trees to be equal");
@@ -83,7 +84,7 @@ class StateTests {
     @Tag(TestComponentTags.PLATFORM)
     @DisplayName("State Copy Test")
     void stateCopyTest() {
-        final State copiedState = state.copy();
+        final RootNodeState copiedState = state.copy();
         MerkleCryptoFactory.getInstance().digestTreeSync(copiedState);
 
         assertEquals(state.getHash(), copiedState.getHash(), "expected trees to be equal");

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
@@ -37,7 +37,7 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
-import com.swirlds.platform.state.RootNodeState;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.iss.DefaultIssDetector;
 import com.swirlds.platform.state.iss.IssDetector;
@@ -705,7 +705,7 @@ class IssDetectorTests extends PlatformTest {
     private static ReservedSignedState mockState(final long round, final Hash hash) {
         final ReservedSignedState rs = mock(ReservedSignedState.class);
         final SignedState ss = mock(SignedState.class);
-        final RootNodeState s = mock(State.class);
+        final MerkleRoot s = mock(State.class);
         when(rs.get()).thenReturn(ss);
         when(ss.getState()).thenReturn(s);
         when(ss.getRound()).thenReturn(round);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
@@ -37,6 +37,7 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
+import com.swirlds.platform.state.RootNodeState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.iss.DefaultIssDetector;
 import com.swirlds.platform.state.iss.IssDetector;
@@ -704,7 +705,7 @@ class IssDetectorTests extends PlatformTest {
     private static ReservedSignedState mockState(final long round, final Hash hash) {
         final ReservedSignedState rs = mock(ReservedSignedState.class);
         final SignedState ss = mock(SignedState.class);
-        final State s = mock(State.class);
+        final RootNodeState s = mock(State.class);
         when(rs.get()).thenReturn(ss);
         when(ss.getState()).thenReturn(s);
         when(ss.getRound()).thenReturn(round);


### PR DESCRIPTION
**Description**:

PR highlights: 

- extracted `com.swirlds.platform.state.RootNodeState` interface from `com.swirlds.platform.state.State` and used it wherever it's applicable
- added this interface to `com.hedera.node.app.state.merkle.MerkleHederaState`. However, proper implementation of this interface will be a part of https://github.com/hashgraph/hedera-services/issues/11773 

**Related issue(s)**:

Fixes #13691 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
