### PR TITLE
chore: increase wait-to-`ACTIVE` timeout

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -64,13 +64,13 @@ val prCheckTags =
     )
 val prCheckStartPorts =
     mapOf(
-        "hapiTestCrypto" to "30000",
-        "hapiTestToken" to "31000",
-        "hapiTestRestart" to "32000",
-        "hapiTestSmartContract" to "33000",
-        "hapiTestNDReconnect" to "34000",
-        "hapiTestTimeConsuming" to "35000",
-        "hapiTestMisc" to "36000"
+        "hapiTestCrypto" to "26000",
+        "hapiTestToken" to "27000",
+        "hapiTestRestart" to "28000",
+        "hapiTestSmartContract" to "29000",
+        "hapiTestNDReconnect" to "30000",
+        "hapiTestTimeConsuming" to "31000",
+        "hapiTestMisc" to "32000"
     )
 
 tasks { prCheckTags.forEach { (taskName, _) -> register(taskName) { dependsOn("test") } } }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LifecycleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LifecycleTest.java
@@ -63,7 +63,7 @@ public interface LifecycleTest {
     Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(60);
     Duration MIXED_OPS_BURST_DURATION = Duration.ofSeconds(10);
     Duration EXEC_IMMEDIATE_MF_TIMEOUT = Duration.ofSeconds(10);
-    Duration RESTART_TO_ACTIVE_TIMEOUT = Duration.ofSeconds(180);
+    Duration RESTART_TO_ACTIVE_TIMEOUT = Duration.ofSeconds(210);
     Duration PORT_UNBINDING_WAIT_PERIOD = Duration.ofSeconds(180);
     AtomicInteger CURRENT_CONFIG_VERSION = new AtomicInteger(0);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -22,6 +22,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForActive;
+import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.RESTART_TO_ACTIVE_TIMEOUT;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.burstOfTps;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -54,9 +55,8 @@ public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
                         // Restart node2
                         FakeNmt.restartNode("Carol"),
-                        logIt("Node 2 is supposedly restarted"),
                         // Wait for node2 ACTIVE (BUSY and RECONNECT_COMPLETE are too transient to reliably poll for)
-                        waitForActive("Carol", LifecycleTest.RESTART_TO_ACTIVE_TIMEOUT))
+                        waitForActive("Carol", RESTART_TO_ACTIVE_TIMEOUT))
                 .then(
                         // Run some more transactions
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),


### PR DESCRIPTION
**Description**:
- Try to stabilize `ND Reconnect` PR check by,
   * Increasing wait-to-active timeout by 30 seconds
   * Using ports outside the ephemeral range