### PR TITLE
fix: yahcli reward rate; build `SuiteRunner` and `yahcli` JARs only as needed

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Compile
         id: gradle-build
-        run: ${GRADLE_EXEC} assemble --scan
+        run: ${GRADLE_EXEC} assemble :test-clients:yahCliJar --scan
 
       - name: Spotless Check
         if: ${{ inputs.enable-spotless-check && !cancelled() }}

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -408,7 +408,7 @@ jobs:
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: assemble --scan
+          arguments: assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -275,11 +275,6 @@ val cleanYahCli =
         delete(File(project.file("yahcli"), "yahcli.jar"))
     }
 
-tasks.assemble {
-    dependsOn(tasks.shadowJar)
-    dependsOn(copyYahCli)
-}
-
 tasks.clean {
     dependsOn(cleanYahCli)
     dependsOn(cleanValidation)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StakingSuite.java
@@ -86,10 +86,6 @@ public class StakingSuite {
     private static final String ALICE = "alice";
     private static final String BOB = "bob";
     private static final String CAROL = "carol";
-    public static final String STAKING_START_THRESHOLD = "staking.startThreshold";
-    public static final String REWARD_BALANCE_THRESHOLD = "staking.rewardBalanceThreshold";
-    public static final String PER_HBAR_REWARD_RATE = "staking.perHbarRewardRate";
-    public static final String STAKING_REWARD_RATE = "staking.perHbarRewardRate";
     public static final String FIRST_TRANSFER = "firstTransfer";
     private static final long STAKING_PERIOD_MINS = 1L;
 
@@ -97,9 +93,9 @@ public class StakingSuite {
     static void beforeAll(@NonNull final SpecManager specManager) throws Throwable {
         specManager.setup(
                 overridingThree(
-                        STAKING_START_THRESHOLD, "" + 10 * ONE_HBAR,
-                        PER_HBAR_REWARD_RATE, "" + SUITE_PER_HBAR_REWARD_RATE,
-                        REWARD_BALANCE_THRESHOLD, "" + 0),
+                        "staking.startThreshold", "" + 10 * ONE_HBAR,
+                        "staking.perHbarRewardRate", "" + SUITE_PER_HBAR_REWARD_RATE,
+                        "staking.rewardBalanceThreshold", "0"),
                 cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StartStaking.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StartStaking.java
@@ -25,7 +25,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.staking.StakingSuite.STAKING_REWARD_RATE;
 
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -152,7 +151,7 @@ public class StartStaking extends HapiSuite {
                         "default.payer.pemKeyLoc", PAYER_PEM_LOC,
                         "default.payer.pemKeyPassphrase", PAYER_PEM_PASSPHRASE))
                 .given(
-                        overriding(STAKING_REWARD_RATE, "" + CANONICAL_REWARD_RATE),
+                        overriding("staking.perHbarRewardRate", "" + CANONICAL_REWARD_RATE),
                         cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, STAKING_REWARD, REWARD_START_BALANCE)))
                 .when(
                         inParallel(IntStream.range(0, NUM_TARGET_NODES)

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/SetupStakeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/SetupStakeCommand.java
@@ -32,7 +32,7 @@ import picocli.CommandLine;
         subcommands = {CommandLine.HelpCommand.class},
         description = "Activates staking on the target network (requires 0.0.2 payer)")
 public class SetupStakeCommand implements Callable<Integer> {
-    private static final long CANONICAL_REWARD_RATE = 273972602739726L;
+    private static final long CANONICAL_REWARD_RATE = 6849L;
     private static final long CANONICAL_800_START_BALANCE = 250 * HapiSuite.ONE_MILLION_HBARS;
     private static final long TOTAL_HBAR_SUPPLY = 50_000_000_000L * 100_000_000L;
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/StakeSetupSuite.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/StakeSetupSuite.java
@@ -24,7 +24,6 @@ import com.hedera.services.bdd.spec.transactions.TxnVerbs;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiSuite;
-import com.hedera.services.bdd.suites.staking.StakingSuite;
 import com.hedera.services.yahcli.config.ConfigManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
@@ -70,7 +69,7 @@ public class StakeSetupSuite extends HapiSuite {
         return HapiSpec.customHapiSpec("StartStakingAndExportCreatedStakers")
                 .withProperties(specConfig)
                 .given(
-                        overriding(StakingSuite.STAKING_REWARD_RATE, String.valueOf(stakingRewardRate)),
+                        overriding("staking.perHbarRewardRate", String.valueOf(stakingRewardRate)),
                         TxnVerbs.cryptoTransfer(HapiCryptoTransfer.tinyBarsFromTo(
                                 HapiSuite.DEFAULT_PAYER, HapiSuite.STAKING_REWARD, rewardAccountBalance)))
                 .when()

--- a/hedera-node/test-clients/yahcli/run/build.sh
+++ b/hedera-node/test-clients/yahcli/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.4.3'}
+TAG=${1:-'0.4.7'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""
@@ -19,7 +19,7 @@ SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
 OLD_CWD="$(pwd)"
 
 cd "${SCRIPT_PATH}/../../../../"
-./gradlew assemble
+./gradlew copyYahCli
 cd "${SCRIPT_PATH}/.."
 
 rm -f assets/yahcli.jar >/dev/null 2>&1 || true


### PR DESCRIPTION
**Description**:
 - Closes #14184 
 - Only builds `yahcli` and `SuiteRunner` JARs during PR checks as needed, not every `assemble`.