### PR TITLE
fix: 14230 Fixed incorrect deserialization of `PlatformState`

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
@@ -225,6 +225,8 @@ public class PlatformState extends PartialMerkleLeaf implements MerkleLeaf {
     private void skipUptimeData(final @NonNull SerializableDataInputStream in) throws IOException {
         int numOfEntries = in.readInt();
         for (int i = 0; i < numOfEntries; i++) {
+            // nodeId
+            in.readLong();
             // lastEventRound
             in.readLong();
             // lastEventTime


### PR DESCRIPTION
Description:

One line fix of incorrect condition in deserialize method. Introduced with https://github.com/hashgraph/hedera-services/pull/14231

Related issue(s):

Relates to https://github.com/hashgraph/hedera-services/issues/14230
