### PR TITLE
fix: Ethereum contract calls where high-bit of amount is set, fail

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/EvmTxProcessor.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.mono.contracts.execution;
 
-import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
+import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_IN_A_TINYBAR;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -284,13 +284,13 @@ abstract class EvmTxProcessor extends HederaEvmTxProcessor {
                     validateTrue(relayerCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
                     mutableRelayer.decrementBalance(gasCost);
                     allowanceCharged = gasCost;
-                } else if (userOfferedGasPrice.divide(WEIBARS_TO_TINYBARS).compareTo(BigInteger.valueOf(gasPrice))
+                } else if (userOfferedGasPrice.divide(WEIBARS_IN_A_TINYBAR).compareTo(BigInteger.valueOf(gasPrice))
                         < 0) {
                     // If sender gas price < current gas price, pay the difference from gas
                     // allowance
                     final var senderFee = Wei.of(userOfferedGasPrice
                             .multiply(BigInteger.valueOf(gasLimit))
-                            .divide(WEIBARS_TO_TINYBARS));
+                            .divide(WEIBARS_IN_A_TINYBAR));
                     validateTrue(senderAccount.getBalance().compareTo(senderFee) >= 0, INSUFFICIENT_PAYER_BALANCE);
                     final var remainingFee = gasCost.subtract(senderFee);
                     validateTrue(gasAllowance.greaterOrEqualThan(remainingFee), INSUFFICIENT_TX_FEE);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.mono.contracts.execution;
 
-import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
+import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_IN_A_TINYBAR;
 import static com.hedera.node.app.service.mono.contracts.ContractsV_0_30Module.EVM_VERSION_0_30;
 import static com.hedera.node.app.service.mono.contracts.ContractsV_0_34Module.EVM_VERSION_0_34;
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
@@ -571,7 +571,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -621,7 +621,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -710,7 +710,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -750,7 +750,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -790,7 +790,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -821,7 +821,7 @@ class CallEvmTxProcessorTest {
         given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         final long offeredGasPrice = 10L;
         final int gasLimit = 1000;
-        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR);
 
         assertThrows(
                 InvalidTransactionException.class,
@@ -854,7 +854,7 @@ class CallEvmTxProcessorTest {
         given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         final long offeredGasPrice = 10L;
         final int gasLimit = 1000;
-        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR);
 
         assertThrows(
                 InvalidTransactionException.class,
@@ -888,7 +888,7 @@ class CallEvmTxProcessorTest {
         given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         final long offeredGasPrice = 10L;
         final int gasLimit = 1000;
-        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR);
 
         assertThrows(
                 InvalidTransactionException.class,
@@ -932,7 +932,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -959,7 +959,7 @@ class CallEvmTxProcessorTest {
         given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         final long offeredGasPrice = 0L;
         final int gasLimit = 1000;
-        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR);
 
         assertThrows(
                 InvalidTransactionException.class,
@@ -994,7 +994,7 @@ class CallEvmTxProcessorTest {
         given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         final long offeredGasPrice = 0L;
         final int gasLimit = 1000;
-        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR);
 
         assertThrows(
                 InvalidTransactionException.class,
@@ -1037,7 +1037,7 @@ class CallEvmTxProcessorTest {
                 1234L,
                 Bytes.EMPTY,
                 consensusTime,
-                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR),
                 relayer,
                 10 * ONE_HBAR);
 
@@ -1066,7 +1066,7 @@ class CallEvmTxProcessorTest {
         given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         final long offeredGasPrice = 50L;
         final int gasLimit = 1000;
-        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+        final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_IN_A_TINYBAR);
 
         assertThrows(
                 InvalidTransactionException.class,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
@@ -27,7 +27,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
 public record HederaEvmContext(
-        long gasPrice,
+        long gasPrice, // weibar
         boolean staticCall,
         @NonNull HederaEvmBlocks blocks,
         @NonNull TinybarValues tinybarValues,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
@@ -39,7 +39,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SERIALIZATION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.WRONG_CHAIN_ID;
-import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
+import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_IN_A_TINYBAR;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.AN_ED25519_KEY;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.AUTO_ASSOCIATING_CONTRACTS_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.AUTO_ASSOCIATING_LEDGER_CONFIG;
@@ -582,12 +582,12 @@ class HevmTransactionFactoryTest {
         assertEquals(Bytes.EMPTY, transaction.payload());
         assertEquals(Bytes.wrap(ETH_DATA_WITH_TO_ADDRESS.chainId()), transaction.chainId());
         assertEquals(
-                ETH_DATA_WITH_TO_ADDRESS.value().divide(WEIBARS_TO_TINYBARS).longValueExact(), transaction.value());
+                ETH_DATA_WITH_TO_ADDRESS.value().divide(WEIBARS_IN_A_TINYBAR).longValueExact(), transaction.value());
         assertEquals(ETH_DATA_WITH_TO_ADDRESS.gasLimit(), transaction.gasLimit());
         assertEquals(
                 ETH_DATA_WITH_TO_ADDRESS
                         .getMaxGasAsBigInteger(TOP_LEVEL_TINYBAR_GAS_PRICE)
-                        .divide(WEIBARS_TO_TINYBARS)
+                        .divide(WEIBARS_IN_A_TINYBAR)
                         .longValueExact(),
                 transaction.offeredGasPrice());
         assertEquals(MAX_GAS_ALLOWANCE, transaction.maxGasAllowance());
@@ -611,7 +611,7 @@ class HevmTransactionFactoryTest {
         assertEquals(0, transaction.nonce());
         assertEquals(CALL_DATA, transaction.payload());
         assertEquals(Bytes.wrap(dataToUse.chainId()), transaction.chainId());
-        assertEquals(dataToUse.value().divide(WEIBARS_TO_TINYBARS).longValueExact(), transaction.value());
+        assertEquals(dataToUse.value().divide(WEIBARS_IN_A_TINYBAR).longValueExact(), transaction.value());
         assertEquals(dataToUse.gasLimit(), transaction.gasLimit());
         assertEquals(
                 dataToUse.effectiveOfferedGasPriceInTinybars(TOP_LEVEL_TINYBAR_GAS_PRICE),

--- a/hedera-node/test-clients/src/itest/java/ConcurrentSuites.java
+++ b/hedera-node/test-clients/src/itest/java/ConcurrentSuites.java
@@ -20,6 +20,7 @@ import com.hedera.services.bdd.suites.consensus.TopicCreateSuite;
 import com.hedera.services.bdd.suites.consensus.TopicDeleteSuite;
 import com.hedera.services.bdd.suites.consensus.TopicUpdateSuite;
 import com.hedera.services.bdd.suites.contract.evm.Evm46ValidationSuite;
+import com.hedera.services.bdd.suites.contract.hapi.ContractCallHapiOnlySuite;
 import com.hedera.services.bdd.suites.contract.hapi.ContractCallLocalSuite;
 import com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite;
 import com.hedera.services.bdd.suites.contract.hapi.ContractCreateSuite;
@@ -118,6 +119,7 @@ public class ConcurrentSuites {
             SelfDestructSuite::new,
             // contract.hapi
             ContractCallLocalSuite::new,
+            ContractCallHapiOnlySuite::new,
             ContractCallSuite::new,
             ContractCreateSuite::new,
             ContractDeleteSuite::new,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
@@ -30,7 +30,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.FIVE_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.MAX_CALL_DATA_SIZE;
 import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
-import static com.hedera.services.bdd.suites.HapiSuite.WEIBARS_TO_TINYBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.WEIBARS_IN_A_TINYBAR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 import com.esaulpaugh.headlong.util.Integers;
@@ -77,11 +77,11 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
     private EthTxData.EthTransactionType type = EthTxData.EthTransactionType.EIP1559;
     private long nonce = 0L;
     private boolean useSpecNonce = true;
-    private BigInteger gasPrice = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(DEFAULT_GAS_PRICE_TINYBARS));
-    private BigInteger maxFeePerGas = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(DEFAULT_GAS_PRICE_TINYBARS));
+    private BigInteger gasPrice = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(DEFAULT_GAS_PRICE_TINYBARS));
+    private BigInteger maxFeePerGas = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(DEFAULT_GAS_PRICE_TINYBARS));
     private long maxPriorityGas = 1_000L;
     private Optional<Long> maxGasAllowance = Optional.of(FIVE_HBARS);
-    private Optional<BigInteger> valueSent = Optional.of(BigInteger.ZERO);
+    private Optional<BigInteger> valueSent = Optional.of(BigInteger.ZERO); // weibar
     private Consumer<Object[]> resultObserver = null;
     private Consumer<ByteString> eventDataObserver = null;
     private Optional<FileID> ethFileID = Optional.empty();
@@ -114,7 +114,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
 
     public HapiEthereumCall(String account, long amount) {
         this.account = account;
-        this.valueSent = Optional.of(WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(amount)));
+        this.valueSent = Optional.of(WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(amount)));
         this.abi = Optional.of(FALLBACK_ABI);
         this.params = Optional.of(new Object[0]);
         this.payer = Optional.of(RELAYER);
@@ -122,7 +122,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
 
     public HapiEthereumCall(ByteString account, long amount) {
         this.alias = account;
-        this.valueSent = Optional.of(WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(amount)));
+        this.valueSent = Optional.of(WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(amount)));
         this.abi = Optional.of(FALLBACK_ABI);
         this.params = Optional.of(new Object[0]);
         this.payer = Optional.of(RELAYER);
@@ -131,7 +131,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
     public static HapiEthereumCall explicitlyTo(@NonNull final byte[] to, long amount) {
         final var call = new HapiEthereumCall();
         call.explicitTo = to;
-        call.valueSent = Optional.of(WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(amount)));
+        call.valueSent = Optional.of(WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(amount)));
         call.abi = Optional.of(FALLBACK_ABI);
         call.params = Optional.of(new Object[0]);
         call.payer = Optional.of(RELAYER);
@@ -160,7 +160,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         this.privateKeyRef = contractCall.getPrivateKeyRef();
         this.deferStatusResolution = contractCall.getDeferStatusResolution();
         if (contractCall.getValueSent().isPresent()) {
-            this.valueSent = Optional.of(WEIBARS_TO_TINYBARS.multiply(
+            this.valueSent = Optional.of(WEIBARS_IN_A_TINYBAR.multiply(
                     BigInteger.valueOf(contractCall.getValueSent().orElseThrow())));
         }
         if (!contractCall.otherSigs.isEmpty()) {
@@ -214,8 +214,13 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         return sigMapPrefixes(uniqueWithFullPrefixesFor(keys));
     }
 
-    public HapiEthereumCall sending(long amount) {
-        valueSent = Optional.of(WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(amount)));
+    public HapiEthereumCall sending(long amountInTinybars) {
+        valueSent = Optional.of(WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(amountInTinybars)));
+        return this;
+    }
+
+    public HapiEthereumCall sendingWeibars(final BigInteger amountInWeibars) {
+        valueSent = Optional.of(amountInWeibars);
         return this;
     }
 
@@ -246,12 +251,12 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
     }
 
     public HapiEthereumCall gasPrice(long gasPrice) {
-        this.gasPrice = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(gasPrice));
+        this.gasPrice = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(gasPrice));
         return this;
     }
 
     public HapiEthereumCall maxFeePerGas(long maxFeePerGas) {
-        this.maxFeePerGas = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(maxFeePerGas));
+        this.maxFeePerGas = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(maxFeePerGas));
         return this;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
@@ -25,7 +25,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.MAX_CALL_DATA_SIZE;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
-import static com.hedera.services.bdd.suites.HapiSuite.WEIBARS_TO_TINYBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.WEIBARS_IN_A_TINYBAR;
 
 import com.esaulpaugh.headlong.util.Integers;
 import com.google.protobuf.ByteString;
@@ -58,8 +58,8 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
     private EthTxData.EthTransactionType type;
     private long nonce = 0L;
     private boolean useSpecNonce = true;
-    private BigInteger gasPrice = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(50L));
-    private BigInteger maxFeePerGas = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(50L));
+    private BigInteger gasPrice = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(50L));
+    private BigInteger maxFeePerGas = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(50L));
     private long maxPriorityGas = 20_000L;
     private Optional<FileID> ethFileID = Optional.empty();
     private boolean invalidateEthData = false;
@@ -226,12 +226,12 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
     }
 
     public HapiEthereumContractCreate gasPrice(long gasPrice) {
-        this.gasPrice = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(gasPrice));
+        this.gasPrice = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(gasPrice));
         return this;
     }
 
     public HapiEthereumContractCreate maxFeePerGas(long maxFeePerGas) {
-        this.maxFeePerGas = WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(maxFeePerGas));
+        this.maxFeePerGas = WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(maxFeePerGas));
         return this;
     }
 
@@ -336,7 +336,7 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
             return Optional.empty();
         }
         try {
-            return Optional.of(WEIBARS_TO_TINYBARS.multiply(BigInteger.valueOf(balance.get())));
+            return Optional.of(WEIBARS_IN_A_TINYBAR.multiply(BigInteger.valueOf(balance.get())));
         } catch (ArithmeticException e) {
             return Optional.empty();
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiSuite.java
@@ -107,7 +107,7 @@ public abstract class HapiSuite {
             .build();
     private static final int BYTES_PER_KB = 1024;
     public static final int MAX_CALL_DATA_SIZE = 6 * BYTES_PER_KB;
-    public static final BigInteger WEIBARS_TO_TINYBARS = BigInteger.valueOf(10_000_000_000L);
+    public static final BigInteger WEIBARS_IN_A_TINYBAR = BigInteger.valueOf(10_000_000_000L);
     // Useful for testing overflow scenarios when an ERC-20/721 ABI specifies
     // a uint256, but a valid value on Hedera will be an 8-byte long only
     public static final BigInteger MAX_UINT256_VALUE =

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallHapiOnlySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallHapiOnlySuite.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.suites.contract.hapi;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
+import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.ifHapiTest;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
+
+import com.hedera.services.bdd.junit.HapiTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Test suite for contract call tests that are valid _only_ as HAPI contract calls, not as
+ * Ethereum transactions.
+ */
+@Tag(SMART_CONTRACT)
+public class ContractCallHapiOnlySuite {
+
+    public static final String TOKEN = "yahcliToken";
+    private static final long DEPOSIT_AMOUNT = 1000;
+    public static final String PAY_RECEIVABLE_CONTRACT = "PayReceivable";
+    private static final String PAY_TXN = "payTxn";
+
+    @HapiTest
+    final Stream<DynamicTest> callFailsWhenAmountIsNegativeButStillChargedFee() {
+        final var payer = "payer";
+        return defaultHapiSpec("callFailsWhenAmountIsNegativeButStillChargedFee")
+                .given(
+                        uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                        contractCreate(PAY_RECEIVABLE_CONTRACT)
+                                .adminKey(THRESHOLD)
+                                .gas(1_000_000)
+                                .refusingEthConversion(),
+                        cryptoCreate(payer).balance(ONE_MILLION_HBARS).payingWith(GENESIS))
+                .when(ifHapiTest(withOpContext((spec, ignore) -> {
+                    final var subop1 = balanceSnapshot("balanceBefore0", payer);
+                    final var subop2 = contractCall(PAY_RECEIVABLE_CONTRACT)
+                            .via(PAY_TXN)
+                            .payingWith(payer)
+                            .sending(-DEPOSIT_AMOUNT)
+                            .hasKnownStatus(CONTRACT_NEGATIVE_VALUE)
+                            .refusingEthConversion();
+                    final var subop3 = getTxnRecord(PAY_TXN).logged();
+                    allRunFor(spec, subop1, subop2, subop3);
+                    final var delta = subop3.getResponseRecord()
+                            .getTransferList()
+                            .getAccountAmounts(0)
+                            .getAmount();
+                    final var subop4 =
+                            getAccountBalance(payer).hasTinyBars(changeFromSnapshot("balanceBefore0", -delta));
+                    allRunFor(spec, subop4);
+                })))
+                .then();
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -69,7 +69,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createLargeFile;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.ifHapiTest;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
@@ -112,7 +111,6 @@ import static com.hedera.services.bdd.suites.leaky.LeakyContractTestsSuite.NESTE
 import static com.hedera.services.bdd.suites.regression.factories.HollowAccountCompletedFuzzingFactory.CONTRACT;
 import static com.hedera.services.bdd.suites.utils.ECDSAKeysUtils.randomHeadlongAddress;
 import static com.hedera.services.bdd.suites.utils.contracts.SimpleBytesResult.bigIntResult;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_NEGATIVE_VALUE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -1569,38 +1567,6 @@ public class ContractCallSuite {
                         // It's also ok to use a default PBJ ContractID (i.e. an id with
                         // UNSET contract oneof) to make a no-op call to address 0x00...00
                         contractCall(DEFAULT_ID_SENTINEL));
-    }
-
-    @HapiTest
-    final Stream<DynamicTest> callFailsWhenAmountIsNegativeButStillChargedFee() {
-        final var payer = "payer";
-        return defaultHapiSpec("callFailsWhenAmountIsNegativeButStillChargedFee")
-                .given(
-                        uploadInitCode(PAY_RECEIVABLE_CONTRACT),
-                        contractCreate(PAY_RECEIVABLE_CONTRACT)
-                                .adminKey(THRESHOLD)
-                                .gas(1_000_000)
-                                .refusingEthConversion(),
-                        cryptoCreate(payer).balance(ONE_MILLION_HBARS).payingWith(GENESIS))
-                .when(ifHapiTest(withOpContext((spec, ignore) -> {
-                    final var subop1 = balanceSnapshot("balanceBefore0", payer);
-                    final var subop2 = contractCall(PAY_RECEIVABLE_CONTRACT)
-                            .via(PAY_TXN)
-                            .payingWith(payer)
-                            .sending(-DEPOSIT_AMOUNT)
-                            .hasKnownStatus(CONTRACT_NEGATIVE_VALUE)
-                            .refusingEthConversion();
-                    final var subop3 = getTxnRecord(PAY_TXN).logged();
-                    allRunFor(spec, subop1, subop2, subop3);
-                    final var delta = subop3.getResponseRecord()
-                            .getTransferList()
-                            .getAccountAmounts(0)
-                            .getAmount();
-                    final var subop4 =
-                            getAccountBalance(payer).hasTinyBars(changeFromSnapshot("balanceBefore0", -delta));
-                    allRunFor(spec, subop4);
-                })))
-                .then();
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:

Ethereum contract calls have an amount - the amount of the native currency to transfer. In Ethereum this amount is unsigned. But as a recent regression we are interpreting this amount as signed (2's complement), leading to failure when the amount's high-order bit is 1.

Bug was introduced in https://github.com/hashgraph/hedera-services/pull/12834.

Fix is to (manually) revert the particular change that treats these amounts as signed.

As a freebie code cleanup also renamed constants `WEIBARS_TO_TINYBAR` to `WEIBARS_IN_A_TINYBAR` to reflect their actual semantic meaning.

**Related issue(s)**:

Fixes #13816

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
