### PR TITLE
chore: Upgrade settings to 0.52

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -157,7 +157,7 @@ fun includeAllProjects(containingFolder: String) {
 }
 
 // The HAPI API version to use for Protobuf sources.
-val hapiProtoVersion = "0.51.0"
+val hapiProtoVersion = "0.52.0"
 
 
 dependencyResolutionManagement {


### PR DESCRIPTION
**Description**:

- Fix failing Prepare Release [Tag] CI Job : We still require the tag version to match the hapiProtoVersion specified 
- Run TAG_MAJOR="$(semver get major "v0.52.0-alpha.0")"

**Related issue(s)**:

Fixes #13935 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
