### PR TITLE
fix: include auto-association work in `gas` cost of transfer system contracts

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SingleTransactionRecordBuilderImpl.java
@@ -687,6 +687,15 @@ public class SingleTransactionRecordBuilderImpl
     }
 
     /**
+     * Returns the number of automatic token associations
+     *
+     * @return the number of associations
+     */
+    public int getNumAutoAssociations() {
+        return automaticTokenAssociations.size();
+    }
+
+    /**
      * Sets the alias.
      *
      * @param alias the alias

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -20,6 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RECEIVING_NODE_
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.node.app.service.contract.impl.exec.gas.DispatchType.ASSOCIATE;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.haltResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call.PricedResult.gasOnly;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes.encodedRc;
@@ -123,8 +124,8 @@ public class ClassicTransfersCall extends AbstractCall {
                     INVALID_TRANSACTION_BODY,
                     false);
         }
-        final var gasRequirement =
-                transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId, selector);
+        // Will be updated with additional charges for any auto-associations done by the transfer
+        var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId, selector);
         if (preemptingFailureStatus != null) {
             return reversionWith(preemptingFailureStatus, gasRequirement);
         }
@@ -158,6 +159,9 @@ public class ClassicTransfersCall extends AbstractCall {
             specialRewardReceivers.addInFrame(frame, op, recordBuilder.getAssessedCustomFees());
         } else {
             recordBuilder.status(callStatusStandardizer.codeForFailure(recordBuilder.status(), frame, op));
+        }
+        if (recordBuilder.getNumAutoAssociations() > 0) {
+            gasRequirement += recordBuilder.getNumAutoAssociations() * gasCalculator.canonicalGasRequirement(ASSOCIATE);
         }
         return completionWith(gasRequirement, recordBuilder, encodedRc(recordBuilder.status()));
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractCallRecordBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractCallRecordBuilder.java
@@ -113,4 +113,11 @@ public interface ContractCallRecordBuilder extends ContractOperationRecordBuilde
 
     @NonNull
     ContractCallRecordBuilder entropyBytes(@NonNull final Bytes prngBytes);
+
+    /**
+     * Returns the number of auto-associations created in the dispatch.
+     *
+     * @return the number of auto-associations created
+     */
+    int getNumAutoAssociations();
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/SpecEntityExtension.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/SpecEntityExtension.java
@@ -155,7 +155,9 @@ public class SpecEntityExtension implements ParameterResolver, BeforeAllCallback
                 .map(AccountSpec::name)
                 .filter(n -> !n.isBlank())
                 .orElse(defaultName);
-        return new SpecAccount(name);
+        final var account = new SpecAccount(name);
+        account.builder().maxAutoAssociations(annotation == null ? 0 : annotation.maxAutoAssociations());
+        return account;
     }
 
     private SpecKey keyFrom(@Nullable final KeySpec annotation, @NonNull final String defaultName) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/annotations/AccountSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/annotations/AccountSpec.java
@@ -36,4 +36,10 @@ public @interface AccountSpec {
      * @return the spec name of the account
      */
     String name() default "";
+
+    /**
+     * If set, the maximum number of auto-associations to allow for the account.
+     * @return the maximum number of auto-associations
+     */
+    int maxAutoAssociations() default 0;
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/SpecAccount.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/SpecAccount.java
@@ -150,7 +150,9 @@ public class SpecAccount extends AbstractSpecEntity<HapiCryptoCreate, Account>
     @Override
     protected Creation<HapiCryptoCreate, Account> newCreation(@NonNull final HapiSpec spec) {
         final var model = builder.build();
-        final var op = cryptoCreate(name).balance(ONE_HUNDRED_HBARS);
+        final var op = cryptoCreate(name)
+                .balance(ONE_HUNDRED_HBARS)
+                .maxAutomaticTokenAssociations(model.maxAutoAssociations());
         return new Creation<>(op, model);
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -1489,6 +1489,29 @@ public class UtilVerbs {
         });
     }
 
+    /**
+     * Validates that an amount is within a certain percentage of an expected value.
+     * @param expected expected value
+     * @param actual actual value
+     * @param allowedPercentDiff allowed percentage difference
+     * @param quantity quantity being compared
+     * @param context context of the comparison
+     */
+    public static void assertCloseEnough(
+            final double expected,
+            final double actual,
+            final double allowedPercentDiff,
+            final String quantity,
+            final String context) {
+        assertEquals(
+                expected,
+                actual,
+                (allowedPercentDiff / 100.0) * expected,
+                String.format(
+                        "%s %s (%s) more than %.2f percent different than expected",
+                        CryptoTransferSuite.sdec(actual, 4), quantity, context, allowedPercentDiff));
+    }
+
     public static CustomSpecAssert validateChargedUsdWithin(String txn, double expectedUsd, double allowedPercentDiff) {
         return assertionsHold((spec, assertLog) -> {
             final var actualUsdCharged = getChargedUsed(spec, txn);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -287,8 +287,6 @@ public class ContractCallSuite {
                                 .exposingTo(txnRecord -> gasWithoutAutoAssociation.set(
                                         txnRecord.getContractCallResult().getGasUsed())),
                         getTxnRecord("autoAssociation")
-                                .andAllChildRecords()
-                                .logged()
                                 .exposingTo(txnRecord -> gasWithAutoAssociation.set(
                                         txnRecord.getContractCallResult().getGasUsed())),
                         withOpContext((spec, opLog) -> {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -308,7 +308,8 @@ public class ContractCallSuite {
                             assertCloseEnough(
                                     expectedUsdAssociationFee,
                                     approxUsdDiff,
-                                    5.0,
+                                    // Allow at most one percent deviation from expected
+                                    1.0,
                                     "USD value of gas difference",
                                     "auto-association fee");
                         }));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AtomicCryptoTransferHTSSuite.java
@@ -102,6 +102,7 @@ import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
 public class AtomicCryptoTransferHTSSuite {
+    private static final long GAS_FOR_AUTO_ASSOCIATING_CALLS = 2_000_000;
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
     private static final long GAS_TO_OFFER = 5_000_000L;
     private static final long TOTAL_SUPPLY = 1_000;
@@ -1077,6 +1078,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                             accountAmount(receiver, allowance + 1, true))
                                                     .build()))
                                     .via(revertingTransferFromTxnFungible)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                             // Try to send allowance amount but turn off isApproval
                             // flag
@@ -1095,6 +1097,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                             accountAmount(receiver, 1L, false))
                                                     .build()))
                                     .via(successfulTransferFromTxn)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(SUCCESS),
                             // Try to send 1/2 of the allowance amount from owner to
                             // receiver
@@ -1112,6 +1115,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                             accountAmount(receiver, (allowance - 1) / 2, true))
                                                     .build()))
                                     .via(successfulTransferFromTxn2)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(SUCCESS),
                             // Try to send second 1/2 of the allowance amount from
                             // owner to receiver
@@ -1129,6 +1133,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                             accountAmount(receiver, (allowance - 1) / 2, true))
                                                     .build()))
                                     .via(successfulTransferFromTxn3)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(SUCCESS),
                             getAccountDetails(OWNER)
                                     .payingWith(GENESIS)
@@ -1255,6 +1260,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                     .withNftTransfers(nftTransfer(owner, receiver, 1L, true))
                                                     .build()))
                                     .via(revertingTransferFromTxnNft)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                             // transfer allowed NFT
                             contractCall(
@@ -1268,6 +1274,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                     .withNftTransfers(nftTransfer(owner, receiver, 2L, true))
                                                     .build()))
                                     .via(successfulTransferFromTxn)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(SUCCESS));
                 }))
                 .then(
@@ -1295,7 +1302,6 @@ public class AtomicCryptoTransferHTSSuite {
     @HapiTest
     final Stream<DynamicTest> cryptoTransferAllowanceToContractFromContract() {
         final var successfulTransferFromTxn = "txn";
-        final var revertingTransferFromTxnNft = "revertWhenMoreThanAllowanceNft";
         final var simpleStorageContract = "SimpleStorage";
         final long allowance = 10L;
 
@@ -1350,6 +1356,7 @@ public class AtomicCryptoTransferHTSSuite {
                                                             accountAmount(receiver, allowance, true))
                                                     .build()))
                                     .via(successfulTransferFromTxn)
+                                    .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                     .hasKnownStatus(SUCCESS));
                 }))
                 .then();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -86,6 +86,10 @@ public class ContractKeysStillWorkAsExpectedSuite {
 
         return hapiTest(
                 streamMustInclude(recordedChildBodyWithId(TOKEN_UNIT_FROM_TO_OTHERS_TXN, 1, (spec, txn) -> {
+                    if (txn.hasNodeStakeUpdate()) {
+                        // Avoid asserting something about an end-of-staking-period NodeStakeUpdate in CI
+                        return;
+                    }
                     final var tokenTransfers = txn.getCryptoTransfer().getTokenTransfersList();
                     assertEquals(1, tokenTransfers.size());
                     final var tokenTransfer = tokenTransfers.getFirst();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
@@ -112,6 +112,7 @@ public class CryptoTransferHTSSuite {
 
     private static final Logger log = LogManager.getLogger(CryptoTransferHTSSuite.class);
 
+    private static final long GAS_FOR_AUTO_ASSOCIATING_CALLS = 2_000_000;
     private static final long GAS_TO_OFFER = 4_000_000L;
     public static final long TOTAL_SUPPLY = 1_000;
     private static final String FUNGIBLE_TOKEN = "TokenA";
@@ -204,6 +205,7 @@ public class CryptoTransferHTSSuite {
                                                 asAddress(spec.registry().getAccountID(RECEIVER))),
                                         BigInteger.valueOf(allowance + 1))
                                 .via(revertingTransferFromTxn)
+                                .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         // transfer allowance/2 amount
                         contractCall(
@@ -217,6 +219,7 @@ public class CryptoTransferHTSSuite {
                                                 asAddress(spec.registry().getAccountID(RECEIVER))),
                                         BigInteger.valueOf(allowance / 2))
                                 .via(successfulTransferFromTxn)
+                                .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                 .hasKnownStatus(SUCCESS),
                         // transfer the rest of the allowance
                         contractCall(
@@ -230,6 +233,7 @@ public class CryptoTransferHTSSuite {
                                                 asAddress(spec.registry().getAccountID(RECEIVER))),
                                         BigInteger.valueOf(allowance / 2))
                                 .via(successfulTransferFromTxn2)
+                                .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                 .hasKnownStatus(SUCCESS),
                         getAccountDetails(OWNER)
                                 .payingWith(GENESIS)
@@ -246,6 +250,7 @@ public class CryptoTransferHTSSuite {
                                                 asAddress(spec.registry().getAccountID(RECEIVER))),
                                         BigInteger.ONE)
                                 .via(revertingTransferFromTxn2)
+                                .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED))))
                 .then(
                         childRecordsCheck(
@@ -778,6 +783,7 @@ public class CryptoTransferHTSSuite {
                                                 asAddress(spec.registry().getAccountID(RECEIVER))),
                                         BigInteger.ONE)
                                 .via(revertingTransferFromTxn)
+                                .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         // transfer allowed NFT
                         contractCall(
@@ -791,6 +797,7 @@ public class CryptoTransferHTSSuite {
                                                 asAddress(spec.registry().getAccountID(RECEIVER))),
                                         BigInteger.TWO)
                                 .via(successfulTransferFromTxn)
+                                .gas(GAS_FOR_AUTO_ASSOCIATING_CALLS)
                                 .hasKnownStatus(SUCCESS))))
                 .then(
                         childRecordsCheck(


### PR DESCRIPTION
**Description**:
 - C.f. #14234 
 - Increases `gas` cost of a transfer system contract by how many auto-associations are reported in the stream builder returned from dispatch.
 - Covered in `@HapiTest` that does NFT transfer with and without auto-association and asserts the USD price of the increased gas cost is $0.06 (HAPI cost with 20% surcharge through EVM).