### PR TITLE
fix: Cherry pick 11381 for 0.51

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.reports.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.reports.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("jvm-ecosystem")
     id("jacoco-report-aggregation")
+    id("com.hedera.gradle.lifecycle")
     id("com.hedera.gradle.repositories")
     id("com.hedera.gradle.jpms-modules")
     id("com.hedera.gradle.jpms-module-dependencies")


### PR DESCRIPTION
**Description**:

Cherry-pick fix for gradle task :reports:releaseMavenCentral into release/0.51

**Related issue(s)**:

Fixes error: `Could not determine the dependencies of task ':closeSonatypeStagingRepository'.`