### PR TITLE
chore: fix Javadoc warnings in 'test-clients'

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -19,7 +19,6 @@ package com.hedera.services.bdd.junit.hedera.embedded;
 import static com.hedera.hapi.util.HapiUtils.parseAccount;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.ADDRESS_BOOK;
-import static com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader.loadConfigFile;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.status.PlatformStatus.ACTIVE;
 import static com.swirlds.platform.system.status.PlatformStatus.FREEZE_COMPLETE;
@@ -45,6 +44,7 @@ import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
 import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.system.address.Address;
@@ -235,7 +235,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
 
     private static AddressBook loadAddressBook(@NonNull final Path path) {
         requireNonNull(path);
-        final var configFile = loadConfigFile(path.toAbsolutePath());
+        final var configFile = LegacyConfigPropertiesLoader.loadConfigFile(path.toAbsolutePath());
         final var randomAddressBook = RandomAddressBookBuilder.create(new Random())
                 .withSize(1)
                 .withRealKeysEnabled(true)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/WorkingDirUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/WorkingDirUtils.java
@@ -16,12 +16,12 @@
 
 package com.hedera.services.bdd.junit.hedera.utils;
 
-import static com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader.loadConfigFile;
 import static java.util.Objects.requireNonNull;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
 
 import com.hedera.services.bdd.spec.props.JutilPropertySource;
+import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -309,7 +309,7 @@ public class WorkingDirUtils {
      */
     public static AddressBook loadAddressBook(@NonNull final Path path) {
         requireNonNull(path);
-        final var configFile = loadConfigFile(path.toAbsolutePath());
+        final var configFile = LegacyConfigPropertiesLoader.loadConfigFile(path.toAbsolutePath());
         final var randomAddressBook = RandomAddressBookBuilder.create(new Random())
                 .withSize(1)
                 .withRealKeysEnabled(true)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/SpecContract.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/SpecContract.java
@@ -130,7 +130,7 @@ public class SpecContract extends AbstractSpecEntity<SpecOperation, Account>
      * Returns an operation to associate the contract with the given tokens. Will ultimately fail if the contract
      * does not have an admin key.
      *
-     * @param tokens the tokens to associate
+     * @param token the tokens to associate
      * @return the operation
      */
     public TransferTokenOperation transferToken(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/BuildUpgradeZipOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/BuildUpgradeZipOp.java
@@ -45,9 +45,9 @@ import java.util.zip.ZipOutputStream;
  *     <li><b>(Optional)</b> A <i>settings.txt</i> at the given path.</li>
  *     <li><b>(Optional)</b> A <i>config.txt</i> obtained by removing a requested
  *     node from the target network's current <i>config.txt</i>. If this is specified,
- *     the target network must be a {@link SubProcessNetwork}</li>, since this is
+ *     the target network must be a {@link SubProcessNetwork}, since this is
  *     the only case in which the test can meaningfully inspect and change the
- *     address book.
+ *     address book.</li>
  * </ol>
  */
 public class BuildUpgradeZipOp extends UtilOp {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip583/CreateWithAliasDisabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip583/CreateWithAliasDisabledTest.java
@@ -69,7 +69,7 @@ import org.junit.jupiter.api.DynamicTest;
 
 /**
  * Tests expected behavior when the {@code cryptoCreateWithAlias.enabled} feature flag is off for
- * <a href="https://hips.hedera.com/hip/hip-583">HIP-583, "Expand alias support in CryptoCreate & CryptoTransfer Transactions"</a>.
+ * <a href="https://hips.hedera.com/hip/hip-583">HIP-583, "Expand alias support in CryptoCreate &amp; CryptoTransfer Transactions"</a>.
  */
 @HapiTestLifecycle
 public class CreateWithAliasDisabledTest {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LifecycleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LifecycleTest.java
@@ -95,7 +95,7 @@ public interface LifecycleTest {
     }
 
     /**
-     * Returns an operation that builds a fake upgrade ZIP, uploads it to file {@code 0.0.150),
+     * Returns an operation that builds a fake upgrade ZIP, uploads it to file {@code 0.0.150},
      * issues a {@code PREPARE_UPGRADE}, and awaits writing of the <i>execute_immediate.mf</i>.
      * @return the operation
      */


### PR DESCRIPTION
**Description**:
Fixes warnings given by the `javadoc` tool. 

**Related issue(s)**:

In preparation for #13645

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
