### PR TITLE
feat(reconnect): log ReconnectMapStats

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/LearningSynchronizer.java
@@ -247,6 +247,7 @@ public class LearningSynchronizer implements ReconnectNodeCount {
                 .setInternalNodes(internalNodesReceived)
                 .setRedundantInternalNodes(redundantInternalNodes)
                 .toString());
+        logger.info(RECONNECT.getMarker(), () -> mapStats.format());
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapMetrics.java
@@ -29,6 +29,10 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
 
     private static final String RECONNECT_MAP_CATEGORY = "reconnect_vmap";
 
+    /** A map label as passed to the constructor, w/o any normalization. */
+    @Nullable
+    private final String originalLabel;
+
     private final ReconnectMapStats aggregateStats;
 
     private final Counter transfersFromTeacher;
@@ -57,6 +61,7 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
             @Nullable final String originalLabel,
             @Nullable final ReconnectMapStats aggregateStats) {
         Objects.requireNonNull(metrics, "metrics must not be null");
+        this.originalLabel = originalLabel;
         this.aggregateStats = aggregateStats;
         // Normalize the label
         final String label = originalLabel == null ? null : originalLabel.replace('.', '_');
@@ -166,5 +171,31 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
         if (aggregateStats != null) {
             aggregateStats.incrementLeafData(dataNum, cleanDataNum);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String format() {
+        final StringBuilder sb = new StringBuilder("ReconnectMapMetrics: ");
+
+        if (originalLabel != null) {
+            sb.append("label=").append(originalLabel).append("; ");
+        }
+
+        sb.append("transfersFromTeacher=").append(transfersFromTeacher.get()).append("; ");
+        sb.append("transfersFromLearner=").append(transfersFromLearner.get()).append("; ");
+
+        sb.append("internalHashes=").append(internalHashes.get()).append("; ");
+        sb.append("internalCleanHashes=").append(internalCleanHashes.get()).append("; ");
+        sb.append("internalData=").append(internalData.get()).append("; ");
+        sb.append("internalCleanData=").append(internalCleanData.get()).append("; ");
+        sb.append("leafHashes=").append(leafHashes.get()).append("; ");
+        sb.append("leafCleanHashes=").append(leafCleanHashes.get()).append("; ");
+        sb.append("leafData=").append(leafData.get()).append("; ");
+        sb.append("leafCleanData=").append(leafCleanData.get());
+
+        return sb.toString();
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapStats.java
@@ -72,4 +72,13 @@ public interface ReconnectMapStats {
      * @param cleanDataNum the number of data payloads transferred unnecessarily because they were clean
      */
     default void incrementLeafData(int dataNum, int cleanDataNum) {}
+
+    /**
+     * Formats a string with all the accumulated stats and any other useful information
+     * maintained by the implementation of this interface, such as the map name and similar.
+     * @return a string with the stats, useful for e.g. logging
+     */
+    default String format() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }


### PR DESCRIPTION
**Description**:
Log the stats collected in `ReconnectMapStats`.

While an implementation of the `ReconnectMapStats` interface, such as the `ReconnectMapMetrics`, emits actual metrics already, it is still useful to also log the accumulated stat values once the reconnect is finished. This simplifies analyzing the metric values in a situation when the metrics are not published to Grafana directly, for example, when running a test on a developer branch locally or in a custom test network.

**Related issue(s)**:

Fixes #13749

**Notes for reviewer**:
Trivial changes simply adding extra logging.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
