### PR TITLE
feat: HIP-904: Add `TokenCancelAirdrop` transaction verb for `test-clients`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/GrpcUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/GrpcUtils.java
@@ -186,6 +186,8 @@ public class GrpcUtils {
             case TokenUpdateNfts -> clients.getTokenSvcStub(nodeAccountId, false)
                     .updateNfts(transaction);
             case TokenAirdrop -> clients.getTokenSvcStub(nodeAccountId, false).airdropTokens(transaction);
+            case TokenCancelAirdrop -> clients.getTokenSvcStub(nodeAccountId, false)
+                    .cancelAirdrop(transaction);
             default -> throw new IllegalArgumentException(functionality + " is not a transaction");
         };
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnFactory.java
@@ -57,6 +57,7 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenAirdropTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenAssociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenBurnTransactionBody;
+import com.hederahashgraph.api.proto.java.TokenCancelAirdropTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenDeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenDissociateTransactionBody;
@@ -402,6 +403,10 @@ public class TxnFactory {
     }
 
     public Consumer<TokenAirdropTransactionBody.Builder> defaultDefTokenAirdropTransactionBody() {
+        return builder -> {};
+    }
+
+    public Consumer<TokenCancelAirdropTransactionBody.Builder> defaultDefTokenCancelAirdropTransactionBody() {
         return builder -> {};
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -77,6 +77,7 @@ import com.hedera.services.bdd.spec.transactions.system.HapiSysUndelete;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenAirdrop;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenAssociate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenBurn;
+import com.hedera.services.bdd.spec.transactions.token.HapiTokenCancelAirdrop;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenDelete;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenDissociate;
@@ -97,6 +98,7 @@ import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.EthereumTransactionBody;
+import com.hederahashgraph.api.proto.java.PendingAirdropId;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TopicID;
@@ -164,6 +166,12 @@ public class TxnVerbs {
 
     public static HapiTokenAirdrop tokenAirdrop(TokenMovement... sources) {
         return new HapiTokenAirdrop(sources);
+    }
+
+    @SafeVarargs
+    public static HapiTokenCancelAirdrop tokenCancelAirdrop(
+            final Function<HapiSpec, PendingAirdropId>... pendingAirdropIds) {
+        return new HapiTokenCancelAirdrop(pendingAirdropIds);
     }
 
     public static HapiCryptoUpdate cryptoUpdate(String account) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCancelAirdrop.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCancelAirdrop.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.transactions.token;
+
+import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
+
+import com.hedera.node.app.hapi.fees.usage.TxnUsageEstimator;
+import com.hedera.node.app.hapi.fees.usage.token.TokenDissociateUsage;
+import com.hedera.node.app.hapi.utils.fee.SigValueObj;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.NftID;
+import com.hederahashgraph.api.proto.java.PendingAirdropId;
+import com.hederahashgraph.api.proto.java.TokenCancelAirdropTransactionBody;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
+
+    private final List<Function<HapiSpec, PendingAirdropId>> pendingAirdropIds;
+
+    @SafeVarargs
+    public HapiTokenCancelAirdrop(Function<HapiSpec, PendingAirdropId>... pendingAirdropIds) {
+        this.pendingAirdropIds = List.of(pendingAirdropIds);
+    }
+
+    @Override
+    protected HapiTokenCancelAirdrop self() {
+        return null;
+    }
+
+    @Override
+    public HederaFunctionality type() {
+        return HederaFunctionality.TokenCancelAirdrop;
+    }
+
+    @Override
+    protected Consumer<TransactionBody.Builder> opBodyDef(HapiSpec spec) throws Throwable {
+        final var pendingAirdrops =
+                pendingAirdropIds.stream().map(f -> f.apply(spec)).toList();
+        final TokenCancelAirdropTransactionBody opBody = spec.txns()
+                .<TokenCancelAirdropTransactionBody, TokenCancelAirdropTransactionBody.Builder>body(
+                        TokenCancelAirdropTransactionBody.class, b -> b.addAllPendingAirdrops(pendingAirdrops));
+        return builder -> builder.setTokenCancelAirdrop(opBody);
+    }
+
+    public static Function<HapiSpec, PendingAirdropId> cancelPendingAirdrop(
+            final String sender, final String receiver, final String token) {
+        return spec -> {
+            final var tokenID = TxnUtils.asTokenId(token, spec);
+            final var senderID = TxnUtils.asId(sender, spec);
+            final var receiverID = TxnUtils.asId(receiver, spec);
+            return PendingAirdropId.newBuilder()
+                    .setFungibleTokenType(tokenID)
+                    .setSenderId(senderID)
+                    .setReceiverId(receiverID)
+                    .build();
+        };
+    }
+
+    public static Function<HapiSpec, PendingAirdropId> cancelPendingNFTAirdrop(
+            final String sender, final String receiver, final String token, final long serialNum) {
+        return spec -> {
+            final var tokenID = TxnUtils.asTokenId(token, spec);
+            final var senderID = TxnUtils.asId(sender, spec);
+            final var receiverID = TxnUtils.asId(receiver, spec);
+            return PendingAirdropId.newBuilder()
+                    .setNonFungibleToken(NftID.newBuilder()
+                            .setTokenID(tokenID)
+                            .setSerialNumber(serialNum)
+                            .build())
+                    .setSenderId(senderID)
+                    .setReceiverId(receiverID)
+                    .build();
+        };
+    }
+
+    @Override
+    protected long feeFor(HapiSpec spec, Transaction txn, int numPayerKeys) throws Throwable {
+        return spec.fees()
+                .forActivityBasedOp(HederaFunctionality.TokenCancelAirdrop, this::usageEstimate, txn, numPayerKeys);
+    }
+
+    private FeeData usageEstimate(final TransactionBody txn, final SigValueObj svo) {
+        return TokenDissociateUsage.newEstimate(txn, new TxnUsageEstimator(suFrom(svo), txn, ESTIMATOR_UTILS))
+                .get();
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCancelAirdrop.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCancelAirdrop.java
@@ -28,6 +28,7 @@ import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.NftID;
 import com.hederahashgraph.api.proto.java.PendingAirdropId;
 import com.hederahashgraph.api.proto.java.TokenCancelAirdropTransactionBody;
@@ -36,6 +37,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
 
@@ -95,6 +97,19 @@ public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
                     .setReceiverId(receiverID)
                     .build();
         };
+    }
+
+    @Override
+    protected List<Function<HapiSpec, Key>> defaultSigners() {
+        return Stream.concat(
+                        Stream.of(spec -> spec.registry().getKey(effectivePayer(spec))),
+                        pendingAirdropIds.stream()
+                                .map(pendingAirdropId -> (Function<HapiSpec, Key>) spec -> spec.registry()
+                                        .getKey(spec.registry()
+                                                .getAccountIdName(pendingAirdropId
+                                                        .apply(spec)
+                                                        .getSenderId()))))
+                .toList();
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCancelAirdrop.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCancelAirdrop.java
@@ -19,6 +19,7 @@ package com.hedera.services.bdd.spec.transactions.token;
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.hedera.node.app.hapi.fees.usage.TxnUsageEstimator;
 import com.hedera.node.app.hapi.fees.usage.token.TokenDissociateUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
@@ -41,13 +42,13 @@ public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
     private final List<Function<HapiSpec, PendingAirdropId>> pendingAirdropIds;
 
     @SafeVarargs
-    public HapiTokenCancelAirdrop(Function<HapiSpec, PendingAirdropId>... pendingAirdropIds) {
+    public HapiTokenCancelAirdrop(final Function<HapiSpec, PendingAirdropId>... pendingAirdropIds) {
         this.pendingAirdropIds = List.of(pendingAirdropIds);
     }
 
     @Override
     protected HapiTokenCancelAirdrop self() {
-        return null;
+        return this;
     }
 
     @Override
@@ -65,7 +66,7 @@ public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
         return builder -> builder.setTokenCancelAirdrop(opBody);
     }
 
-    public static Function<HapiSpec, PendingAirdropId> cancelPendingAirdrop(
+    public static Function<HapiSpec, PendingAirdropId> pendingAirdrop(
             final String sender, final String receiver, final String token) {
         return spec -> {
             final var tokenID = TxnUtils.asTokenId(token, spec);
@@ -79,7 +80,7 @@ public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
         };
     }
 
-    public static Function<HapiSpec, PendingAirdropId> cancelPendingNFTAirdrop(
+    public static Function<HapiSpec, PendingAirdropId> pendingNFTAirdrop(
             final String sender, final String receiver, final String token, final long serialNum) {
         return spec -> {
             final var tokenID = TxnUtils.asTokenId(token, spec);
@@ -100,6 +101,11 @@ public class HapiTokenCancelAirdrop extends HapiTxnOp<HapiTokenCancelAirdrop> {
     protected long feeFor(HapiSpec spec, Transaction txn, int numPayerKeys) throws Throwable {
         return spec.fees()
                 .forActivityBasedOp(HederaFunctionality.TokenCancelAirdrop, this::usageEstimate, txn, numPayerKeys);
+    }
+
+    @Override
+    protected ToStringHelper toStringHelper() {
+        return super.toStringHelper().add("pendingAirdropIds", pendingAirdropIds);
     }
 
     private FeeData usageEstimate(final TransactionBody txn, final SigValueObj svo) {


### PR DESCRIPTION
**Description**:

Added `HapiTokenCancelAirdrop` operation and exposed it to `TxnVerbs`

**Related issue(s)**:

Fixes #13949 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
