### PR TITLE
chore: Exclude most common static code analyzer's rules that we do not follow

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -3,10 +3,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
     <description>PMD Rules</description>
-    <rule ref="category/java/bestpractices.xml"/>
-    <rule ref="category/java/codestyle.xml"/>
-    <rule ref="category/java/documentation.xml"/>
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="JUnitTestContainsTooManyAsserts"/>
+1    </rule>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="AtLeastOneConstructor"/>
+        <exclude name="LongVariable"/>
+    </rule>
+    <rule ref="category/java/documentation.xml">
+        <exclude name="CommentSize"/>
+        <exclude name="CommentRequired"/>
+    </rule>
+    <rule ref="category/java/documentation.xml/CommentRequired">
+        <properties>
+            <property name="fieldCommentRequirement" value="Ignored"/>
+        </properties>
+    </rule>
     <rule ref="category/java/design.xml">
+        <exclude name="LawOfDemeter"/>
         <exclude name="LoosePackageCoupling"/>
     </rule>
     <rule ref="category/java/errorprone.xml"/>


### PR DESCRIPTION
**Description**:

This PR excludes the most often reported rules of the static code analyzer that we do not follow.

1. `JUnitTestContainsTooManyAsserts` - We do not limit the number of asserts in a unit test. (While ensuring that unit tests are not too complex, measuring the number of asserts seems wrong.)
2. `AtLeastOneConstructor` - We do not require a constructor. (What is the point of enforcing a public empty constructor, if nothing else is needed?)
3. `LongVariable` - We do not limit variable names. (This should be left to the judgement of the engineers involved.)
4. `CommentSize` - We do not limit the size of comments. (Too large comments!? I think this is an April's Fools joke that somehow made it into production.)
5. `CommentRequired.fieldCommentRequirement` - We do not require comments on fields. (Debatable but currently not mandated according to the Style Guide.)
6. `LawOfDemeter` - While the law of Demeter does make sense, the current implementation of the rule is unable to ignore Builders, which we use heavily.

**Related issue(s)**:

Partially fixes #14188 
