### PR TITLE
fix: work around missing `clearOneOfType()` method on PBJ builder

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingUtilities.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingUtilities.java
@@ -77,9 +77,27 @@ public class StakingUtilities {
         final var differStakedNodeId = !originalAccount
                 .stakedNodeIdOrElse(SENTINEL_NODE_ID)
                 .equals(modifiedAccount.stakedNodeIdOrElse(SENTINEL_NODE_ID));
-        final var differStakeAccountId = !originalAccount
-                .stakedAccountIdOrElse(AccountID.DEFAULT)
-                .equals(modifiedAccount.stakedAccountIdOrElse(AccountID.DEFAULT));
+        final var differStakeAccountId =
+                !effectiveStakedAccountId(originalAccount).equals(effectiveStakedAccountId(modifiedAccount));
         return differDeclineReward || differStakedNodeId || differStakeAccountId;
+    }
+
+    /**
+     * Returns the account id the given account is staked to, or {@link AccountID#DEFAULT} if it is
+     * not staked to a node. Notice that {@link Account#stakedAccountIdOrElse(AccountID)} doesn't
+     * work directly, because this will be explicitly set to {@code null} if a staked account id
+     * was removed via the {@code 0.0.0} sentinel.
+     *
+     * <p>Will be unnecessary once https://github.com/hashgraph/pbj/issues/160 is done.
+     *
+     * @param account the account
+     * @return the account id the given account is staked to, or {@link AccountID#DEFAULT}
+     */
+    private static AccountID effectiveStakedAccountId(@NonNull final Account account) {
+        if (account.hasStakedAccountId()) {
+            return account.stakedAccountId() == null ? AccountID.DEFAULT : account.stakedAccountId();
+        } else {
+            return AccountID.DEFAULT;
+        }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -133,23 +133,20 @@ public class CryptoUpdateSuite {
                                 .has(AccountInfoAsserts.accountWith()
                                         .stakedAccountId("0.0.20")
                                         .noStakingNodeId()
-                                        .isDeclinedReward(true))
-                                .logged())
+                                        .isDeclinedReward(true)))
                 .when(
                         cryptoUpdate("user").newStakedNodeId(0L).newDeclinedReward(false),
                         getAccountInfo("user")
                                 .has(AccountInfoAsserts.accountWith()
                                         .noStakedAccountId()
                                         .stakedNodeId(0L)
-                                        .isDeclinedReward(false))
-                                .logged(),
+                                        .isDeclinedReward(false)),
                         cryptoUpdate("user").newStakedNodeId(-1L),
                         getAccountInfo("user")
                                 .has(AccountInfoAsserts.accountWith()
                                         .noStakedAccountId()
                                         .noStakingNodeId()
-                                        .isDeclinedReward(false))
-                                .logged())
+                                        .isDeclinedReward(false)))
                 .then(
                         cryptoUpdate("user")
                                 .key(ADMIN_KEY)
@@ -167,7 +164,13 @@ public class CryptoUpdateSuite {
                                         .noStakedAccountId()
                                         .noStakingNodeId()
                                         .isDeclinedReward(true))
-                                .logged());
+                                .logged(),
+                        // For completeness stake back to a node
+                        cryptoUpdate("user").key(ADMIN_KEY).newStakedNodeId(1),
+                        getAccountInfo("user")
+                                .has(AccountInfoAsserts.accountWith()
+                                        .stakedNodeId(1L)
+                                        .isDeclinedReward(true)));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Cherry-pick #13843 