### PR TITLE
fix: remove hard dependency on 'commons.compress'

### DIFF
--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -21,9 +21,6 @@ plugins {
 dependencies {
     api(enforcedPlatform("io.netty:netty-bom:4.1.110.Final"))
 
-    // Force commons compress version to close a security vulnerability
-    api(javaModuleDependencies.gav("org.apache.commons.compress"))
-
     // forward logging from modules using SLF4J (e.g. 'org.hyperledger.besu.evm') to Log4J
     runtime(javaModuleDependencies.gav("org.apache.logging.log4j.slf4j2.impl"))
 }

--- a/platform-sdk/swirlds-logging/build.gradle.kts
+++ b/platform-sdk/swirlds-logging/build.gradle.kts
@@ -29,6 +29,7 @@ mainModuleInfo { annotationProcessor("com.google.auto.service.processor") }
 
 testModuleInfo {
     requires("org.apache.logging.log4j.core")
+    requires("org.apache.commons.lang3")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("com.swirlds.logging.test.fixtures")
     requires("org.assertj.core")


### PR DESCRIPTION
**Description**:

Follow up to #11656.

The removed statement added 'commons.compress' to the runtime **and compile** classpath of ALL modules. That's not needed and conceptually wrong. To update the version, the other changes of #11656 are sufficient.

**Related issue(s)**:

#11656

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
