### PR TITLE
ci: Removes e2e tests & Integration tests step from node-flow-pull-request-checks

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -63,8 +63,6 @@ jobs:
     with:
       custom-job-label: "Check"
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-spotless-check: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
@@ -80,8 +78,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: true
-      enable-e2e-tests: false
-      enable-integration-tests: false
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
@@ -98,8 +94,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-misc: true
       enable-network-log-capture: true
     secrets:
@@ -116,8 +110,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-crypto: true
       enable-network-log-capture: true
     secrets:
@@ -134,8 +126,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-token: true
       enable-network-log-capture: true
     secrets:
@@ -152,8 +142,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-smart-contract: true
       enable-network-log-capture: true
     secrets:
@@ -170,8 +158,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-time-consuming: true
       enable-network-log-capture: true
     secrets:
@@ -188,8 +174,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-restart: true
       enable-network-log-capture: true
     secrets:
@@ -206,8 +190,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-hapi-tests-nd-reconnect: true
       enable-network-log-capture: true
     secrets:
@@ -277,8 +259,6 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: false
       enable-snyk-scan: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -89,42 +89,6 @@ jobs:
       codacy-project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-  eet-tests:
-    name: E2E Tests
-    if: ${{ false }}
-    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
-    needs:
-      - dependency-check
-      - spotless
-    with:
-      custom-job-label: Standard
-      enable-unit-tests: false
-      enable-e2e-tests: true
-      enable-integration-tests: false
-      enable-network-log-capture: true
-    secrets:
-      access-token: ${{ secrets.GITHUB_TOKEN }}
-      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-
-  integration-tests:
-    name: Integration Tests
-    if: ${{ false }}
-    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
-    needs:
-      - dependency-check
-      - spotless
-    with:
-      custom-job-label: Standard
-      enable-unit-tests: false
-      enable-e2e-tests: false
-      enable-integration-tests: true
-      enable-network-log-capture: true
-    secrets:
-      access-token: ${{ secrets.GITHUB_TOKEN }}
-      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-
   hapi-tests-misc:
     name: HAPI Tests (Misc)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -23,16 +23,6 @@ on:
         type: boolean
         required: false
         default: false
-      enable-e2e-tests:
-        description: "End to End Testing Enabled"
-        type: boolean
-        required: false
-        default: false
-      enable-integration-tests:
-        description: "Integration Testing Enabled"
-        type: boolean
-        required: false
-        default: false
       enable-hapi-tests-misc:
         description: "HAPI Testing (misc) Enabled"
         type: boolean
@@ -245,46 +235,6 @@ jobs:
           name: Unit Test Report
           path: "**/build/test-results/test/TEST-*.xml"
           retention-days: 7
-
-      - name: Setup Docker BuildX
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        if: ${{ (inputs.enable-integration-tests || inputs.enable-e2e-tests) && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          version: v0.11.0
-
-      - name: Build Docker Image # build the image for hedera-node
-        if: ${{ (inputs.enable-integration-tests || inputs.enable-e2e-tests) && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        run: ${GRADLE_EXEC} createDockerImage --scan
-
-      - name: Integration Testing
-        id: gradle-itest
-        if: ${{ inputs.enable-integration-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        run: ${GRADLE_EXEC} itest --scan
-
-      - name: Publish Integration Test Report
-        uses: EnricoMi/publish-unit-test-result-action@30eadd5010312f995f0d3b3cff7fe2984f69409e # v2.16.1
-        if: ${{ inputs.enable-integration-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          check_name: 'Node: Integration Test Results'
-          check_run_disabled: false
-          json_thousands_separator: ','
-          junit_files: "**/build/test-results/itest/TEST-*.xml"
-
-      - name: Upload Integration Test Report Artifacts
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        if: ${{ inputs.enable-integration-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          name: Integration Test Report
-          path: "**/build/test-results/itest/TEST-*.xml"
-          retention-days: 7
-
-      - name: Upload Integration Test Network Logs
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        if: ${{ inputs.enable-integration-tests && inputs.enable-network-log-capture && steps.gradle-itest.conclusion == 'failure' && !cancelled() }}
-        with:
-          name: Integration Test Network Logs
-          path: |
-            hedera-node/test-clients/build/network/itest/output/**
 
       - name: HAPI Testing (Misc)
         id: gradle-hapi-misc
@@ -524,37 +474,6 @@ jobs:
           path: |
             hedera-node/test-clients/build/hapi-test/**/output/**
             hedera-node/test-clients/build/hapi-test/*.log
-          retention-days: 7
-
-      - name: E2E Testing
-        id: gradle-eet
-        if: ${{ inputs.enable-e2e-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        run: ${GRADLE_EXEC} eet --scan
-
-      - name: Publish E2E Test Report
-        uses: EnricoMi/publish-unit-test-result-action@30eadd5010312f995f0d3b3cff7fe2984f69409e # v2.16.1
-        if: ${{ inputs.enable-e2e-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          check_name: 'Node: E2E Test Results'
-          check_run_disabled: false
-          json_thousands_separator: ','
-          junit_files: "**/build/test-results/eet/TEST-*.xml"
-
-      - name: Upload E2E Test Report Artifacts
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        if: ${{ inputs.enable-e2e-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          name: E2E Test Report
-          path: "**/build/test-results/eet/TEST-*.xml"
-          retention-days: 7
-
-      - name: Upload E2E Test Network Logs
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        if: ${{ inputs.enable-e2e-tests && inputs.enable-network-log-capture && steps.gradle-eet.conclusion == 'failure' && !cancelled() }}
-        with:
-          name: E2E Test Network Logs
-          path: |
-            hedera-node/test-clients/build/network/eet/output/**
           retention-days: 7
 
       - name: Publish To Codecov


### PR DESCRIPTION
Removes integration tests step from node-flow-pull-request-checks

**Description**:

Per [Freshdesk ticket 3065](https://swirldslabs.freshdesk.com/a/tickets/3065) we've removed e2e tests and integration tests from the Node: PR Checks flow.

**Related issue(s)**:

Fixes #13838 
