### PR TITLE
fix: [develop] register empty gradle tasks at root (releaseAdhocCommit, releaseDevelopCommit, releaseDevelopDailySnapshot, releaseDevelopSnapshot, releasePrereleaseChannel)

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
@@ -38,17 +38,10 @@ tasks.register("qualityGate") {
 
 tasks.register("releaseMavenCentral")
 
-// Register these tasks if they are not registered yet
+// Register these empty tasks:
 // https://github.com/hashgraph/hedera-services/blob/63641ffdab4ec13759b901a58682f95b64bd4651/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts#L70-L86
-val taskNames = listOf(
-    "releaseAdhocCommit",
-    "releaseDevelopCommit",
-    "releaseDevelopDailySnapshot",
-    "releaseDevelopSnapshot",
-    "releasePrereleaseChannel",
-)
-taskNames.forEach { taskName ->
-    if (!tasks.names.contains(taskName)) {
-        tasks.register(taskName)
-    }
-}
+tasks.register("releaseAdhocCommit")
+tasks.register("releaseDevelopCommit")
+tasks.register("releaseDevelopDailySnapshot")
+tasks.register("releaseDevelopSnapshot")
+tasks.register("releasePrereleaseChannel")

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
@@ -37,3 +37,10 @@ tasks.register("qualityGate") {
 }
 
 tasks.register("releaseMavenCentral")
+
+// Register these tasks: https://github.com/hashgraph/hedera-services/blob/63641ffdab4ec13759b901a58682f95b64bd4651/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts#L70-L86
+tasks.register("releaseAdhocCommit")
+tasks.register("releaseDevelopCommit")
+tasks.register("releaseDevelopDailySnapshot")
+tasks.register("releaseDevelopSnapshot")
+tasks.register("releasePrereleaseChannel")

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
@@ -38,9 +38,17 @@ tasks.register("qualityGate") {
 
 tasks.register("releaseMavenCentral")
 
-// Register these tasks: https://github.com/hashgraph/hedera-services/blob/63641ffdab4ec13759b901a58682f95b64bd4651/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts#L70-L86
-tasks.register("releaseAdhocCommit")
-tasks.register("releaseDevelopCommit")
-tasks.register("releaseDevelopDailySnapshot")
-tasks.register("releaseDevelopSnapshot")
-tasks.register("releasePrereleaseChannel")
+// Register these tasks if they are not registered yet
+// https://github.com/hashgraph/hedera-services/blob/63641ffdab4ec13759b901a58682f95b64bd4651/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts#L70-L86
+val taskNames = listOf(
+    "releaseAdhocCommit",
+    "releaseDevelopCommit",
+    "releaseDevelopDailySnapshot",
+    "releaseDevelopSnapshot",
+    "releasePrereleaseChannel",
+)
+taskNames.forEach { taskName ->
+    if (!tasks.names.contains(taskName)) {
+        tasks.register(taskName)
+    }
+}

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
@@ -41,7 +41,11 @@ tasks.register("releaseMavenCentral")
 // Register these empty tasks:
 // https://github.com/hashgraph/hedera-services/blob/63641ffdab4ec13759b901a58682f95b64bd4651/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts#L70-L86
 tasks.register("releaseAdhocCommit")
+
 tasks.register("releaseDevelopCommit")
+
 tasks.register("releaseDevelopDailySnapshot")
+
 tasks.register("releaseDevelopSnapshot")
+
 tasks.register("releasePrereleaseChannel")

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts
@@ -88,8 +88,19 @@ publishing.repositories {
 // Register one 'release*' task for each publishing repository
 publishing.repositories.all {
     val ucName = name.replaceFirstChar { it.titlecase() }
-    tasks.register("release$ucName") {
-        group = "release"
-        dependsOn(tasks.named("publishMavenPublicationTo${ucName}Repository"))
+    val taskName = "release$ucName"
+
+    // Register the task if it is not already registered
+    if (!tasks.names.contains(taskName)) {
+        tasks.register(taskName) {
+            group = "release"
+            dependsOn(tasks.named("publishMavenPublicationTo${ucName}Repository"))
+        }
+    } else {
+        // If the task is already registered, we just add the group & dependency
+        tasks.named(taskName) {
+            group = "release"
+            dependsOn(tasks.named("publishMavenPublicationTo${ucName}Repository"))
+        }
     }
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.versions.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.versions.gradle.kts
@@ -24,5 +24,3 @@ plugins {
 group = "com.hedera.hashgraph"
 
 javaPlatform { allowDependencies() }
-
-tasks.register("releaseMavenCentral")


### PR DESCRIPTION
fixes: 
* https://github.com/hashgraph/hedera-services/pull/14147

does:
- **register missing gradle tasks**
- **remove releaseMavenCentral task, duplicate in \*.lifecycle.grade.kts**
