### PR TITLE
feat: HIP-850: HTS mutable metadata in treasury

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.cloneHederaProtobufs {
     // uncomment below to use a specific tag
     //    tag = "v0.51.0"
     // uncomment below to use a specific branch
-    branch = "main"
+    branch = "14109-hts-mutable-metadata-in-treasury"
 }
 
 sourceSets {

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonPbjConverters.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonPbjConverters.java
@@ -683,6 +683,7 @@ public class CommonPbjConverters {
             case INVALID_IPV4_ADDRESS -> ResponseCodeEnum.INVALID_IPV4_ADDRESS;
             case EMPTY_TOKEN_REFERENCE_LIST -> ResponseCodeEnum.EMPTY_TOKEN_REFERENCE_LIST;
             case UPDATE_NODE_ACCOUNT_NOT_ALLOWED -> ResponseCodeEnum.UPDATE_NODE_ACCOUNT_NOT_ALLOWED;
+            case TOKEN_HAS_NO_METADATA_OR_SUPPLY_KEY -> ResponseCodeEnum.TOKEN_HAS_NO_METADATA_OR_SUPPLY_KEY;
             case UNRECOGNIZED -> throw new RuntimeException("UNRECOGNIZED Response code!");
         };
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -550,7 +550,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
      * @param keysRequired keys required
      * @return threshold key with threshold 1
      */
-    private Key oneOf(@NonNull final Key... keysRequired) {
+    public static Key oneOf(@NonNull final Key... keysRequired) {
         return Key.newBuilder()
                 .thresholdKey(ThresholdKey.newBuilder()
                         .keys(new KeyList(Arrays.asList(keysRequired)))

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
@@ -87,9 +87,10 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
         final var txn = context.body();
         final var op = txn.tokenUpdateNftsOrThrow();
         final var tokenStore = context.createStore(ReadableTokenStore.class);
-        final var nftStore = context.createStore(ReadableNftStore.class);
         final var token = tokenStore.get(op.tokenOrElse(TokenID.DEFAULT));
         if (token == null) throw new PreCheckException(INVALID_TOKEN_ID);
+
+        final var nftStore = context.createStore(ReadableNftStore.class);
         if (serialNumbersInTreasury(
                 token.treasuryAccountIdOrThrow(), op.serialNumbers(), nftStore, token.tokenIdOrThrow())) {
             if (token.hasMetadataKey() && token.hasSupplyKey()) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
@@ -20,6 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_METADATA_KEY;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory.newReadableStoreWithTokens;
 import static com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory.newWritableStoreWithTokenRels;
 import static com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory.newWritableStoreWithTokens;
@@ -280,7 +281,7 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
     }
 
     @Test
-    void failsEhenMetadatKeyNotSet() {
+    void failsWhenMetadatKeyAndSupplyKeyNotSet() {
         final List<Long> serialNumbers = new ArrayList<>(Arrays.asList(1L, 2L));
         readableTokenStore =
                 newReadableStoreWithTokens(Token.newBuilder().tokenId(TOKEN_123).build());
@@ -309,7 +310,7 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
 
         Assertions.assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
-                .has(responseCode(TOKEN_HAS_NO_METADATA_KEY));
+                .has(responseCode(TOKEN_IS_IMMUTABLE));
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateNftsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateNftsSuite.java
@@ -90,8 +90,8 @@ public class TokenUpdateNftsSuite {
      * @return the dynamic test
      */
     @HapiTest
-    final Stream<DynamicTest> failsIfNoMetadataKeyOrSupplyKey() {
-        return defaultHapiSpec("failsIfNoMetadataKeyOrSupplyKey")
+    final Stream<DynamicTest> failsIfNoMetadataKeyOrSupplyKeySigns() {
+        return defaultHapiSpec("failsIfNoMetadataKeyOrSupplyKeySigns")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(METADATA_KEY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateNftsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateNftsSuite.java
@@ -38,6 +38,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_METADATA_KEY;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
@@ -80,39 +81,274 @@ public class TokenUpdateNftsSuite {
                         .signedBy(DEFAULT_PAYER, "multiKey")));
     }
 
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction fails if it is not signed by the metadata key or the supply key.
+     * @return the dynamic test
+     */
     @HapiTest
-    final Stream<DynamicTest> failsIfTokenHasNoMetadataKey() {
-        return defaultHapiSpec("failsIfTokenHasNoMetadataKey")
+    final Stream<DynamicTest> failsIfNoMetadataKeyOrSupplyKey() {
+        return defaultHapiSpec("failsIfNoMetadataKeyOrSupplyKey")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
                         tokenCreate(NON_FUNGIBLE_TOKEN)
                                 .supplyType(TokenSupplyType.FINITE)
                                 .tokenType(NON_FUNGIBLE_UNIQUE)
                                 .treasury(TOKEN_TREASURY)
-                                .supplyKey(SUPPLY_KEY)
                                 .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
                                 .initialSupply(0L),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"))))
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
                 .when()
-                .then(
-                        getTokenNftInfo(NON_FUNGIBLE_TOKEN, 1L).hasMetadata(ByteString.copyFromUtf8("a")),
-                        tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
-                                .hasKnownStatus(TOKEN_HAS_NO_METADATA_KEY),
-                        getTokenNftInfo(NON_FUNGIBLE_TOKEN, 1L).hasMetadata(ByteString.copyFromUtf8("a")));
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(INVALID_SIGNATURE));
     }
 
     /**
      * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
-     * Tests that the supply key can sign the transaction while the NFT serials are in the treasury, tokenUpdateNfts
-     * is expected to have a status of TOKEN_IS_IMMUTABLE as serial 1 is not in the treasury
+     * Tests that the transaction succeeds if it is signed by the supply key and metadata key while serials are in the treasury.
      * @return the dynamic test
      */
     @HapiTest
-    final Stream<DynamicTest> failsIfSupplyKeyNftsNotInTreasury() {
-        return defaultHapiSpec("failsIfSupplyKeyNftsNotInTreasury")
+    final Stream<DynamicTest> supplyKeyAndMetadataKeyInTreasury() {
+        return defaultHapiSpec("supplyKeyAndMetadataKeyInTreasury")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when()
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(SUPPLY_KEY, METADATA_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction succeeds if it is signed by the supply key and metadata key while serials are outside the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> supplyKeyAndMetadataKeyOutsideTreasury() {
+        return defaultHapiSpec("supplyKeyAndMetadataKeyOutsideTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when(cryptoTransfer(
+                        TokenMovement.movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(TOKEN_TREASURY, RECEIVER)))
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(SUPPLY_KEY, METADATA_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction succeeds if it is signed by the metadata key while serials are in the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> metadataKeySignedInTreasury() {
+        return defaultHapiSpec("supplyKeyAndMetadataKeyOutsideTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when()
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(METADATA_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests the transaction succeeds if it is signed by the metadata key while serials are outside the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> metadataKeySignedOutsideTreasury() {
+        return defaultHapiSpec("metadataKeySignedOutsideTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when(cryptoTransfer(
+                        TokenMovement.movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(TOKEN_TREASURY, RECEIVER)))
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(METADATA_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction succeeds if it is signed by the supply key while serials are in the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> supplyKeySignedInTreasury() {
+        return defaultHapiSpec("supplyKeySignedInTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when()
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(SUPPLY_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction fails if it is signed by the supply key while serials are outside the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> supplyKeySignedOutsideTreasury() {
+        return defaultHapiSpec("supplyKeySignedOutsideTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .metadataKey(METADATA_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when(cryptoTransfer(
+                        TokenMovement.movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(TOKEN_TREASURY, RECEIVER)))
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(SUPPLY_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(INVALID_SIGNATURE));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction succeeds if it is signed by the supply key (Token no metadata key) while serials are in the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> noMetadataKeySignedInTreasury() {
+        return defaultHapiSpec("noMetadataKeySignedInTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
+                        cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
+                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .initialSupply(0L),
+                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("a"), copyFromUtf8("b"))))
+                .when()
+                .then(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L))
+                        .signedBy(SUPPLY_KEY)
+                        .payingWith(TOKEN_TREASURY)
+                        .fee(10 * ONE_HBAR)
+                        .via("nftUpdateTxn")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    /**
+     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
+     * Tests that the transaction fails if it is signed by the supply key (Token no metadata key) while serials are outside the treasury.
+     * @return the dynamic test
+     */
+    @HapiTest
+    final Stream<DynamicTest> noMetadataKeySignedOutsideTreasury() {
+        return defaultHapiSpec("noMetadataKeySignedOutsideTreasury")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(METADATA_KEY),
                         cryptoCreate(TOKEN_TREASURY).maxAutomaticTokenAssociations(4),
                         cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(4),
                         tokenCreate(NON_FUNGIBLE_TOKEN)
@@ -132,42 +368,6 @@ public class TokenUpdateNftsSuite {
                         .fee(10 * ONE_HBAR)
                         .via("nftUpdateTxn")
                         .hasKnownStatus(TOKEN_HAS_NO_METADATA_KEY));
-    }
-
-    /**
-     * <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-850.md">HIP-850</a>
-     * Tests that the supply key can sign the transaction while the NFT serials are in the treasury
-     * @return the dynamic test
-     */
-    @HapiTest
-    final Stream<DynamicTest> supplyKeyCanSignTransactionNoMetadataKey() {
-        return defaultHapiSpec("supplyKeyCanSignTransaction")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .maxSupply(12L)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0L),
-                        mintToken(
-                                NON_FUNGIBLE_TOKEN,
-                                List.of(
-                                        copyFromUtf8("a"),
-                                        copyFromUtf8("b"),
-                                        copyFromUtf8("c"),
-                                        copyFromUtf8("d"),
-                                        copyFromUtf8("e"))))
-                .when(tokenUpdateNfts(NON_FUNGIBLE_TOKEN, NFT_TEST_METADATA, List.of(1L, 2L, 3L, 4L, 5L))
-                        .signedBy(SUPPLY_KEY)
-                        .payingWith(TOKEN_TREASURY)
-                        .fee(10 * ONE_HBAR)
-                        .via("nftUpdateTxn"))
-                .then(getTokenNftInfo(NON_FUNGIBLE_TOKEN, 1L)
-                        .hasSerialNum(1L)
-                        .hasMetadata(ByteString.copyFromUtf8(NFT_TEST_METADATA)));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR implements the functionality required for [HIP-850](https://hips.hedera.com/hip/hip-850) 
Enhancing Supply Key Functionality for NFT Updates in Treasury Account. Specifically enabling the Supply Key to update an NFT metadata field while the NFT is held in the treasury account

See https://github.com/hashgraph/hedera-protobufs/pull/394
for protobuf changes (new `ResponseCodeEnum` value).

Fixes #14109 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
