### PR TITLE
fix(gossip): wait outside of lock

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/permits/SyncPermitProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/permits/SyncPermitProvider.java
@@ -203,12 +203,12 @@ public class SyncPermitProvider {
                 if (usedPermits == 0) {
                     return;
                 }
-                try {
-                    MILLISECONDS.sleep(10);
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException("interrupted while waiting for all permits to be released", e);
-                }
+            }
+            try {
+                MILLISECONDS.sleep(10);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("interrupted while waiting for all permits to be released", e);
             }
         }
     }


### PR DESCRIPTION
**Description**:
Fixing a bug discovered by @lpetrovic05 in `SyncPermitProvider` by moving a `sleep()` call outside of a `synchronized {}` block to allow other threads to acquire the lock and eventually satisfy the waiting condition.

**Related issue(s)**:

Fixes #14094

**Notes for reviewer**:
This is a timing issue that is difficult to reproduce consistently, therefore there's no any new tests. Existing unit tests in `swirlds-platform-core` pass though.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
