### PR TITLE
build: filter publishing by deactivating tasks (develop)

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -841,7 +841,7 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.sdk-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: ":release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds --scan -PpublishSigningEnabled=true --no-configuration-cache"
+          arguments: "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds --scan -PpublishSigningEnabled=true --no-configuration-cache"
 
       - name: Gradle Publish Services to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
         uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3.1.0
@@ -851,7 +851,7 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.svcs-ossrh-password }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: ":release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera --scan -PpublishSigningEnabled=true --no-configuration-cache"
+          arguments: "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera --scan -PpublishSigningEnabled=true --no-configuration-cache"
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.lifecycle.gradle.kts
@@ -37,15 +37,3 @@ tasks.register("qualityGate") {
 }
 
 tasks.register("releaseMavenCentral")
-
-// Register these empty tasks:
-// https://github.com/hashgraph/hedera-services/blob/63641ffdab4ec13759b901a58682f95b64bd4651/gradle/plugins/src/main/kotlin/com.hedera.gradle.platform-publish.gradle.kts#L70-L86
-tasks.register("releaseAdhocCommit")
-
-tasks.register("releaseDevelopCommit")
-
-tasks.register("releaseDevelopDailySnapshot")
-
-tasks.register("releaseDevelopSnapshot")
-
-tasks.register("releasePrereleaseChannel")

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
@@ -37,20 +37,10 @@ nexusPublishing {
     }
 }
 
-// 'platform' and 'services' need to be published separately as they use different credentials
-val platformPublishTasks =
-    subprojects.filter { it.name.startsWith("swirlds") }.map { ":${it.name}:releaseMavenCentral" }
-val servicesPublishTasks =
-    subprojects.filter { !it.name.startsWith("swirlds") }.map { ":${it.name}:releaseMavenCentral" }
-
 tasks.named("closeSonatypeStagingRepository") {
-    // The publishing of all components to Maven Central is automatically done before close
-    // (which is done before release).
-    if (isPlatformPublish) {
-        dependsOn(platformPublishTasks)
-    } else {
-        dependsOn(servicesPublishTasks)
-    }
+    // The publishing of all components to Maven Central is automatically done before close (which
+    // is done before release).
+    dependsOn(subprojects.map { ":${it.name}:releaseMavenCentral" })
 }
 
 tasks.named("releaseMavenCentral") {
@@ -60,9 +50,5 @@ tasks.named("releaseMavenCentral") {
 
 tasks.register("releaseMavenCentralSnapshot") {
     group = "release"
-    if (isPlatformPublish) {
-        dependsOn(platformPublishTasks)
-    } else {
-        dependsOn(servicesPublishTasks)
-    }
+    dependsOn(subprojects.map { ":${it.name}:releaseMavenCentral" })
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.services-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.services-publish.gradle.kts
@@ -19,6 +19,14 @@ plugins {
     id("com.hedera.gradle.maven-publish")
 }
 
+// Publishing tasks are only enabled if we publish to the matching group.
+// Otherwise, Nexus configuration and credentials do not fit.
+val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    enabled = publishingPackageGroup == "com.hedera"
+}
+
 publishing {
     publications {
         named<MavenPublication>("maven") {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.versions.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.versions.gradle.kts
@@ -24,3 +24,5 @@ plugins {
 group = "com.hedera.hashgraph"
 
 javaPlatform { allowDependencies() }
+
+tasks.register("releaseMavenCentral")


### PR DESCRIPTION
...rather than changing task dependencies.

With this change, we can still call ALL tasks of a certain publishing profile. E.g, we can do 'releaseMavenCentral' or 'releaseDevelopCommit' (without leading ':'). This is less risky of breaking if Gradle is called wrongly. And, more importantly, it allows us to again call all tasks that publish to CGP repositories (not Nexus) and only exist in the _platform_ projects.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Same as #14160 but for **develop**

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
