### PR TITLE
Used key types to scope token keys in HapiSpecRegistry

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -231,20 +231,20 @@ public class HapiSpecRegistry {
         put(name, key, Key.class);
     }
 
+    public void saveTokenKey(String name, String role, Key key) {
+        put(name + role, key, Optional.empty(), Key.class);
+    }
+
+    public Key getTokenKey(String name, String role) {
+        return get(name + role, Key.class);
+    }
+
     public void forgetAdminKey(String name) {
         remove(name + "Admin", Key.class);
     }
 
-    public void saveAdminKey(String name, Key key) {
-        put(name + "Admin", key, Key.class);
-    }
-
     public boolean hasAdminKey(String name) {
         return has(name + "Admin", Key.class);
-    }
-
-    public void saveFreezeKey(String name, Key key) {
-        put(name + "Freeze", key, Key.class);
     }
 
     public boolean hasFeeScheduleKey(String name) {
@@ -255,24 +255,8 @@ public class HapiSpecRegistry {
         remove(name + "FeeSchedule", Key.class);
     }
 
-    public void saveFeeScheduleKey(String name, Key key) {
-        put(name + "FeeSchedule", key, Key.class);
-    }
-
-    public Key getFeeScheduleKey(String name) {
-        return get(name + "FeeSchedule", Key.class);
-    }
-
-    public void savePauseKey(String name, Key key) {
-        put(name + "Pause", key, Key.class);
-    }
-
     public boolean hasPauseKey(String name) {
         return has(name + "Pause", Key.class);
-    }
-
-    public Key getPauseKey(String name) {
-        return get(name + "Pause", Key.class);
     }
 
     public void forgetPauseKey(String name) {
@@ -295,16 +279,8 @@ public class HapiSpecRegistry {
         put(name + "CreationTime", value, Timestamp.class);
     }
 
-    public void saveSupplyKey(String name, Key key) {
-        put(name + "Supply", key, Key.class);
-    }
-
     public boolean hasSupplyKey(String name) {
         return has(name + "Supply", Key.class);
-    }
-
-    public void saveWipeKey(String name, Key key) {
-        put(name + "Wipe", key, Key.class);
     }
 
     public boolean hasWipeKey(String name) {
@@ -321,10 +297,6 @@ public class HapiSpecRegistry {
 
     public boolean hasKycKey(String name) {
         return has(name + "Kyc", Key.class);
-    }
-
-    public void saveKycKey(String name, Key key) {
-        put(name + "Kyc", key, Key.class);
     }
 
     public void forgetKycKey(String name) {
@@ -381,22 +353,6 @@ public class HapiSpecRegistry {
 
     public Key getAdminKey(String name) {
         return get(name + "Admin", Key.class);
-    }
-
-    public Key getFreezeKey(String name) {
-        return get(name + "Freeze", Key.class);
-    }
-
-    public Key getSupplyKey(String name) {
-        return get(name + "Supply", Key.class);
-    }
-
-    public Key getWipeKey(String name) {
-        return get(name + "Wipe", Key.class);
-    }
-
-    public Key getKycKey(String name) {
-        return get(name + "Kyc", Key.class);
     }
 
     public Long getExpiry(String name) {
@@ -902,14 +858,6 @@ public class HapiSpecRegistry {
 
     public void forgetMetadataKey(String name) {
         remove(name + "Metadata", Key.class);
-    }
-
-    public void saveMetadataKey(String name, Key metadataKey) {
-        put(name + "Metadata", metadataKey, Key.class);
-    }
-
-    public Key getMetadataKey(String name) {
-        return get(name + "Metadata", Key.class);
     }
 
     public boolean hasMetadataKey(String name) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SpecKey.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/persistence/SpecKey.java
@@ -205,27 +205,27 @@ public class SpecKey {
         }
 
         public static RegistryForms asKycKeyFor(String token) {
-            return new RegistryForms(kycKeyFor(token), (registry, key) -> registry.saveKycKey(token, key));
+            return new RegistryForms(kycKeyFor(token), (registry, key) -> registry.saveTokenKey(token, "Kyc", key));
         }
 
         public static RegistryForms asWipeKeyFor(String token) {
-            return new RegistryForms(wipeKeyFor(token), (registry, key) -> registry.saveWipeKey(token, key));
+            return new RegistryForms(wipeKeyFor(token), (registry, key) -> registry.saveTokenKey(token, "Wipe", key));
         }
 
         public static RegistryForms asSupplyKeyFor(String token) {
-            return new RegistryForms(supplyKeyFor(token), (registry, key) -> registry.saveSupplyKey(token, key));
+            return new RegistryForms(supplyKeyFor(token), (registry, key) -> registry.saveTokenKey(token, "Supply", key));
         }
 
         public static RegistryForms asFreezeKeyFor(String token) {
-            return new RegistryForms(freezeKeyFor(token), (registry, key) -> registry.saveFreezeKey(token, key));
+            return new RegistryForms(freezeKeyFor(token), (registry, key) -> registry.saveTokenKey(token, "Freeze", key));
         }
 
         public static RegistryForms asAdminKeyFor(String entity) {
-            return new RegistryForms(adminKeyFor(entity), (registry, key) -> registry.saveAdminKey(entity, key));
+            return new RegistryForms(adminKeyFor(entity), (registry, key) -> registry.saveTokenKey(entity, "Admin", key));
         }
 
         public static RegistryForms asPauseKeyFor(String token) {
-            return new RegistryForms(pauseKeyFor(token), (registry, key) -> registry.savePauseKey(token, key));
+            return new RegistryForms(pauseKeyFor(token), (registry, key) -> registry.saveTokenKey(token, "Pause", key));
         }
 
         public String name() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
@@ -478,7 +478,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getFreezeKey(),
                     expectedFreezeKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getFreezeKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "Freeze"),
                     "Wrong token freeze key!",
                     registry);
         }
@@ -504,7 +504,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getWipeKey(),
                     expectedWipeKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getWipeKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "Wipe"),
                     "Wrong token wipe key!",
                     registry);
         }
@@ -517,7 +517,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getKycKey(),
                     expectedKycKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getKycKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "Kyc"),
                     "Wrong token KYC key!",
                     registry);
         }
@@ -530,7 +530,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getSupplyKey(),
                     expectedSupplyKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getSupplyKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "Supply"),
                     "Wrong token supply key!",
                     registry);
         }
@@ -543,7 +543,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getFeeScheduleKey(),
                     expectedFeeScheduleKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getFeeScheduleKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "FeeSchedule"),
                     "Wrong token fee schedule key!",
                     registry);
         }
@@ -556,7 +556,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getPauseKey(),
                     expectedPauseKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getPauseKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "Pause"),
                     "Wrong token pause key!",
                     registry);
         }
@@ -569,7 +569,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getMetadataKey(),
                     expectedMetadataKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getMetadataKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getTokenKey(n, "Metadata"),
                     "Wrong token metadata key!",
                     registry);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
@@ -273,7 +273,7 @@ public class HapiScheduleCreate<T extends HapiTxnOp<T>> extends HapiTxnOp<HapiSc
         var registry = spec.registry();
         registry.saveScheduleId(scheduleEntity, lastReceipt.getScheduleID());
         adminKey.ifPresent(
-                k -> registry.saveAdminKey(scheduleEntity, spec.registry().getKey(k)));
+                k -> registry.saveTokenKey(scheduleEntity, "Admin", spec.registry().getKey(k)));
         if (saveExpectedScheduledTxnId) {
             if (verboseLoggingOn) {
                 log.info("Returned receipt for scheduled txn is {}", lastReceipt.getScheduledTransactionID());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenBurn.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenBurn.java
@@ -107,7 +107,7 @@ public class HapiTokenBurn extends HapiTxnOp<HapiTokenBurn> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getSupplyKey(token));
+                .getTokenKey(token, "Supply"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -425,28 +425,28 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
             final var submittedBody = CommonUtils.extractTransactionBody(txnSubmitted);
             final var op = submittedBody.getTokenCreation();
             if (op.hasKycKey()) {
-                registry.saveKycKey(token, op.getKycKey());
+                registry.saveTokenKey(token, "Kyc", op.getKycKey());
             }
             if (op.hasWipeKey()) {
-                registry.saveWipeKey(token, op.getWipeKey());
+                registry.saveTokenKey(token, "Wipe", op.getWipeKey());
             }
             if (op.hasAdminKey()) {
-                registry.saveAdminKey(token, op.getAdminKey());
+                registry.saveTokenKey(token, "Admin", op.getAdminKey());
             }
             if (op.hasSupplyKey()) {
-                registry.saveSupplyKey(token, op.getSupplyKey());
+                registry.saveTokenKey(token, "Supply", op.getSupplyKey());
             }
             if (op.hasFreezeKey()) {
-                registry.saveFreezeKey(token, op.getFreezeKey());
+                registry.saveTokenKey(token, "Freeze", op.getFreezeKey());
             }
             if (op.hasFeeScheduleKey()) {
-                registry.saveFeeScheduleKey(token, op.getFeeScheduleKey());
+                registry.saveTokenKey(token, "FeeSchedule", op.getFeeScheduleKey());
             }
             if (op.hasPauseKey()) {
-                registry.savePauseKey(token, op.getPauseKey());
+                registry.saveTokenKey(token, "Pause", op.getPauseKey());
             }
             if (op.hasMetadataKey()) {
-                registry.saveMetadataKey(token, op.getMetadataKey());
+                registry.saveTokenKey(token, "Metadata", op.getMetadataKey());
             }
         } catch (final InvalidProtocolBufferException impossible) {
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
@@ -112,7 +112,7 @@ public class HapiTokenFeeScheduleUpdate extends HapiTxnOp<HapiTokenFeeScheduleUp
         signers.add(spec -> spec.registry().getKey(effectivePayer(spec)));
         signers.add(spec -> {
             final var registry = spec.registry();
-            return registry.hasFeeScheduleKey(token) ? registry.getFeeScheduleKey(token) : Key.getDefaultInstance();
+            return registry.hasFeeScheduleKey(token) ? registry.getTokenKey(token, "FeeSchedule") : Key.getDefaultInstance();
         });
         return signers;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
@@ -109,7 +109,7 @@ public class HapiTokenFreeze extends HapiTxnOp<HapiTokenFreeze> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getFreezeKey(token));
+                .getTokenKey(token, "Freeze"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
@@ -106,7 +106,7 @@ public class HapiTokenKycGrant extends HapiTxnOp<HapiTokenKycGrant> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getKycKey(token));
+                .getTokenKey(token, "Kyc"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
@@ -107,7 +107,7 @@ public class HapiTokenKycRevoke extends HapiTxnOp<HapiTokenKycRevoke> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getKycKey(token));
+                .getTokenKey(token, "Kyc"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
@@ -148,7 +148,7 @@ public class HapiTokenMint extends HapiTxnOp<HapiTokenMint> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getSupplyKey(token));
+                .getTokenKey(token, "Supply"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenPause.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenPause.java
@@ -71,7 +71,7 @@ public class HapiTokenPause extends HapiTxnOp<HapiTokenPause> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getPauseKey(token));
+                .getTokenKey(token, "Pause"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
@@ -109,7 +109,7 @@ public class HapiTokenUnfreeze extends HapiTxnOp<HapiTokenUnfreeze> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getFreezeKey(token));
+                .getTokenKey(token, "Freeze"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnpause.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnpause.java
@@ -71,7 +71,7 @@ public class HapiTokenUnpause extends HapiTxnOp<HapiTokenUnpause> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getPauseKey(token));
+                .getTokenKey(token, "Pause"));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
@@ -544,16 +544,16 @@ public class HapiTokenUpdate extends HapiTxnOp<HapiTokenUpdate> {
             registry.forgetMetadataKey(token);
         }
         newMemo.ifPresent(m -> registry.saveMemo(token, m));
-        newAdminKey.ifPresent(n -> registry.saveAdminKey(token, registry.getKey(n)));
+        newAdminKey.ifPresent(n -> registry.saveTokenKey(token, "Admin", registry.getKey(n)));
         newSymbol.ifPresent(s -> registry.saveSymbol(token, s));
         newName.ifPresent(s -> registry.saveName(token, s));
-        newFreezeKey.ifPresent(n -> registry.saveFreezeKey(token, registry.getKey(n)));
-        newSupplyKey.ifPresent(n -> registry.saveSupplyKey(token, registry.getKey(n)));
-        newWipeKey.ifPresent(n -> registry.saveWipeKey(token, registry.getKey(n)));
-        newKycKey.ifPresent(n -> registry.saveKycKey(token, registry.getKey(n)));
-        newFeeScheduleKey.ifPresent(n -> registry.saveFeeScheduleKey(token, registry.getKey(n)));
-        newPauseKey.ifPresent(n -> registry.savePauseKey(token, registry.getKey(n)));
-        newMetadataKey.ifPresent(n -> registry.saveMetadataKey(token, registry.getKey(n)));
+        newFreezeKey.ifPresent(n -> registry.saveTokenKey(token, "Freeze", registry.getKey(n)));
+        newSupplyKey.ifPresent(n -> registry.saveTokenKey(token, "Supply", registry.getKey(n)));
+        newWipeKey.ifPresent(n -> registry.saveTokenKey(token, "Wipe", registry.getKey(n)));
+        newKycKey.ifPresent(n -> registry.saveTokenKey(token, "Kyc", registry.getKey(n)));
+        newFeeScheduleKey.ifPresent(n -> registry.saveTokenKey(token, "FeeSchedule", registry.getKey(n)));
+        newPauseKey.ifPresent(n -> registry.saveTokenKey(token, "Pause", registry.getKey(n)));
+        newMetadataKey.ifPresent(n -> registry.saveTokenKey(token, "Metadata", registry.getKey(n)));
         newMetadata.ifPresent(n -> registry.saveMetadata(token, n));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdateNfts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdateNfts.java
@@ -133,7 +133,7 @@ public class HapiTokenUpdateNfts extends HapiTxnOp<HapiTokenUpdateNfts> {
         final List<Function<HapiSpec, Key>> signers = new ArrayList<>();
         signers.add(spec -> spec.registry().getKey(effectivePayer(spec)));
         if (metadataKey.isPresent()) {
-            signers.add(spec -> spec.registry().getMetadataKey(token));
+            signers.add(spec -> spec.registry().getTokenKey(token, "Metadata"));
         }
         return signers;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
@@ -145,7 +145,7 @@ public class HapiTokenWipe extends HapiTxnOp<HapiTokenWipe> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getWipeKey(token));
+                .getTokenKey(token, "Wipe"));
     }
 
     @Override


### PR DESCRIPTION
**Description**:
<!--

-->
Eliminated save and get specific methods and created methods that append a suffix to the token name to indicate the key type

**Related issue(s)**:

Fixes #13640 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
