### PR TITLE
chore: Remove `allowAutoAssociations` feature flag

### DIFF
--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -63,7 +63,6 @@ balances.exportTokenBalances=true
 balances.nodeBalanceWarningThreshold=0
 balances.compressOnCreation=true
 cache.records.ttl=180
-contracts.allowAutoAssociations=false
 contracts.allowSystemUseOfHapiSigs=TokenAssociateToAccount,TokenDissociateFromAccount,TokenFreezeAccount,TokenUnfreezeAccount,TokenGrantKycToAccount,TokenRevokeKycFromAccount,TokenAccountWipe,TokenBurn,TokenDelete,TokenMint,TokenUnpause,TokenPause,TokenCreate,TokenUpdate,ContractCall,CryptoTransfer
 contracts.maxNumWithHapiSigsAccess=0
 contracts.withSpecialHapiSigsAccess=

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -36,7 +36,6 @@ public record ContractsConfig(
         @ConfigProperty(value = "localCall.estRetBytes", defaultValue = "4096") @NetworkProperty
                 int localCallEstRetBytes,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean allowCreate2,
-        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean allowAutoAssociations,
         @ConfigProperty(defaultValue = "0") @NetworkProperty long maxNumWithHapiSigsAccess,
         @ConfigProperty(value = "nonces.externalization.enabled", defaultValue = "true") @NetworkProperty
                 boolean noncesExternalizationEnabled,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -24,7 +24,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOU
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_MAX_AUTO_ASSOCIATIONS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hedera.hapi.util.HapiUtils.EMPTY_KEY_LIST;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
@@ -58,7 +57,6 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.StakingConfig;
@@ -175,7 +173,6 @@ public class ContractUpdateHandler implements TransactionHandler {
             final var ledgerConfig = context.configuration().getConfigData(LedgerConfig.class);
             final var entitiesConfig = context.configuration().getConfigData(EntitiesConfig.class);
             final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
-            final var contractsConfig = context.configuration().getConfigData(ContractsConfig.class);
 
             final long newMaxAssociations = op.maxAutomaticTokenAssociationsOrThrow();
 
@@ -191,8 +188,6 @@ public class ContractUpdateHandler implements TransactionHandler {
                 validateFalse(
                         entitiesConfig.limitTokenAssociations() && newMaxAssociations > tokensConfig.maxPerAccount(),
                         REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT);
-
-                validateTrue(contractsConfig.allowAutoAssociations(), NOT_SUPPORTED);
             }
         }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
@@ -30,7 +30,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_MAX_AUTO_ASSOCI
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NEGATIVE_ALLOWANCE_AMOUNT;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SERIALIZATION_FAILED;
@@ -324,11 +323,8 @@ public class HevmTransactionFactory {
         validateTrue(body.gas() >= 0, CONTRACT_NEGATIVE_GAS);
         validateTrue(body.initialBalance() >= 0, CONTRACT_NEGATIVE_VALUE);
         validateTrue(body.gas() <= contractsConfig.maxGasPerSec(), MAX_GAS_LIMIT_EXCEEDED);
-        final var usesUnsupportedAutoAssociations =
-                body.maxAutomaticTokenAssociations() > 0 && !contractsConfig.allowAutoAssociations();
         final var usesInvalidAutoAssociations = body.maxAutomaticTokenAssociations() < UNLIMITED_AUTOMATIC_ASSOCIATIONS
                 && entitiesConfig.unlimitedAutoAssociationsEnabled();
-        validateFalse(usesUnsupportedAutoAssociations, NOT_SUPPORTED);
         validateFalse(usesInvalidAutoAssociations, INVALID_MAX_AUTO_ASSOCIATIONS);
         validateTrue(
                 body.maxAutomaticTokenAssociations() <= ledgerConfig.maxAutoAssociations(),

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
@@ -142,9 +142,6 @@ public class TestHelpers {
     public static final HederaConfig DEFAULT_HEDERA_CONFIG = DEFAULT_CONFIG.getConfigData(HederaConfig.class);
     public static final ContractsConfig DEFAULT_CONTRACTS_CONFIG = DEFAULT_CONFIG.getConfigData(ContractsConfig.class);
     public static final EntitiesConfig DEFAULT_ENTITIES_CONFIG = DEFAULT_CONFIG.getConfigData(EntitiesConfig.class);
-    public static final Configuration AUTO_ASSOCIATING_CONFIG = HederaTestConfigBuilder.create()
-            .withValue("contracts.allowAutoAssociations", true)
-            .getOrCreateConfig();
 
     public static final Configuration PERMITTED_CALLERS_CONFIG = HederaTestConfigBuilder.create()
             .withValue("contracts.permittedContractCallers", Set.of(1062787L))
@@ -154,10 +151,6 @@ public class TestHelpers {
     public static final Configuration V2_TRANSFER_DISABLED_CONFIG = HederaTestConfigBuilder.create()
             .withValue("contracts.precompile.atomicCryptoTransfer.enabled", "false")
             .getOrCreateConfig();
-    public static final LedgerConfig AUTO_ASSOCIATING_LEDGER_CONFIG =
-            AUTO_ASSOCIATING_CONFIG.getConfigData(LedgerConfig.class);
-    public static final ContractsConfig AUTO_ASSOCIATING_CONTRACTS_CONFIG =
-            AUTO_ASSOCIATING_CONFIG.getConfigData(ContractsConfig.class);
     public static final ContractsConfig DEV_CHAIN_ID_CONTRACTS_CONFIG =
             DEV_CHAIN_ID_CONFIG.getConfigData(ContractsConfig.class);
     public static final int HEDERA_MAX_REFUND_PERCENTAGE = 20;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/infra/HevmTransactionFactoryTest.java
@@ -34,15 +34,12 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NEGATIVE_ALLOWANCE_AMOUNT;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SERIALIZATION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.WRONG_CHAIN_ID;
 import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_IN_A_TINYBAR;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.AN_ED25519_KEY;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.AUTO_ASSOCIATING_CONTRACTS_CONFIG;
-import static com.hedera.node.app.service.contract.impl.test.TestHelpers.AUTO_ASSOCIATING_LEDGER_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.A_DELETED_CONTRACT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALL_DATA;
@@ -321,18 +318,11 @@ class HevmTransactionFactoryTest {
     }
 
     @Test
-    void fromHapiCreationDoesNotPermitUnsupportedAutoAssociations() {
-        assertCreateFailsWith(NOT_SUPPORTED, b -> b.gas(DEFAULT_CONTRACTS_CONFIG.maxGasPerSec())
-                .maxAutomaticTokenAssociations(1)
-                .autoRenewPeriod(SOME_DURATION));
-    }
-
-    @Test
     void fromHapiCreationDoesNotPermitExcessAutoAssociations() {
         givenInsteadAutoAssociatingSubject();
         assertCreateFailsWith(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT, b -> b.gas(
                         DEFAULT_CONTRACTS_CONFIG.maxGasPerSec())
-                .maxAutomaticTokenAssociations(AUTO_ASSOCIATING_LEDGER_CONFIG.maxAutoAssociations() + 1)
+                .maxAutomaticTokenAssociations(DEFAULT_LEDGER_CONFIG.maxAutoAssociations() + 1)
                 .autoRenewPeriod(SOME_DURATION));
     }
 
@@ -717,12 +707,12 @@ class HevmTransactionFactoryTest {
     private void givenInsteadAutoAssociatingSubject() {
         subject = new HevmTransactionFactory(
                 networkInfo,
-                AUTO_ASSOCIATING_LEDGER_CONFIG,
+                DEFAULT_LEDGER_CONFIG,
                 DEFAULT_HEDERA_CONFIG,
                 featureFlags,
                 gasCalculator,
                 DEFAULT_STAKING_CONFIG,
-                AUTO_ASSOCIATING_CONTRACTS_CONFIG,
+                DEFAULT_CONTRACTS_CONFIG,
                 DEFAULT_ENTITIES_CONFIG,
                 null,
                 accountStore,
@@ -737,12 +727,12 @@ class HevmTransactionFactoryTest {
     private void givenInsteadFailedHydrationSubject() {
         subject = new HevmTransactionFactory(
                 networkInfo,
-                AUTO_ASSOCIATING_LEDGER_CONFIG,
+                DEFAULT_LEDGER_CONFIG,
                 DEFAULT_HEDERA_CONFIG,
                 featureFlags,
                 gasCalculator,
                 DEFAULT_STAKING_CONFIG,
-                AUTO_ASSOCIATING_CONTRACTS_CONFIG,
+                DEFAULT_CONTRACTS_CONFIG,
                 DEFAULT_ENTITIES_CONFIG,
                 HydratedEthTxData.failureFrom(CONTRACT_FILE_EMPTY),
                 accountStore,
@@ -757,7 +747,7 @@ class HevmTransactionFactoryTest {
     private void givenInsteadHydratedEthTxWithWrongChainId(@NonNull final EthTxData ethTxData) {
         subject = new HevmTransactionFactory(
                 networkInfo,
-                AUTO_ASSOCIATING_LEDGER_CONFIG,
+                DEFAULT_LEDGER_CONFIG,
                 DEFAULT_HEDERA_CONFIG,
                 featureFlags,
                 gasCalculator,
@@ -777,7 +767,7 @@ class HevmTransactionFactoryTest {
     private void givenInsteadHydratedEthTxWithRightChainId(@NonNull final EthTxData ethTxData) {
         subject = new HevmTransactionFactory(
                 networkInfo,
-                AUTO_ASSOCIATING_LEDGER_CONFIG,
+                DEFAULT_LEDGER_CONFIG,
                 DEFAULT_HEDERA_CONFIG,
                 featureFlags,
                 gasCalculator,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -2757,20 +2757,6 @@ public class ContractCallSuite {
     }
 
     @HapiTest
-    final Stream<DynamicTest> rejectsCreationAndUpdateOfAssociationsWhenFlagDisabled() {
-        return hapiTest(
-                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
-                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
-                        .maxAutomaticTokenAssociations(5)
-                        .hasPrecheck(NOT_SUPPORTED),
-                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT).maxAutomaticTokenAssociations(0),
-                contractUpdate(EMPTY_CONSTRUCTOR_CONTRACT)
-                        .newMaxAutomaticAssociations(5)
-                        .hasPrecheck(NOT_SUPPORTED),
-                contractUpdate(EMPTY_CONSTRUCTOR_CONTRACT).newMemo("Hola!"));
-    }
-
-    @HapiTest
     final Stream<DynamicTest> lazyCreateInConstructor() {
         final var depositAmount = 1000;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -50,7 +50,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCallWit
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCustomCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractDelete;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoApproveAllowance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
@@ -103,7 +102,6 @@ import static com.hedera.services.bdd.suites.contract.Utils.asToken;
 import static com.hedera.services.bdd.suites.contract.Utils.captureChildCreate2MetaFor;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIForContract;
-import static com.hedera.services.bdd.suites.contract.hapi.ContractCreateSuite.EMPTY_CONSTRUCTOR_CONTRACT;
 import static com.hedera.services.bdd.suites.contract.opcodes.Create2OperationSuite.SALT;
 import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.ECDSA_KEY;
 import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.LAZY_MEMO;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -66,7 +66,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getEcdsaPrivateKeyF
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
@@ -80,7 +79,6 @@ import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NON
 import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NONDETERMINISTIC_TRANSACTION_FEES;
 import static com.hedera.services.bdd.suites.HapiSuite.CHAIN_ID;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
-import static com.hedera.services.bdd.suites.HapiSuite.FALSE_VALUE;
 import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
@@ -107,7 +105,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_OVERSIZE;
@@ -341,13 +338,13 @@ public class ContractCreateSuite {
         final var multiPurpose = "Multipurpose";
         final var createContract = "CreateTrivial";
         return propertyPreservingHapiSpec("contractCreationsHaveValidAssociations")
-                .preserving(
-                        ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED,
-                        LEDGER_MAX_AUTO_ASSOCIATIONS)
+                .preserving(ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED, LEDGER_MAX_AUTO_ASSOCIATIONS)
                 .given(
                         overridingTwo(
-                                ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED, TRUE_VALUE,
-                                LEDGER_MAX_AUTO_ASSOCIATIONS, "5000"),
+                                ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED,
+                                TRUE_VALUE,
+                                LEDGER_MAX_AUTO_ASSOCIATIONS,
+                                "5000"),
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
@@ -821,9 +818,7 @@ public class ContractCreateSuite {
         final var contract1 = "EmptyOne";
         final var contract2 = "EmptyTwo";
         return defaultHapiSpec("contractCreateShouldChargeTheSame")
-                .given(
-                        uploadInitCode(contract1),
-                        uploadInitCode(contract2))
+                .given(uploadInitCode(contract1), uploadInitCode(contract2))
                 .when(
                         contractCreate(contract1)
                                 .via(contract1)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -67,6 +67,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
@@ -162,7 +163,6 @@ public class ContractCreateSuite {
             "f8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222";
     private static final String EXPECTED_DEPLOYER_ADDRESS = "4e59b44847b379578588920ca78fbf26c0b4956c";
     private static final String DEPLOYER = "DeployerContract";
-    public static final String CONTRACTS_ALLOW_AUTO_ASSOCIATIONS = "contracts.allowAutoAssociations";
     public static final String ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED =
             "entities.unlimitedAutoAssociationsEnabled";
     public static final String LEDGER_MAX_AUTO_ASSOCIATIONS = "ledger.maxAutoAssociations";
@@ -342,12 +342,10 @@ public class ContractCreateSuite {
         final var createContract = "CreateTrivial";
         return propertyPreservingHapiSpec("contractCreationsHaveValidAssociations")
                 .preserving(
-                        CONTRACTS_ALLOW_AUTO_ASSOCIATIONS,
                         ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED,
                         LEDGER_MAX_AUTO_ASSOCIATIONS)
                 .given(
-                        overridingThree(
-                                CONTRACTS_ALLOW_AUTO_ASSOCIATIONS, TRUE_VALUE,
+                        overridingTwo(
                                 ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED, TRUE_VALUE,
                                 LEDGER_MAX_AUTO_ASSOCIATIONS, "5000"),
                         newKeyNamed(MULTI_KEY),
@@ -818,17 +816,14 @@ public class ContractCreateSuite {
                         .logged());
     }
 
-    @LeakyHapiTest(PROPERTY_OVERRIDES)
     final Stream<DynamicTest> contractCreateShouldChargeTheSame() {
         final var createFeeWithMaxAutoAssoc = 10L;
         final var contract1 = "EmptyOne";
         final var contract2 = "EmptyTwo";
-        return propertyPreservingHapiSpec("contractCreateShouldChargeTheSame")
-                .preserving("contracts.allowAutoAssociations")
+        return defaultHapiSpec("contractCreateShouldChargeTheSame")
                 .given(
                         uploadInitCode(contract1),
-                        uploadInitCode(contract2),
-                        overriding("contracts.allowAutoAssociations", TRUE_VALUE))
+                        uploadInitCode(contract2))
                 .when(
                         contractCreate(contract1)
                                 .via(contract1)
@@ -954,19 +949,6 @@ public class ContractCreateSuite {
                                 .logged())
                 .when()
                 .then();
-    }
-
-    @LeakyHapiTest(PROPERTY_OVERRIDES)
-    final Stream<DynamicTest> cannotSetMaxAutomaticAssociations() {
-        return propertyPreservingHapiSpec("cannotSetMaxAutomaticAssociations")
-                .preserving(CONTRACTS_ALLOW_AUTO_ASSOCIATIONS)
-                .given(
-                        uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
-                        overriding(CONTRACTS_ALLOW_AUTO_ASSOCIATIONS, FALSE_VALUE))
-                .when()
-                .then(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
-                        .maxAutomaticTokenAssociations(10)
-                        .hasKnownStatus(NOT_SUPPORTED));
     }
 
     private EthTxData placeholderEthTx() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -42,6 +42,7 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
@@ -505,30 +506,14 @@ public class ContractUpdateSuite {
     }
 
     @LeakyHapiTest(PROPERTY_OVERRIDES)
-    final Stream<DynamicTest> cannotUpdateMaxAutomaticAssociations() {
-        return propertyPreservingHapiSpec("cannotUpdateMaxAutomaticAssociations")
-                .preserving("contracts.allowAutoAssociations")
-                .given(
-                        overriding("contracts.allowAutoAssociations", FALSE_VALUE),
-                        newKeyNamed(ADMIN_KEY),
-                        uploadInitCode(CONTRACT),
-                        contractCreate(CONTRACT).adminKey(ADMIN_KEY))
-                .when()
-                .then(contractUpdate(CONTRACT).newMaxAutomaticAssociations(20).hasKnownStatus(NOT_SUPPORTED));
-    }
-
-    @LeakyHapiTest(PROPERTY_OVERRIDES)
     final Stream<DynamicTest> tryContractUpdateWithMaxAutoAssociations() {
         return propertyPreservingHapiSpec("tryContractUpdateWithMaxAutoAssociations")
                 .preserving(
-                        "contracts.allowAutoAssociations",
                         "ledger.maxAutoAssociations",
                         UNLIMITED_AUTO_ASSOCIATIONS_ENABLED)
                 .given(
-                        overridingThree(
+                        overridingTwo(
                                 UNLIMITED_AUTO_ASSOCIATIONS_ENABLED,
-                                TRUE_VALUE,
-                                "contracts.allowAutoAssociations",
                                 TRUE_VALUE,
                                 "ledger.maxAutoAssociations",
                                 "5000"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -40,8 +40,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
@@ -53,7 +51,6 @@ import static com.hedera.services.bdd.spec.utilops.records.SnapshotMatchMode.NON
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_SENDER;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PROPS;
-import static com.hedera.services.bdd.suites.HapiSuite.FALSE_VALUE;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
@@ -71,7 +68,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_MAX_AU
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
@@ -508,15 +504,10 @@ public class ContractUpdateSuite {
     @LeakyHapiTest(PROPERTY_OVERRIDES)
     final Stream<DynamicTest> tryContractUpdateWithMaxAutoAssociations() {
         return propertyPreservingHapiSpec("tryContractUpdateWithMaxAutoAssociations")
-                .preserving(
-                        "ledger.maxAutoAssociations",
-                        UNLIMITED_AUTO_ASSOCIATIONS_ENABLED)
+                .preserving("ledger.maxAutoAssociations", UNLIMITED_AUTO_ASSOCIATIONS_ENABLED)
                 .given(
                         overridingTwo(
-                                UNLIMITED_AUTO_ASSOCIATIONS_ENABLED,
-                                TRUE_VALUE,
-                                "ledger.maxAutoAssociations",
-                                "5000"),
+                                UNLIMITED_AUTO_ASSOCIATIONS_ENABLED, TRUE_VALUE, "ledger.maxAutoAssociations", "5000"),
                         newKeyNamed(ADMIN_KEY),
                         uploadInitCode(CONTRACT),
                         contractCreate(CONTRACT).adminKey(ADMIN_KEY))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
@@ -133,11 +133,9 @@ public class AtomicCryptoTransferHTSSuite {
         final var cryptoTransferRevertBalanceTooLowTxn = "cryptoTransferRevertBalanceTooLowTxn";
 
         return propertyPreservingHapiSpec("cryptoTransferForHbarOnly")
-                .preserving("contracts.allowAutoAssociations", "contracts.precompile.atomicCryptoTransfer.enabled")
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(SENDER2).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS).receiverSigRequired(true),
@@ -324,10 +322,9 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving("contracts.allowAutoAssociations", "contracts.precompile.atomicCryptoTransfer.enabled")
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
+                        overriding(
                                 "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(SENDER2).balance(10 * ONE_HUNDRED_HBARS),
@@ -432,11 +429,9 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving("contracts.allowAutoAssociations", "contracts.precompile.atomicCryptoTransfer.enabled")
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS).receiverSigRequired(true),
                         cryptoCreate(TOKEN_TREASURY),
@@ -524,11 +519,9 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving("contracts.allowAutoAssociations", "contracts.precompile.atomicCryptoTransfer.enabled")
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS),
@@ -1365,9 +1358,7 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_TRANSACTION_FEES)
                 .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS).receiverSigRequired(true),
                         uploadInitCode(CONTRACT),
@@ -1420,9 +1411,7 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_TRANSACTION_FEES)
                 .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS),
                         uploadInitCode(CONTRACT),
@@ -1465,11 +1454,9 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving("contracts.allowAutoAssociations", "contracts.precompile.atomicCryptoTransfer.enabled")
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true",
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(RECEIVER).balance(1 * ONE_HUNDRED_HBARS).receiverSigRequired(true),
                         uploadInitCode(CONTRACT),
                         contractCreate(CONTRACT).maxAutomaticTokenAssociations(1),
@@ -1543,9 +1530,7 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving(
-                        "contracts.allowAutoAssociations",
-                        "contracts.precompile.atomicCryptoTransfer.enabled",
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled",
                         CONTRACTS_PERMITTED_DELEGATE_CALLERS)
                 .given(
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
@@ -1564,9 +1549,7 @@ public class AtomicCryptoTransferHTSSuite {
                             whitelistedCalleeMirrorAddr.set(asHexedSolidityAddress(0, 0, num));
                         }))
                 .when(
-                        overridingThree(
-                                "contracts.allowAutoAssociations",
-                                "true",
+                        overridingTwo(
                                 "contracts.precompile.atomicCryptoTransfer.enabled",
                                 "true",
                                 CONTRACTS_PERMITTED_DELEGATE_CALLERS,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
@@ -55,7 +55,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.nftTransfer;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.tokenTransferList;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.tokenTransferLists;
@@ -324,8 +323,7 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_NONCE)
                 .preserving("contracts.precompile.atomicCryptoTransfer.enabled")
                 .given(
-                        overriding(
-                                "contracts.precompile.atomicCryptoTransfer.enabled", "true"),
+                        overriding("contracts.precompile.atomicCryptoTransfer.enabled", "true"),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(SENDER2).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS).receiverSigRequired(true),
@@ -1530,8 +1528,7 @@ public class AtomicCryptoTransferHTSSuite {
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving("contracts.precompile.atomicCryptoTransfer.enabled",
-                        CONTRACTS_PERMITTED_DELEGATE_CALLERS)
+                .preserving("contracts.precompile.atomicCryptoTransfer.enabled", CONTRACTS_PERMITTED_DELEGATE_CALLERS)
                 .given(
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -144,9 +144,7 @@ public class CryptoUpdateSuite {
         return propertyPreservingHapiSpec("updateForMaxAutoAssociationsForAccountsWorks")
                 .preserving("entities.unlimitedAutoAssociationsEnabled")
                 .given(
-                        overriding(
-                                "entities.unlimitedAutoAssociationsEnabled",
-                                "true"),
+                        overriding("entities.unlimitedAutoAssociationsEnabled", "true"),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT_ALICE).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(0),
                         cryptoCreate(ACCOUNT_PETER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(-1),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -43,6 +43,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
@@ -141,13 +142,11 @@ public class CryptoUpdateSuite {
     @LeakyHapiTest(PROPERTY_OVERRIDES)
     final Stream<DynamicTest> updateForMaxAutoAssociationsForAccountsWorks() {
         return propertyPreservingHapiSpec("updateForMaxAutoAssociationsForAccountsWorks")
-                .preserving("entities.unlimitedAutoAssociationsEnabled", "contracts.allowAutoAssociations")
+                .preserving("entities.unlimitedAutoAssociationsEnabled")
                 .given(
-                        overridingTwo(
+                        overriding(
                                 "entities.unlimitedAutoAssociationsEnabled",
-                                "true",
-                                "contracts.allowAutoAssociations",
-                                TRUE_VALUE),
+                                "true"),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT_ALICE).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(0),
                         cryptoCreate(ACCOUNT_PETER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(-1),
@@ -532,12 +531,11 @@ public class CryptoUpdateSuite {
         final String ADMIN_KEY = "adminKey";
 
         return propertyPreservingHapiSpec("updateMaxAutoAssociationsWorks", NONDETERMINISTIC_TRANSACTION_FEES)
-                .preserving("contracts.allowAutoAssociations", UNLIMITED_AUTO_ASSOCIATIONS_ENABLED)
+                .preserving(UNLIMITED_AUTO_ASSOCIATIONS_ENABLED)
                 .given(
                         cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS),
                         newKeyNamed(ADMIN_KEY),
-                        overridingTwo(
-                                "contracts.allowAutoAssociations", "true", UNLIMITED_AUTO_ASSOCIATIONS_ENABLED, "true"),
+                        overriding(UNLIMITED_AUTO_ASSOCIATIONS_ENABLED, "true"),
                         uploadInitCode(CONTRACT),
                         contractCreate(CONTRACT).adminKey(ADMIN_KEY).maxAutomaticTokenAssociations(originalMax),
                         tokenCreate(tokenA)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
@@ -1237,10 +1237,8 @@ public class LeakyCryptoTestsSuite {
         final String tokenBcreateTxn = "tokenBCreate";
         final String transferToFU = "transferToFU";
 
-        return propertyPreservingHapiSpec("autoAssociationWorksForContracts", NONDETERMINISTIC_TRANSACTION_FEES)
-                .preserving("contracts.allowAutoAssociations")
+        return defaultHapiSpec("autoAssociationWorksForContracts", NONDETERMINISTIC_TRANSACTION_FEES)
                 .given(
-                        overriding("contracts.allowAutoAssociations", "true"),
                         newKeyNamed(SUPPLY_KEY),
                         uploadInitCode(theContract),
                         contractCreate(theContract).maxAutomaticTokenAssociations(2),
@@ -1306,10 +1304,8 @@ public class LeakyCryptoTestsSuite {
         final var otherCollector = "otherCollector";
         final var finalTxn = "finalTxn";
 
-        return propertyPreservingHapiSpec("CustomFeesHaveExpectedAutoCreateInteractions", FULLY_NONDETERMINISTIC)
-                .preserving("contracts.allowAutoAssociations")
+        return defaultHapiSpec("CustomFeesHaveExpectedAutoCreateInteractions", FULLY_NONDETERMINISTIC)
                 .given(
-                        overriding("contracts.allowAutoAssociations", "true"),
                         wellKnownTokenEntities(),
                         cryptoCreate(otherCollector),
                         cryptoCreate(CIVILIAN).maxAutomaticTokenAssociations(42),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -290,7 +290,6 @@ public class LeakyContractTestsSuite {
     private static final String CONTRACTS_NONCES_EXTERNALIZATION_ENABLED = "contracts.nonces.externalization.enabled";
     private static final KeyShape DELEGATE_CONTRACT_KEY_SHAPE =
             KeyShape.threshOf(1, KeyShape.SIMPLE, DELEGATE_CONTRACT);
-    private static final String CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY = "contracts.allowAutoAssociations";
     private static final String TRANSFER_CONTRACT = "NonDelegateCryptoTransfer";
     private static final String CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS = "contracts.allowSystemUseOfHapiSigs";
     private static final String CRYPTO_TRANSFER = "CryptoTransfer";
@@ -1708,9 +1707,8 @@ public class LeakyContractTestsSuite {
         final int maxAutoAssociations = 100;
         final String CONTRACT = "Multipurpose";
 
-        return propertyPreservingHapiSpec("autoAssociationSlotsAppearsInInfo", NONDETERMINISTIC_NONCE)
-                .preserving(CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY)
-                .given(overriding(CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY, "true"))
+        return defaultHapiSpec("autoAssociationSlotsAppearsInInfo", NONDETERMINISTIC_NONCE)
+                .given()
                 .when()
                 .then(
                         newKeyNamed(ADMIN_KEY),
@@ -1936,16 +1934,14 @@ public class LeakyContractTestsSuite {
         final var DELEGATE_KEY = "contractKey";
         final var NOT_SUPPORTED_TXN = "notSupportedTxn";
         final var TOTAL_SUPPLY = 1_000;
-        final var ALLOW_AUTO_ASSOCIATIONS_PROPERTY = CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY;
 
         return propertyPreservingHapiSpec(
                         "lazyCreateThroughPrecompileNotSupportedWhenFlagDisabled",
                         NONDETERMINISTIC_FUNCTION_PARAMETERS,
                         NONDETERMINISTIC_TRANSACTION_FEES,
                         NONDETERMINISTIC_NONCE)
-                .preserving(ALLOW_AUTO_ASSOCIATIONS_PROPERTY, LAZY_CREATION_ENABLED)
+                .preserving(LAZY_CREATION_ENABLED)
                 .given(
-                        overriding(ALLOW_AUTO_ASSOCIATIONS_PROPERTY, "true"),
                         UtilVerbs.overriding(LAZY_CREATION_ENABLED, FALSE),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(TOKEN_TREASURY),

--- a/hedera-node/test-clients/src/main/resource/bootstrap.properties
+++ b/hedera-node/test-clients/src/main/resource/bootstrap.properties
@@ -63,7 +63,6 @@ balances.exportTokenBalances=true
 balances.nodeBalanceWarningThreshold=0
 balances.compressOnCreation=true
 cache.records.ttl=180
-contracts.allowAutoAssociations=true
 contracts.allowSystemUseOfHapiSigs=TokenAssociateToAccount,TokenDissociateFromAccount,TokenFreezeAccount,TokenUnfreezeAccount,TokenGrantKycToAccount,TokenRevokeKycFromAccount,TokenAccountWipe,TokenBurn,TokenDelete,TokenMint,TokenUnpause,TokenPause,TokenCreate,TokenUpdate,ContractCall,CryptoTransfer
 contracts.maxNumWithHapiSigsAccess=0
 contracts.withSpecialHapiSigsAccess=


### PR DESCRIPTION
**Description**:

With HIP-904 we remove the pre-paying for auto association slots. This change makes the `contracts.allowAutoAssociations` flag obsolete as it was blocking the setting of `maxAutoAssociations` for `ContractCreate` and `ContractUpdate` transactions.
It is no longer the expected behaviour and we are charging for associations at point-of-use.
So with this PR we remove the feature flag and adjust or remove related tests.

**Related issue(s)**:

Fixes #13954 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
