### PR TITLE
chore: File Service compiler warning fixes

### DIFF
--- a/hedera-node/hedera-file-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-file-service-impl/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
 
 description = "Default Hedera File Service Implementation"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports,-static") }
-
 mainModuleInfo { annotationProcessor("dagger.compiler") }
 
 testModuleInfo {

--- a/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module com.hedera.node.app.service.file.impl {
     requires transitive com.swirlds.state.api;
     requires transitive com.hedera.pbj.runtime;
     requires transitive dagger;
+    requires transitive static java.compiler; // javax.annotation.processing.Generated
     requires transitive javax.inject;
     requires com.swirlds.common;
     requires com.fasterxml.jackson.databind;
@@ -16,7 +17,6 @@ module com.hedera.node.app.service.file.impl {
     requires org.apache.commons.lang3;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
-    requires transitive static java.compiler; // javax.annotation.processing.Generated
 
     exports com.hedera.node.app.service.file.impl.handlers;
     exports com.hedera.node.app.service.file.impl.records;

--- a/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
@@ -16,7 +16,7 @@ module com.hedera.node.app.service.file.impl {
     requires org.apache.commons.lang3;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
-    requires static java.compiler; // javax.annotation.processing.Generated
+    requires transitive static java.compiler; // javax.annotation.processing.Generated
 
     exports com.hedera.node.app.service.file.impl.handlers;
     exports com.hedera.node.app.service.file.impl.records;

--- a/hedera-node/hedera-file-service/build.gradle.kts
+++ b/hedera-node/hedera-file-service/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
 
 description = "Hedera File Service API"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
-
 testModuleInfo {
     requires("org.assertj.core")
     requires("org.junit.jupiter.api")

--- a/hedera-node/hedera-token-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-token-service-impl/build.gradle.kts
@@ -21,12 +21,6 @@ plugins {
 
 description = "Default Hedera Token Service Implementation"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Xlint:-exports,-lossy-conversions,-static")
-}
-
 mainModuleInfo { annotationProcessor("dagger.compiler") }
 
 testModuleInfo {

--- a/hedera-node/hedera-token-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-token-service-impl/build.gradle.kts
@@ -21,6 +21,12 @@ plugins {
 
 description = "Default Hedera Token Service Implementation"
 
+// Remove the following line to enable all 'javac' lint checks that we have turned on by default
+// and then fix the reported issues.
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-exports,-lossy-conversions,-static")
+}
+
 mainModuleInfo { annotationProcessor("dagger.compiler") }
 
 testModuleInfo {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Removed `-Xlint:-*` compilerArgs from hedera-file-service and hedera-file-service-impl which would disable warnings for those names.

Only issue was requiring transitive for java.compiler in the file service impl `module-info.java`


**Related issue(s)**:

Fixes #14213 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
