### PR TITLE
fix: Cherry-pick: Enable tokens.balancesInQueries.enabled

### DIFF
--- a/hedera-node/configuration/mainnet/application.properties
+++ b/hedera-node/configuration/mainnet/application.properties
@@ -3,3 +3,4 @@
 # hedera-config), this requirement will no longer be valid.
 # It's used by modular code for property overrides, taking hedera-config/ as the base, 
 # with overrides from this file (configuration/mainnet/application.properties).
+ledger.id=0x00

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
@@ -50,7 +50,7 @@ public record TokensConfig(
         @ConfigProperty(value = "autoCreations.isEnabled", defaultValue = "true") @NetworkProperty
                 boolean autoCreationsIsEnabled,
         @ConfigProperty(value = "maxMetadataBytes", defaultValue = "100") @NetworkProperty int tokensMaxMetadataBytes,
-        @ConfigProperty(value = "balancesInQueries.enabled", defaultValue = "false") @NetworkProperty
+        @ConfigProperty(value = "balancesInQueries.enabled", defaultValue = "true") @NetworkProperty
                 boolean balancesInQueriesEnabled,
         @ConfigProperty(value = "nfts.maxBatchSizeUpdate", defaultValue = "10") @NetworkProperty
                 int nftsMaxBatchSizeUpdate) {}

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountInfoHandlerTest.java
@@ -484,10 +484,8 @@ class CryptoGetAccountInfoHandlerTest extends CryptoHandlerTestBase {
     private void setupConfig(boolean balancesInQueriesEnabled) {
         final var configBuilder = HederaTestConfigBuilder.create()
                 .withValue("tokens.maxRelsPerInfoQuery", 2)
-                .withValue("ledger.id", "0x03");
-        if (balancesInQueriesEnabled) {
-            configBuilder.withValue("tokens.balancesInQueries.enabled", true);
-        }
+                .withValue("ledger.id", "0x03")
+                .withValue("tokens.balancesInQueries.enabled", balancesInQueriesEnabled);
         given(context.configuration()).willReturn(configBuilder.getOrCreateConfig());
     }
 


### PR DESCRIPTION
**Description**:

This PR updates the configuration to enable balances in queries.
It also updates the application.properties file with the changes that were done for the 0.49 release.

**Related issue(s)**:

Fixes #13715 
