### PR TITLE
fix: address null pointer exception in hollow contract flow

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -29,6 +29,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.*;
 import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
+import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;
 import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.SignedTransaction;
@@ -351,7 +352,11 @@ public class HandleHederaOperations implements HederaOperations {
     public void externalizeHollowAccountMerge(
             @NonNull ContractID contractId, @NonNull ContractID parentId, @Nullable Bytes evmAddress) {
         final var accountStore = context.readableStore(ReadableAccountStore.class);
-        final var parent = requireNonNull(accountStore.getContractById(parentId));
+        var parent = accountStore.getContractById(parentId);
+        // If the parent contract is not found, use the default Account to create the contract
+        if (parent == null) {
+            parent = Account.DEFAULT;
+        }
         final var recordBuilder = context.addRemovableChildRecordBuilder(ContractCreateRecordBuilder.class)
                 .contractID(contractId)
                 .status(SUCCESS)

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
@@ -109,13 +109,8 @@ public class SynthTxnUtils {
         } else if (parent.hasStakedAccountId()) {
             builder.stakedAccountId(parent.stakedAccountIdOrThrow());
         }
-        final var parentAdminKey = parent.keyOrThrow();
-        if (isSelfAdmin(parent)) {
-            // The new contract will manage itself as well, which we indicate via self-referential admin key
-            builder.adminKey(Key.newBuilder().contractID(pendingId));
-        } else {
-            builder.adminKey(parentAdminKey);
-        }
+
+        builder.adminKey(Key.newBuilder().contractID(pendingId));
         return builder.build();
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
@@ -110,7 +110,13 @@ public class SynthTxnUtils {
             builder.stakedAccountId(parent.stakedAccountIdOrThrow());
         }
 
-        builder.adminKey(Key.newBuilder().contractID(pendingId));
+        if (!parent.hasKey() || isSelfAdmin(parent)) {
+            // The new contract will manage itself as well, which we indicate via self-referential admin key
+            builder.adminKey(Key.newBuilder().contractID(pendingId));
+        } else {
+            final var parentAdminKey = parent.keyOrThrow();
+            builder.adminKey(parentAdminKey);
+        }
         return builder.build();
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -316,8 +316,6 @@ class HandleHederaOperationsTest {
                 .build();
         final var pendingId = ContractID.newBuilder().contractNum(666L).build();
         final var synthContractCreation = synthContractCreationFromParent(pendingId, parent);
-        final var synthContractNoKey =
-                synthContractCreation.copyBuilder().adminKey((Key) null).build();
 
         final var synthAccountCreation =
                 synthAccountCreationFromHapi(pendingId, CANONICAL_ALIAS, synthContractCreation);
@@ -344,7 +342,7 @@ class HandleHederaOperationsTest {
 
         subject.createContract(666L, NON_SYSTEM_ACCOUNT_ID.accountNumOrThrow(), CANONICAL_ALIAS);
 
-        assertInternalFinisherAsExpected(captor.getValue(), synthContractNoKey);
+        assertInternalFinisherAsExpected(captor.getValue(), synthContractCreation);
         verify(tokenServiceApi)
                 .markAsContract(AccountID.newBuilder().accountNum(666L).build(), NON_SYSTEM_ACCOUNT_ID);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -316,7 +316,8 @@ class HandleHederaOperationsTest {
                 .build();
         final var pendingId = ContractID.newBuilder().contractNum(666L).build();
         final var synthContractCreation = synthContractCreationFromParent(pendingId, parent);
-        final var synthContractNoKey = synthContractCreation.copyBuilder().adminKey((Key) null).build();
+        final var synthContractNoKey =
+                synthContractCreation.copyBuilder().adminKey((Key) null).build();
 
         final var synthAccountCreation =
                 synthAccountCreationFromHapi(pendingId, CANONICAL_ALIAS, synthContractCreation);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -316,6 +316,8 @@ class HandleHederaOperationsTest {
                 .build();
         final var pendingId = ContractID.newBuilder().contractNum(666L).build();
         final var synthContractCreation = synthContractCreationFromParent(pendingId, parent);
+        final var synthContractNoKey = synthContractCreation.copyBuilder().adminKey((Key) null).build();
+
         final var synthAccountCreation =
                 synthAccountCreationFromHapi(pendingId, CANONICAL_ALIAS, synthContractCreation);
         final var synthTxn = TransactionBody.newBuilder()
@@ -341,7 +343,7 @@ class HandleHederaOperationsTest {
 
         subject.createContract(666L, NON_SYSTEM_ACCOUNT_ID.accountNumOrThrow(), CANONICAL_ALIAS);
 
-        assertInternalFinisherAsExpected(captor.getValue(), synthContractCreation);
+        assertInternalFinisherAsExpected(captor.getValue(), synthContractNoKey);
         verify(tokenServiceApi)
                 .markAsContract(AccountID.newBuilder().accountNum(666L).build(), NON_SYSTEM_ACCOUNT_ID);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
@@ -87,7 +87,8 @@ class SynthTxnUtilsTest {
                 .maxAutoAssociations(321)
                 .memo("Something")
                 .build();
-        final var matchingCreationKey = Key.newBuilder().contractID(CALLED_CONTRACT_ID).build();
+        final var matchingCreationKey =
+                Key.newBuilder().contractID(CALLED_CONTRACT_ID).build();
         final var matchingCreation = synthContractCreationFromParent(CALLED_CONTRACT_ID, parent);
         assertEquals(parent.maxAutoAssociations(), matchingCreation.maxAutomaticTokenAssociations());
         assertEquals(parent.declineReward(), matchingCreation.declineReward());

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
@@ -87,6 +87,7 @@ class SynthTxnUtilsTest {
                 .maxAutoAssociations(321)
                 .memo("Something")
                 .build();
+        final var matchingCreationKey = Key.newBuilder().contractID(CALLED_CONTRACT_ID).build();
         final var matchingCreation = synthContractCreationFromParent(CALLED_CONTRACT_ID, parent);
         assertEquals(parent.maxAutoAssociations(), matchingCreation.maxAutomaticTokenAssociations());
         assertEquals(parent.declineReward(), matchingCreation.declineReward());
@@ -94,7 +95,7 @@ class SynthTxnUtilsTest {
         assertEquals(
                 parent.autoRenewSeconds(), matchingCreation.autoRenewPeriod().seconds());
         assertEquals(parent.autoRenewAccountId(), matchingCreation.autoRenewAccountId());
-        assertEquals(parent.key(), matchingCreation.adminKey());
+        assertEquals(matchingCreationKey, matchingCreation.adminKey());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
@@ -87,8 +87,6 @@ class SynthTxnUtilsTest {
                 .maxAutoAssociations(321)
                 .memo("Something")
                 .build();
-        final var matchingCreationKey =
-                Key.newBuilder().contractID(CALLED_CONTRACT_ID).build();
         final var matchingCreation = synthContractCreationFromParent(CALLED_CONTRACT_ID, parent);
         assertEquals(parent.maxAutoAssociations(), matchingCreation.maxAutomaticTokenAssociations());
         assertEquals(parent.declineReward(), matchingCreation.declineReward());
@@ -96,7 +94,7 @@ class SynthTxnUtilsTest {
         assertEquals(
                 parent.autoRenewSeconds(), matchingCreation.autoRenewPeriod().seconds());
         assertEquals(parent.autoRenewAccountId(), matchingCreation.autoRenewAccountId());
-        assertEquals(matchingCreationKey, matchingCreation.adminKey());
+        assertEquals(parent.key(), matchingCreation.adminKey());
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
@@ -90,7 +90,9 @@ public class AutoCreateUtils {
     public static HapiSpecOperation[] createHollowAccountFrom(@NonNull final String key) {
         return createHollowAccountFrom(key, INITIAL_BALANCE * ONE_HBAR, ONE_HUNDRED_HBARS);
     }
-    public static HapiSpecOperation[] createHollowAccountFrom(@NonNull final String key, final long sponsorBalance, final long transferAmount) {
+
+    public static HapiSpecOperation[] createHollowAccountFrom(
+            @NonNull final String key, final long sponsorBalance, final long transferAmount) {
         return new HapiSpecOperation[] {
             cryptoCreate(LAZY_CREATE_SPONSOR).balance(sponsorBalance),
             cryptoCreate(CRYPTO_TRANSFER_RECEIVER).balance(INITIAL_BALANCE * ONE_HBAR),
@@ -110,10 +112,12 @@ public class AutoCreateUtils {
                                 .memo(LAZY_MEMO));
 
                 // create a hollow account with the correct create1 address
-                final var create1Address = contractAddress(Address.wrap(Bytes.wrap(recoverAddressFromPubKey(ecdsaKey))), 0L);
+                final var create1Address =
+                        contractAddress(Address.wrap(Bytes.wrap(recoverAddressFromPubKey(ecdsaKey))), 0L);
                 final var create1ByteString = ByteString.copyFrom(create1Address.toArray());
 
-                final var op3 = cryptoTransfer(tinyBarsFromTo(LAZY_CREATE_SPONSOR, create1ByteString, ONE_HUNDRED_HBARS))
+                final var op3 = cryptoTransfer(
+                                tinyBarsFromTo(LAZY_CREATE_SPONSOR, create1ByteString, ONE_HUNDRED_HBARS))
                         .hasKnownStatus(SUCCESS)
                         .via(TRANSFER_TXN_FOR_CREATE_1);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
@@ -34,6 +34,7 @@ import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.LAZ
 import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.INITIAL_BALANCE;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.TRANSFER_TXN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static org.hyperledger.besu.datatypes.Address.contractAddress;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -45,8 +46,13 @@ import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
 
 public class AutoCreateUtils {
+
+    private static final String TRANSFER_TXN_FOR_CREATE_1 = "transferTxnForCreate1";
+
     public static ByteString randomValidEd25519Alias() {
         final var alias = RandomStringUtils.random(128, true, true);
         return Key.newBuilder()
@@ -82,26 +88,38 @@ public class AutoCreateUtils {
     }
 
     public static HapiSpecOperation[] createHollowAccountFrom(@NonNull final String key) {
+        return createHollowAccountFrom(key, INITIAL_BALANCE * ONE_HBAR, ONE_HUNDRED_HBARS);
+    }
+    public static HapiSpecOperation[] createHollowAccountFrom(@NonNull final String key, final long sponsorBalance, final long transferAmount) {
         return new HapiSpecOperation[] {
-            cryptoCreate(LAZY_CREATE_SPONSOR).balance(INITIAL_BALANCE * ONE_HBAR),
+            cryptoCreate(LAZY_CREATE_SPONSOR).balance(sponsorBalance),
             cryptoCreate(CRYPTO_TRANSFER_RECEIVER).balance(INITIAL_BALANCE * ONE_HBAR),
             withOpContext((spec, opLog) -> {
                 final var ecdsaKey =
                         spec.registry().getKey(key).getECDSASecp256K1().toByteArray();
                 final var evmAddress = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
-                final var op = cryptoTransfer(tinyBarsFromTo(LAZY_CREATE_SPONSOR, evmAddress, ONE_HUNDRED_HBARS))
+                final var op = cryptoTransfer(tinyBarsFromTo(LAZY_CREATE_SPONSOR, evmAddress, transferAmount))
                         .hasKnownStatus(SUCCESS)
                         .via(TRANSFER_TXN);
                 final var op2 = getAliasedAccountInfo(evmAddress)
                         .has(accountWith()
                                 .hasEmptyKey()
-                                .expectedBalanceWithChargedUsd(ONE_HUNDRED_HBARS, 0, 0)
+                                .expectedBalanceWithChargedUsd(transferAmount, 0, 0)
                                 .autoRenew(THREE_MONTHS_IN_SECONDS)
                                 .receiverSigReq(false)
                                 .memo(LAZY_MEMO));
+
+                // create a hollow account with the correct create1 address
+                final var create1Address = contractAddress(Address.wrap(Bytes.wrap(recoverAddressFromPubKey(ecdsaKey))), 0L);
+                final var create1ByteString = ByteString.copyFrom(create1Address.toArray());
+
+                final var op3 = cryptoTransfer(tinyBarsFromTo(LAZY_CREATE_SPONSOR, create1ByteString, ONE_HUNDRED_HBARS))
+                        .hasKnownStatus(SUCCESS)
+                        .via(TRANSFER_TXN_FOR_CREATE_1);
+
                 final HapiGetTxnRecord hapiGetTxnRecord =
                         getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged();
-                allRunFor(spec, op, op2, hapiGetTxnRecord);
+                allRunFor(spec, op, op2, op3, hapiGetTxnRecord);
 
                 final AccountID newAccountID = hapiGetTxnRecord
                         .getFirstNonStakingChildRecord()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -33,6 +33,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
@@ -71,6 +72,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountInfo;
@@ -441,6 +443,40 @@ public class HollowAccountFinalizationSuite {
                     final var evmAddress = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
                     final var op2 = contractCreate(CONTRACT)
                             .adminKey(ADMIN_KEY)
+                            .payingWith(SECP_256K1_SOURCE_KEY)
+                            .sigMapPrefixes(uniqueWithFullPrefixesFor(SECP_256K1_SOURCE_KEY))
+                            .hasKnownStatus(SUCCESS)
+                            .via(TRANSFER_TXN_2);
+                    final var op3 = getAliasedAccountInfo(evmAddress)
+                            .has(accountWith().key(SECP_256K1_SOURCE_KEY).noAlias());
+                    final var hapiGetSecondTxnRecord =
+                            getTxnRecord(TRANSFER_TXN_2).andAllChildRecords().logged();
+
+                    allRunFor(spec, op2, op3, hapiGetSecondTxnRecord);
+                }));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> hollowAccountCompletionWithEthereumContractCreate() {
+        final var CONTRACT = "CreateTrivial";
+        return defaultHapiSpec("hollowAccountCompletionWithEthereumContractCreate")
+                .given(
+                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                        newKeyNamed(ADMIN_KEY),
+                        uploadInitCode(CONTRACT))
+                .when(createHollowAccountFrom(SECP_256K1_SOURCE_KEY, INITIAL_BALANCE * ONE_MILLION_HBARS, 1_000_000 * ONE_HUNDRED_HBARS))
+                .then(withOpContext((spec, opLog) -> {
+                    final var ecdsaKey = spec.registry()
+                            .getKey(SECP_256K1_SOURCE_KEY)
+                            .getECDSASecp256K1()
+                            .toByteArray();
+                    final var evmAddress = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
+                    final var op2 = ethereumContractCreate(CONTRACT)
+                            .type(EthTransactionType.LEGACY_ETHEREUM)
+                            .nonce(0)
+                            .gasPrice(2L)
+                            .maxPriorityGas(2L)
+                            .gasLimit(1_000_000L)
                             .payingWith(SECP_256K1_SOURCE_KEY)
                             .sigMapPrefixes(uniqueWithFullPrefixesFor(SECP_256K1_SOURCE_KEY))
                             .hasKnownStatus(SUCCESS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -464,7 +464,8 @@ public class HollowAccountFinalizationSuite {
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         newKeyNamed(ADMIN_KEY),
                         uploadInitCode(CONTRACT))
-                .when(createHollowAccountFrom(SECP_256K1_SOURCE_KEY, INITIAL_BALANCE * ONE_MILLION_HBARS, 1_000_000 * ONE_HUNDRED_HBARS))
+                .when(createHollowAccountFrom(
+                        SECP_256K1_SOURCE_KEY, INITIAL_BALANCE * ONE_MILLION_HBARS, 1_000_000 * ONE_HUNDRED_HBARS))
                 .then(withOpContext((spec, opLog) -> {
                     final var ecdsaKey = spec.registry()
                             .getKey(SECP_256K1_SOURCE_KEY)


### PR DESCRIPTION
**Description**:
Due to mono service fidelity, the parent contracts attributes were copied for externalizing the record in the hollow creation flow for contracts.  If the contract frame does not have a contract parent then handle with default values.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
