### PR TITLE
chore:Disallow backpressure for direct schedulers

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/deterministic/DeterministicTaskSchedulerBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/model/internal/deterministic/DeterministicTaskSchedulerBuilder.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.common.wiring.model.internal.deterministic;
 
+import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType.DIRECT;
 import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType.DIRECT_THREADSAFE;
 import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType.NO_OP;
 
@@ -66,6 +67,10 @@ public class DeterministicTaskSchedulerBuilder<OUT> extends AbstractTaskSchedule
     @NonNull
     @Override
     public TaskScheduler<OUT> build() {
+        // Check to ensure unhandled task capacity is not set for direct schedulers
+        if ((type == DIRECT || type == DIRECT_THREADSAFE) && unhandledTaskCapacity != 1) {
+            throw new IllegalArgumentException("Direct schedulers cannot have an unhandled task capacity.");
+        }
 
         final boolean insertionIsBlocking = unhandledTaskCapacity != UNLIMITED_CAPACITY || externalBackPressure;
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/internal/AbstractTaskSchedulerBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/internal/AbstractTaskSchedulerBuilder.java
@@ -136,6 +136,9 @@ public abstract class AbstractTaskSchedulerBuilder<OUT> implements TaskScheduler
     @Override
     @NonNull
     public AbstractTaskSchedulerBuilder<OUT> withType(@NonNull final TaskSchedulerType type) {
+        if ((type == DIRECT || type == DIRECT_THREADSAFE) && unhandledTaskCapacity != 1) {
+            throw new IllegalArgumentException("Direct schedulers cannot have an unhandled task capacity.");
+        }
         this.type = Objects.requireNonNull(type);
         return this;
     }
@@ -146,6 +149,9 @@ public abstract class AbstractTaskSchedulerBuilder<OUT> implements TaskScheduler
     @Override
     @NonNull
     public AbstractTaskSchedulerBuilder<OUT> withUnhandledTaskCapacity(final long unhandledTaskCapacity) {
+        if (type == DIRECT || type == DIRECT_THREADSAFE) {
+            throw new IllegalArgumentException("Cannot set unhandled task capacity for direct schedulers.");
+        }
         this.unhandledTaskCapacity = unhandledTaskCapacity;
         return this;
     }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/internal/StandardTaskSchedulerBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/schedulers/builders/internal/StandardTaskSchedulerBuilder.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.common.wiring.schedulers.builders.internal;
 
+import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType.DIRECT;
 import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType.DIRECT_THREADSAFE;
 import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerType.NO_OP;
 
@@ -119,6 +120,11 @@ public class StandardTaskSchedulerBuilder<OUT> extends AbstractTaskSchedulerBuil
     @Override
     @NonNull
     public TaskScheduler<OUT> build() {
+        // Check to ensure unhandled task capacity is not set for direct schedulers
+        if ((type == DIRECT || type == DIRECT_THREADSAFE) && unhandledTaskCapacity != 1) {
+            throw new IllegalArgumentException(
+                    "Direct schedulers cannot have an unhandled task capacity other than the default.");
+        }
         final Counters counters = buildCounters();
         final FractionalTimer busyFractionTimer = buildBusyTimer();
 


### PR DESCRIPTION
**Description**:
Added logic in TaskSchedulerBuilder.withType(), TaskSchedulerBuilder.withUnhandledTaskCapacity(), and TaskSchedulerBuilder.build() to disallow backpressure for direct schedulers.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #10870 

**Notes for reviewer**:
The condition throws an IllegalArgumentException when the type is DIRECT or DIRECT_THREADSAFE and if unhandledTaskCapacity is set.

<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
