### PR TITLE
chore: Increase default to 40 million each

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
@@ -36,6 +36,6 @@ public record AccountsConfig(
         @ConfigProperty(defaultValue = "2") @NetworkProperty long treasury,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean storeOnDisk,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean releaseAliasAfterDeletion,
-        @ConfigProperty(defaultValue = "20000000") @NetworkProperty long maxNumber,
+        @ConfigProperty(defaultValue = "40000000") @NetworkProperty long maxNumber,
         @ConfigProperty(value = "blocklist.enabled", defaultValue = "false") @NetworkProperty boolean blocklistEnabled,
         @ConfigProperty(value = "blocklist.path", defaultValue = "") @NetworkProperty String blocklistResource) {}

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
@@ -38,7 +38,7 @@ public record TokensConfig(
         @ConfigProperty(value = "nfts.maxBatchSizeBurn", defaultValue = "10") @NetworkProperty int nftsMaxBatchSizeBurn,
         @ConfigProperty(value = "nfts.maxBatchSizeWipe", defaultValue = "10") @NetworkProperty int nftsMaxBatchSizeWipe,
         @ConfigProperty(value = "nfts.maxBatchSizeMint", defaultValue = "10") @NetworkProperty int nftsMaxBatchSizeMint,
-        @ConfigProperty(value = "nfts.maxAllowedMints", defaultValue = "20000000") @NetworkProperty
+        @ConfigProperty(value = "nfts.maxAllowedMints", defaultValue = "40000000") @NetworkProperty
                 long nftsMaxAllowedMints,
         @ConfigProperty(value = "nfts.maxQueryRange", defaultValue = "100") @NetworkProperty long nftsMaxQueryRange,
         @ConfigProperty(value = "nfts.useTreasuryWildcards", defaultValue = "true") @NetworkProperty

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusConfig.java
@@ -36,5 +36,5 @@ import com.swirlds.platform.state.MinimumJudgeInfo;
 @ConfigData("consensus")
 public record ConsensusConfig(
         @ConfigProperty(defaultValue = "26") int roundsNonAncient,
-        @ConfigProperty(defaultValue = "500") int roundsExpired,
+        @ConfigProperty(defaultValue = "1500") int roundsExpired,
         @ConfigProperty(defaultValue = "12") int coinFreq) {}


### PR DESCRIPTION
Fixes #13856 

Increases accounts and NFTs to 40 million each, and increases the number of rounds kept in memory from 500 to 1500.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
