### PR TITLE
feat: remove attributes when externalizing finalized hollow contract

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -29,7 +29,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.*;
 import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
-import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;
 import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.SignedTransaction;
@@ -349,19 +348,13 @@ public class HandleHederaOperations implements HederaOperations {
     }
 
     @Override
-    public void externalizeHollowAccountMerge(
-            @NonNull ContractID contractId, @NonNull ContractID parentId, @Nullable Bytes evmAddress) {
+    public void externalizeHollowAccountMerge(@NonNull ContractID contractId, @Nullable Bytes evmAddress) {
         final var accountStore = context.readableStore(ReadableAccountStore.class);
-        var parent = accountStore.getContractById(parentId);
-        // If the parent contract is not found, use the default Account to create the contract
-        if (parent == null) {
-            parent = Account.DEFAULT;
-        }
         final var recordBuilder = context.addRemovableChildRecordBuilder(ContractCreateRecordBuilder.class)
                 .contractID(contractId)
                 .status(SUCCESS)
                 .transaction(transactionWith(TransactionBody.newBuilder()
-                        .contractCreateInstance(synthContractCreationFromParent(contractId, parent))
+                        .contractCreateInstance(synthContractCreationForExternalization(contractId))
                         .build()))
                 .contractCreateResult(ContractFunctionResult.newBuilder()
                         .contractID(contractId)

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
@@ -250,8 +250,7 @@ public interface HederaOperations {
      * @param contractId    ContractId of hollow account
      * @param evmAddress    Evm address of hollow account
      */
-    void externalizeHollowAccountMerge(
-            @NonNull ContractID contractId, @NonNull ContractID parentId, @Nullable Bytes evmAddress);
+    void externalizeHollowAccountMerge(@NonNull ContractID contractId, @Nullable Bytes evmAddress);
 
     /**
      * Given a {@link ContractID}, returns it if the shard and realm match for this node; otherwise,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaOperations.java
@@ -268,8 +268,7 @@ public class QueryHederaOperations implements HederaOperations {
         return EMPTY_CHECKPOINT;
     }
 
-    public void externalizeHollowAccountMerge(
-            @NonNull ContractID contractId, @NonNull ContractID parentId, @Nullable Bytes evmAddress) {
+    public void externalizeHollowAccountMerge(@NonNull ContractID contractId, @Nullable Bytes evmAddress) {
         throw new UnsupportedOperationException("Queries cannot create accounts");
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyWorldUpdater.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyWorldUpdater.java
@@ -307,18 +307,11 @@ public class ProxyWorldUpdater implements HederaWorldUpdater {
      */
     @Override
     public void finalizeHollowAccount(@NonNull final Address address, @NonNull final Address parent) {
-        // (FUTURE) Since for mono-service parity we externalize a ContractCreate populated with the
-        // contract-specific Hedera properties of the parent, we should either (1) actually set those
-        // properties on the finalized hollow account with those properties; or (2) stop adding them
-        // to the externalized creation record
         evmFrameState.finalizeHollowAccount(address);
         // Reset pending creation to null, as a CREATE2 operation "collided" with an existing
         // hollow account instead of creating a truly new contract
         pendingCreation = null;
-        enhancement
-                .operations()
-                .externalizeHollowAccountMerge(
-                        getHederaContractId(address), getHederaContractId(parent), aliasFrom(address));
+        enhancement.operations().externalizeHollowAccountMerge(getHederaContractId(address), aliasFrom(address));
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SynthTxnUtils.java
@@ -121,6 +121,20 @@ public class SynthTxnUtils {
     }
 
     /**
+     * Create a new empty {@link ContractCreateTransactionBody} with only the key set for externalization.
+     *
+     * @param pendingId the pending id
+     * @return the corresponding {@link CryptoCreateTransactionBody}
+     */
+    public static ContractCreateTransactionBody synthContractCreationForExternalization(
+            @NonNull final ContractID pendingId) {
+        requireNonNull(pendingId);
+        return ContractCreateTransactionBody.newBuilder()
+                .adminKey(Key.newBuilder().contractID(pendingId).build())
+                .build();
+    }
+
+    /**
      * Returns whether the given account has an auto-renew account id that is not
      * {@code 0.0.0}.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -627,7 +627,6 @@ class HandleHederaOperationsTest {
                 .build();
         var contractId = ContractID.newBuilder().contractNum(1001).build();
         given(context.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
-        given(readableAccountStore.getContractById(ContractID.DEFAULT)).willReturn(parentAccount);
         given(context.addRemovableChildRecordBuilder(eq(ContractCreateRecordBuilder.class)))
                 .willReturn(contractCreateRecordBuilder);
         given(contractCreateRecordBuilder.contractID(eq(contractId))).willReturn(contractCreateRecordBuilder);
@@ -637,7 +636,7 @@ class HandleHederaOperationsTest {
                 .willReturn(contractCreateRecordBuilder);
 
         // when
-        subject.externalizeHollowAccountMerge(contractId, ContractID.DEFAULT, VALID_CONTRACT_ADDRESS.evmAddress());
+        subject.externalizeHollowAccountMerge(contractId, VALID_CONTRACT_ADDRESS.evmAddress());
 
         // then
         verify(contractCreateRecordBuilder).contractID(contractId);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyWorldUpdaterTest.java
@@ -218,7 +218,6 @@ class ProxyWorldUpdaterTest {
     @Test
     void delegatesHollowFinalization() {
         given(evmFrameState.getAccount(EIP_1014_ADDRESS)).willReturn(proxyEvmContract);
-        given(evmFrameState.getAccount(PERMITTED_ADDRESS_CALLER)).willReturn(proxyEvmContract);
         given(proxyEvmContract.hederaContractId())
                 .willReturn(ContractID.newBuilder().contractNum(999L).build());
         subject.setupTopLevelLazyCreate(EIP_1014_ADDRESS);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/SynthTxnUtilsTest.java
@@ -29,6 +29,7 @@ import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.DEFA
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.LAZY_CREATION_MEMO;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.synthAccountCreationFromHapi;
+import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.synthContractCreationForExternalization;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.synthContractCreationFromParent;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.synthHollowAccountCreation;
 import static org.junit.jupiter.api.Assertions.*;
@@ -95,6 +96,13 @@ class SynthTxnUtilsTest {
                 parent.autoRenewSeconds(), matchingCreation.autoRenewPeriod().seconds());
         assertEquals(parent.autoRenewAccountId(), matchingCreation.autoRenewAccountId());
         assertEquals(parent.key(), matchingCreation.adminKey());
+    }
+
+    @Test
+    void onlySetContractKeyForExternalization() {
+        final var matchingKey = Key.newBuilder().contractID(CALLED_CONTRACT_ID).build();
+        final var matchingCreation = synthContractCreationForExternalization(CALLED_CONTRACT_ID);
+        assertEquals(matchingKey, matchingCreation.adminKey());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
When finalizing a contract create onto a hollow account, for externalization purposes, only set the adminKey to be the contract key.

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
