### PR TITLE
feat: HIP-904 Add crypto transfer fee calculations

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCalculator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCalculator.java
@@ -102,4 +102,10 @@ public interface FeeCalculator {
      */
     @NonNull
     FeeCalculator resetUsage();
+
+    /**
+     * Gets the price for signature verifications only.
+     * @return the vpt price
+     */
+    long getVptPrice();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
@@ -20,9 +20,11 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
 
 public interface FeeContext {
     /**
@@ -92,4 +94,27 @@ public interface FeeContext {
      * @return the computed fees
      */
     Fees dispatchComputeFees(@NonNull TransactionBody txBody, @NonNull AccountID syntheticPayerId);
+
+    /**
+     * Returns the {@link TransactionCategory}
+     * @return the transactionCategory in this fee context
+     */
+    @NonNull
+    TransactionCategory transactionCategory();
+
+    /**
+     * Gets a {@link ExchangeRateInfo} which provides information about the current exchange rate.
+     *
+     * @return The {@link ExchangeRateInfo} .
+     */
+    @NonNull
+    ExchangeRateInfo exchangeRateInfo();
+
+    /**
+     * Returns the current consensus time.
+     *
+     * @return the current consensus time
+     */
+    @NonNull
+    Instant consensusNow();
 }

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeCalculator.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/fees/FakeFeeCalculator.java
@@ -80,4 +80,9 @@ public class FakeFeeCalculator implements FeeCalculator {
     public FakeFeeCalculator resetUsage() {
         return this;
     }
+
+    @Override
+    public long getVptPrice() {
+        return 0;
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ChildFeeContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ChildFeeContextImpl.java
@@ -25,9 +25,11 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.util.UnknownHederaFunctionality;
 import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.fees.ExchangeRateInfo;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -47,6 +49,7 @@ public class ChildFeeContextImpl implements FeeContext {
     private final Authorizer authorizer;
     private final ReadableStoreFactory storeFactory;
     private final Instant consensusNow;
+    private final TransactionCategory transactionCategory;
 
     public ChildFeeContextImpl(
             @NonNull final FeeManager feeManager,
@@ -56,7 +59,8 @@ public class ChildFeeContextImpl implements FeeContext {
             final boolean computeFeesAsInternalDispatch,
             @NonNull final Authorizer authorizer,
             @NonNull final ReadableStoreFactory storeFactory,
-            @NonNull final Instant consensusNow) {
+            @NonNull final Instant consensusNow,
+            TransactionCategory transactionCategory) {
         this.feeManager = requireNonNull(feeManager);
         this.context = requireNonNull(context);
         this.body = requireNonNull(body);
@@ -65,6 +69,7 @@ public class ChildFeeContextImpl implements FeeContext {
         this.authorizer = requireNonNull(authorizer);
         this.storeFactory = requireNonNull(storeFactory);
         this.consensusNow = requireNonNull(consensusNow);
+        this.transactionCategory = requireNonNull(transactionCategory);
     }
 
     @Override
@@ -119,5 +124,23 @@ public class ChildFeeContextImpl implements FeeContext {
     @Override
     public Fees dispatchComputeFees(@NonNull final TransactionBody txBody, @NonNull final AccountID syntheticPayerId) {
         return context.dispatchComputeFees(txBody, syntheticPayerId);
+    }
+
+    @NonNull
+    @Override
+    public TransactionCategory transactionCategory() {
+        return transactionCategory;
+    }
+
+    @Override
+    @NonNull
+    public ExchangeRateInfo exchangeRateInfo() {
+        return context.exchangeRateInfo();
+    }
+
+    @Override
+    @NonNull
+    public Instant consensusNow() {
+        return context.consensusNow();
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
@@ -227,6 +227,11 @@ public class FeeCalculatorImpl implements FeeCalculator {
         return this;
     }
 
+    @Override
+    public long getVptPrice() {
+        return feeData.getNetworkdata().getVpt() / 1000L;
+    }
+
     @NonNull
     @Override
     public Fees legacyCalculate(@NonNull Function<SigValueObj, com.hederahashgraph.api.proto.java.FeeData> callback) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeContextImpl.java
@@ -54,8 +54,8 @@ public class FeeContextImpl implements FeeContext {
     private final TransactionDispatcher transactionDispatcher;
     private final HederaState state;
     private final ExchangeRateManager exchangeRateManager;
+    private final TransactionCategory transactionCategory;
     private ExchangeRateInfo exchangeRateInfo;
-    private TransactionCategory transactionCategory;
 
     /**
      * Constructor of {@code FeeContextImpl}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeCalculator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/NoOpFeeCalculator.java
@@ -70,6 +70,11 @@ public class NoOpFeeCalculator implements FeeCalculator {
         return this;
     }
 
+    @Override
+    public long getVptPrice() {
+        return 0;
+    }
+
     @NonNull
     @Override
     public Fees legacyCalculate(@NonNull Function<SigValueObj, FeeData> callback) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/flow/DispatchHandleContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/flow/DispatchHandleContext.java
@@ -226,6 +226,11 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
         return dispatchComputeFees(childTxBody, syntheticPayerId, ComputeDispatchFeesAsTopLevel.NO);
     }
 
+    @Override
+    public TransactionCategory transactionCategory() {
+        return TransactionCategory.USER;
+    }
+
     @NonNull
     @Override
     public BlockRecordInfo blockRecordInfo() {
@@ -399,7 +404,8 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
                 computeDispatchFeesAsTopLevel == ComputeDispatchFeesAsTopLevel.NO,
                 authorizer,
                 readableStoreFactory,
-                consensusNow));
+                consensusNow,
+                CHILD));
     }
 
     @NonNull

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -39,6 +39,7 @@ import com.hedera.hapi.node.base.SignaturePair;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.annotations.NodeSelfId;
+import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeContextImpl;
 import com.hedera.node.app.fees.FeeManager;
 import com.hedera.node.app.info.CurrentPlatformStatus;
@@ -50,6 +51,7 @@ import com.hedera.node.app.signature.SignatureVerifier;
 import com.hedera.node.app.spi.authorization.Authorizer;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.throttle.SynchronizedThrottleAccumulator;
@@ -96,6 +98,7 @@ public final class IngestChecker {
     private final AccountID nodeAccount;
     private final Authorizer authorizer;
     private final SynchronizedThrottleAccumulator synchronizedThrottleAccumulator;
+    private final ExchangeRateManager exchangeRateManager;
 
     /**
      * Constructor of the {@code IngestChecker}
@@ -109,6 +112,7 @@ public final class IngestChecker {
      * @param dispatcher the {@link TransactionDispatcher} that dispatches transactions
      * @param feeManager the {@link FeeManager} that manages {@link com.hedera.node.app.spi.fees.FeeCalculator}s
      * @param synchronizedThrottleAccumulator the {@link SynchronizedThrottleAccumulator} that checks transaction should be throttled
+     * @param exchangeRateManager The {@link ExchangeRateManager} used to obtain exchange rate information
      * @throws NullPointerException if one of the arguments is {@code null}
      */
     @Inject
@@ -123,7 +127,8 @@ public final class IngestChecker {
             @NonNull final TransactionDispatcher dispatcher,
             @NonNull final FeeManager feeManager,
             @NonNull final Authorizer authorizer,
-            @NonNull final SynchronizedThrottleAccumulator synchronizedThrottleAccumulator) {
+            @NonNull final SynchronizedThrottleAccumulator synchronizedThrottleAccumulator,
+            @NonNull final ExchangeRateManager exchangeRateManager) {
         this.nodeAccount = requireNonNull(nodeAccount, "nodeAccount must not be null");
         this.currentPlatformStatus = requireNonNull(currentPlatformStatus, "currentPlatformStatus must not be null");
         this.transactionChecker = requireNonNull(transactionChecker, "transactionChecker must not be null");
@@ -135,6 +140,7 @@ public final class IngestChecker {
         this.feeManager = requireNonNull(feeManager, "feeManager must not be null");
         this.authorizer = requireNonNull(authorizer, "authorizer must not be null");
         this.synchronizedThrottleAccumulator = requireNonNull(synchronizedThrottleAccumulator);
+        this.exchangeRateManager = requireNonNull(exchangeRateManager, "exchangeRateManager must not be null");
     }
 
     /**
@@ -214,6 +220,7 @@ public final class IngestChecker {
         // 7. Check payer solvency
         final var numSigs = txInfo.signatureMap().sigPair().size();
         final FeeContext feeContext = new FeeContextImpl(
+                state,
                 consensusTime,
                 txInfo,
                 payerKey,
@@ -223,7 +230,9 @@ public final class IngestChecker {
                 configuration,
                 authorizer,
                 numSigs,
-                dispatcher);
+                dispatcher,
+                exchangeRateManager,
+                TransactionCategory.USER);
         final var fees = dispatcher.dispatchComputeFees(feeContext);
         solvencyPreCheck.checkSolvency(txInfo, payer, fees, WorkflowCheck.INGEST);
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -234,7 +234,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                         // 3.iv Calculate costs
                         final var queryFees = handler.computeFees(context).totalFee();
                         final var txFees = queryChecker.estimateTxFees(
-                                storeFactory, consensusTime, transactionInfo, payer.keyOrThrow(), configuration);
+                                state, storeFactory, consensusTime, transactionInfo, payer.keyOrThrow(), configuration);
 
                         // 3.v Check account balances
                         queryChecker.validateAccountBalances(accountStore, transactionInfo, payer, queryFees, txFees);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ChildFeeContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ChildFeeContextImplTest.java
@@ -35,6 +35,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.authorization.Authorizer;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeContext;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
@@ -90,7 +91,15 @@ class ChildFeeContextImplTest {
     @BeforeEach
     void setUp() {
         subject = new ChildFeeContextImpl(
-                feeManager, context, SAMPLE_BODY, PAYER_ID, true, authorizer, storeFactory, NOW);
+                feeManager,
+                context,
+                SAMPLE_BODY,
+                PAYER_ID,
+                true,
+                authorizer,
+                storeFactory,
+                NOW,
+                TransactionCategory.CHILD);
     }
 
     @Test
@@ -117,7 +126,15 @@ class ChildFeeContextImplTest {
     @Test
     void propagatesInvalidBodyAsIllegalStateException() {
         subject = new ChildFeeContextImpl(
-                feeManager, context, TransactionBody.DEFAULT, PAYER_ID, true, authorizer, storeFactory, NOW);
+                feeManager,
+                context,
+                TransactionBody.DEFAULT,
+                PAYER_ID,
+                true,
+                authorizer,
+                storeFactory,
+                NOW,
+                TransactionCategory.CHILD);
         assertThrows(
                 IllegalStateException.class,
                 () -> subject.feeCalculator(SubType.TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -56,6 +56,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.transaction.UncheckedSubmitBody;
+import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeManager;
 import com.hedera.node.app.fixtures.AppTestBase;
 import com.hedera.node.app.info.CurrentPlatformStatus;
@@ -125,6 +126,9 @@ class IngestCheckerTest extends AppTestBase {
     private FeeManager feeManager;
 
     @Mock(strictness = LENIENT)
+    private ExchangeRateManager exchangeRateManager;
+
+    @Mock(strictness = LENIENT)
     private Authorizer authorizer;
 
     @Mock(strictness = LENIENT)
@@ -183,7 +187,8 @@ class IngestCheckerTest extends AppTestBase {
                 dispatcher,
                 feeManager,
                 authorizer,
-                synchronizedThrottleAccumulator);
+                synchronizedThrottleAccumulator,
+                exchangeRateManager);
     }
 
     @Nested
@@ -232,7 +237,8 @@ class IngestCheckerTest extends AppTestBase {
                 dispatcher,
                 feeManager,
                 authorizer,
-                synchronizedThrottleAccumulator);
+                synchronizedThrottleAccumulator,
+                exchangeRateManager);
 
         // Then the checker should throw a PreCheckException
         assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
@@ -46,8 +46,10 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeManager;
 import com.hedera.node.app.fixtures.AppTestBase;
+import com.hedera.node.app.fixtures.state.FakeHederaState;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.CryptoTransferHandler;
 import com.hedera.node.app.spi.authorization.Authorizer;
@@ -93,31 +95,79 @@ class QueryCheckerTest extends AppTestBase {
     @Mock
     private TransactionDispatcher dispatcher;
 
+    @Mock
+    private ExchangeRateManager exchangeRateManager;
+
     private QueryChecker checker;
 
     @BeforeEach
     void setup() {
         checker = new QueryChecker(
-                authorizer, cryptoTransferHandler, solvencyPreCheck, expiryValidation, feeManager, dispatcher);
+                authorizer,
+                cryptoTransferHandler,
+                solvencyPreCheck,
+                expiryValidation,
+                feeManager,
+                dispatcher,
+                exchangeRateManager);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test
     void testConstructorWithIllegalArguments() {
         assertThatThrownBy(() -> new QueryChecker(
-                        null, cryptoTransferHandler, solvencyPreCheck, expiryValidation, feeManager, dispatcher))
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() ->
-                        new QueryChecker(authorizer, null, solvencyPreCheck, expiryValidation, feeManager, dispatcher))
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new QueryChecker(
-                        authorizer, cryptoTransferHandler, null, expiryValidation, feeManager, dispatcher))
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new QueryChecker(
-                        authorizer, cryptoTransferHandler, solvencyPreCheck, null, feeManager, dispatcher))
+                        null,
+                        cryptoTransferHandler,
+                        solvencyPreCheck,
+                        expiryValidation,
+                        feeManager,
+                        dispatcher,
+                        exchangeRateManager))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new QueryChecker(
-                        authorizer, cryptoTransferHandler, solvencyPreCheck, expiryValidation, null, dispatcher))
+                        authorizer,
+                        null,
+                        solvencyPreCheck,
+                        expiryValidation,
+                        feeManager,
+                        dispatcher,
+                        exchangeRateManager))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QueryChecker(
+                        authorizer,
+                        cryptoTransferHandler,
+                        null,
+                        expiryValidation,
+                        feeManager,
+                        dispatcher,
+                        exchangeRateManager))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QueryChecker(
+                        authorizer,
+                        cryptoTransferHandler,
+                        solvencyPreCheck,
+                        null,
+                        feeManager,
+                        dispatcher,
+                        exchangeRateManager))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QueryChecker(
+                        authorizer,
+                        cryptoTransferHandler,
+                        solvencyPreCheck,
+                        expiryValidation,
+                        null,
+                        dispatcher,
+                        exchangeRateManager))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QueryChecker(
+                        authorizer,
+                        cryptoTransferHandler,
+                        solvencyPreCheck,
+                        expiryValidation,
+                        feeManager,
+                        dispatcher,
+                        null))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -468,6 +518,7 @@ class QueryCheckerTest extends AppTestBase {
     @Test
     void testEstimateTxFees(@Mock final ReadableStoreFactory storeFactory) {
         // given
+        final var hederaState = new FakeHederaState();
         final var consensusNow = Instant.ofEpochSecond(0);
         final var txInfo = createPaymentInfo(ALICE.accountID());
         final var configuration = HederaTestConfigBuilder.createConfig();
@@ -476,7 +527,7 @@ class QueryCheckerTest extends AppTestBase {
 
         // when
         final var result = checker.estimateTxFees(
-                storeFactory, consensusNow, txInfo, ALICE.account().key(), configuration);
+                hederaState, storeFactory, consensusNow, txInfo, ALICE.account().key(), configuration);
 
         // then
         assertThat(result).isEqualTo(fees.totalFee());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -690,7 +690,12 @@ class QueryWorkflowImplTest extends AppTestBase {
         given(handler.computeFees(any(QueryContext.class))).willReturn(new Fees(1L, 20L, 300L));
         when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);
         when(queryChecker.estimateTxFees(
-                        any(), any(), eq(transactionInfo), eq(ALICE.account().key()), eq(configuration)))
+                        any(),
+                        any(),
+                        any(),
+                        eq(transactionInfo),
+                        eq(ALICE.account().key()),
+                        eq(configuration)))
                 .thenReturn(4000L);
         doThrow(new InsufficientBalanceException(INSUFFICIENT_TX_FEE, 12345L))
                 .when(queryChecker)

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/EntitiesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/EntitiesConfig.java
@@ -24,4 +24,5 @@ import com.swirlds.config.api.ConfigProperty;
 public record EntitiesConfig(
         @ConfigProperty(defaultValue = "3153600000") @NetworkProperty long maxLifetime,
         // @ConfigProperty(defaultValue = "FILE") Set<EntityType> systemDeletable
-        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean limitTokenAssociations) {}
+        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean limitTokenAssociations,
+        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean unlimitedAutoAssociationsEnabled) {}

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -60,6 +60,12 @@ import org.apache.logging.log4j.Logger;
  * Provides common functionality for token handlers.
  */
 public class BaseTokenHandler {
+
+    /**
+     * The value for unlimited automatic associations
+     */
+    public static final int UNLIMITED_AUTOMATIC_ASSOCIATIONS = -1;
+
     private static final Logger log = LogManager.getLogger(BaseTokenHandler.class);
     /**
      * The set of token keys that are not admin keys.
@@ -461,5 +467,21 @@ public class BaseTokenHandler {
                 .tokenId(tokenId)
                 .accountId(accountId)
                 .build();
+    }
+
+    /**
+     * Checks if the given account has unlimited auto-associations enabled.
+     *
+     * @param account        the account to check; must not be null
+     * @param entitiesConfig the configuration settings to check against; must not be null
+     * @return               {@code true} if unlimited auto-associations is enabled and the account's
+     *                       max auto-associations is set to {@code UNLIMITED_AUTOMATIC_ASSOCIATIONS},
+     *                       otherwise {@code false}
+     * @throws NullPointerException if either {@code account} or {@code entitiesConfig} is null
+     */
+    public static boolean hasUnlimitedAutoAssociations(
+            @NonNull final Account account, @NonNull EntitiesConfig entitiesConfig) {
+        return entitiesConfig.unlimitedAutoAssociationsEnabled()
+                && account.maxAutoAssociations() == UNLIMITED_AUTOMATIC_ASSOCIATIONS;
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -23,6 +23,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_R
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
+import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.txnEstimateFactory;
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.fromPbj;
 import static com.hedera.node.app.service.token.impl.comparator.TokenComparators.TOKEN_ID_COMPARATOR;
@@ -36,11 +37,12 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.hapi.fees.pricing.AssetsLoader;
 import com.hedera.node.app.service.mono.fees.calculation.token.txns.TokenAssociateResourceUsage;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -50,6 +52,7 @@ import com.hedera.node.app.service.token.impl.validators.TokenListChecks;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -57,6 +60,9 @@ import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.node.config.data.TokensConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -68,12 +74,14 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class TokenAssociateToAccountHandler extends BaseTokenHandler implements TransactionHandler {
+
+    private final AssetsLoader assetsLoader;
     /**
      * Default constructor for injection.
      */
     @Inject
-    public TokenAssociateToAccountHandler() {
-        // Exists for injection
+    public TokenAssociateToAccountHandler(@NonNull final AssetsLoader assetsLoader) {
+        this.assetsLoader = requireNonNull(assetsLoader, "The supplied argument 'assetsLoader' must not be null");
     }
 
     @Override
@@ -192,14 +200,60 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
     @Override
     public Fees calculateFees(@NonNull final FeeContext feeContext) {
         requireNonNull(feeContext);
+        requireNonNull(feeContext.configuration());
+
         final var body = feeContext.body();
         final var op = body.tokenAssociateOrThrow();
+        final var calculator = feeContext.feeCalculator(DEFAULT);
         final var accountId = op.accountOrThrow();
         final var readableAccountStore = feeContext.readableStore(ReadableAccountStore.class);
         final var account = readableAccountStore.getAccountById(accountId);
+        final var unlimitedAutoAssociations =
+                feeContext.configuration().getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled();
 
-        return feeContext.feeCalculator(SubType.DEFAULT).legacyCalculate(sigValueObj -> new TokenAssociateResourceUsage(
-                        txnEstimateFactory)
-                .usageGiven(fromPbj(body), sigValueObj, account));
+        if (unlimitedAutoAssociations) {
+            final var exchangeRateInfo = feeContext.exchangeRateInfo();
+
+            calculator.resetUsage();
+            final var price = getTinybarsFromTinyCents(
+                    calculator.getVptPrice(), exchangeRateInfo.activeRate(feeContext.consensusNow()));
+            final var newAssociationsCount = op.tokens().size();
+
+            final var associateInTinyCents = getFixedAssociatePriceInTinyCents();
+            final var associateInTinybars = getTinybarsFromTinyCents(
+                    associateInTinyCents, exchangeRateInfo.activeRate(feeContext.consensusNow()));
+
+            var sigPrice = 0L;
+            if (feeContext.transactionCategory() == TransactionCategory.USER) {
+                sigPrice = (feeContext.numTxnSignatures() - 1) * price;
+            }
+            return new Fees(0L, sigPrice + newAssociationsCount * associateInTinybars, 0L);
+        }
+
+        return calculator.legacyCalculate(sigValueObj ->
+                new TokenAssociateResourceUsage(txnEstimateFactory).usageGiven(fromPbj(body), sigValueObj, account));
+    }
+
+    private long getFixedAssociatePriceInTinyCents() {
+        BigDecimal usdFee;
+        try {
+            usdFee = assetsLoader
+                    .loadCanonicalPrices()
+                    .get(com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAssociateToAccount)
+                    .get(com.hederahashgraph.api.proto.java.SubType.DEFAULT);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load canonical prices", e);
+        }
+        final var usdToTinyCents = BigDecimal.valueOf(100 * 100_000_000L);
+        return usdToTinyCents.multiply(usdFee).longValue();
+    }
+
+    private long getTinybarsFromTinyCents(final long tinyCents, final ExchangeRate rate) {
+        final var aMultiplier = BigInteger.valueOf(rate.hbarEquiv());
+        final var bDivisor = BigInteger.valueOf(rate.centEquiv());
+        return BigInteger.valueOf(tinyCents)
+                .multiply(aMultiplier)
+                .divide(bDivisor)
+                .longValueExact();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -39,13 +39,17 @@ import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
+import com.hedera.hapi.node.token.TokenAssociateTransactionBody.Builder;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNftStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
+import com.hedera.node.app.spi.workflows.ComputeDispatchFeesAsTopLevel;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.config.data.EntitiesConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
@@ -167,13 +171,29 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
                 getIfUsableForAliasedId(accountId, accountStore, handleContext.expiryValidator(), INVALID_ACCOUNT_ID);
         final var tokenRel = tokenRelStore.get(accountId, tokenId);
         final var config = handleContext.configuration();
+        final var entitiesConfig = config.getConfigData(EntitiesConfig.class);
 
-        if (tokenRel == null && account.maxAutoAssociations() > 0) {
-            validateFalse(
-                    account.usedAutoAssociations() >= account.maxAutoAssociations(),
-                    NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
+        if (tokenRel == null && account.maxAutoAssociations() != 0) {
+            boolean validAssociations = hasUnlimitedAutoAssociations(account, entitiesConfig)
+                    || account.usedAutoAssociations() < account.maxAutoAssociations();
+            validateTrue(validAssociations, NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
             validateFalse(token.hasKycKey(), ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN);
             validateFalse(token.accountsFrozenByDefault(), ACCOUNT_FROZEN_FOR_TOKEN);
+
+            final var unlimitedAutoAssociations =
+                    config.getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled();
+            if (unlimitedAutoAssociations) {
+                final var topLevelPayer = handleContext.payer();
+                final var syntheticCreation = TransactionBody.newBuilder()
+                        .tokenAssociate(
+                                new Builder().account(account.accountId()).tokens(token.tokenId()));
+                final var fees = handleContext.dispatchComputeFees(
+                        syntheticCreation.build(), topLevelPayer, ComputeDispatchFeesAsTopLevel.NO);
+                handleContext
+                        .feeAccumulator()
+                        .chargeNetworkFee(topLevelPayer, fees.nodeFee() + fees.networkFee() + fees.serviceFee());
+            }
+
             final var newRelation = autoAssociate(account, token, accountStore, tokenRelStore, config);
             return asTokenAssociation(newRelation.tokenId(), newRelation.accountId());
         } else {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
@@ -56,6 +56,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.TokenAssociateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.hapi.fees.pricing.AssetsLoader;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
@@ -90,7 +91,7 @@ class TokenAssociateToAccountHandlerTest {
 
     @BeforeEach
     void setUp() {
-        subject = new TokenAssociateToAccountHandler();
+        subject = new TokenAssociateToAccountHandler(new AssetsLoader());
     }
 
     @Nested

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
@@ -42,6 +42,7 @@ import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.TokenFeeScheduleUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.CustomFee;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeContextImpl;
 import com.hedera.node.app.fees.FeeManager;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -56,6 +57,7 @@ import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -64,6 +66,7 @@ import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.platform.test.fixtures.state.MapWritableKVState;
+import com.swirlds.state.HederaState;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -256,8 +259,10 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     public void testCalculateFeesHappyPath() {
+        HederaState state = mock(HederaState.class);
         TransactionInfo txnInfo = mock(TransactionInfo.class);
         FeeManager feeManager = mock(FeeManager.class);
+        ExchangeRateManager exchangeRateManager = mock(ExchangeRateManager.class);
         FeeCalculator feeCalculator = mock(FeeCalculator.class);
         ReadableStoreFactory storeFactory = mock(ReadableStoreFactory.class);
         TransactionBody transactionBody = mock(TransactionBody.class);
@@ -285,6 +290,7 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         when(feeCalculator.calculate()).thenReturn(Fees.FREE);
 
         final var feeContext = new FeeContextImpl(
+                state,
                 consensusInstant,
                 txnInfo,
                 payerKey,
@@ -294,7 +300,9 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
                 configuration,
                 null,
                 -1,
-                transactionDispatcher);
+                transactionDispatcher,
+                exchangeRateManager,
+                TransactionCategory.USER);
 
         final var calculateFees = subject.calculateFees(feeContext);
         assertEquals(calculateFees, Fees.FREE);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
@@ -34,6 +34,7 @@ import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.node.app.service.token.impl.handlers.transfer.AssociateTokenRecipientsStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.spi.fees.FeeAccumulator;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
@@ -55,8 +56,8 @@ public class AssociateTokenRecipientsStepTest extends StepsBase {
     @Mock
     private ExpiryValidator expiryValidator;
 
-    //    @Mock
-    //    private EntitiesConfig entitiesConfig;
+    @Mock
+    private FeeAccumulator feeAccumulator;
 
     private AssociateTokenRecipientsStep subject;
     private CryptoTransferTransactionBody txn;
@@ -97,6 +98,7 @@ public class AssociateTokenRecipientsStepTest extends StepsBase {
                 .withValue("entities.unlimitedAutoAssociationsEnabled", true)
                 .getOrCreateConfig();
         given(handleContext.configuration()).willReturn(modifiedConfiguration);
+        given(handleContext.feeAccumulator()).willReturn(feeAccumulator);
 
         subject.doIn(transferContext);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV2SecurityModelSuite.java
@@ -45,7 +45,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.HapiSuite.FALSE_VALUE;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THOUSAND_HBAR;
@@ -735,12 +734,12 @@ public class AssociatePrecompileV2SecurityModelSuite {
                         // associating ACCOUNT to the token
                         // SIGNER → call → CONTRACT A → call → HTS
                         contractCall(
-                                ASSOCIATE_CONTRACT,
-                                "tokenAssociate",
-                                HapiParserUtil.asHeadlongAddress(
-                                        asAddress(spec.registry().getAccountID(ACCOUNT))),
-                                HapiParserUtil.asHeadlongAddress(
-                                        asAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN))))
+                                        ASSOCIATE_CONTRACT,
+                                        "tokenAssociate",
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getAccountID(ACCOUNT))),
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN))))
                                 .signedBy(SIGNER)
                                 .payingWith(SIGNER)
                                 .hasRetryPrecheckFrom(BUSY)
@@ -753,12 +752,12 @@ public class AssociatePrecompileV2SecurityModelSuite {
                         // SIGNER → call → CONTRACT A → call → HTS
                         tokenUpdate(NON_FUNGIBLE_TOKEN).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
                         contractCall(
-                                ASSOCIATE_CONTRACT,
-                                "tokenAssociate",
-                                HapiParserUtil.asHeadlongAddress(
-                                        asAddress(spec.registry().getAccountID(ACCOUNT))),
-                                HapiParserUtil.asHeadlongAddress(
-                                        asAddress(spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))))
+                                        ASSOCIATE_CONTRACT,
+                                        "tokenAssociate",
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getAccountID(ACCOUNT))),
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))))
                                 .signedBy(SIGNER)
                                 .payingWith(SIGNER)
                                 .hasRetryPrecheckFrom(BUSY)
@@ -766,35 +765,32 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                 .gas(750_000L)
                                 .hasKnownStatus(SUCCESS),
                         contractCall(
-                                ASSOCIATE_CONTRACT,
-                                "tokensAssociate",
-                                HapiParserUtil.asHeadlongAddress(
-                                        asAddress(spec.registry().getAccountID(ACCOUNT))),
-                                new Address[] {
+                                        ASSOCIATE_CONTRACT,
+                                        "tokensAssociate",
                                         HapiParserUtil.asHeadlongAddress(
-                                                asAddress(spec.registry().getTokenID(FROZEN_TOKEN))),
-                                        HapiParserUtil.asHeadlongAddress(
-                                                asAddress(spec.registry().getTokenID(UNFROZEN_TOKEN))),
-                                })
+                                                asAddress(spec.registry().getAccountID(ACCOUNT))),
+                                        new Address[] {
+                                            HapiParserUtil.asHeadlongAddress(
+                                                    asAddress(spec.registry().getTokenID(FROZEN_TOKEN))),
+                                            HapiParserUtil.asHeadlongAddress(
+                                                    asAddress(spec.registry().getTokenID(UNFROZEN_TOKEN))),
+                                        })
                                 .signedBy(SIGNER)
                                 .payingWith(SIGNER)
                                 .hasRetryPrecheckFrom(BUSY)
                                 .via("multipleTokensAssociate")
                                 .gas(1_600_000L)
                                 .hasKnownStatus(SUCCESS))))
-                .then(getAccountInfo(ACCOUNT)
-                        .hasToken(relationshipWith(FUNGIBLE_TOKEN)
-                                .kyc(KycNotApplicable)
-                                .freeze(FreezeNotApplicable))
-                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
-                                .kyc(KycNotApplicable)
-                                .freeze(FreezeNotApplicable)),
-                        validateChargedUsd(
-                                "fungibleTokenAssociate", expectedFeeForOneAssociation),
-                        validateChargedUsd(
-                                "nonFungibleTokenAssociate", expectedFeeForOneAssociation),
-                        validateChargedUsd(
-                                "multipleTokensAssociate", expectedFeeForTwoAssociations));
+                .then(
+                        getAccountInfo(ACCOUNT)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN)
+                                        .kyc(KycNotApplicable)
+                                        .freeze(FreezeNotApplicable))
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
+                                        .kyc(KycNotApplicable)
+                                        .freeze(FreezeNotApplicable)),
+                        validateChargedUsd("fungibleTokenAssociate", expectedFeeForOneAssociation),
+                        validateChargedUsd("nonFungibleTokenAssociate", expectedFeeForOneAssociation),
+                        validateChargedUsd("multipleTokensAssociate", expectedFeeForTwoAssociations));
     }
-
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV2SecurityModelSuite.java
@@ -16,8 +16,10 @@
 
 package com.hedera.services.bdd.suites.contract.precompile;
 
+import static com.hedera.services.bdd.junit.ContextRequirement.PROPERTY_OVERRIDES;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.CONTRACT;
@@ -40,10 +42,14 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.FALSE_VALUE;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THOUSAND_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.TRUE_VALUE;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.getNestedContractAddress;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
@@ -62,6 +68,7 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations.AssociationsTranslator;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
 import com.hederahashgraph.api.proto.java.TokenType;
@@ -675,4 +682,119 @@ public class AssociatePrecompileV2SecurityModelSuite {
                         emptyChildRecordsCheck("associateCallcodeFungibleTxn", CONTRACT_REVERT_EXECUTED),
                         getAccountInfo(ACCOUNT).hasNoTokenRelationship(FUNGIBLE_TOKEN));
     }
+
+    @LeakyHapiTest(PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> associateSingleTokenWithDelegateContractKeyValidateFees() {
+        final double expectedFeeForOneAssociation = 0.0621609828;
+        final double expectedFeeForTwoAssociations = 0.1222927572;
+
+        return propertyPreservingHapiSpec("associateSingleTokenWithDelegateContractKeyValidateFees")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
+                .given(
+                        overriding("entities.unlimitedAutoAssociationsEnabled", TRUE_VALUE),
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                        cryptoCreate(ACCOUNT).balance(10 * ONE_HUNDRED_HBARS),
+                        newKeyNamed(FREEZE_KEY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(TOKEN_TREASURY)
+                                .adminKey(TOKEN_TREASURY),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(TOKEN_TREASURY)
+                                .supplyKey(TOKEN_TREASURY),
+                        tokenCreate(FROZEN_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .initialSupply(TOTAL_SUPPLY)
+                                .freezeKey(FREEZE_KEY)
+                                .freezeDefault(true)
+                                .adminKey(TOKEN_TREASURY)
+                                .supplyKey(TOKEN_TREASURY),
+                        tokenCreate(UNFROZEN_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .freezeKey(FREEZE_KEY)
+                                .freezeDefault(false)
+                                .adminKey(TOKEN_TREASURY)
+                                .supplyKey(TOKEN_TREASURY),
+                        uploadInitCode(ASSOCIATE_CONTRACT, MINT_TOKEN_CONTRACT),
+                        contractCreate(MINT_TOKEN_CONTRACT),
+                        contractCreate(ASSOCIATE_CONTRACT))
+                .when(withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        newKeyNamed(CONTRACT_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, ASSOCIATE_CONTRACT))),
+                        cryptoUpdate(SIGNER).key(CONTRACT_KEY),
+                        tokenUpdate(FUNGIBLE_TOKEN).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
+                        // Test Case 1: Account paying and signing a fungible TOKEN ASSOCIATE TRANSACTION,
+                        // when signer has a threshold key
+                        // associating ACCOUNT to the token
+                        // SIGNER → call → CONTRACT A → call → HTS
+                        contractCall(
+                                ASSOCIATE_CONTRACT,
+                                "tokenAssociate",
+                                HapiParserUtil.asHeadlongAddress(
+                                        asAddress(spec.registry().getAccountID(ACCOUNT))),
+                                HapiParserUtil.asHeadlongAddress(
+                                        asAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN))))
+                                .signedBy(SIGNER)
+                                .payingWith(SIGNER)
+                                .hasRetryPrecheckFrom(BUSY)
+                                .via("fungibleTokenAssociate")
+                                .gas(750_000L)
+                                .hasKnownStatus(SUCCESS),
+                        // Test Case 2: Account paying and signing a non fungible TOKEN ASSOCIATE TRANSACTION,
+                        // when signer has a threshold key
+                        // associating ACCOUNT to the token
+                        // SIGNER → call → CONTRACT A → call → HTS
+                        tokenUpdate(NON_FUNGIBLE_TOKEN).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
+                        contractCall(
+                                ASSOCIATE_CONTRACT,
+                                "tokenAssociate",
+                                HapiParserUtil.asHeadlongAddress(
+                                        asAddress(spec.registry().getAccountID(ACCOUNT))),
+                                HapiParserUtil.asHeadlongAddress(
+                                        asAddress(spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))))
+                                .signedBy(SIGNER)
+                                .payingWith(SIGNER)
+                                .hasRetryPrecheckFrom(BUSY)
+                                .via("nonFungibleTokenAssociate")
+                                .gas(750_000L)
+                                .hasKnownStatus(SUCCESS),
+                        contractCall(
+                                ASSOCIATE_CONTRACT,
+                                "tokensAssociate",
+                                HapiParserUtil.asHeadlongAddress(
+                                        asAddress(spec.registry().getAccountID(ACCOUNT))),
+                                new Address[] {
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(FROZEN_TOKEN))),
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(UNFROZEN_TOKEN))),
+                                })
+                                .signedBy(SIGNER)
+                                .payingWith(SIGNER)
+                                .hasRetryPrecheckFrom(BUSY)
+                                .via("multipleTokensAssociate")
+                                .gas(1_600_000L)
+                                .hasKnownStatus(SUCCESS))))
+                .then(getAccountInfo(ACCOUNT)
+                        .hasToken(relationshipWith(FUNGIBLE_TOKEN)
+                                .kyc(KycNotApplicable)
+                                .freeze(FreezeNotApplicable))
+                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
+                                .kyc(KycNotApplicable)
+                                .freeze(FreezeNotApplicable)),
+                        validateChargedUsd(
+                                "fungibleTokenAssociate", expectedFeeForOneAssociation),
+                        validateChargedUsd(
+                                "nonFungibleTokenAssociate", expectedFeeForOneAssociation),
+                        validateChargedUsd(
+                                "multipleTokensAssociate", expectedFeeForTwoAssociations));
+    }
+
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -18,12 +18,14 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
+import static com.hedera.services.bdd.junit.ContextRequirement.PROPERTY_OVERRIDES;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
 import static com.hedera.services.bdd.spec.HapiPropertySource.accountIdFromHexedMirrorAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairsInAnyOrder;
@@ -89,10 +91,12 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withTargetLedgerId;
@@ -112,13 +116,12 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
 import static com.hedera.services.bdd.suites.HapiSuite.STAKING_REWARD;
 import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
+import static com.hedera.services.bdd.suites.HapiSuite.TRUE_VALUE;
 import static com.hedera.services.bdd.suites.contract.Utils.aaWith;
 import static com.hedera.services.bdd.suites.contract.Utils.accountId;
 import static com.hedera.services.bdd.suites.contract.Utils.captureOneChildCreate2MetaFor;
 import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
 import static com.hedera.services.bdd.suites.contract.Utils.ocWith;
-import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.A_TOKEN;
-import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.PARTY;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
@@ -151,10 +154,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts;
 import com.hedera.services.bdd.spec.keys.SigControl;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
@@ -170,14 +175,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(CRYPTO)
 public class CryptoTransferSuite {
-    private static final Logger LOG = LogManager.getLogger(CryptoTransferSuite.class);
     private static final String OWNER = "owner";
     private static final String OTHER_OWNER = "otherOwner";
     private static final String SPENDER = "spender";
@@ -1553,6 +1555,63 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    final Stream<DynamicTest> autoAssociateTokensHappyPath() {
+        final String tokenA = "tokenA";
+        final String tokenB = "tokenB";
+        final String firstUser = "firstUser";
+        final String secondUser = "secondUser";
+        final String tokenAcreateTxn = "tokenACreate";
+        final String tokenBcreateTxn = "tokenBCreate";
+        final String transferToFU = "transferToFU";
+        final String transferToSU = "transferToSU";
+        return propertyPreservingHapiSpec("autoAssociateTokensHappyPath")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
+                .given(
+                        overriding("entities.unlimitedAutoAssociationsEnabled", TRUE_VALUE),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(firstUser).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(secondUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(10))
+                .when(
+                        tokenCreate(tokenA)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(Long.MAX_VALUE)
+                                .treasury(firstUser)
+                                .via(tokenAcreateTxn),
+                        getTxnRecord(tokenAcreateTxn)
+                                .hasNewTokenAssociation(tokenA, firstUser)
+                                .logged(),
+                        tokenCreate(tokenB)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .supplyKey(MULTI_KEY)
+                                .treasury(firstUser)
+                                .via(tokenBcreateTxn),
+                        getTxnRecord(tokenBcreateTxn)
+                                .hasNewTokenAssociation(tokenB, firstUser)
+                                .logged(),
+                        mintToken(
+                                tokenB,
+                                List.of(ByteString.copyFromUtf8("metadata1"), ByteString.copyFromUtf8("metadata2"))),
+                        // Transfer fungible token
+                        cryptoTransfer(moving(1, tokenA).between(firstUser, secondUser))
+                                .signedBy(firstUser)
+                                .payingWith(firstUser)
+                                .via(transferToFU),
+                        getTxnRecord(transferToFU)
+                                .hasNewTokenAssociation(tokenA, secondUser)
+                                .logged(),
+                        // Transfer NFT
+                        cryptoTransfer(movingUnique(tokenB, 1).between(firstUser, secondUser))
+                                .signedBy(firstUser)
+                                .payingWith(firstUser)
+                                .via(transferToSU),
+                        getTxnRecord(transferToSU)
+                                .hasNewTokenAssociation(tokenB, secondUser)
+                                .logged())
+                .then();
+    }
+
+    @HapiTest
     final Stream<DynamicTest> baseCryptoTransferFeeChargedAsExpected() {
         final var expectedHbarXferPriceUsd = 0.0001;
         final var expectedHtsXferPriceUsd = 0.001;
@@ -2305,28 +2364,36 @@ public class CryptoTransferSuite {
                         .hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE));
     }
 
-    @HapiTest
-    final Stream<DynamicTest> createHollowAccountWithNftTransferAndCompleteIt() {
+    @LeakyHapiTest(PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> createHollowAccountWithFtTransferAndCompleteIt() {
         final var tokenA = "tokenA";
+        final var tokenB = "tokenB";
         final var hollowAccountKey = "hollowAccountKey";
-        final var transferTokenAAndBToHollowAccountTxn = "transferTokenAToHollowAccountTxn";
         final AtomicReference<TokenID> tokenIdA = new AtomicReference<>();
+        final AtomicReference<TokenID> tokenIdB = new AtomicReference<>();
         final AtomicReference<ByteString> treasuryAlias = new AtomicReference<>();
         final AtomicReference<ByteString> hollowAccountAlias = new AtomicReference<>();
+        final var transferTokenAAndBToHollowAccountTxn = "transferTokenAAndBToHollowAccountTxn";
+        final double transferFee = 0.00189;
+        final double expectedFeeForOneAssociation = 0.05;
+        final double expectedCryptoTransferAndAssociationUsd = transferFee + 2 * expectedFeeForOneAssociation;
 
-        return defaultHapiSpec("createHollowAccountWithNftTransferAndCompleteIt")
+        return propertyPreservingHapiSpec("createHollowAccountWithFtTransferAndCompleteIt")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
                 .given(
+                        overriding("entities.unlimitedAutoAssociationsEnabled", TRUE_VALUE),
                         newKeyNamed(hollowAccountKey).shape(SECP_256K1_SHAPE),
-                        newKeyNamed(MULTI_KEY),
                         cryptoCreate(TREASURY).balance(10_000 * ONE_MILLION_HBARS),
+                        // Create FT1
                         tokenCreate(tokenA)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0L)
-                                .supplyKey(MULTI_KEY)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(10L)
                                 .treasury(TREASURY),
-                        // Mint NFTs
-                        mintToken(tokenA, List.of(ByteString.copyFromUtf8("metadata1"))),
-                        mintToken(tokenA, List.of(ByteString.copyFromUtf8("metadata2"))),
+                        // Create FT2
+                        tokenCreate(tokenB)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(10L)
+                                .treasury(TREASURY),
                         withOpContext((spec, opLog) -> {
                             final var registry = spec.registry();
                             final var treasuryAccountId = registry.getAccountID(TREASURY);
@@ -2339,32 +2406,343 @@ public class CryptoTransferSuite {
                                     .toByteArray();
                             final var evmAddressBytes = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
                             hollowAccountAlias.set(evmAddressBytes);
-                            tokenIdA.set(registry.getTokenID(A_TOKEN));
+                            tokenIdA.set(registry.getTokenID(tokenA));
+                            tokenIdB.set(registry.getTokenID(tokenB));
                         }))
                 .when(withOpContext((spec, opLog) -> allRunFor(
                         spec,
-                        // Create hollow account
+                        // create account with maxAutomaticAssociations set to 0
+                        cryptoCreate("testAccount").key(hollowAccountKey).alias(hollowAccountAlias.get()),
+                        // Verify there is no auto association
+                        getAccountInfo("testAccount")
+                                .hasAlreadyUsedAutomaticAssociations(0)
+                                .has(accountWith().key(hollowAccountKey)),
+                        // Delete the hollow account
+                        cryptoDelete("testAccount").hasKnownStatus(SUCCESS),
+                        // Create hollow account with 2 token transfers
                         cryptoTransfer((s, b) -> b.addTokenTransfers(TokenTransferList.newBuilder()
-                                        .setToken(tokenIdA.get())
-                                        .addNftTransfers(ocWith(
-                                                accountId(treasuryAlias.get()),
-                                                accountId(hollowAccountAlias.get()),
-                                                1L))))
+                                                .setToken(tokenIdA.get())
+                                                .addTransfers(aaWith(treasuryAlias.get(), -1))
+                                                .addTransfers(aaWith(hollowAccountAlias.get(), +1)))
+                                        .addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdB.get())
+                                                .addTransfers(aaWith(treasuryAlias.get(), -1))
+                                                .addTransfers(aaWith(hollowAccountAlias.get(), +1))))
                                 .payingWith(TREASURY)
                                 .signedBy(TREASURY)
                                 .via(transferTokenAAndBToHollowAccountTxn),
-                        // Verify hollow account creation
+                        // Verify there is an auto association to FT1 and FT2
                         getAliasedAccountInfo(hollowAccountKey)
                                 .hasToken(relationshipWith(tokenA))
+                                .hasToken(relationshipWith(tokenB))
                                 .has(accountWith().hasEmptyKey())
                                 .exposingIdTo(id -> spec.registry().saveAccountId(hollowAccountKey, id)),
                         // Transfer some hbars to the hollow account so that it could pay the next transaction
                         cryptoTransfer(movingHbar(ONE_MILLION_HBARS).between(TREASURY, hollowAccountKey)),
                         // Send transfer to complete the hollow account
+                        cryptoTransfer(moving(1, tokenA).between(hollowAccountKey, TREASURY))
+                                .payingWith(hollowAccountKey)
+                                .signedBy(hollowAccountKey, TREASURY)
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor(hollowAccountKey)),
+                        // Verify hollow account completion
+                        getAliasedAccountInfo(hollowAccountKey)
+                                .has(accountWith().key(hollowAccountKey))
+                                .hasAlreadyUsedAutomaticAssociations(2))))
+                .then(validateChargedUsd(
+                        transferTokenAAndBToHollowAccountTxn, expectedCryptoTransferAndAssociationUsd));
+    }
+
+    @LeakyHapiTest(PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> createHollowAccountWithNftTransferAndCompleteIt() {
+        final var tokenA = "tokenA";
+        final var tokenB = "tokenB";
+        final var hollowAccountKey = "hollowAccountKey";
+        final var transferTokenAAndBToHollowAccountTxn = "transferTokenAToHollowAccountTxn";
+        final AtomicReference<TokenID> tokenIdA = new AtomicReference<>();
+        final AtomicReference<TokenID> tokenIdB = new AtomicReference<>();
+        final AtomicReference<ByteString> treasuryAlias = new AtomicReference<>();
+        final AtomicReference<ByteString> hollowAccountAlias = new AtomicReference<>();
+        final double transferFee = 0.00189;
+        final double expectedFeeForOneAssociation = 0.05;
+        final double expectedCryptoTransferAndAssociationUsd = transferFee + 2 * expectedFeeForOneAssociation;
+
+        return propertyPreservingHapiSpec("createHollowAccountWithNftTransferAndCompleteIt")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
+                .given(
+                        overriding("entities.unlimitedAutoAssociationsEnabled", TRUE_VALUE),
+                        newKeyNamed(hollowAccountKey).shape(SECP_256K1_SHAPE),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(TREASURY).balance(10_000 * ONE_MILLION_HBARS),
+                        // Create NFT1
+                        tokenCreate(tokenA)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .supplyKey(MULTI_KEY)
+                                .treasury(TREASURY),
+                        // Create NFT2
+                        tokenCreate(tokenB)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .supplyKey(MULTI_KEY)
+                                .treasury(TREASURY),
+                        withOpContext((spec, opLog) -> {
+                            final var registry = spec.registry();
+                            final var treasuryAccountId = registry.getAccountID(TREASURY);
+                            treasuryAlias.set(ByteString.copyFrom(asSolidityAddress(treasuryAccountId)));
+
+                            // Save the alias for the hollow account
+                            final var ecdsaKey = spec.registry()
+                                    .getKey(hollowAccountKey)
+                                    .getECDSASecp256K1()
+                                    .toByteArray();
+                            final var evmAddressBytes = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
+                            hollowAccountAlias.set(evmAddressBytes);
+                            tokenIdA.set(registry.getTokenID(tokenA));
+                            tokenIdB.set(registry.getTokenID(tokenB));
+                        }))
+                .when(withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        // Mint all NFTs
+                        mintToken(tokenA, List.of(ByteString.copyFromUtf8("metadata1"))),
+                        mintToken(tokenA, List.of(ByteString.copyFromUtf8("metadata2"))),
+                        mintToken(tokenB, List.of(ByteString.copyFromUtf8("metadata3"))),
+                        mintToken(tokenB, List.of(ByteString.copyFromUtf8("metadata4"))),
+                        // create account with maxAutomaticAssociations set to 2
+                        cryptoCreate("testAccount")
+                                .key(hollowAccountKey)
+                                .maxAutomaticTokenAssociations(2)
+                                .alias(hollowAccountAlias.get()),
+                        // Verify maxAutomaticAssociations is set to 2 and there is no auto association
+                        getAccountInfo("testAccount")
+                                .hasAlreadyUsedAutomaticAssociations(0)
+                                .has(accountWith().key(hollowAccountKey).maxAutoAssociations(2)),
+                        // Delete the hollow account
+                        cryptoDelete("testAccount").hasKnownStatus(SUCCESS),
+                        // Create hollow account
+                        cryptoTransfer((s, b) -> b.addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdA.get())
+                                                .addNftTransfers(ocWith(
+                                                        accountId(treasuryAlias.get()),
+                                                        accountId(hollowAccountAlias.get()),
+                                                        1L)))
+                                        .addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdB.get())
+                                                .addNftTransfers(ocWith(
+                                                        accountId(treasuryAlias.get()),
+                                                        accountId(hollowAccountAlias.get()),
+                                                        1L))))
+                                .payingWith(TREASURY)
+                                .signedBy(TREASURY)
+                                .via(transferTokenAAndBToHollowAccountTxn),
+                        // Verify there is an auto association to NFT1 and NFT2
+                        // NFT2
+                        getAliasedAccountInfo(hollowAccountKey)
+                                .hasToken(relationshipWith(tokenA))
+                                .hasToken(relationshipWith(tokenB))
+                                .hasAlreadyUsedAutomaticAssociations(2)
+                                .has(accountWith().hasEmptyKey())
+                                .exposingIdTo(id -> spec.registry().saveAccountId(hollowAccountKey, id)),
+                        // Transfer some hbars to the hollow account so that it could pay the next transaction
+                        cryptoTransfer(movingHbar(ONE_MILLION_HBARS).between(TREASURY, hollowAccountKey)),
                         cryptoTransfer(movingUnique(tokenA, 1L).between(hollowAccountKey, TREASURY))
                                 .payingWith(hollowAccountKey)
                                 .signedBy(hollowAccountKey, TREASURY)
-                                .sigMapPrefixes(uniqueWithFullPrefixesFor(hollowAccountKey)))))
-                .then(getAliasedAccountInfo(hollowAccountKey).has(accountWith().key(hollowAccountKey)));
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor(hollowAccountKey)),
+                        // Verify hollow account completion
+                        getAliasedAccountInfo(hollowAccountKey)
+                                .has(accountWith().key(hollowAccountKey))
+                                .hasAlreadyUsedAutomaticAssociations(2))))
+                .then(validateChargedUsd(
+                        transferTokenAAndBToHollowAccountTxn, expectedCryptoTransferAndAssociationUsd));
+    }
+
+    @LeakyHapiTest(PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> createHollowAccountWithMultipleSendersAndCompleteIt() {
+        final var ALICE = "ALICE";
+        final var BOB = "BOB";
+        final var CAROL = "CAROL";
+        final var DAVE = "DAVE";
+        final var transfersToHollowAccountTxn = "transfersToHollowAccountTxn";
+        final AtomicReference<TokenID> tokenIdA = new AtomicReference<>();
+        final AtomicReference<TokenID> tokenIdB = new AtomicReference<>();
+        final AtomicReference<ByteString> aliceAlias = new AtomicReference<>();
+        final AtomicReference<ByteString> bobAlias = new AtomicReference<>();
+        final AtomicReference<ByteString> carolHollowAccountAlias = new AtomicReference<>();
+        final double transferFee = 0.00189;
+        final double expectedFeeForOneAssociation = 0.05;
+        final double expectedCryptoTransferAndAssociationUsd = 2 * transferFee + 2 * expectedFeeForOneAssociation;
+
+        return propertyPreservingHapiSpec("createHollowAccountWithMultipleSendersAndCompleteIt")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
+                .given(
+                        overriding("entities.unlimitedAutoAssociationsEnabled", TRUE_VALUE),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ALICE).balance(10_000 * ONE_MILLION_HBARS),
+                        cryptoCreate(BOB).balance(10_000 * ONE_MILLION_HBARS),
+                        newKeyNamed(CAROL).shape(SECP_256K1_SHAPE),
+                        cryptoCreate(DAVE).maxAutomaticTokenAssociations(1),
+                        cryptoCreate(TREASURY).balance(ONE_MILLION_HBARS),
+                        // Create fungible token
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(5)
+                                .treasury(ALICE),
+                        // Create NFT
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .supplyKey(MULTI_KEY)
+                                .treasury(BOB),
+                        withOpContext((spec, opLog) -> {
+                            final var registry = spec.registry();
+                            aliceAlias.set(ByteString.copyFrom(asSolidityAddress(registry.getAccountID(ALICE))));
+                            bobAlias.set(ByteString.copyFrom(asSolidityAddress(registry.getAccountID(BOB))));
+
+                            // Save the alias for the hollow account
+                            final var ecdsaKey = spec.registry()
+                                    .getKey(CAROL)
+                                    .getECDSASecp256K1()
+                                    .toByteArray();
+                            final var evmAddressBytes = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
+                            carolHollowAccountAlias.set(evmAddressBytes);
+                            tokenIdA.set(registry.getTokenID(FUNGIBLE_TOKEN));
+                            tokenIdB.set(registry.getTokenID(NON_FUNGIBLE_TOKEN));
+                        }))
+                .when(withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        // Mint the NFT
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("metadata1"))),
+                        // Transfer both tokens to hollow account with different senders.
+                        cryptoTransfer((s, b) -> b.addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdA.get())
+                                                .addTransfers(aaWith(aliceAlias.get(), -1))
+                                                .addTransfers(aaWith(carolHollowAccountAlias.get(), +1)))
+                                        .addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdB.get())
+                                                .addNftTransfers(ocWith(
+                                                        accountId(bobAlias.get()),
+                                                        accountId(carolHollowAccountAlias.get()),
+                                                        1L))))
+                                .payingWith(ALICE)
+                                .signedBy(ALICE, BOB)
+                                .via(transfersToHollowAccountTxn),
+                        // Verify the auto associations to the fungible token and the NFT in the hollow account
+                        getAliasedAccountInfo(CAROL)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN))
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN))
+                                .has(accountWith().hasEmptyKey())
+                                .exposingIdTo(id -> spec.registry().saveAccountId(CAROL, id)),
+                        // Transfer some hbars to the hollow account so that it could pay the next transaction
+                        cryptoTransfer(movingHbar(ONE_MILLION_HBARS).between(BOB, CAROL)),
+                        // Send transfer to complete the hollow account
+                        cryptoTransfer(moving(1, FUNGIBLE_TOKEN).between(CAROL, DAVE))
+                                .payingWith(CAROL)
+                                .signedBy(CAROL, DAVE)
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor(CAROL)),
+                        // Verify Dave received the transfer
+                        getAccountInfo(DAVE).hasToken(relationshipWith(FUNGIBLE_TOKEN)),
+                        // Verify the hollow account is completed
+                        getAliasedAccountInfo(CAROL).has(accountWith().key(CAROL)))))
+                .then(validateChargedUsd(transfersToHollowAccountTxn, expectedCryptoTransferAndAssociationUsd));
+    }
+
+    @LeakyHapiTest(PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> createHollowAccountWithMultipleReceiversAndCompleteIt() {
+        final var ALICE = "ALICE";
+        final var BOB = "BOB";
+        final var CAROL = "CAROL";
+        final var DAVE = "DAVE";
+        final var transferTokensToHollowAccountsTxn = "transferTokensToHollowAccountsTxn";
+        final AtomicReference<TokenID> tokenIdA = new AtomicReference<>();
+        final AtomicReference<TokenID> tokenIdB = new AtomicReference<>();
+        final AtomicReference<ByteString> aliceAlias = new AtomicReference<>();
+        final AtomicReference<ByteString> bobHollowAccountAlias = new AtomicReference<>();
+        final AtomicReference<ByteString> carolHollowAccountAlias = new AtomicReference<>();
+        final double transferFee = 0.00189;
+        final double expectedFeeForOneAssociation = 0.05;
+        final double expectedCryptoTransferAndAssociationUsd = 2 * transferFee + 2 * expectedFeeForOneAssociation;
+
+        return propertyPreservingHapiSpec("createHollowAccountWithMultipleReceiversAndCompleteIt")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
+                .given(
+                        overriding("entities.unlimitedAutoAssociationsEnabled", TRUE_VALUE),
+                        cryptoCreate(ALICE).balance(1_000 * ONE_MILLION_HBARS),
+                        newKeyNamed(BOB).shape(SECP_256K1_SHAPE),
+                        newKeyNamed(CAROL).shape(SECP_256K1_SHAPE),
+                        cryptoCreate(DAVE).balance(1_000 * ONE_MILLION_HBARS).maxAutomaticTokenAssociations(1),
+                        // Create FT
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(10L)
+                                .treasury(ALICE),
+                        // Create NFT
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .supplyKey(ALICE)
+                                .treasury(ALICE),
+                        withOpContext((spec, opLog) -> {
+                            final var registry = spec.registry();
+                            aliceAlias.set(ByteString.copyFrom(asSolidityAddress(registry.getAccountID(ALICE))));
+
+                            // Save the alias for the hollow account
+                            final var ecdsaKeyBob = spec.registry()
+                                    .getKey(BOB)
+                                    .getECDSASecp256K1()
+                                    .toByteArray();
+                            final var evmAddressBytesBob = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKeyBob));
+                            bobHollowAccountAlias.set(evmAddressBytesBob);
+
+                            // Save the alias for the hollow account
+                            final var ecdsaKeyCarol = spec.registry()
+                                    .getKey(CAROL)
+                                    .getECDSASecp256K1()
+                                    .toByteArray();
+                            final var evmAddressBytesCarol =
+                                    ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKeyCarol));
+                            carolHollowAccountAlias.set(evmAddressBytesCarol);
+                            tokenIdA.set(spec.registry().getTokenID(FUNGIBLE_TOKEN));
+                            tokenIdB.set(spec.registry().getTokenID(NON_FUNGIBLE_TOKEN));
+                        }))
+                .when(withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        // Mint the NFT
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(ByteString.copyFromUtf8("metadata1"))),
+                        // Create the hollow accounts
+                        cryptoTransfer((s, b) -> b.addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdA.get())
+                                                .addTransfers(aaWith(aliceAlias.get(), -1))
+                                                .addTransfers(aaWith(bobHollowAccountAlias.get(), +1)))
+                                        .addTokenTransfers(TokenTransferList.newBuilder()
+                                                .setToken(tokenIdB.get())
+                                                .addNftTransfers(ocWith(
+                                                        accountId(aliceAlias.get()),
+                                                        accountId(carolHollowAccountAlias.get()),
+                                                        1L))))
+                                .payingWith(ALICE)
+                                .signedBy(ALICE)
+                                .via(transferTokensToHollowAccountsTxn),
+                        // Verify there is an auto association to FT
+                        getAliasedAccountInfo(BOB)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN))
+                                .has(accountWith().hasEmptyKey()),
+                        // Verify there is an auto association to NFT
+                        getAliasedAccountInfo(CAROL)
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN))
+                                .has(accountWith().hasEmptyKey())
+                                .exposingIdTo(id -> spec.registry().saveAccountId(CAROL, id)),
+                        // Transfer some hbars to the hollow account so that it could pay the next transaction
+                        cryptoTransfer(movingHbar(ONE_MILLION_HBARS).between(ALICE, CAROL)),
+                        // Send transfer to complete the hollow account
+                        cryptoTransfer(TokenMovement.movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                        .between(CAROL, DAVE))
+                                .payingWith(CAROL)
+                                .signedBy(CAROL)
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor(CAROL)),
+                        // Verify Dave received the transfer
+                        getAccountInfo(DAVE).hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)),
+                        // Verify the hollow account is completed
+                        getAliasedAccountInfo(CAROL).has(accountWith().key(CAROL)))))
+                .then(validateChargedUsd(transferTokensToHollowAccountsTxn, expectedCryptoTransferAndAssociationUsd));
     }
 }


### PR DESCRIPTION
**Description**:
This pr is a clone of https://github.com/hashgraph/hedera-services/pull/13853.
This pr aims to be opened against develop without needing all the logic from https://github.com/hashgraph/hedera-services/pull/13687 only needing the feature flag.

As we only want this pr to contain the crypto transfer fee calculations and be independent from the other changes in https://github.com/hashgraph/hedera-services/pull/13687. This makes it easier for review. This pr will have duplicated logic from 13687 only the logic that adds the maxAutoAssocation feature flag.

This PR adds the needed changes in the calculations needed for HIP-904. Now the sender of a crypto transfer is charged for the auto association slots if the unlimitedAutoAssociations flag is enabled.

This PR modifies 
`FeeContext` - adds needed classes for TokenAssociateToAccountHandler.calculateFees()
`AssociateTokenRecipientsStep` add fee logic based on the maxAutoAssociations flag.

**Related issue(s)**:

Fixes #13375

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
