### PR TITLE
feat: require admin key for maxAutoAssociations during contractUpdate

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -120,6 +120,7 @@ public class ContractUpdateHandler implements TransactionHandler {
     private boolean isAdminSigRequired(final ContractUpdateTransactionBody op) {
         return !op.hasExpirationTime()
                 || hasCryptoAdminKey(op)
+                || op.hasMaxAutomaticTokenAssociations()
                 || op.hasProxyAccountID()
                 || op.hasAutoRenewPeriod()
                 || op.hasFileID()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -99,6 +99,28 @@ public class ContractUpdateSuite {
     public static final String INITIAL_ADMIN_KEY = "initialAdminKey";
 
     @HapiTest
+    final Stream<DynamicTest> updateMaxAutomaticAssociationsAndRequireKey() {
+        final var newExpiry = Instant.now().getEpochSecond() + DEFAULT_PROPS.defaultExpirationSecs() * 2;
+        return defaultHapiSpec("updateMaxAutomaticAssociationsAndRequireKey")
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        uploadInitCode(CONTRACT),
+                        contractCreate(CONTRACT).adminKey(ADMIN_KEY))
+                .when(
+                        contractUpdate(CONTRACT).newMaxAutomaticAssociations(20).signedBy(DEFAULT_PAYER, ADMIN_KEY),
+                        contractUpdate(CONTRACT)
+                                .newMaxAutomaticAssociations(20)
+                                .newExpirySecs(newExpiry)
+                                .signedBy(DEFAULT_PAYER, ADMIN_KEY),
+                        contractUpdate(CONTRACT)
+                                .newMaxAutomaticAssociations(20)
+                                .newExpirySecs(newExpiry + 1)
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE))
+                .then(getContractInfo(CONTRACT).has(contractWith().maxAutoAssociations(20)));
+    }
+
+    @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
         return defaultHapiSpec("idVariantsTreatedAsExpected")
                 .given(
@@ -493,7 +515,7 @@ public class ContractUpdateSuite {
                         getContractBytecode(simpleStorageContract).saveResultTo("initialBytecode"))
                 .when(contractUpdate(simpleStorageContract).bytecode(emptyConstructorContract))
                 .then(withOpContext((spec, log) -> {
-                    var op = getContractBytecode(simpleStorageContract)
+                    final var op = getContractBytecode(simpleStorageContract)
                             .hasBytecode(spec.registry().getBytes("initialBytecode"));
                     allRunFor(spec, op);
                 }));
@@ -536,9 +558,9 @@ public class ContractUpdateSuite {
         final var players = IntStream.range(1, 30).mapToObj(i -> "Player" + i).toList();
         final var contract = "MusicalChairs";
 
-        List<HapiSpecOperation> given = new ArrayList<>();
-        List<HapiSpecOperation> when = new ArrayList<>();
-        List<HapiSpecOperation> then = new ArrayList<>();
+        final List<HapiSpecOperation> given = new ArrayList<>();
+        final List<HapiSpecOperation> when = new ArrayList<>();
+        final List<HapiSpecOperation> then = new ArrayList<>();
 
         ////// Create contract //////
         given.add(cryptoCreate(dj).balance(10 * ONE_HUNDRED_HBARS));


### PR DESCRIPTION
**Description**:
Require admin key for maxAutoAssociations during contractUpdate

**Related issue(s)**:

Fixes #14111 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
