### PR TITLE
feat: servicedefinition tests

### DIFF
--- a/hedera-node/hedera-consensus-service/build.gradle.kts
+++ b/hedera-node/hedera-consensus-service/build.gradle.kts
@@ -25,4 +25,7 @@ description = "Hedera Consensus Service API"
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
-testModuleInfo { requires("org.assertj.core") }
+testModuleInfo {
+    requires("org.assertj.core")
+    requires("org.junit.jupiter.api")
+}

--- a/hedera-node/hedera-consensus-service/build.gradle.kts
+++ b/hedera-node/hedera-consensus-service/build.gradle.kts
@@ -24,3 +24,5 @@ description = "Hedera Consensus Service API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+testModuleInfo { requires("org.assertj.core") }

--- a/hedera-node/hedera-consensus-service/src/test/java/com/hedera/node/app/service/consensus/ConsensusServiceDefinitionTest.java
+++ b/hedera-node/hedera-consensus-service/src/test/java/com/hedera/node/app/service/consensus/ConsensusServiceDefinitionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.consensus;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConsensusServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(ConsensusServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.ConsensusService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = ConsensusServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("createTopic", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("updateTopic", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("deleteTopic", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("getTopicInfo", Query.class, Response.class),
+                        new RpcMethodDefinition<>("submitMessage", Transaction.class, TransactionResponse.class));
+    }
+}

--- a/hedera-node/hedera-file-service/build.gradle.kts
+++ b/hedera-node/hedera-file-service/build.gradle.kts
@@ -24,3 +24,5 @@ description = "Hedera File Service API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+testModuleInfo { requires("org.assertj.core") }

--- a/hedera-node/hedera-file-service/build.gradle.kts
+++ b/hedera-node/hedera-file-service/build.gradle.kts
@@ -25,4 +25,7 @@ description = "Hedera File Service API"
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
-testModuleInfo { requires("org.assertj.core") }
+testModuleInfo {
+    requires("org.assertj.core")
+    requires("org.junit.jupiter.api")
+}

--- a/hedera-node/hedera-file-service/src/test/java/com/hedera/node/app/service/file/FileServiceDefinitionTest.java
+++ b/hedera-node/hedera-file-service/src/test/java/com/hedera/node/app/service/file/FileServiceDefinitionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.file;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FileServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(FileServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.FileService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = FileServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("createFile", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("updateFile", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("deleteFile", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("appendContent", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("getFileContent", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getFileInfo", Query.class, Response.class),
+                        new RpcMethodDefinition<>("systemDelete", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("systemUndelete", Transaction.class, TransactionResponse.class));
+    }
+}

--- a/hedera-node/hedera-network-admin-service/build.gradle.kts
+++ b/hedera-node/hedera-network-admin-service/build.gradle.kts
@@ -25,4 +25,7 @@ description = "Hedera NetworkAdmin Service API"
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
-testModuleInfo { requires("org.assertj.core") }
+testModuleInfo {
+    requires("org.assertj.core")
+    requires("org.junit.jupiter.api")
+}

--- a/hedera-node/hedera-network-admin-service/build.gradle.kts
+++ b/hedera-node/hedera-network-admin-service/build.gradle.kts
@@ -24,3 +24,5 @@ description = "Hedera NetworkAdmin Service API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+testModuleInfo { requires("org.assertj.core") }

--- a/hedera-node/hedera-network-admin-service/src/test/java/com/hedera/node/app/service/networkadmin/FreezeServiceDefinitionTest.java
+++ b/hedera-node/hedera-network-admin-service/src/test/java/com/hedera/node/app/service/networkadmin/FreezeServiceDefinitionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.networkadmin;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FreezeServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(FreezeServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.FreezeService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = FreezeServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("freeze", Transaction.class, TransactionResponse.class));
+    }
+}

--- a/hedera-node/hedera-network-admin-service/src/test/java/com/hedera/node/app/service/networkadmin/NetworkServiceDefinitionTest.java
+++ b/hedera-node/hedera-network-admin-service/src/test/java/com/hedera/node/app/service/networkadmin/NetworkServiceDefinitionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.networkadmin;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class NetworkServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(NetworkServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.NetworkService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = NetworkServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("getVersionInfo", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getExecutionTime", Query.class, Response.class),
+                        new RpcMethodDefinition<>("uncheckedSubmit", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("getAccountDetails", Query.class, Response.class));
+    }
+}

--- a/hedera-node/hedera-schedule-service/build.gradle.kts
+++ b/hedera-node/hedera-schedule-service/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("com.hedera.gradle.services-publish")
 }
 
-description = "Hedera Scheduled Service API"
+description = "Hedera Schedule Service API"
 
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.

--- a/hedera-node/hedera-token-service/build.gradle.kts
+++ b/hedera-node/hedera-token-service/build.gradle.kts
@@ -26,4 +26,7 @@ description = "Hedera Token Service API"
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
-testModuleInfo { requires("org.assertj.core") }
+testModuleInfo {
+    requires("org.assertj.core")
+    requires("org.junit.jupiter.api")
+}

--- a/hedera-node/hedera-token-service/build.gradle.kts
+++ b/hedera-node/hedera-token-service/build.gradle.kts
@@ -25,3 +25,5 @@ description = "Hedera Token Service API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+testModuleInfo { requires("org.assertj.core") }

--- a/hedera-node/hedera-token-service/src/test/java/com/hedera/node/app/service/token/CryptoServiceDefinitionTest.java
+++ b/hedera-node/hedera-token-service/src/test/java/com/hedera/node/app/service/token/CryptoServiceDefinitionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CryptoServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(CryptoServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.CryptoService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = CryptoServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("createAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("updateAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("cryptoTransfer", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("cryptoDelete", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("approveAllowances", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("deleteAllowances", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("addLiveHash", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("deleteLiveHash", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("getLiveHash", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getAccountRecords", Query.class, Response.class),
+                        new RpcMethodDefinition<>("cryptoGetBalance", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getAccountInfo", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getTransactionReceipts", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getFastTransactionRecord", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getTxRecordByTxID", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getStakersByAccountID", Query.class, Response.class));
+    }
+}

--- a/hedera-node/hedera-token-service/src/test/java/com/hedera/node/app/service/token/TokenServiceDefinitionTest.java
+++ b/hedera-node/hedera-token-service/src/test/java/com/hedera/node/app/service/token/TokenServiceDefinitionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.token;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Response;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TokenServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(TokenServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.TokenService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = TokenServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("createToken", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("updateToken", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("mintToken", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("burnToken", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("deleteToken", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("wipeTokenAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("freezeTokenAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("unfreezeTokenAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>(
+                                "grantKycToTokenAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>(
+                                "revokeKycFromTokenAccount", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("associateTokens", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("dissociateTokens", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>(
+                                "updateTokenFeeSchedule", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("getTokenInfo", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getAccountNftInfos", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getTokenNftInfo", Query.class, Response.class),
+                        new RpcMethodDefinition<>("getTokenNftInfos", Query.class, Response.class),
+                        new RpcMethodDefinition<>("pauseToken", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("updateNfts", Transaction.class, TransactionResponse.class),
+                        new RpcMethodDefinition<>("unpauseToken", Transaction.class, TransactionResponse.class));
+    }
+}

--- a/hedera-node/hedera-util-service/build.gradle.kts
+++ b/hedera-node/hedera-util-service/build.gradle.kts
@@ -25,4 +25,7 @@ description = "Hedera Util Service API"
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
-testModuleInfo { requires("org.assertj.core") }
+testModuleInfo {
+    requires("org.assertj.core")
+    requires("org.junit.jupiter.api")
+}

--- a/hedera-node/hedera-util-service/build.gradle.kts
+++ b/hedera-node/hedera-util-service/build.gradle.kts
@@ -24,3 +24,5 @@ description = "Hedera Util Service API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+testModuleInfo { requires("org.assertj.core") }

--- a/hedera-node/hedera-util-service/src/test/java/com/hedera/node/app/service/util/UtilServiceDefinitionTest.java
+++ b/hedera-node/hedera-util-service/src/test/java/com/hedera/node/app/service/util/UtilServiceDefinitionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.util;
+
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.TransactionResponse;
+import com.hedera.pbj.runtime.RpcMethodDefinition;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UtilServiceDefinitionTest {
+
+    @Test
+    void checkBasePath() {
+        Assertions.assertThat(UtilServiceDefinition.INSTANCE.basePath()).isEqualTo("proto.UtilService");
+    }
+
+    @Test
+    void methodsDefined() {
+        final var methods = UtilServiceDefinition.INSTANCE.methods();
+        Assertions.assertThat(methods)
+                .containsExactlyInAnyOrder(
+                        new RpcMethodDefinition<>("prng", Transaction.class, TransactionResponse.class));
+    }
+}


### PR DESCRIPTION
**Description**:
Add test coverage for the non-impl service modules:

- hedera-consensus-service
- hedera-file-service
- hedera-network-admin-service
- hedera-token-service
- hedera-util-service

hedera-schedule-service already had tests set up.

**Related issue(s)**:

Fixes #13724 
Fixes #13729 
Fixes #13728 
Fixes #13727 
Fixes #13725 
Fixes #13726 
Fixes #13288 
