### PR TITLE
docs: add evm-transaction-response-codes.md

### DIFF
--- a/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
+++ b/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
@@ -1,12 +1,16 @@
 # EVM Transaction Response Codes in Hedera
 
-When executing an EVM transaction to a smart contract using `contractCall` in Hedera, different response codes may be present for the top-level status after the transaction is finished. These responses are found in the transaction receipt.
+When executing an EVM transaction to a smart contract using `contractCall` in Hedera and it fails, a response code is present in the transaction receipt to indicate the top-level status.
 
-The errors listed below could occur for a `contractCall` which creates child transactions, and the revertReason or haltReason which is set when operation fails is propagated to the top-level call.
-There are other errors that could occur in the childs, but the ones listed below are the specific ones that are propagated to the top-level call, which currently happens [here](https://github.com/hashgraph/hedera-services/blob/774ed309600e4b4acd9e1ca72fcd87d354c8b9ff/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionResult.java#L141-L169), in the `HederaEvmTransactionResult` in the `finalStatus()` method.
-Other revert/halt reasons from the child should default to CONTRACT_REVERT_EXECUTED for the top-level status.
+The default status for a failing `contractCall` is CONTRACT_REVERT_EXECUTED, which is included in the receipt. Child transactions might have more specific errors.
+In certain cases, the top-level status may differ from CONTRACT_REVERT_EXECUTED. The errors listed below are those special cases that can occur during the execution of a transaction and will be propagated as the top-level status.
+
+The handling of those cases currently happens [here](https://github.com/hashgraph/hedera-services/blob/774ed309600e4b4acd9e1ca72fcd87d354c8b9ff/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionResult.java#L141-L169), in the `HederaEvmTransactionResult` in the `finalStatus()` method.
+
 
 ## Possible Propagated Response Codes
+
+Note: The description for the statuses is copied from [protobuf repo](https://github.com/hashgraph/hedera-protobufs/blob/main/services/response_code.proto)
 
 - **INVALID_SOLIDITY_ADDRESS**
     -  The system is not able to find the user’s Solidity address.

--- a/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
+++ b/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
@@ -1,7 +1,7 @@
 # EVM Transaction Response Codes in Hedera
 
 When executing a transaction processed by the EVM (i.e., EVM Transaction) using `ContractCreate`, `ContractCall`, `EthereumTransaction`, and `ContractCallLocal` in Hedera, different response codes may be present for the top-level status after the transaction is finished. 
-These responses are found in the transaction receipt. This document's goal is to list the possible EVM transaction type-specific status codes for failure.
+These responses are found in the transaction receipt. This document's goal is to list the possible EVM transaction type-specific status codes for failure (i.e. different from SUCCESS).
 
 ## Propagated EVM Transaction Response Codes
 These response codes can appear for `ContractCall`, `ContractCreate`, and `EthereumTransaction`.

--- a/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
+++ b/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
@@ -1,59 +1,118 @@
 # EVM Transaction Response Codes in Hedera
 
-When executing an EVM transaction to a smart contract using `contractCall` in Hedera and it fails, a response code is present in the transaction receipt to indicate the top-level status.
+When executing a transaction processed by the EVM (i.e., EVM Transaction) using `ContractCreate`, `ContractCall`, `EthereumTransaction`, and `ContractCallLocal` in Hedera, different response codes may be present for the top-level status after the transaction is finished. 
+These responses are found in the transaction receipt. This document's goal is to list the possible EVM transaction type-specific status codes for failure.
 
-The default status for a failing `contractCall` is CONTRACT_REVERT_EXECUTED, which is included in the receipt. Child transactions might have more specific errors.
-In certain cases, the top-level status may differ from CONTRACT_REVERT_EXECUTED. The errors listed below are those special cases that can occur during the execution of a transaction and will be propagated as the top-level status.
-
-The handling of those cases currently happens [here](https://github.com/hashgraph/hedera-services/blob/774ed309600e4b4acd9e1ca72fcd87d354c8b9ff/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionResult.java#L141-L169), in the `HederaEvmTransactionResult` in the `finalStatus()` method.
-
-
-## Possible Propagated Response Codes
-
-Note: The description for the statuses is copied from [protobuf repo](https://github.com/hashgraph/hedera-protobufs/blob/main/services/response_code.proto)
-
-- **INVALID_SOLIDITY_ADDRESS**
-    -  The system is not able to find the user’s Solidity address.
-
-- **INVALID_ALIAS_KEY**
-    -  An alias used in a CryptoTransfer transaction is not the serialization of a primitive Key message. This means a Key with a single Ed25519 or ECDSA(secp256k1) public key and no unknown protobuf fields.
-
-- **INVALID_SIGNATURE**
-    -  The transaction signature is not valid.
-
-- **MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED**
-    -  The maximum number of entities allowed in the current price regime have been created.
-
-- **INSUFFICIENT_GAS**
-    -  Not enough gas was supplied to execute the transaction.
-
-- **LOCAL_CALL_MODIFICATION_EXCEPTION**
-    -  Local execution (query) is requested for a function which changes state.
-
-- **MAX_CHILD_RECORDS_EXCEEDED**
-    -  A contract transaction tried to use more than the allowed number of child records, either through system contract records or internal contract creations.
-
-- **INVALID_CONTRACT_ID**
-    -  The contract ID is invalid or does not exist.
-
-- **INVALID_FEE_SUBMITTED**
-    -  The fee submitted is invalid.
-
-- **MAX_CONTRACT_STORAGE_EXCEEDED**
-    -  Contract permanent storage exceeded the currently allowable limit.
-
-- **MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED**
-    -  All contract storage allocated to the current price regime has been consumed.
-
-- **INSUFFICIENT_TX_FEE**
-    -  The fee provided in the transaction is insufficient for this type of transaction.
-
-- **INSUFFICIENT_PAYER_BALANCE**
-    -  The transaction payer could not afford a custom fee.
-
-- **CONTRACT_EXECUTION_EXCEPTION**
-    -  This code is used for any contract execution-related error not handled by specific error codes listed above.
-    - *Example:* An error in Besu due to differences in supported Solidity versions. For instance, if Besu supports up to 0.8.23 and the contract is compiled with a version higher than 0.8.23 containing opcode changes, this error would be thrown.
+## Propagated EVM Transaction Response Codes
+These response codes can appear for `ContractCall`, `ContractCreate`, and `EthereumTransaction`.
+It is possible for `ContractCreate` and `ContractCall` to create child transactions, and if one of them fails with a special revert or halt reason, the status is propagated to the top-level status of the transaction.
+`ContractCall` creates child transactions by executing logic that results in another call to a function/contract.
+`ContractCreate` creates child transactions by having logic containing calls in the constructor.
 
 - **CONTRACT_REVERT_EXECUTED**
-    -  The default error for contract execution being reverted. Which also happens when REVERT OPCODE is executed in the contract.
+  - The default error for contract execution being reverted. This also happens when the REVERT opcode is executed in the contract.
+
+- **INVALID_SOLIDITY_ADDRESS**
+  - The system cannot find the user’s Solidity address.
+
+- **INVALID_ALIAS_KEY**
+  - An alias used in a `CryptoTransfer` transaction is not the serialization of a primitive Key message. This means a Key with a single Ed25519 or ECDSA (secp256k1) public key and no unknown protobuf fields.
+
+- **INVALID_SIGNATURE**
+  - The transaction signature is not valid.
+
+- **INSUFFICIENT_GAS**
+  - Not enough gas was supplied to execute the transaction.
+
+- **LOCAL_CALL_MODIFICATION_EXCEPTION**
+  - Local execution (query) is requested for a function that changes state.
+
+- **MAX_CHILD_RECORDS_EXCEEDED**
+  - A contract transaction tried to use more than the allowed number of child records, either through system contract records or internal contract creations.
+
+- **INVALID_CONTRACT_ID**
+  - The contract ID is invalid or does not exist.
+
+- **INVALID_FEE_SUBMITTED**
+  - The fee submitted is invalid.
+
+- **INSUFFICIENT_TX_FEE**
+  - The fee provided in the transaction is insufficient for this type of transaction.
+
+- **INSUFFICIENT_PAYER_BALANCE**
+  - The transaction payer could not afford a custom fee.
+
+- **CONTRACT_EXECUTION_EXCEPTION**
+  - This code is used for any contract execution-related error not handled by specific error codes listed above.
+  - *Example*: An error in Besu due to differences in supported EVM versions. For instance, if Besu supports up to the Shanghai version and the contract is compiled with the Cancun version containing opcode changes, this error would be thrown.
+
+Those are some possible, but very unlikely to happen, top-level status codes. 
+As for MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED and MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED, they indicate too many contracts/entities in the entire system, so the caller can't do anything except wait until the network is fixed.
+MAX_CONTRACT_STORAGE_EXCEEDED applies to an individual contract but still is very hard to reach under normal operation.
+
+- **MAX_CONTRACT_STORAGE_EXCEEDED**
+  - Contract permanent storage exceeded the currently allowable limit.
+
+- **MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED**
+  - All contract storage allocated to the current price regime has been consumed.
+
+- **MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED**
+  - The maximum number of entities allowed in the current price regime have been created.
+
+## Additional statuses, that are not propagated from child transactions, but can be returned as top-level status:
+Those status codes can also be present for `ContractCall`, `ContractCreate` via `EthereumTransaction`.
+
+- **CONTRACT_NEGATIVE_VALUE**
+  - Negative value/initial balance was specified in a smart contract call/create.
+
+- **CONTRACT_DELETED**
+  - Contract is marked as deleted.
+  - Scope: This can happen as a top-level status only for contract call and ethereum contract call.
+
+## Create operation Specific Response Codes
+These responses do include ContractCreate via EthereumTransaction.
+
+- **AUTORENEW_DURATION_NOT_IN_RANGE**
+  - The duration is not a subset of `[MINIMUM_AUTORENEW_DURATION, MAXIMUM_AUTORENEW_DURATION]`.
+
+- **CONTRACT_NEGATIVE_GAS**
+  - Negative gas was offered in a smart contract call.
+
+- **MAX_GAS_LIMIT_EXCEEDED**
+  - Gas exceeded the currently allowable gas limit per transaction.
+
+- **INVALID_MAX_AUTO_ASSOCIATIONS**
+  - The maximum automatic associations value is not valid. The most common cause for this error is a value less than `-1`.
+
+- **INVALID_AUTORENEW_ACCOUNT**
+  - The `autoRenewAccount` specified is not a valid, active account.
+
+- **ERROR_DECODING_BYTESTRING**
+  - Decoding the smart contract binary to a byte array failed. Check that the input is a valid hex string.
+
+- **INVALID_FILE_ID**
+  - The file ID is invalid or does not exist.
+
+- **FILE_DELETED**
+  - The file has been marked as deleted.
+
+- **CONTRACT_BYTECODE_EMPTY**
+  - Bytecode for the smart contract is of length zero.
+
+- **CONTRACT_FILE_EMPTY**
+  - The file to create a smart contract was of length zero.
+
+- **INVALID_ACCOUNT_ID**
+  - The account ID is invalid or does not exist.
+
+## Ethereum Transaction Specific Response Codes
+These are additional response codes that can appear specifically for `EthereumTransaction`.
+
+- **WRONG_NONCE**
+  - This transaction specified an `ethereumNonce` that is not the current `ethereumNonce` of the account.
+
+- **WRONG_CHAIN_ID**
+  - `EthereumTransaction` was signed against a chain ID that this network does not support.
+
+- **INVALID_ETHEREUM_TRANSACTION**
+  - The Ethereum transaction either failed parsing or failed signature validation, or some other `EthereumTransaction` error not covered by another response code.

--- a/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
+++ b/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
@@ -116,3 +116,5 @@ These are additional response codes that can appear specifically for `EthereumTr
 
 - **INVALID_ETHEREUM_TRANSACTION**
   - The Ethereum transaction either failed parsing or failed signature validation, or some other `EthereumTransaction` error not covered by another response code.
+
+Note: The description for the statuses is copied from [protobuf repo](https://github.com/hashgraph/hedera-protobufs/blob/main/services/response_code.proto)

--- a/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
+++ b/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
@@ -6,8 +6,11 @@ These responses are found in the transaction receipt. This document's goal is to
 ## Propagated EVM Transaction Response Codes
 These response codes can appear for `ContractCall`, `ContractCreate`, and `EthereumTransaction`.
 It is possible for `ContractCreate` and `ContractCall` to create child transactions, and if one of them fails with a special revert or halt reason, the status is propagated to the top-level status of the transaction.
-`ContractCall` creates child transactions by executing logic that results in another call to a function/contract.
-`ContractCreate` creates child transactions by having logic containing calls in the constructor.
+- `ContractCall` creates child transactions by executing logic that results in another call to a function/contract.
+- `ContractCreate` creates child transactions by having logic containing calls in the constructor.
+- `EthereumTransaction` allows for wrapped ContractCall and ContractCreate transactions, which can also create child transactions in the same manner as described above.
+
+Note: The description for the statuses is copied from [protobuf repo](https://github.com/hashgraph/hedera-protobufs/blob/main/services/response_code.proto)
 
 - **CONTRACT_REVERT_EXECUTED**
   - The default error for contract execution being reverted. This also happens when the REVERT opcode is executed in the contract.
@@ -84,6 +87,12 @@ These responses do include ContractCreate via EthereumTransaction.
 - **INVALID_MAX_AUTO_ASSOCIATIONS**
   - The maximum automatic associations value is not valid. The most common cause for this error is a value less than `-1`.
 
+- **REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT**
+  - Cannot set the number of automatic associations for an account more than the maximum allowed token associations tokens.maxPerAccount. If you would like to exceed that, you should set maxAutoAssociations to -1.
+
+- **PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED** 
+  - Proxy account ID field is deprecated.
+
 - **INVALID_AUTORENEW_ACCOUNT**
   - The `autoRenewAccount` specified is not a valid, active account.
 
@@ -114,7 +123,8 @@ These are additional response codes that can appear specifically for `EthereumTr
 - **WRONG_CHAIN_ID**
   - `EthereumTransaction` was signed against a chain ID that this network does not support.
 
+- **NEGATIVE_ALLOWANCE_AMOUNT**
+  - The maxGasAllowance field is set to less than 0. This represents the maximum amount of tinybars, that the payer of the transaction is willing to pay to complete the transaction.
+
 - **INVALID_ETHEREUM_TRANSACTION**
   - The Ethereum transaction either failed parsing or failed signature validation, or some other `EthereumTransaction` error not covered by another response code.
-
-Note: The description for the statuses is copied from [protobuf repo](https://github.com/hashgraph/hedera-protobufs/blob/main/services/response_code.proto)

--- a/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
+++ b/hedera-node/docs/design/services/smart-contract-service/evm-transaction-response-codes.md
@@ -1,0 +1,55 @@
+# EVM Transaction Response Codes in Hedera
+
+When executing an EVM transaction to a smart contract using `contractCall` in Hedera, different response codes may be present for the top-level status after the transaction is finished. These responses are found in the transaction receipt.
+
+The errors listed below could occur for a `contractCall` which creates child transactions, and the revertReason or haltReason which is set when operation fails is propagated to the top-level call.
+There are other errors that could occur in the childs, but the ones listed below are the specific ones that are propagated to the top-level call, which currently happens [here](https://github.com/hashgraph/hedera-services/blob/774ed309600e4b4acd9e1ca72fcd87d354c8b9ff/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmTransactionResult.java#L141-L169), in the `HederaEvmTransactionResult` in the `finalStatus()` method.
+Other revert/halt reasons from the child should default to CONTRACT_REVERT_EXECUTED for the top-level status.
+
+## Possible Propagated Response Codes
+
+- **INVALID_SOLIDITY_ADDRESS**
+    -  The system is not able to find the user’s Solidity address.
+
+- **INVALID_ALIAS_KEY**
+    -  An alias used in a CryptoTransfer transaction is not the serialization of a primitive Key message. This means a Key with a single Ed25519 or ECDSA(secp256k1) public key and no unknown protobuf fields.
+
+- **INVALID_SIGNATURE**
+    -  The transaction signature is not valid.
+
+- **MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED**
+    -  The maximum number of entities allowed in the current price regime have been created.
+
+- **INSUFFICIENT_GAS**
+    -  Not enough gas was supplied to execute the transaction.
+
+- **LOCAL_CALL_MODIFICATION_EXCEPTION**
+    -  Local execution (query) is requested for a function which changes state.
+
+- **MAX_CHILD_RECORDS_EXCEEDED**
+    -  A contract transaction tried to use more than the allowed number of child records, either through system contract records or internal contract creations.
+
+- **INVALID_CONTRACT_ID**
+    -  The contract ID is invalid or does not exist.
+
+- **INVALID_FEE_SUBMITTED**
+    -  The fee submitted is invalid.
+
+- **MAX_CONTRACT_STORAGE_EXCEEDED**
+    -  Contract permanent storage exceeded the currently allowable limit.
+
+- **MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED**
+    -  All contract storage allocated to the current price regime has been consumed.
+
+- **INSUFFICIENT_TX_FEE**
+    -  The fee provided in the transaction is insufficient for this type of transaction.
+
+- **INSUFFICIENT_PAYER_BALANCE**
+    -  The transaction payer could not afford a custom fee.
+
+- **CONTRACT_EXECUTION_EXCEPTION**
+    -  This code is used for any contract execution-related error not handled by specific error codes listed above.
+    - *Example:* An error in Besu due to differences in supported Solidity versions. For instance, if Besu supports up to 0.8.23 and the contract is compiled with a version higher than 0.8.23 containing opcode changes, this error would be thrown.
+
+- **CONTRACT_REVERT_EXECUTED**
+    -  The default error for contract execution being reverted. Which also happens when REVERT OPCODE is executed in the contract.


### PR DESCRIPTION
**Description**:
This PR adds a doc with possible response codes for failed smart-contract EVM transactions that could be propagated to the top-level status.

**Related issue(s)**:

Fixes #14207 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
