### PR TITLE
chore: Initial BlockStreamManagerImpl wip

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.cloneHederaProtobufs {
     // uncomment below to use a specific tag
     //    tag = "v0.51.0"
     // uncomment below to use a specific branch
-    branch = "continue-block-node"
+    branch = "driley/fix-compile-services"
 }
 
 sourceSets {

--- a/hapi/src/main/java/module-info.java
+++ b/hapi/src/main/java/module-info.java
@@ -58,6 +58,7 @@ module com.hedera.node.hapi {
     exports com.hedera.hapi.block.stream;
     exports com.hedera.hapi.block.stream.input;
     exports com.hedera.hapi.block.stream.output;
+    exports com.hedera.hapi.block.stream.schema;
 
     requires transitive com.google.common;
     requires transitive com.google.protobuf;

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/module-info.java
@@ -25,4 +25,5 @@ module com.hedera.node.app.service.addressbook.impl {
     exports com.hedera.node.app.service.addressbook.impl.handlers;
     exports com.hedera.node.app.service.addressbook.impl.records;
     exports com.hedera.node.app.service.addressbook.impl.validators;
+    exports com.hedera.node.app.service.addressbook.impl.schemas;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ServicesConfigExtension.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ServicesConfigExtension.java
@@ -43,6 +43,7 @@ import com.hedera.node.config.data.AutoRenew2Config;
 import com.hedera.node.config.data.AutoRenewConfig;
 import com.hedera.node.config.data.BalancesConfig;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
+import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.BootstrapConfig;
 import com.hedera.node.config.data.CacheConfig;
 import com.hedera.node.config.data.ConsensusConfig;
@@ -102,6 +103,7 @@ public class ServicesConfigExtension implements ConfigurationExtension {
                 AutoRenewConfig.class,
                 BalancesConfig.class,
                 BlockRecordStreamConfig.class,
+                BlockStreamConfig.class,
                 BootstrapConfig.class,
                 CacheConfig.class,
                 ConsensusConfig.class,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
@@ -18,27 +18,40 @@ package com.hedera.node.app.records;
 
 import com.hedera.node.app.records.impl.BlockRecordManagerImpl;
 import com.hedera.node.app.records.impl.BlockRecordStreamProducer;
+import com.hedera.node.app.records.impl.BlockStreamManagerImpl;
+import com.hedera.node.app.records.impl.BlockStreamProducer;
 import com.hedera.node.app.records.impl.producers.BlockRecordFormat;
 import com.hedera.node.app.records.impl.producers.BlockRecordWriterFactory;
+import com.hedera.node.app.records.impl.producers.BlockStreamFormat;
+import com.hedera.node.app.records.impl.producers.BlockStreamProducerSingleThreaded;
+import com.hedera.node.app.records.impl.producers.BlockStreamWriterFactory;
 import com.hedera.node.app.records.impl.producers.StreamFileProducerConcurrent;
 import com.hedera.node.app.records.impl.producers.StreamFileProducerSingleThreaded;
 import com.hedera.node.app.records.impl.producers.formats.BlockRecordWriterFactoryImpl;
+import com.hedera.node.app.records.impl.producers.formats.v1.BlockStreamFormatV1;
 import com.hedera.node.app.records.impl.producers.formats.v6.BlockRecordFormatV6;
 import com.hedera.node.app.records.impl.producers.formats.v7.BlockRecordFormatV7;
+import com.hedera.node.app.records.impl.producers.formats.v8.BlockStreamWriterFactoryImpl;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
+import com.hedera.node.config.data.BlockStreamConfig;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.util.concurrent.ExecutorService;
 import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /** A Dagger module for facilities in the {@link com.hedera.node.app.records} package. */
 @Module
 public abstract class BlockRecordInjectionModule {
+
+    private static final Logger logger = LogManager.getLogger(BlockRecordInjectionModule.class);
 
     protected BlockRecordInjectionModule() {
         /* Nothing to do */
@@ -70,20 +83,10 @@ public abstract class BlockRecordInjectionModule {
         };
     }
 
-    /** Provides an implementation of the {@link com.hedera.node.app.records.BlockRecordManager}. */
-    @Provides
-    @Singleton
-    public static BlockRecordManager provideBlockRecordManager(
-            @NonNull final ConfigProvider configProvider,
-            @NonNull final WorkingStateAccessor state,
-            @NonNull final BlockRecordStreamProducer streamFileProducer) {
-        final var hederaState = state.getHederaState();
-        if (hederaState == null) {
-            throw new IllegalStateException("Hedera state is null");
-        }
-        return new BlockRecordManagerImpl(configProvider, hederaState, streamFileProducer);
-    }
-
+    /** Provides an implementation of the {@link BlockRecordFormat}.
+     * @param configProvider the configuration provider
+     * @return the block record format
+     */
     @Provides
     @Singleton
     public static BlockRecordFormat provideBlockRecordFormat(@NonNull final ConfigProvider configProvider) {
@@ -91,8 +94,36 @@ public abstract class BlockRecordInjectionModule {
         final var recordFileVersion = recordStreamConfig.recordFileVersion();
         return switch (recordFileVersion) {
             case BlockRecordFormatV6.VERSION_6 -> BlockRecordFormatV6.INSTANCE;
-            case BlockRecordFormatV7.VERSION_7 -> BlockRecordFormatV7.INSTANCE;
+            case BlockRecordFormatV7.VERSION_7, BlockStreamFormatV1.VERSION_8 -> BlockRecordFormatV7.INSTANCE;
             default -> throw new IllegalArgumentException("Unknown block record version: " + recordFileVersion);
+        };
+    }
+
+    /** Provides an implementation of the {@link com.hedera.node.app.records.BlockRecordManager}. */
+    @Provides
+    @Singleton
+    @NonNull
+    public static BlockRecordManager provideBlockRecordManager(
+            @NonNull final ExecutorService executor,
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final WorkingStateAccessor state,
+            @NonNull final BlockRecordStreamProducer streamFileProducer,
+            @NonNull final BlockStreamProducer blockStreamProducer) {
+        final var hederaState = state.getHederaState();
+        if (hederaState == null) {
+            throw new IllegalStateException("Hedera state is null");
+        }
+
+        final var recordStreamConfig = configProvider.getConfiguration().getConfigData(BlockRecordStreamConfig.class);
+        final var recordFileVersion = recordStreamConfig.recordFileVersion();
+        return switch (recordFileVersion) {
+            case BlockRecordFormatV6.VERSION_6 -> new BlockRecordManagerImpl(
+                    configProvider, hederaState, streamFileProducer);
+            case BlockStreamFormatV1.VERSION_8 -> provideBlockStreamManager(
+                    executor, configProvider, state, blockStreamProducer);
+            default -> {
+                throw new IllegalArgumentException("Unknown block record version: " + recordFileVersion);
+            }
         };
     }
 
@@ -100,4 +131,86 @@ public abstract class BlockRecordInjectionModule {
     @Singleton
     public abstract BlockRecordWriterFactory provideBlockRecordWriterFactory(
             @NonNull BlockRecordWriterFactoryImpl impl);
+
+    @Provides
+    @Singleton
+    @NonNull
+    public static BlockStreamFormat provideBlockStreamFormat(@NonNull final ConfigProvider configProvider) {
+        final var blockVersion = validateBlockStreamVersion(configProvider);
+        return switch (8) {
+            case BlockStreamFormatV1.VERSION_8 -> BlockStreamFormatV1.INSTANCE;
+            default -> {
+                throw new IllegalArgumentException("Unknown block stream version: " + 8);
+            }
+        };
+    }
+
+    /**
+     * Provides a {@link BlockStreamProducer} based on the configuration. It is possible to use a concurrent producer,
+     * or a single-threaded producer, based on configuration.
+     *
+     * <p> We want to use an async ForkJoinPool as the executor, not the common pool. We create recursive tasks within
+     *     the producer, and therefore want the LIFO semantics. This should help reduce latency for the block that is
+     *     currently being constructed.
+     */
+    @Provides
+    @Singleton
+    @NonNull
+    public static BlockStreamProducer provideBlockStreamFileProducer(
+            @NonNull final ExecutorService executor,
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final BlockStreamProducerSingleThreaded serial) {
+        final var recordStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        final var producerType = recordStreamConfig.streamFileProducer().toUpperCase();
+        return switch (producerType) {
+            case "SERIAL" -> serial;
+            default -> {
+                logger.fatal("Unknown stream file producer type: {}", producerType);
+                throw new IllegalArgumentException("Unknown stream file producer type: " + producerType);
+            }
+        };
+    }
+
+    @Binds
+    @Singleton
+    @NonNull
+    public abstract BlockStreamWriterFactory provideBlockStreamWriterFactory(
+            @NonNull BlockStreamWriterFactoryImpl impl);
+
+    // @Provides
+    @Singleton
+    public static BlockRecordManager provideBlockStreamManager(
+            @NonNull final ExecutorService executor,
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final WorkingStateAccessor state,
+            @NonNull final BlockStreamProducer blockStreamProducer) {
+        final var hederaState = state.getHederaState();
+        if (hederaState == null) {
+            throw new IllegalStateException("Hedera state is null");
+        }
+        return new BlockStreamManagerImpl(executor, configProvider, hederaState, blockStreamProducer);
+    }
+
+    private static int validateBlockStreamVersion(@NonNull final ConfigProvider configProvider) {
+        // This is the only time BlockRecordStreamConfig should be referenced in this package.
+        final var recordStreamConfig = configProvider.getConfiguration().getConfigData(BlockRecordStreamConfig.class);
+        final var recordFileVersion = recordStreamConfig.recordFileVersion();
+
+        final var blockStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        final var blockVersion = blockStreamConfig.blockVersion();
+
+        // This is a sanity check until record streams are deprecated and we are fully switched to block streams.
+        // FUTURE: Remove this check once we deprecate records.
+        if (recordFileVersion != blockVersion) {
+            logger.fatal("Record file version must match block stream version.");
+            throw new IllegalArgumentException("Record file version must match block stream version.");
+        }
+        if (blockVersion < BlockStreamFormatV1.VERSION_8) {
+            // This is only a hint as block streams started at version 8.
+            logger.fatal("Block stream version must be >= 8. See BlockRecordInjectionModule instead.");
+            throw new IllegalArgumentException(
+                    "Block stream version must be >= 8. See BlockRecordInjectionModule instead.");
+        }
+        return blockVersion;
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockStreamManagerImpl.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl;
+
+import static com.hedera.node.app.records.BlockRecordService.EPOCH;
+import static com.hedera.node.app.records.impl.BlockRecordInfoUtils.HASH_SIZE;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.node.app.records.BlockRecordManager;
+import com.hedera.node.app.records.BlockRecordService;
+import com.hedera.node.app.records.schemas.V0490BlockRecordSchema;
+import com.hedera.node.app.state.SingleTransactionStreamRecord;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.crypto.DigestType;
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.spi.WritableSingletonStateBase;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
+import com.swirlds.state.HederaState;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ *
+ */
+@Singleton
+public class BlockStreamManagerImpl implements BlockRecordManager {
+    private static final Logger logger = LogManager.getLogger(BlockStreamManagerImpl.class);
+    private final ExecutorService executor;
+
+    /**
+     * The number of rounds in the current provisional block. "provisional" because the block is not yet complete.
+     */
+    // Should this be stored in BlockInfo so that it's safe for restarts?
+    private int roundsUntilNextBlock;
+
+    /**
+     * Keeps track if this block is currently open.
+     */
+    // Should this be stored in BlockInfo so that it's safe for restarts?
+    private boolean blockOpen;
+
+    private final int numBlockHashesToKeepBytes;
+    private final int numRoundsInBlock;
+    private final BlockStreamProducer blockStreamProducer;
+    /** True when we have completed event recovery. This is not yet implemented properly. */
+    private boolean eventRecoveryCompleted = false;
+
+    /**
+     * A {@link BlockInfo} of the most recently completed block. This is actually available in state, but there
+     * is no reason for us to read it from state every time we need it, we can just recompute and cache this every
+     * time we finish a provisional block.
+     */
+    private BlockInfo lastBlockInfo;
+
+    @Inject
+    public BlockStreamManagerImpl(
+            @NonNull final ExecutorService executor,
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final HederaState state,
+            @NonNull final BlockStreamProducer blockStreamProducer) {
+
+        this.executor = requireNonNull(executor);
+        requireNonNull(state);
+        requireNonNull(configProvider);
+        this.blockStreamProducer = requireNonNull(blockStreamProducer);
+
+        // Get static configuration that is assumed not to change while the node is running
+        final var blockStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        this.numRoundsInBlock = blockStreamConfig.numRoundsInBlock();
+        if (this.numRoundsInBlock <= 0) {
+            throw new IllegalArgumentException("numRoundsInBlock must be greater than 0");
+        }
+        this.numBlockHashesToKeepBytes = blockStreamConfig.numOfBlockHashesInState() * HASH_SIZE;
+
+        // Initialize the last block info and provisional block info.
+        // NOTE: State migration happens BEFORE dagger initialization, and this object is managed by dagger. So we are
+        // guaranteed that the state exists PRIOR to this call.
+        final var states = state.getReadableStates(BlockRecordService.NAME);
+        final var blockInfoState = states.<BlockInfo>getSingleton(V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY);
+        this.lastBlockInfo = blockInfoState.get();
+        assert this.lastBlockInfo != null : "Cannot be null, because this state is created at genesis";
+        this.blockOpen = false;
+        this.roundsUntilNextBlock = numRoundsInBlock;
+
+        // Initialize the stream file producer. NOTE, if the producer cannot be initialized, and a random exception is
+        // thrown here, then startup of the node will fail. This is the intended behavior. We MUST be able to produce
+        // block streams, or there really is no point to running the node!
+        final var runningHashState =
+                states.<RunningHashes>getSingleton(V0490BlockRecordSchema.RUNNING_HASHES_STATE_KEY);
+        final var lastRunningHashes = runningHashState.get();
+        assert lastRunningHashes != null : "Cannot be null, because this state is created at genesis";
+        this.blockStreamProducer.initFromLastBlock(lastRunningHashes, this.lastBlockInfo.lastBlockNumber());
+    }
+
+    @Override
+    public boolean startUserTransaction(
+            @NonNull Instant consensusTime, @NonNull HederaState state, @NonNull PlatformState platformState) {
+        if (EPOCH.equals(lastBlockInfo.firstConsTimeOfCurrentBlock())) {
+            // This is the first transaction of the first block, so set both the firstConsTimeOfCurrentBlock
+            // and the current consensus time to now
+            final var now = new Timestamp(consensusTime.getEpochSecond(), consensusTime.getNano());
+            lastBlockInfo = lastBlockInfo
+                    .copyBuilder()
+                    .consTimeOfLastHandledTxn(now)
+                    .firstConsTimeOfCurrentBlock(now)
+                    .build();
+            putLastBlockInfo(state);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void advanceConsensusClock(@NonNull Instant consensusTime, @NonNull HederaState state) {
+        final var builder = this.lastBlockInfo
+                .copyBuilder()
+                .consTimeOfLastHandledTxn(Timestamp.newBuilder()
+                        .seconds(consensusTime.getEpochSecond())
+                        .nanos(consensusTime.getNano()));
+        if (!this.lastBlockInfo.migrationRecordsStreamed()) {
+            // Any records created during migration should have been published already. Now we shut off the flag to
+            // disallow further publishing
+            builder.migrationRecordsStreamed(true);
+        }
+        final var newBlockInfo = builder.build();
+
+        // Update the latest block info in state
+        final var states = state.getWritableStates(BlockRecordService.NAME);
+        final var blockInfoState = states.<BlockInfo>getSingleton(V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY);
+        blockInfoState.put(newBlockInfo);
+        // Commit the changes. We don't ever want to roll back when advancing the consensus clock
+        ((WritableSingletonStateBase<BlockInfo>) blockInfoState).commit();
+
+        // Cache the updated block info
+        this.lastBlockInfo = newBlockInfo;
+    }
+
+    @Override
+    public void endUserTransaction(
+            @NonNull SingleTransactionStreamRecord transactionRecord, @NonNull HederaState state) {
+        // check if we need to run event recovery before we can write any new records to stream
+        if (!this.eventRecoveryCompleted) {
+            // FUTURE create event recovery class and call it here. Should this be in startUserTransaction()?
+            this.eventRecoveryCompleted = true;
+        }
+
+        // Write the user transaction records to the block stream.
+        blockStreamProducer.writeBlockItems(
+                transactionRecord.blockItemStream() == null
+                        ? Stream.empty()
+                        : requireNonNull(transactionRecord.blockItemStream()));
+    }
+
+    @Override
+    public void startRound() {
+        roundsUntilNextBlock--;
+
+        // We do not have an open block so create a new one.
+        if (!isBlockOpen()) beginBlock();
+    }
+
+    @Override
+    public void endRound(@NonNull HederaState state) {
+        if (roundsUntilNextBlock <= 0) {
+            updateBlockInfoForEndRound(state);
+            resetRoundsUntilNextBlock();
+        }
+
+        updateRunningHashesInState(state);
+
+        blockStreamProducer.endBlock();
+    }
+
+    @Override
+    public void close() {
+        try {
+            blockStreamProducer.close();
+        } catch (final Exception e) {
+            // This is a fairly serious warning. This basically means we cannot guarantee that some records were
+            // produced. However, since the {@link BlockRecordManager} is a singleton, this close method is only called
+            // when the node is being shutdown anyway.
+            logger.warn("Failed to close blockStreamProducer properly", e);
+        }
+    }
+
+    @Override
+    public void markMigrationRecordsStreamed() {
+        lastBlockInfo =
+                lastBlockInfo.copyBuilder().migrationRecordsStreamed(true).build();
+    }
+
+    @NonNull
+    @Override
+    public Instant consTimeOfLastHandledTxn() {
+        final var lastHandledTxn = lastBlockInfo.consTimeOfLastHandledTxn();
+        return lastHandledTxn != null
+                ? Instant.ofEpochSecond(lastHandledTxn.seconds(), lastHandledTxn.nanos())
+                : Instant.EPOCH;
+    }
+
+    @Override
+    public void processSystemTransaction(ConsensusTransaction platformTxn) {
+        blockStreamProducer.writeSystemTransaction(platformTxn);
+    }
+
+    @Nullable
+    @Override
+    public Bytes getRunningHash() {
+        return blockStreamProducer.getRunningHash();
+    }
+
+    @Nullable
+    @Override
+    public Bytes getNMinus3RunningHash() {
+        return blockStreamProducer.getNMinus3RunningHash();
+    }
+
+    @Override
+    public long lastBlockNo() {
+        return lastBlockInfo.lastBlockNumber();
+    }
+
+    @Nullable
+    @Override
+    public Instant firstConsTimeOfLastBlock() {
+        return BlockRecordInfoUtils.firstConsTimeOfLastBlock(lastBlockInfo);
+    }
+
+    @NonNull
+    @Override
+    public Timestamp currentBlockTimestamp() {
+        return lastBlockInfo.firstConsTimeOfCurrentBlockOrThrow();
+    }
+
+    @Nullable
+    @Override
+    public Bytes lastBlockHash() {
+        return BlockRecordInfoUtils.lastBlockHash(lastBlockInfo);
+    }
+
+    @Nullable
+    @Override
+    public Bytes blockHashByBlockNumber(long blockNo) {
+        return BlockRecordInfoUtils.blockHashByBlockNumber(lastBlockInfo, blockNo);
+    }
+
+    private boolean isBlockOpen() {
+        return blockOpen;
+    }
+
+    /**
+     * Begin a new block.
+     */
+    private void beginBlock() {
+        blockOpen = true;
+        blockStreamProducer.beginBlock();
+        // Log start of block if needed.
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    """
+                                    --- BLOCK UPDATE ---
+                                      Started: #{} @ {}""",
+                    provisionalCurrentBlockNumber(),
+                    consTimeOfLastHandledTxn());
+        }
+    }
+
+    /**
+     * End the current block.
+     */
+    private void updateBlockInfoForEndRound(@NonNull final HederaState state) {
+        blockOpen = false;
+
+        // Compute the state for the newly completed block. The `lastBlockHashBytes` is the running hash after
+        // the last transaction.
+        final var justFinishedBlockNumber = provisionalCurrentBlockNumber();
+        final var lastBlockHashBytes = blockStreamProducer.getRunningHash();
+        lastBlockInfo = infoOfJustFinished(lastBlockInfo, justFinishedBlockNumber, lastBlockHashBytes);
+
+        // Update BlockInfo state.
+        final var states = state.getWritableStates(BlockRecordService.NAME);
+        final var blockInfoState = states.<BlockInfo>getSingleton(V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY);
+        blockInfoState.put(lastBlockInfo);
+
+        final var consensusTime = consTimeOfLastHandledTxn();
+
+        // Log end of block if needed.
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    """
+                                    --- BLOCK UPDATE ---
+                                      Finished: #{} @ {} with hash {}""",
+                    justFinishedBlockNumber,
+                    consensusTime,
+                    new Hash(lastBlockHashBytes.toByteArray(), DigestType.SHA_384));
+        }
+    }
+
+    /**
+     * The provisional current block number. This is the block number of the block we are currently writing to. This is
+     * provisional because the block is not yet complete.
+     * @return The provisional current block number.
+     */
+    private long provisionalCurrentBlockNumber() {
+        return lastBlockInfo.lastBlockNumber() + 1;
+    }
+
+    /**
+     * Create a new updated BlockInfo from existing BlockInfo and new block information. BlockInfo stores block hashes as a single
+     * byte array, so we need to append or if full shift left and insert new block hash.
+     *
+     * @param lastBlockInfo The current block info
+     * @param justFinishedBlockNumber The new block number
+     * @param hashOfJustFinishedBlock The new block hash
+     */
+    @NonNull
+    private BlockInfo infoOfJustFinished(
+            @NonNull final BlockInfo lastBlockInfo,
+            final long justFinishedBlockNumber,
+            @NonNull final Bytes hashOfJustFinishedBlock) {
+        // compute new block hashes bytes
+        final byte[] blockHashesBytes = lastBlockInfo.blockHashes().toByteArray();
+        byte[] newBlockHashesBytes;
+        if (blockHashesBytes.length < numBlockHashesToKeepBytes) {
+            // append new hash bytes to end
+            newBlockHashesBytes = new byte[blockHashesBytes.length + HASH_SIZE];
+            System.arraycopy(blockHashesBytes, 0, newBlockHashesBytes, 0, blockHashesBytes.length);
+            hashOfJustFinishedBlock.getBytes(0, newBlockHashesBytes, newBlockHashesBytes.length - HASH_SIZE, HASH_SIZE);
+        } else {
+            // shift bytes left by HASH_SIZE and then set new hash bytes to at end HASH_SIZE bytes
+            newBlockHashesBytes = blockHashesBytes;
+            System.arraycopy(
+                    newBlockHashesBytes, HASH_SIZE, newBlockHashesBytes, 0, newBlockHashesBytes.length - HASH_SIZE);
+            hashOfJustFinishedBlock.getBytes(0, newBlockHashesBytes, newBlockHashesBytes.length - HASH_SIZE, HASH_SIZE);
+        }
+
+        return new BlockInfo(
+                justFinishedBlockNumber,
+                lastBlockInfo.firstConsTimeOfCurrentBlock(),
+                Bytes.wrap(newBlockHashesBytes),
+                lastBlockInfo.consTimeOfLastHandledTxn(),
+                lastBlockInfo.migrationRecordsStreamed(),
+                null);
+    }
+
+    private void putLastBlockInfo(@NonNull final HederaState state) {
+        final var states = state.getWritableStates(BlockRecordService.NAME);
+        final var blockInfoState = states.<BlockInfo>getSingleton(V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY);
+        blockInfoState.put(lastBlockInfo);
+    }
+
+    private void resetRoundsUntilNextBlock() {
+        roundsUntilNextBlock = numRoundsInBlock;
+    }
+
+    private void updateRunningHashesInState(@NonNull final HederaState state) {
+        // We get the latest running hash from the BlockStreamProducer, blocking if needed for it to be computed.
+        final var currentRunningHash = blockStreamProducer.getRunningHash();
+        // Update running hashes in state with the latest running hash and the previous 3 running hashes.
+        final var states = state.getWritableStates(BlockRecordService.NAME);
+        final var runningHashesState =
+                states.<RunningHashes>getSingleton(V0490BlockRecordSchema.RUNNING_HASHES_STATE_KEY);
+        final var existingRunningHashes = runningHashesState.get();
+        assert existingRunningHashes != null : "This cannot be null because genesis migration sets it";
+        runningHashesState.put(new RunningHashes(
+                currentRunningHash,
+                existingRunningHashes.runningHash(),
+                existingRunningHashes.nMinus1RunningHash(),
+                existingRunningHashes.nMinus2RunningHash()));
+        // Commit the changes to the merkle tree.
+        ((WritableSingletonStateBase<RunningHashes>) runningHashesState).commit();
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockStreamProducer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockStreamProducer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.stream.Stream;
+
+/**
+ * Produces a stream of blocks. This is used by the {@link BlockStreamManagerImpl}
+ */
+public interface BlockStreamProducer extends AutoCloseable {
+
+    /**
+     * Write a stream of Block Items to the block stream.
+     *
+     * @param blockItems The record stream items to write.
+     */
+    void writeBlockItems(@NonNull final Stream<BlockItem> blockItems);
+
+    /**
+     * Initialize the current running hash of record stream items. This is called only once to initialize the running
+     * hash on startup. This is called on the handle transaction thread. It is loaded from a saved state. At genesis,
+     * there is no saved state, so this will be called with null.
+     *
+     * @param runningHashes The initial running hashes, all future running hashes produced will be
+     *                                    computed based on this hash.
+     * @param lastBlockNumber The last block number that was committed to state.
+     */
+    void initFromLastBlock(@NonNull final RunningHashes runningHashes, final long lastBlockNumber);
+
+    /**
+     * Get the current running hash of block items. This is called on the handle transaction thread. It will
+     * block if a background thread is still hashing. It will always return the running hash after the last block item
+     * is added. Hence, any block items not yet committed via write methods called before
+     * {@link BlockStreamProducer#endBlock} will not be included.
+     *
+     * @return The current running hash upto and including the last record stream item sent in writeRecordStreamItems().
+     */
+    @NonNull
+    Bytes getRunningHash();
+
+    /**
+     * Get the previous, previous, previous runningHash of all RecordStreamObjects. This will block if
+     * the running hash has not yet been computed for the most recent user transaction.
+     *
+     * @return the previous, previous, previous runningHash of all RecordStreamObject
+     */
+    @Nullable
+    Bytes getNMinus3RunningHash();
+
+    /**
+     * Called at the beginning of a block.
+     *
+     * <p>Begins a new block. It is an error to begin a new block when the previous block has not been closed.
+     */
+    void beginBlock();
+
+    /**
+     * Called to close the current open block.
+     */
+    void endBlock();
+
+    void writeSystemTransaction(ConsensusTransaction platformTxn);
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockStreamProducerSingleThreaded.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockStreamProducerSingleThreaded.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl.producers;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.BlockHeader;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.BlockHashAlgorithm;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.hapi.streams.HashAlgorithm;
+import com.hedera.hapi.streams.HashObject;
+import com.hedera.node.app.records.impl.BlockStreamProducer;
+import com.hedera.node.app.service.addressbook.impl.schemas.V052AddressBookSchema;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
+import com.swirlds.state.spi.info.SelfNodeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.MessageDigest;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ *  A single threaded implementation of {@link BlockStreamProducer} where operations may block the single calling thread.
+ *  This simple implementation is also useful for testing and for the "Hedera Local Node", which is a version of a
+ *  consensus node that may be run as a standalone application, useful for development. This class is not thread-safe.
+ */
+public class BlockStreamProducerSingleThreaded implements BlockStreamProducer {
+
+    private static final Logger logger = LogManager.getLogger(BlockStreamProducerSingleThreaded.class);
+    /** Creates new {@link BlockStreamWriter} instances */
+    private final BlockStreamWriterFactory writerFactory;
+    /** The {@link BlockStreamFormat} used to serialize items for output. */
+    private final BlockStreamFormat format;
+    /**
+     * The {@link BlockStreamWriter} to use for writing produced blocks. A new one is created at the beginning
+     * of each new block.
+     */
+    private volatile BlockStreamWriter writer;
+    /** The running hash at end of the last user transaction */
+    private Bytes runningHash = null;
+    /** The previous running hash */
+    private Bytes runningHashNMinus1 = null;
+    /** The previous, previous running hash */
+    private Bytes runningHashNMinus2 = null;
+    /** The previous, previous, previous running hash */
+    private Bytes runningHashNMinus3 = null;
+
+    private long currentBlockNumber = 0;
+
+    @Inject
+    public BlockStreamProducerSingleThreaded(
+            @NonNull final SelfNodeInfo nodeInfo,
+            @NonNull final BlockStreamFormat format,
+            @NonNull final BlockStreamWriterFactory writerFactory) {
+        this.writerFactory = requireNonNull(writerFactory);
+        this.format = requireNonNull(format);
+    }
+
+    @Override
+    public void writeBlockItems(@NonNull Stream<BlockItem> blockItems) {
+        blockItems.forEach(blockItem -> {
+            final var serializedItem = format.serializeBlockItem(blockItem);
+            updateRunningHashes(serializedItem);
+            writeSerializedBlockItem(serializedItem);
+        });
+    }
+
+    private void writeSerializedBlockItem(@NonNull final Bytes serializedItem) {
+        try {
+            // Depending on the configuration, this writeItem may be an asynchronous or synchronous operation. The
+            // BlockStreamWriterFactory instantiated by dagger will determine this.
+            writer.writeItem(serializedItem, runningHash);
+        } catch (final Exception e) {
+            // This **may** prove fatal. The node should be able to carry on, but then fail when it comes to
+            // actually producing a valid record stream file. We need to have some way of letting all nodesknow
+            // that this node has a problem, so we can make sure at least a minimal threshold of nodes is
+            // successfully producing a blockchain.
+            logger.error("Error writing block item to block stream writer for block {}", currentBlockNumber, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void initFromLastBlock(@NonNull RunningHashes runningHashes, long lastBlockNumber) {
+        if (this.runningHash != null) {
+            throw new IllegalStateException("initFromLastBlock() must only be called once");
+        }
+
+        this.runningHash = runningHashes.runningHash();
+        this.runningHashNMinus1 = runningHashes.nMinus1RunningHash();
+        this.runningHashNMinus2 = runningHashes.nMinus2RunningHash();
+        this.runningHashNMinus3 = runningHashes.nMinus3RunningHash();
+        this.currentBlockNumber = lastBlockNumber;
+    }
+
+    @NonNull
+    @Override
+    public Bytes getRunningHash() {
+        assert runningHash != null : "initFromLastBlock() must be called before getRunningHash()";
+        return runningHash;
+    }
+
+    @Nullable
+    @Override
+    public Bytes getNMinus3RunningHash() {
+        return runningHashNMinus3;
+    }
+
+    @Override
+    public void beginBlock() {
+        this.currentBlockNumber++;
+
+        final var lastRunningHash = getRunningHashObject();
+
+        openWriter(this.currentBlockNumber, lastRunningHash);
+
+        // Write the block header to the block stream as the first item in the block.
+        writeBlockHeader(lastRunningHash);
+    }
+
+    @Override
+    public void endBlock() {
+        final var lastRunningHash = getRunningHashObject();
+        closeWriter(lastRunningHash, this.currentBlockNumber);
+    }
+
+    @Override
+    public void writeSystemTransaction(ConsensusTransaction platformTxn) {
+        final var serializedBlockItem = format.serializeSystemTransaction(platformTxn);
+        updateRunningHashes(serializedBlockItem);
+        writeSerializedBlockItem(serializedBlockItem);
+    }
+
+    @Override
+    public void close() throws Exception {
+        // FUTURE: close() should wait until the block is completed, which cannot happen until the block proof is
+        // produced, and that cannot happen until the signatures have been gossiped. Today, this will close in
+        // unpredictable ways, and will most likely result in the block being written incompletely without a block
+        // proof.
+        final var lastRunningHash = getRunningHashObject();
+        closeWriter(lastRunningHash, this.currentBlockNumber);
+
+        runningHash = null;
+        runningHashNMinus1 = null;
+        runningHashNMinus2 = null;
+        runningHashNMinus3 = null;
+    }
+
+    private void writeBlockHeader(@NonNull final HashObject previousBlockProofHash) {
+        final SemanticVersion hapiProtoVersion = new SemanticVersion(0, 53, 0, null, null);
+        V052AddressBookSchema addressBookSchema = new V052AddressBookSchema();
+        final var blockHeader = getBlockHeader(previousBlockProofHash, addressBookSchema, hapiProtoVersion);
+        final var serializedBlockItem = format.serializeBlockHeader(blockHeader);
+        updateRunningHashes(serializedBlockItem);
+        writeSerializedBlockItem(serializedBlockItem);
+    }
+
+    private @NonNull BlockHeader getBlockHeader(
+            @NonNull HashObject previousBlockProofHash,
+            V052AddressBookSchema addressBookSchema,
+            SemanticVersion hapiProtoVersion) {
+        final SemanticVersion addressBookVersion = addressBookSchema.getVersion();
+        final long number = this.currentBlockNumber;
+        final Bytes previousBlockProofHashBytes = previousBlockProofHash.hash();
+        final BlockHashAlgorithm hashAlgorithm = BlockHashAlgorithm.BLOCK_HASH_SHA_384;
+
+        return new BlockHeader(
+                hapiProtoVersion, number, previousBlockProofHashBytes, hashAlgorithm, addressBookVersion);
+    }
+
+    @NonNull
+    private HashObject getRunningHashObject() {
+        return asHashObject(getRunningHash());
+    }
+
+    @NonNull
+    private HashObject asHashObject(@NonNull final Bytes hash) {
+        return new HashObject(HashAlgorithm.SHA_384, (int) hash.length(), hash);
+    }
+
+    private void closeWriter(@NonNull final HashObject lastRunningHash, final long lastBlockNumber) {
+        if (writer != null) {
+            // If we fail to close the writer, then this node is almost certainly going to end up in deep trouble.
+            // Make sure this is logged. In the FUTURE we may need to do something more drastic, like shut down the
+            // node, or maybe retry a number of times before giving up.
+            try {
+                writer.close();
+            } catch (final Exception e) {
+                logger.error("Error closing block record writer for block {}", lastBlockNumber, e);
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * openWriter uses the writerFactory to create a new writer and initialize it for each block. The writer is not
+     * re-used.
+     * @param newBlockNumber The block number for which the writer is being created.
+     * @param previousBlockProofHash The hash of the previous block's proof.
+     */
+    private void openWriter(final long newBlockNumber, @NonNull final HashObject previousBlockProofHash) {
+        try {
+            // Depending on the configuration, this writer's methods may be asynchronous or synchronous. The
+            // BlockStreamWriterFactory instantiated by dagger will determine this.
+            writer = writerFactory.create();
+            writer.init(currentBlockNumber, previousBlockProofHash);
+        } catch (final Exception e) {
+            // This represents an almost certainly fatal error. In the FUTURE we should look at dealing with this in a
+            // more comprehensive and consistent way. Maybe we retry a bunch of times before giving up, then restart
+            // the node. Or maybe we block forever. Or maybe we disable event intake while we keep trying to get this
+            // to work. Or maybe we just shut down the node.
+            logger.error("Error creating or initializing a block record writer for block {}", newBlockNumber, e);
+            throw e;
+        }
+    }
+
+    private void updateRunningHashes(@NonNull final Bytes serializedItem) {
+        updateRunningHashesWithMessageDigest(format.getMessageDigest(), serializedItem);
+    }
+
+    private void updateRunningHashesWithMessageDigest(
+            @NonNull final MessageDigest messageDigest, @NonNull final Bytes serializedItem) {
+        // Compute new running hash, by adding each serialized BlockItem to the current running hash.
+        runningHashNMinus3 = runningHashNMinus2;
+        runningHashNMinus2 = runningHashNMinus1;
+        runningHashNMinus1 = runningHash;
+        runningHash = format.computeNewRunningHash(messageDigest, runningHash, serializedItem);
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockStreamWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockStreamWriter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl.producers;
+
+import com.hedera.hapi.streams.HashObject;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.UncheckedIOException;
+
+/**
+ *  Writes a block stream to a destination, such as a socket or in memory buffer.
+ *
+ *  <p>A consensus node takes as input transactions from users, and produces a series of blocks. If the node
+ *  fails to produce a block, then the node has effectively failed in its duty to produce a valid blockchain,
+ *  and it must halt processing and reconnect. If enough nodes fail to produce a block, then the network will
+ *  halt processing transactions. In this way, we can ensure that the network is always making progress without losing
+ *  any data in the block stream.
+ *
+ *  <p>Callers must be prepared to deal with all manner of exceptions. Be prepared to handle Throwable. The callers
+ *  <b>can</b> attempt a retry, or they can just fail hard.
+ */
+public interface BlockStreamWriter {
+    /**
+     * Initialize the writer to begin accepting a new block of {@link SerializedSingleTransactionRecord}s.
+     *
+     * <p>>Initialize a new rpc request to a BlockNode. This BlockStreamWriter will not be responsible for deciding
+     *     which Block Node to send the request to as that is the job of the gRPC picker.
+     *
+     * <p>The file implementation of this interface writes directly to a file.
+     *
+     * @param blockNumber the block number of the block
+     * @param previousBlockProofHash the block proof hash of the previous block
+     * @throws IllegalStateException if called after {@link #writeItem(Bytes, Bytes)} or after
+     *                               {@link #close()}.
+     * @throws UncheckedIOException if there is an error writing to the destination
+     */
+    void init(final long blockNumber, @NonNull final HashObject previousBlockProofHash);
+
+    /**
+     * Write a single item to the block stream output. This method may be called multiple times for different items,
+     * but must be called after {@link #init(long, HashObject)} and before
+     * {@link #close()}.
+     *
+     * @param item the item to write
+     * @param endRunningHash the end running hash after this item is written
+     * @throws IllegalStateException if called before {@link #init(long, HashObject)} or after
+     *                               {@link #close()}.
+     * @throws UncheckedIOException if there is an error writing to the destination
+     */
+    void writeItem(@NonNull final Bytes item, @NonNull final Bytes endRunningHash);
+
+    /**
+     * Close the block that has been produced. Must be called after
+     * {@link #init(long, HashObject)}.
+     *
+     * @throws IllegalStateException if called before {@link #init(long, HashObject)}.
+     * @throws UncheckedIOException if there is an error writing to the destination
+     */
+    void close();
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockStreamWriterFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockStreamWriterFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl.producers;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Creates a new {@link BlockStreamWriter} instance on demand, based on configuration. During processing of
+ * transactions, when we determine it is time to write a new block to file, then we need to create a new
+ * {@link BlockStreamWriter} instance. This factory is used to create that instance. Creation of the instance may fail,
+ * for example, if the filesystem is full or the network destination is unavailable. Callers must be prepared to deal
+ * with these failures.
+ */
+public interface BlockStreamWriterFactory {
+    /**
+     * Create a new {@link BlockStreamWriter} instance.
+     *
+     * @return the new instance
+     * @throws RuntimeException if creation fails
+     */
+    @NonNull
+    BlockStreamWriter create() throws RuntimeException;
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v8/BlockStreamFileWriterV1.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v8/BlockStreamFileWriterV1.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl.producers.formats.v8;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.schema.BlockSchema;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.streams.HashObject;
+import com.hedera.node.app.records.impl.producers.BlockStreamWriter;
+import com.hedera.node.app.records.impl.producers.formats.v1.BlockStreamFormatV1;
+import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.pbj.runtime.ProtoConstants;
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import com.swirlds.common.stream.Signer;
+import com.swirlds.state.spi.info.NodeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.math.BigInteger;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public final class BlockStreamFileWriterV1 implements BlockStreamWriter {
+
+    private static final Logger logger = LogManager.getLogger(BlockStreamFileWriterV1.class);
+
+    /** The file extension for block files. */
+    public static final String RECORD_EXTENSION = "blk";
+
+    /** The suffix added to RECORD_EXTENSION when they are compressed. */
+    public static final String COMPRESSION_ALGORITHM_EXTENSION = ".gz";
+
+    /** Whether to compress the record file and sidecar files. */
+    private final boolean compressFiles;
+
+    /** The node-specific path to the directory where block files are written */
+    private final Path nodeScopedBlockDir;
+
+    /** The path to the record file we are writing */
+    private Path blockFilePath;
+
+    /** The file output stream we are writing to, which writes to {@link #blockFilePath} */
+    private OutputStream outputStream;
+
+    private WritableStreamingData writableStreamingData;
+
+    /** The state of this writer */
+    private State state;
+
+    /**
+     * The version of the HAPI protobuf schema used to record transactions. This never changes throughout the execution
+     * of the program.
+     */
+    private final SemanticVersion hapiProtoVersion;
+    /**
+     * The starting running hash before any items in this file. This was the end hash of the previous file. Once it is
+     * set in {@link #init}, it is never changed.
+     */
+    private HashObject startRunningHash;
+
+    /**
+     * The end running hash after any items in this file. This will be set on each call to {@link #writeItem}.
+     */
+    private Bytes endRunningHash;
+    /**
+     * The block number for the file we are writing. Each file corresponds to one, and only one, block. Once it is
+     * set in {@link #init}, it is never changed.
+     */
+    private long blockNumber;
+
+    private enum State {
+        UNINITIALIZED,
+        OPEN_WITHOUT_HEADER,
+        OPEN,
+        CLOSED
+    }
+
+    public BlockStreamFileWriterV1(
+            @NonNull final BlockStreamConfig config,
+            @NonNull final NodeInfo nodeInfo,
+            @NonNull final FileSystem fileSystem,
+            @NonNull final SemanticVersion hapiProtoVersion,
+            @NonNull final Signer signer) {
+
+        if (config.blockVersion() != BlockStreamFormatV1.VERSION_8) {
+            logger.fatal(
+                    "Bad configuration: BlockStreamFileWriterV1 used with block version {}", config.blockVersion());
+            throw new IllegalArgumentException("Configuration block version must be >= 7 for BlockStreamFileWriterV1!");
+        }
+
+        this.state = State.UNINITIALIZED;
+        this.hapiProtoVersion = requireNonNull(hapiProtoVersion);
+        this.compressFiles = config.compressFilesOnCreation();
+
+        // Compute directories for record and sidecar files.
+        final Path blockDir = fileSystem.getPath(config.logDir());
+        nodeScopedBlockDir = blockDir.resolve("block-" + nodeInfo.memo());
+
+        // Create parent directories if needed for the record file itself.
+        try {
+            Files.createDirectories(nodeScopedBlockDir);
+        } catch (final IOException e) {
+            logger.fatal("Could not create block directory {}", nodeScopedBlockDir, e);
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // =================================================================================================================
+    // Implementation of methods in BlockStreamWriter
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(final long blockNumber, @NonNull final HashObject previousBlockProofHash) {
+        if (state != State.UNINITIALIZED)
+            throw new IllegalStateException("Cannot initialize a BlockStreamFileWriterV1 twice");
+
+        if (blockNumber < 0) throw new IllegalArgumentException("Block number must be non-negative");
+
+        this.blockNumber = blockNumber;
+        this.startRunningHash = requireNonNull(previousBlockProofHash);
+
+        // Create the chain of streams.
+        this.blockFilePath = getBlockFilePath(blockNumber);
+
+        OutputStream out = null;
+        try {
+            out = Files.newOutputStream(blockFilePath);
+            out = new BufferedOutputStream(out, 1024 * 1024); // 1 MB
+            if (compressFiles) {
+                out = new GZIPOutputStream(out, 1024 * 256); // 256 KB
+                // This double buffer is needed to reduce the number of synchronized calls to the underlying
+                // GZIPOutputStream. We know most files are going to be ~3-4 MB, so we can safely buffer that much.
+                out = new BufferedOutputStream(out, 1024 * 1024 * 4); // 4 MB
+            }
+
+            this.writableStreamingData = new WritableStreamingData(out);
+        } catch (final IOException e) {
+            // If an exception was thrown, we should close the stream if it was opened to prevent a resource leak.
+            if (out != null) {
+                try {
+                    out.close();
+                } catch (IOException ex) {
+                    logger.error("Error closing the BlockStreamFileWriterV1 output stream", ex);
+                }
+            }
+            // We must be able to produce blocks.
+            logger.fatal("Could not create block file {}", blockFilePath, e);
+            throw new UncheckedIOException(e);
+        }
+        this.outputStream = out;
+
+        state = State.OPEN;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeItem(@NonNull final Bytes item, @NonNull final Bytes endRunningHash) {
+        assert item.length() > 0 : "BlockItem must be non-empty";
+        if (state != State.OPEN) {
+            throw new IllegalStateException(
+                    "Cannot write to a BlockStreamFileWriterV1 that is not open for block: " + this.blockNumber);
+        }
+
+        this.endRunningHash = endRunningHash;
+
+        // Write the ITEMS tag.
+        ProtoWriterTools.writeTag(writableStreamingData, BlockSchema.ITEMS, ProtoConstants.WIRE_TYPE_DELIMITED);
+        // Write the length of the item.
+        writableStreamingData.writeVarInt((int) item.length(), false);
+        // Write the item bytes themselves.
+        item.writeTo(writableStreamingData);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        if (state.ordinal() < State.OPEN.ordinal()) {
+            throw new IllegalStateException("Cannot close a BlockStreamFileWriterV1 that is not open");
+        } else if (state.ordinal() == State.CLOSED.ordinal()) {
+            throw new IllegalStateException("Cannot close a BlockStreamFileWriterV1 that is already closed");
+        }
+
+        // Close the writableStreamingData.
+        try {
+            writableStreamingData.close();
+            state = State.CLOSED;
+        } catch (final IOException e) {
+            logger.error("Error closing the BlockStreamFileWriterV1 output stream", e);
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Get the record file path for a record file with the given consensus time
+     *
+     * @param blockNumber the block number for the block file
+     * @return Path to a record file for that block number
+     */
+    @NonNull
+    private Path getBlockFilePath(final long blockNumber) {
+        return nodeScopedBlockDir.resolve(longToFileName(blockNumber) + "." + RECORD_EXTENSION
+                + (compressFiles ? COMPRESSION_ALGORITHM_EXTENSION : ""));
+    }
+
+    @NonNull
+    public static String longToFileName(final long value) {
+        // Convert the signed long to an unsigned long using BigInteger for correct representation
+        BigInteger unsignedValue =
+                BigInteger.valueOf(value & Long.MAX_VALUE).add(BigInteger.valueOf(Long.MIN_VALUE & value));
+
+        // Format the unsignedValue as a 20-character string, padded with leading zeros to ensure we have enough digits
+        // for an unsigned long. However, to allow for future expansion, we use 36 characters as that's what UUID uses.
+        return String.format("%036d", unsignedValue);
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v8/BlockStreamWriterFactoryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v8/BlockStreamWriterFactoryImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl.producers.formats.v8;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.records.impl.producers.BlockStreamWriter;
+import com.hedera.node.app.records.impl.producers.BlockStreamWriterFactory;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.data.BlockStreamConfig;
+import com.swirlds.common.stream.Signer;
+import com.swirlds.state.spi.info.SelfNodeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.FileSystem;
+import java.util.concurrent.ExecutorService;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class BlockStreamWriterFactoryImpl implements BlockStreamWriterFactory {
+    private final ConfigProvider configProvider;
+    private final Signer signer;
+    private final SelfNodeInfo nodeInfo;
+    private final FileSystem fileSystem;
+    private final ExecutorService executor;
+
+    /**
+     * A factory to create writers for the block stream. We specify the annotation @AsyncWorkStealingExecutor to ensure
+     * dagger provides the correct executor.
+     *
+     * @param executor the executor to use for writing the block stream, should be a work stealing executor
+     * @param configProvider the configuration provider
+     * @param nodeInfo the node info
+     * @param fileSystem the file system to use, also used in testing to be able to use a non-standard file system
+     */
+    @Inject
+    public BlockStreamWriterFactoryImpl(
+            @NonNull final ExecutorService executor,
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final SelfNodeInfo nodeInfo,
+            @NonNull final Signer signer,
+            @NonNull final FileSystem fileSystem) {
+        this.executor = requireNonNull(executor);
+        this.configProvider = requireNonNull(configProvider);
+        this.nodeInfo = requireNonNull(nodeInfo);
+        this.fileSystem = requireNonNull(fileSystem);
+        this.signer = requireNonNull(signer);
+    }
+
+    @NonNull
+    @Override
+    public BlockStreamWriter create() throws RuntimeException {
+        // read configuration
+        final var config = configProvider.getConfiguration();
+        final var recordStreamConfig = config.getConfigData(BlockStreamConfig.class);
+        final var recordFileVersion = recordStreamConfig.blockVersion();
+
+        // pick a record file format
+        return switch (recordFileVersion) {
+            case 7 -> throw new IllegalArgumentException(
+                    "Record file version 6 is not supported by BlockRecordWriterFactoryImpl");
+            case 8 -> createBlockStreamWriter(executor, recordStreamConfig.writer());
+            default -> throw new IllegalArgumentException("Unknown record file version: " + recordFileVersion);
+        };
+    }
+
+    @NonNull
+    private BlockStreamWriter createBlockStreamWriter(
+            @NonNull final ExecutorService executor, @NonNull final String writer) {
+        return switch (writer) {
+            case "file" -> new BlockStreamFileWriterV1(
+                    configProvider.getConfiguration().getConfigData(BlockStreamConfig.class),
+                    nodeInfo,
+                    fileSystem,
+                    nodeInfo.hapiVersion(),
+                    signer);
+            case "grpc" -> throw new IllegalArgumentException("grpc writer is not yet implemented.");
+            default -> throw new IllegalArgumentException("Unknown writer type: " + writer);
+        };
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v8/ConcurrentBlockStreamWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v8/ConcurrentBlockStreamWriter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl.producers.formats.v8;
+
+import com.hedera.hapi.streams.HashObject;
+import com.hedera.node.app.records.impl.producers.BlockStreamWriter;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * ConcurrentBlockStreamWriter is a wrapper around a BlockStreamWriter that allows for concurrent writes to multiple
+ * writers. The write methods do not block so that the caller may continue to make progress.
+ *
+ * <p>This implementation of ConcurrentBlockStreamWriter, the doAsync method chains asynchronous tasks in such a
+ *    way that they are executed sequentially by updating lastFutureRef with the new task that should run after the
+ *    previous one completes. This chaining uses thenCompose, which creates a new stage that, when this stage
+ *    completes normally, is executed with this stage's result as the argument to the supplied function.
+ *
+ * <p>If any task in the chain completes exceptionally (for example, due to an exception thrown during its
+ *    execution), the resulting CompletableFuture from thenCompose will also complete exceptionally with a
+ *    CompletionException. This exception wraps the original exception that caused the task to fail. An
+ *    exceptionally completed future will not execute subsequent completion stages that depend on the future's
+ *    normal completion. If one of the futures in the lastFutureRef chain completes exceptionally, it effectively
+ *    halts the execution of subsequent tasks that are dependent on normal completion. This could lead to a scenario
+ *    where the chain of operations is stopped prematurely, and tasks that are supposed to execute next are skipped.
+ *    This may not be an issue, because if one of these tasks fails, this node is unable to produce the block stream
+ *    which is the entire purpose of its existence. If the block stream is not produced, the node is in a bad state
+ *    and will likely need to restart.
+ */
+public class ConcurrentBlockStreamWriter implements BlockStreamWriter {
+    private final BlockStreamWriter writer;
+    private final ExecutorService executor;
+    private volatile CompletableFuture<Void> lastFutureRef;
+
+    /**
+     * ConcurrentBlockStreamWriter ensures that all the methods called on the writer are executed sequentially in the
+     * order in which they are called. This is done by chaining the lastFutureRef to the next write method.
+     * @param executor the executor service to use for writes
+     * @param writer the writer to wrap
+     */
+    public ConcurrentBlockStreamWriter(
+            @NonNull final ExecutorService executor, @NonNull final BlockStreamWriter writer) {
+        this.executor = executor;
+        this.writer = writer;
+        this.lastFutureRef = CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void init(final long blockNumber, @NonNull final HashObject startRunningHash) {
+        appendSerialAsyncTask(() -> writer.init(blockNumber, startRunningHash));
+    }
+
+    @Override
+    public void writeItem(@NonNull final Bytes item, @NonNull final Bytes endRunningHash) {
+        appendSerialAsyncTask(() -> writer.writeItem(item, endRunningHash));
+    }
+
+    @Override
+    public void close() {
+        appendSerialAsyncTask(writer::close);
+    }
+
+    private synchronized void appendSerialAsyncTask(@NonNull final Runnable task) {
+        // Check if the lastFuture completed exceptionally
+        if (lastFutureRef.isCompletedExceptionally()) {
+            lastFutureRef
+                    .exceptionally(ex -> {
+                        // Throw a RuntimeException with the original exception
+                        throw new CompletionException(ex);
+                    })
+                    .join(); // This forces the exception to be thrown if present
+        }
+        // If lastFuture did not complete exceptionally, chain the task so that task only executes after
+        // lastFutureRef has completed.
+        lastFutureRef = lastFutureRef.thenRunAsync(task, executor);
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/SingleTransactionRecord.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/SingleTransactionRecord.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.base.Transaction;
-import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.hapi.streams.TransactionSidecarRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -43,6 +42,5 @@ public record SingleTransactionRecord(
     }
 
     // This is used by BlockStream, and is not serialized.
-    public record TransactionOutputs(
-            @Nullable TokenType tokenType, @NonNull TransactionBody.DataOneOfType transactionBodyType) {}
+    public record TransactionOutputs(@Nullable TokenType tokenType) {}
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/SingleTransactionStreamRecord.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/SingleTransactionStreamRecord.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.state;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.stream.Stream;
+
+/**
+ * This class is a record of a stream of single transaction records and a stream of block items.
+ * It is used to store the streams of single transaction records and block items in a single object.
+ */
+public record SingleTransactionStreamRecord(
+        @Nullable Stream<SingleTransactionRecord> singleTransactionRecordStream,
+        @Nullable Stream<BlockItem> blockItemStream) {}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -326,10 +326,7 @@ public class SingleTransactionRecordBuilderImpl
         logEndTransactionRecord(transactionID, transactionRecord);
 
         return new SingleTransactionRecord(
-                transaction,
-                transactionRecord,
-                transactionSidecarRecords,
-                new TransactionOutputs(tokenType, transaction.body().data().kind()));
+                transaction, transactionRecord, transactionSidecarRecords, new TransactionOutputs(tokenType));
     }
 
     public void nullOutSideEffectFields() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -35,7 +35,6 @@ import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.recordcache.TransactionRecordEntry;
-import com.hedera.hapi.node.transaction.TransactionBody.DataOneOfType;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.fixtures.AppTestBase;
@@ -82,8 +81,7 @@ final class RecordCacheImplTest extends AppTestBase {
             TransactionReceipt.newBuilder().status(UNKNOWN).build();
     private static final AccountID PAYER_ACCOUNT_ID =
             AccountID.newBuilder().accountNum(1001).build();
-    private static final TransactionOutputs SIMPLE_OUTPUT =
-            new TransactionOutputs(TokenType.FUNGIBLE_COMMON, DataOneOfType.CRYPTO_TRANSFER);
+    private static final TransactionOutputs SIMPLE_OUTPUT = new TransactionOutputs(TokenType.FUNGIBLE_COMMON);
 
     private DeduplicationCache dedupeCache;
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -46,6 +46,7 @@ import com.hedera.node.app.records.impl.producers.StreamFileProducerSingleThread
 import com.hedera.node.app.records.impl.producers.formats.BlockRecordWriterFactoryImpl;
 import com.hedera.node.app.records.impl.producers.formats.v6.BlockRecordFormatV6;
 import com.hedera.node.app.records.schemas.V0490BlockRecordSchema;
+import com.hedera.node.app.state.SingleTransactionStreamRecord;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.state.PlatformState;
@@ -201,7 +202,9 @@ final class BlockRecordManagerTest extends AppTestBase {
                         assertThat(blockRecordManager.getRunningHash().toHex())
                                 .isEqualTo(STARTING_RUNNING_HASH_OBJ.hash().toHex());
                     }
-                    blockRecordManager.endUserTransaction(Stream.of(record), hederaState);
+                    SingleTransactionStreamRecord recordStreamRecord =
+                            new SingleTransactionStreamRecord(Stream.of(record), null);
+                    blockRecordManager.endUserTransaction(recordStreamRecord, hederaState);
                     transactionCount++;
                     // pretend rounds happen every 20 transactions
                     if (transactionCount % 20 == 0) {
@@ -291,7 +294,9 @@ final class BlockRecordManagerTest extends AppTestBase {
                                 fromTimestamp(record.transactionRecord().consensusTimestamp()),
                                 hederaState,
                                 mock(PlatformState.class));
-                        blockRecordManager.endUserTransaction(Stream.of(record), hederaState);
+                        SingleTransactionStreamRecord recordStreamRecord =
+                                new SingleTransactionStreamRecord(Stream.of(record), null);
+                        blockRecordManager.endUserTransaction(recordStreamRecord, hederaState);
                         transactionCount++;
                         // collect hashes
                         runningHashNMinus3 = runningHashNMinus2;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordTestData.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/RecordTestData.java
@@ -24,7 +24,6 @@ import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.hapi.node.transaction.TransactionBody.DataOneOfType;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.hapi.streams.HashAlgorithm;
 import com.hedera.hapi.streams.HashObject;
@@ -85,8 +84,7 @@ public class RecordTestData {
     //    block seconds       24,   26,   28,   30,    32,   34,    36,    38,   40
 
     /** Transaction Outputs data */
-    private static final TransactionOutputs SIMPLE_OUTPUT =
-            new TransactionOutputs(TokenType.FUNGIBLE_COMMON, DataOneOfType.CRYPTO_TRANSFER);
+    private static final TransactionOutputs SIMPLE_OUTPUT = new TransactionOutputs(TokenType.FUNGIBLE_COMMON);
     /** Test Signer for signing record stream files */
     public static final Signer SIGNER;
     /** Test user public key */

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
@@ -46,7 +46,7 @@ public record BlockRecordStreamConfig(
         @ConfigProperty(defaultValue = "2") @Min(1) @NodeProperty int logPeriod,
         @ConfigProperty(defaultValue = "5000") @Min(1) @NodeProperty int queueCapacity,
         @ConfigProperty(defaultValue = "256") @Min(1) @Max(1024) @NetworkProperty int sidecarMaxSizeMb,
-        @ConfigProperty(defaultValue = "6") @Min(1) @NetworkProperty int recordFileVersion,
+        @ConfigProperty(defaultValue = "8") @Min(1) @NetworkProperty int recordFileVersion,
         @ConfigProperty(defaultValue = "6") @Min(1) @NetworkProperty int signatureFileVersion,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean logEveryTransaction,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean compressFilesOnCreation, // NOT SURE

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.config.data;
+
+import com.hedera.node.config.NetworkProperty;
+import com.hedera.node.config.NodeProperty;
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Max;
+import com.swirlds.config.api.validation.annotation.Min;
+
+/**
+ * Configuration for block streams. This configuration is enabled when BlockRecordStreamConfig is set to
+ * recordFileVersion=8. It is an error for recordFileVersion != blockVersion.
+ *
+ * @param logDir directory for writing block files
+ * @param compressFilesOnCreation when true record and sidecar files are compressed with GZip when created
+ * @param numOfBlockHashesInState the number of block hashes to keep in state for block history
+ * @param streamFileProducer the type of stream file producer to use. Currently only "concurrent" and "sequential" are supported
+ */
+@ConfigData("hedera.blockStream")
+public record BlockStreamConfig(
+        /* [file|grpc] */
+        @ConfigProperty(defaultValue = "file") @NodeProperty String writer,
+        @ConfigProperty(defaultValue = "data/block-streams") @NodeProperty String logDir,
+        @ConfigProperty(defaultValue = "1") @Min(1) @NetworkProperty int numRoundsInBlock,
+        @ConfigProperty(defaultValue = "8") @Min(1) @NetworkProperty int blockVersion,
+        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean compressFilesOnCreation,
+        @ConfigProperty(defaultValue = "256") @Min(1) @Max(4096) @NetworkProperty int numOfBlockHashesInState,
+        /* [serial|concurrent] */
+        @ConfigProperty(defaultValue = "serial") @NetworkProperty
+                String streamFileProducer) {} // COULD BE NODE LOCAL PROPERTY OR NETWORK PROPERTY

--- a/hedera-node/log4j2.xml
+++ b/hedera-node/log4j2.xml
@@ -221,6 +221,9 @@
     <Logger name="com.hedera.services.queries.answering" level="debug" additivity="false">
       <AppenderRef ref="QueriesRollingFile"/>
     </Logger>
+    <Logger name="com.hedera.node.app.records.impl.BlockStreamManagerImpl" level="debug" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
 
     <Logger name="com.hedera.services.legacy" level="warn" additivity="false">
       <!-- <AppenderRef ref="Console"/> -->


### PR DESCRIPTION
**Work In Progress**

This PR will introduce a new implementation of BlockRecordManager. This new implementation is in BlockStreamManagerImpl and is incomplete in many ways but will serve as a starting point for further development for the team. Currently this implementation is serial in execution and block the handle thread while writing to the block stream.  Only writing to files is currently implemented. If we want to write both the previous Record stream and the Block stream, some additional consideration to the design will be necessary. Perhaps a Set of BlockRecordManager could be invoked upon during HandleWorkflow to produce both streams with the appropriate logic.

A Block begins upon calling `blockRecordManager.startRound();` during `HandleWorkflow::handleRound`. Currently a Block will end in the call to `blockRecordManager.endRound(state);` if the rounds until the next block have passed according to the setting defined in `BlockStreamConfig.java` (numRoundsInBlock). Note the Block needs to actually be closed through some asynchronous process once the Node has gathered enough signatures of the Merkle root hash of the BlockProof.

The `RunningHash` is still maintained in state but is now the running hash of every BlockItem being written to the block stream. I'm not sure if we still need this? We we will need to implement keeping track of the currently computed Merkle root hashes of the transaction input and outputs trees. Perhaps this could be managed through `BlockStreamProducer` impl.

The `BlockStreamWriter` interface defines methods for initializing, writing items and closing a writer. There is an implementation which writes to Files. The `BlockStreamWriterFactoryImpl` provides an implementation which currently is non-concurrent. The `BlockStreamFileWriterV1` can be wrapped by `ConcurrentBlockStreamWriter` to allow for concurrent writes. The writes would not block the caller.

Similarly for `BlockStreamProducer` there is a single threaded implementation that could be wrapped by a concurrent implementation of the interface to make it thread-safe and non-blocking for the caller.

Fixes #14247 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
