### PR TITLE
fix: cherry-pick, to 0.52, #14210 isAuthorizedRaw to charge all gas on failure

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCall.java
@@ -109,7 +109,7 @@ public class IsAuthorizedRawCall extends AbstractCall {
                 };
 
         // Prepare the short-circuit error status returns
-        final Function<ResponseCodeEnum, PricedResult> bail = rce -> reversionWith(rce, gasRequirement);
+        final Function<ResponseCodeEnum, PricedResult> bail = rce -> reversionWith(rce, frame.getRemainingGas());
 
         // Must have a valid signature type to continue
         if (signatureType == SignatureType.INVALID)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
@@ -258,6 +258,27 @@ public class ContractFnResultAsserts extends BaseErroringAssertsProvider<Contrac
     }
 
     /**
+     * Check that the gas used is in a given range
+     * @param lowerBoundInclusive if present (not null), is the lowest acceptable value for gas used
+     * @param upperBoundExclusive if present (not null), is the highest acceptable value for gas used
+     */
+    public ContractFnResultAsserts gasUsedIsInRange(final Long lowerBoundInclusive, final Long upperBoundExclusive) {
+        registerProvider((spec, o) -> {
+            ContractFunctionResult result = (ContractFunctionResult) o;
+            long gasUsed = result.getGasUsed();
+            if (lowerBoundInclusive != null)
+                assertTrue(
+                        gasUsed >= lowerBoundInclusive,
+                        "gas, %d, is less than %d".formatted(gasUsed, lowerBoundInclusive));
+            if (upperBoundExclusive != null)
+                assertTrue(
+                        gasUsed <= upperBoundExclusive,
+                        "gas, %d, is more than %d".formatted(gasUsed, upperBoundExclusive));
+        });
+        return this;
+    }
+
+    /**
      * Adds an assertion that the gas used is the expected value, up to some small
      * variation due to differences in intrinsic gas cost for EVM payloads that
      * reference addresses that may contain different numbers of zero bytes.


### PR DESCRIPTION
**Description:**

Fix should be in 0.52 as well:

isAuthorizedRaw, a system contract method, should take all offered gas when it fails due to bad input.

(Note that give a valid account, message (hash), and signature it is not a failure for the signature to not be valid for that message + account. But if the account doesn't exist that's bad input and that is a failure.)

**Related issue(s):**


Fixes #14217 

Relates to: #14209, #14210 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
