### PR TITLE
build: Make sure also 'reports' has all expected lifecycle tasks

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.reports.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.reports.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("jvm-ecosystem")
     id("jacoco-report-aggregation")
+    id("com.hedera.gradle.lifecycle")
     id("com.hedera.gradle.repositories")
     id("com.hedera.gradle.jpms-modules")
     id("com.hedera.gradle.jpms-module-dependencies")


### PR DESCRIPTION
Fixes this publishing error:

>Could not determine the dependencies of task ':closeSonatypeStagingRepository'.
> Task with path ':reports:releaseMavenCentral' not found in root project 'hedera-services'.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
