### PR TITLE
chore: Update codeowners for smart contracts contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,15 +33,15 @@
 /hedera-node/hedera-admin*/                     @hashgraph/hedera-base @hashgraph/hedera-services
 /hedera-node/hedera-app*/                       @hashgraph/hedera-base
 /hedera-node/hedera-consensus*/                 @hashgraph/hedera-base @hashgraph/hedera-services
-/hedera-node/hedera-evm*/                       @hashgraph/hedera-smart-contracts
+/hedera-node/hedera-evm*/                       @hashgraph/hedera-smart-contracts-core
 /hedera-node/hedera-file*/                      @hashgraph/hedera-base @hashgraph/hedera-services
 /hedera-node/hedera-network*/                   @hashgraph/hedera-base @hashgraph/hedera-services
 /hedera-node/hedera-schedule*/                  @hashgraph/hedera-base @hashgraph/hedera-services
-/hedera-node/hedera-smart-contract*/            @hashgraph/hedera-smart-contracts @tinker-michaelj
+/hedera-node/hedera-smart-contract*/            @hashgraph/hedera-smart-contracts-core @tinker-michaelj
 /hedera-node/hedera-token*/                     @hashgraph/hedera-base @hashgraph/hedera-services
 /hedera-node/hedera-util*/                      @hashgraph/hedera-base @hashgraph/hedera-services
 /hedera-node/hedera-staking*/                   @hashgraph/hedera-base @hashgraph/hedera-services
-/hedera-node/test-clients/                      @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/hedera-smart-contracts
+/hedera-node/test-clients/                      @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core
 /hedera-node/**/module-info.java                @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/devops-ci
 
 #########################


### PR DESCRIPTION
**Description**:
Update smart contract directory owners to allow for focused reviewers  
- Set `hedera-smart-contracts-core` as codeowners in `CODEOWNERS`

**Related issue(s)**:

Fixes #14153 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
