### PR TITLE
chore: fix Javadoc warnings in 'services' modules

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerificationFutureImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerificationFutureImpl.java
@@ -85,7 +85,6 @@ public final class SignatureVerificationFutureImpl implements SignatureVerificat
         return key;
     }
 
-    /** {@inheritDoc} */
     @NonNull
     public TransactionSignature txSig() {
         return txSig;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ServiceApiFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ServiceApiFactory.java
@@ -49,9 +49,6 @@ public class ServiceApiFactory {
         this.storeMetricsService = requireNonNull(storeMetricsService);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public <C> C getApi(@NonNull final Class<C> apiInterface) throws IllegalArgumentException {
         requireNonNull(apiInterface);
         final var provider = API_PROVIDER.get(apiInterface);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
@@ -111,7 +111,6 @@ public interface HederaOperations {
 
     /**
      * Returns the lazy creation cost within this scope.
-     * @param recipient the recipient contract address
      *
      * @param recipient the recipient contract address
      * @return the lazy creation cost in gas


### PR DESCRIPTION
**Description**:
Fixes warnings given by the `javadoc` tool. 

**Related issue(s)**:

In preparation for #13645

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
