### PR TITLE
build: split publish of 'platform' and 'services' / do not publish blocknode 

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -833,15 +833,25 @@ jobs:
             gpg --output "${PUBLIC_ARCHIVE_FILE}.sha256.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}.sha256"
           echo "::endgroup::"
 
-      - name: Gradle Publish to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
+      - name: Gradle Publish Platform to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
         uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3.1.0
         if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
-          OSSRH_USERNAME: ${{ secrets.sdk-ossrh-username }}
-          OSSRH_PASSWORD: ${{ secrets.sdk-ossrh-password }}
+          NEXUS_USERNAME: ${{ secrets.sdk-ossrh-username }}
+          NEXUS_PASSWORD: ${{ secrets.sdk-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: "release${{ inputs.release-profile }} --scan -PpublishSigningEnabled=true --no-configuration-cache"
+          arguments: ":release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds --scan -PpublishSigningEnabled=true --no-configuration-cache"
+
+      - name: Gradle Publish Services to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
+        uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3.1.0
+        if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
+        env:
+          NEXUS_USERNAME: ${{ secrets.svcs-ossrh-username }}
+          NEXUS_PASSWORD: ${{ secrets.svcs-ossrh-password }}
+        with:
+          gradle-version: ${{ inputs.gradle-version }}
+          arguments: ":release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera --scan -PpublishSigningEnabled=true --no-configuration-cache"
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/block-node/blocknode-core-spi/build.gradle.kts
+++ b/block-node/blocknode-core-spi/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/block-node/blocknode-core/build.gradle.kts
+++ b/block-node/blocknode-core/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/block-node/blocknode-filesystem-api/build.gradle.kts
+++ b/block-node/blocknode-filesystem-api/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/block-node/blocknode-filesystem-local/build.gradle.kts
+++ b/block-node/blocknode-filesystem-local/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/block-node/blocknode-filesystem-s3/build.gradle.kts
+++ b/block-node/blocknode-filesystem-s3/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/block-node/blocknode-grpc-api/build.gradle.kts
+++ b/block-node/blocknode-grpc-api/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/block-node/blocknode-state/build.gradle.kts
+++ b/block-node/blocknode-state/build.gradle.kts
@@ -16,5 +16,5 @@
 
 plugins {
     id("com.hedera.gradle.blocknode")
-    id("com.hedera.gradle.blocknode-publish")
+    // id("com.hedera.gradle.blocknode-publish")
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
@@ -19,19 +19,38 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin")
 }
 
+val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+val isPlatformPublish = publishingPackageGroup == "com.swirlds"
+
 nexusPublishing {
+    packageGroup = publishingPackageGroup
     repositories {
         sonatype {
-            username = System.getenv("OSSRH_USERNAME")
-            password = System.getenv("OSSRH_PASSWORD")
+            username = System.getenv("NEXUS_USERNAME")
+            password = System.getenv("NEXUS_PASSWORD")
+            if (isPlatformPublish) {
+                nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+                snapshotRepositoryUrl =
+                    uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            }
         }
     }
 }
 
+// 'platform' and 'services' need to be published separately as they use different credentials
+val platformPublishTasks =
+    subprojects.filter { it.name.startsWith("swirlds") }.map { ":${it.name}:releaseMavenCentral" }
+val servicesPublishTasks =
+    subprojects.filter { !it.name.startsWith("swirlds") }.map { ":${it.name}:releaseMavenCentral" }
+
 tasks.named("closeSonatypeStagingRepository") {
-    // The publishing of all components to Maven Central is automatically done before close (which
-    // is done before release).
-    dependsOn(subprojects.map { ":${it.name}:releaseMavenCentral" })
+    // The publishing of all components to Maven Central is automatically done before close
+    // (which is done before release).
+    if (isPlatformPublish) {
+        dependsOn(platformPublishTasks)
+    } else {
+        dependsOn(servicesPublishTasks)
+    }
 }
 
 tasks.named("releaseMavenCentral") {
@@ -41,5 +60,9 @@ tasks.named("releaseMavenCentral") {
 
 tasks.register("releaseMavenCentralSnapshot") {
     group = "release"
-    dependsOn(subprojects.map { ":${it.name}:releaseMavenCentral" })
+    if (isPlatformPublish) {
+        dependsOn(platformPublishTasks)
+    } else {
+        dependsOn(servicesPublishTasks)
+    }
 }


### PR DESCRIPTION
**Description**:

Pulls changes from `release/0.51` into `develop` to update the publishing steps to maven central such that they use the new credentials for both `SVCS_OSSRH` and `PLATFORM_OSSRH`.

