### PR TITLE
fix: HAS.isAuthorizedRaw: Choose proper gas amount for EC vs ED signature verification

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCalculator.java
@@ -91,6 +91,18 @@ public class CustomGasCalculator extends CancunGasCalculator {
     }
 
     /**
+     * Gas charge to do a signature verification for an ED key.
+     *
+     * Based on the cost of system resources used.
+     *
+     * FUTURE: Gas for system contract method calls needs to be a) determined by measurement of
+     * resources consumed, and b) incorporated into the fee schedule.
+     */
+    public long getEdSignatureVerificationSystemContractGasCost() {
+        return 1_500_000L;
+    }
+
+    /**
      * Logically, would return the gas cost of storing the given number of bytes for the given number of seconds,
      * given the relative prices of a byte-hour and a gas unit in tinybar.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawTranslator.java
@@ -22,6 +22,7 @@ import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.node.app.service.contract.impl.annotations.ServicesV051;
 import com.hedera.node.app.service.contract.impl.exec.FeatureFlags;
+import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
@@ -44,9 +45,14 @@ public class IsAuthorizedRawTranslator extends AbstractCallTranslator<HasCallAtt
     private static final int HASH_ARG = 1;
     private static final int SIGNATURE_ARG = 2;
 
+    private final CustomGasCalculator customGasCalculator;
+
     @Inject
-    public IsAuthorizedRawTranslator(@ServicesV051 @NonNull final FeatureFlags featureFlags) {
+    public IsAuthorizedRawTranslator(
+            @ServicesV051 @NonNull final FeatureFlags featureFlags,
+            @NonNull final CustomGasCalculator customGasCalculator) {
         requireNonNull(featureFlags, "featureFlags");
+        this.customGasCalculator = requireNonNull(customGasCalculator);
     }
 
     /**
@@ -77,7 +83,7 @@ public class IsAuthorizedRawTranslator extends AbstractCallTranslator<HasCallAtt
             final var messageHash = (byte[]) call.get(HASH_ARG);
             final var signature = (byte[]) call.get(SIGNATURE_ARG);
 
-            return new IsAuthorizedRawCall(attempt, address, messageHash, signature);
+            return new IsAuthorizedRawCall(attempt, address, messageHash, signature, customGasCalculator);
         }
         return null;
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
@@ -32,6 +32,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 
 import com.esaulpaugh.headlong.abi.Address;
+import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauthorizedraw.IsAuthorizedRawCall;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
@@ -48,6 +49,8 @@ class IsAuthorizedRawCallTest extends CallTestBase {
 
     @Mock
     private HasCallAttempt attempt;
+
+    private CustomGasCalculator customGasCalculator = new CustomGasCalculator();
 
     @BeforeEach
     void setup() {
@@ -91,6 +94,6 @@ class IsAuthorizedRawCallTest extends CallTestBase {
 
     @NonNull
     IsAuthorizedRawCall getSubject(@NonNull final Address address) {
-        return new IsAuthorizedRawCall(attempt, address, messageHash, signature);
+        return new IsAuthorizedRawCall(attempt, address, messageHash, signature, customGasCalculator);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawTranslatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
+import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceTranslator;
@@ -55,12 +56,15 @@ public class IsAuthorizedRawTranslatorTest {
     @Mock
     private SystemContractGasCalculator gasCalculator;
 
+    @Mock
+    private CustomGasCalculator customGasCalculator;
+
     private IsAuthorizedRawTranslator subject;
 
     @BeforeEach
     void setUp() {
         final var featureFlags = new Version051FeatureFlags();
-        subject = new IsAuthorizedRawTranslator(featureFlags);
+        subject = new IsAuthorizedRawTranslator(featureFlags, customGasCalculator);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

Chooses gas requirement for `isAuthorizedRaw` based on whether you're verifying an EC key (3000) or an ED key (1.5M).


**Related issue(s)**:

Fixes #14156 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
