### PR TITLE
refactor: 13274 Rename `MerkleState` to `State`.

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -555,7 +555,7 @@ public final class Hedera implements SwirldMain {
 
         if (daggerApp != null) {
             logger.debug("Shutting down the state");
-            final var state = daggerApp.workingStateAccessor().getMerkleState();
+            final var state = daggerApp.workingStateAccessor().getState();
             if (state instanceof MerkleStateRoot msr) {
                 msr.close();
             }
@@ -614,7 +614,7 @@ public final class Hedera implements SwirldMain {
      */
     public void onHandleConsensusRound(
             @NonNull final Round round, @NonNull final PlatformState platformState, @NonNull final State state) {
-        daggerApp.workingStateAccessor().setMerkleState(state);
+        daggerApp.workingStateAccessor().setState(state);
         daggerApp.platformStateAccessor().setPlatformState(platformState);
         daggerApp.handleWorkflow().handleRound(state, platformState, round);
     }
@@ -734,7 +734,7 @@ public final class Hedera implements SwirldMain {
                 .contractServiceImpl(contractServiceImpl)
                 .metrics(metrics)
                 .build();
-        daggerApp.workingStateAccessor().setMerkleState(state);
+        daggerApp.workingStateAccessor().setState(state);
         daggerApp.platformStateAccessor().setPlatformState(platformState);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -87,7 +87,6 @@ import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.MerkleStateRoot;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.platform.state.State;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -96,7 +95,7 @@ import com.swirlds.platform.system.SwirldMain;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.system.status.PlatformStatus;
 import com.swirlds.platform.system.transaction.Transaction;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.WritableSingletonStateBase;
 import com.swirlds.state.spi.info.SelfNodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -321,7 +320,8 @@ public final class Hedera implements SwirldMain {
     @Override
     @NonNull
     public MerkleRoot newMerkleStateRoot() {
-        final State state = new State();
+        // this State class will be deprecated in https://github.com/hashgraph/hedera-services/pull/14356
+        final com.swirlds.platform.state.State state = new com.swirlds.platform.state.State();
         state.setSwirldState(new MerkleStateRoot(new MerkleStateLifecyclesImpl(this)));
         return state;
         // FUTURE WORK: https://github.com/hashgraph/hedera-services/issues/11773
@@ -341,7 +341,7 @@ public final class Hedera implements SwirldMain {
      */
     @SuppressWarnings("java:S1181") // catching Throwable instead of Exception when we do a direct System.exit()
     public void onStateInitialized(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final Platform platform,
             @NonNull final PlatformState platformState,
             @NonNull final InitTrigger trigger,
@@ -409,7 +409,7 @@ public final class Hedera implements SwirldMain {
      * @param trigger trigger that is calling migration
      */
     private void onMigrate(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @Nullable final HederaSoftwareVersion deserializedVersion,
             @NonNull final InitTrigger trigger,
             @NonNull final Metrics metrics) {
@@ -458,7 +458,7 @@ public final class Hedera implements SwirldMain {
      * {@link #newMerkleStateRoot()} or an instance of {@link MerkleStateRoot} created by the platform and
      * loaded from the saved state).
      *
-     * <p>(FUTURE) Consider moving this initialization into {@link #onStateInitialized(MerkleState, Platform, PlatformState, InitTrigger, SoftwareVersion)}
+     * <p>(FUTURE) Consider moving this initialization into {@link #onStateInitialized(State, Platform, PlatformState, InitTrigger, SoftwareVersion)}
      * instead, as there is no special significance to having it here instead.
      */
     @SuppressWarnings("java:S1181") // catching Throwable instead of Exception when we do a direct System.exit()
@@ -571,7 +571,7 @@ public final class Hedera implements SwirldMain {
     /**
      * Invoked by the platform to handle pre-consensus events. This only happens after {@link #run()} has been called.
      */
-    public void onPreHandle(@NonNull final Event event, @NonNull final MerkleState state) {
+    public void onPreHandle(@NonNull final Event event, @NonNull final State state) {
         final var readableStoreFactory = new ReadableStoreFactory(state);
         final var creator =
                 daggerApp.networkInfo().nodeInfo(event.getCreatorId().id());
@@ -613,7 +613,7 @@ public final class Hedera implements SwirldMain {
      * called.
      */
     public void onHandleConsensusRound(
-            @NonNull final Round round, @NonNull final PlatformState platformState, @NonNull final MerkleState state) {
+            @NonNull final Round round, @NonNull final PlatformState platformState, @NonNull final State state) {
         daggerApp.workingStateAccessor().setMerkleState(state);
         daggerApp.platformStateAccessor().setPlatformState(platformState);
         daggerApp.handleWorkflow().handleRound(state, platformState, round);
@@ -667,7 +667,7 @@ public final class Hedera implements SwirldMain {
     =================================================================================================================*/
 
     private void migrateAndInitialize(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @Nullable final HederaSoftwareVersion deserializedVersion,
             @NonNull final InitTrigger trigger,
             @NonNull final PlatformState platformState,
@@ -710,7 +710,7 @@ public final class Hedera implements SwirldMain {
     =================================================================================================================*/
 
     private void initializeDagger(
-            @NonNull final MerkleState state, @NonNull final InitTrigger trigger, final PlatformState platformState) {
+            @NonNull final State state, @NonNull final InitTrigger trigger, final PlatformState platformState) {
         // The Dagger component should be constructed every time we reach this point, even if
         // it exists (this avoids any problems with mutable singleton state by reconstructing
         // everything); but we must ensure the gRPC server in the old component is fully stopped
@@ -756,7 +756,7 @@ public final class Hedera implements SwirldMain {
         }
     }
 
-    private void initializeFeeManager(@NonNull final MerkleState state) {
+    private void initializeFeeManager(@NonNull final State state) {
         logger.info("Initializing fee schedules");
         final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
         final var fileNum = filesConfig.feeSchedules();
@@ -771,14 +771,14 @@ public final class Hedera implements SwirldMain {
         }
     }
 
-    private Bytes throttleDefinitionsFrom(@NonNull final MerkleState state) {
+    private Bytes throttleDefinitionsFrom(@NonNull final State state) {
         final var config = configProvider.getConfiguration();
         final var filesConfig = config.getConfigData(FilesConfig.class);
         final var throttleDefinitionsId = createFileID(filesConfig.throttleDefinitions(), config);
         return getFileContent(state, throttleDefinitionsId);
     }
 
-    private void initializeExchangeRateManager(@NonNull final MerkleState state) {
+    private void initializeExchangeRateManager(@NonNull final State state) {
         final var filesConfig = configProvider.getConfiguration().getConfigData(FilesConfig.class);
         final var fileNum = filesConfig.exchangeRates();
         final var file = requireNonNull(
@@ -786,7 +786,7 @@ public final class Hedera implements SwirldMain {
         daggerApp.exchangeRateManager().init(state, file.contents());
     }
 
-    private @Nullable File getFileFromStorage(@NonNull final MerkleState state, final long fileNum) {
+    private @Nullable File getFileFromStorage(@NonNull final State state, final long fileNum) {
         final var readableFileStore = new ReadableStoreFactory(state).getStore(ReadableFileStore.class);
         final var hederaConfig = configProvider.getConfiguration().getConfigData(HederaConfig.class);
         final var fileId = FileID.newBuilder()
@@ -797,7 +797,7 @@ public final class Hedera implements SwirldMain {
         return readableFileStore.getFileLeaf(fileId);
     }
 
-    private void unmarkMigrationRecordsStreamed(MerkleState state) {
+    private void unmarkMigrationRecordsStreamed(State state) {
         final var blockServiceState = state.getWritableStates(BlockRecordService.NAME);
         final var blockInfoState = blockServiceState.<BlockInfo>getSingleton(BLOCK_INFO_STATE_KEY);
         final var currentBlockInfo = requireNonNull(blockInfoState.get());
@@ -849,7 +849,7 @@ public final class Hedera implements SwirldMain {
      * @param state the state to check
      * @return true if the given state includes effects of handled the genesis transaction
      */
-    private boolean hasHandledGenesisTxn(@NonNull final MerkleState state) {
+    private boolean hasHandledGenesisTxn(@NonNull final State state) {
         final var blockInfo = state.getReadableStates(BlockRecordService.NAME)
                 .<BlockInfo>getSingleton(BLOCK_INFO_STATE_KEY)
                 .get();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
@@ -35,7 +35,7 @@ import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.RatesConfig;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigInteger;
@@ -79,7 +79,7 @@ public final class ExchangeRateManager {
         this.configProvider = requireNonNull(configProvider, "configProvider must not be null");
     }
 
-    public void init(@NonNull final MerkleState state, @NonNull final Bytes bytes) {
+    public void init(@NonNull final State state, @NonNull final Bytes bytes) {
         requireNonNull(state, "state must not be null");
         requireNonNull(bytes, "bytes must not be null");
 
@@ -170,9 +170,9 @@ public final class ExchangeRateManager {
     /**
      * Updates the midnight rates to the current exchange rates, both internally and in the given state.
      *
-     * @param state the {@link MerkleState} to update the midnight rates in
+     * @param state the {@link State} to update the midnight rates in
      */
-    public void updateMidnightRates(@NonNull final MerkleState state) {
+    public void updateMidnightRates(@NonNull final State state) {
         midnightRates = currentExchangeRateInfo.exchangeRates();
         final var singleton = state.getWritableStates(FeeService.NAME)
                 .<ExchangeRateSet>getSingleton(V0490FeeSchema.MIDNIGHT_RATES_STATE_KEY);
@@ -206,11 +206,11 @@ public final class ExchangeRateManager {
     /**
      * Get the {@link ExchangeRateInfo} that is based on the given state.
      *
-     * @param state The {@link MerkleState} to use.
+     * @param state The {@link State} to use.
      * @return The {@link ExchangeRateInfo}.
      */
     @NonNull
-    public ExchangeRateInfo exchangeRateInfo(@NonNull final MerkleState state) {
+    public ExchangeRateInfo exchangeRateInfo(@NonNull final State state) {
         final var hederaConfig = configProvider.getConfiguration().getConfigData(HederaConfig.class);
         final var shardNum = hederaConfig.shard();
         final var realmNum = hederaConfig.realm();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
@@ -77,7 +77,7 @@ public abstract class BlockRecordInjectionModule {
             @NonNull final ConfigProvider configProvider,
             @NonNull final WorkingStateAccessor state,
             @NonNull final BlockRecordStreamProducer streamFileProducer) {
-        final var merkleState = state.getMerkleState();
+        final var merkleState = state.getState();
         if (merkleState == null) {
             throw new IllegalStateException("Merkle state is null");
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
@@ -20,7 +20,7 @@ import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.node.app.spi.records.BlockRecordInfo;
 import com.hedera.node.app.state.SingleTransactionRecord;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.stream.Stream;
@@ -74,7 +74,7 @@ public interface BlockRecordManager extends BlockRecordInfo, AutoCloseable {
      * @return               true if a new block was created, false otherwise
      */
     boolean startUserTransaction(
-            @NonNull Instant consensusTime, @NonNull MerkleState state, @NonNull PlatformState platformState);
+            @NonNull Instant consensusTime, @NonNull State state, @NonNull PlatformState platformState);
 
     /**
      * "Advances the consensus clock" by updating the latest consensus timestamp that the node has handled. This should
@@ -82,28 +82,28 @@ public interface BlockRecordManager extends BlockRecordInfo, AutoCloseable {
      * to multiple transactions.
      * @param consensusTime the most recent consensus timestamp that the node has <b>started</b> to handle
      */
-    void advanceConsensusClock(@NonNull Instant consensusTime, @NonNull MerkleState state);
+    void advanceConsensusClock(@NonNull Instant consensusTime, @NonNull State state);
 
     /**
      * Add a user transaction's records to the record stream. They must be in exact consensus time order! This must only
      * be called after the user transaction has been committed to state and is 100% done. It must include the record of
      * the user transaction along with all preceding child transactions and any child or transactions after. System
      * transactions are treated as though they were user transactions, calling
-     * {@link #startUserTransaction(Instant, MerkleState, PlatformState)} and this method.
+     * {@link #startUserTransaction(Instant, State, PlatformState)} and this method.
      *
      * @param recordStreamItems Stream of records produced while handling the user transaction
      * @param state             The state to read {@link BlockInfo} from
      */
-    void endUserTransaction(@NonNull Stream<SingleTransactionRecord> recordStreamItems, @NonNull MerkleState state);
+    void endUserTransaction(@NonNull Stream<SingleTransactionRecord> recordStreamItems, @NonNull State state);
 
     /**
      * Called at the end of a round to make sure the running hash and block information is up-to-date in state.
      * This should be called <b>AFTER</b> the last end user transaction in that round has been passed to
-     * {@link #endUserTransaction(Stream, MerkleState)}.
+     * {@link #endUserTransaction(Stream, State)}.
      *
      * @param state The state to update
      */
-    void endRound(@NonNull MerkleState state);
+    void endRound(@NonNull State state);
 
     /**
      * Closes this BlockRecordManager and wait for any threads to finish.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -35,7 +35,7 @@ import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.stream.LinkedObjectStreamUtilities;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.WritableSingletonStateBase;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -95,7 +95,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     @Inject
     public BlockRecordManagerImpl(
             @NonNull final ConfigProvider configProvider,
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final BlockRecordStreamProducer streamFileProducer) {
 
         requireNonNull(state);
@@ -155,7 +155,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      */
     public boolean startUserTransaction(
             @NonNull final Instant consensusTime,
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final PlatformState platformState) {
         if (EPOCH.equals(lastBlockInfo.firstConsTimeOfCurrentBlock())) {
             // This is the first transaction of the first block, so set both the firstConsTimeOfCurrentBlock
@@ -234,7 +234,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
                 lastBlockInfo.lastBlockNumber(), lastBlockInfo.lastBlockNumber() + 1, consensusTime);
     }
 
-    private void putLastBlockInfo(@NonNull final MerkleState state) {
+    private void putLastBlockInfo(@NonNull final State state) {
         final var states = state.getWritableStates(BlockRecordService.NAME);
         final var blockInfoState = states.<BlockInfo>getSingleton(V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY);
         blockInfoState.put(lastBlockInfo);
@@ -244,7 +244,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      * {@inheritDoc}
      */
     public void endUserTransaction(
-            @NonNull final Stream<SingleTransactionRecord> recordStreamItems, @NonNull final MerkleState state) {
+            @NonNull final Stream<SingleTransactionRecord> recordStreamItems, @NonNull final State state) {
         // check if we need to run event recovery before we can write any new records to stream
         if (!this.eventRecoveryCompleted) {
             // FUTURE create event recovery class and call it here. Should this be in startUserTransaction()?
@@ -258,7 +258,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      * {@inheritDoc}
      */
     @Override
-    public void endRound(@NonNull final MerkleState state) {
+    public void endRound(@NonNull final State state) {
         // We get the latest running hash from the StreamFileProducer blocking if needed for it to be computed.
         final var currentRunningHash = streamFileProducer.getRunningHash();
         // Update running hashes in state with the latest running hash and the previous 3 running hashes.
@@ -356,7 +356,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      * {@inheritDoc}
      */
     @Override
-    public void advanceConsensusClock(@NonNull final Instant consensusTime, @NonNull final MerkleState state) {
+    public void advanceConsensusClock(@NonNull final Instant consensusTime, @NonNull final State state) {
         final var builder = this.lastBlockInfo
                 .copyBuilder()
                 .consTimeOfLastHandledTxn(Timestamp.newBuilder()

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/OrderedServiceMigrator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/OrderedServiceMigrator.java
@@ -25,7 +25,7 @@ import com.hedera.node.app.state.merkle.MerkleSchemaRegistry;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.state.MerkleStateRoot;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.SchemaRegistry;
 import com.swirlds.state.spi.Service;
 import com.swirlds.state.spi.info.NetworkInfo;
@@ -56,7 +56,7 @@ public class OrderedServiceMigrator implements ServiceMigrator {
      */
     @Override
     public void doMigrations(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final ServicesRegistry servicesRegistry,
             @Nullable final SemanticVersion previousVersion,
             @NonNull final SemanticVersion currentVersion,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServiceMigrator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServiceMigrator.java
@@ -19,13 +19,13 @@ package com.hedera.node.app.services;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.info.NetworkInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * Defines a type able to perform some related set of migrations on a {@link MerkleState} instance
+ * Defines a type able to perform some related set of migrations on a {@link State} instance
  * given a current and previous version of the state; a configuration; and network information, and
  * the metrics that services will use.
  */
@@ -42,7 +42,7 @@ public interface ServiceMigrator {
      * @param metrics The metrics to use for the migrations
      */
     void doMigrations(
-            @NonNull MerkleState state,
+            @NonNull State state,
             @NonNull ServicesRegistry servicesRegistry,
             @Nullable SemanticVersion previousVersion,
             @NonNull SemanticVersion currentVersion,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HandleConsensusRoundListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/HandleConsensusRoundListener.java
@@ -18,11 +18,11 @@ package com.hedera.node.app.state;
 
 import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.system.Round;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /** Listener invoked for each consensus round that occurs. */
 @FunctionalInterface
 public interface HandleConsensusRoundListener {
-    void onConsensusRound(@NonNull Round round, @NonNull PlatformState platformState, @NonNull MerkleState state);
+    void onConsensusRound(@NonNull Round round, @NonNull PlatformState platformState, @NonNull State state);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidator.java
@@ -16,21 +16,21 @@
 
 package com.hedera.node.app.state;
 
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Validates a {@link MerkleState}, checking to make sure the state is valid. This is used, for example, to verify that
+ * Validates a {@link State}, checking to make sure the state is valid. This is used, for example, to verify that
  * no HBAR were lost during an upgrade. Implementations should execute quickly, because validation will delay restarts
  * and/or upgrades. Most validation will happen asynchronously. At the very least, validation should verify that no
  * HBARs were lost or gained.
  */
 public interface LedgerValidator {
     /**
-     * Performs some kind of validation on the {@link MerkleState}.
+     * Performs some kind of validation on the {@link State}.
      *
      * @param state The state to check
      * @throws IllegalStateException If the state is invalid.
      */
-    void validate(@NonNull MerkleState state) throws IllegalStateException;
+    void validate(@NonNull State state) throws IllegalStateException;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/LedgerValidatorImpl.java
@@ -25,7 +25,7 @@ import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.LedgerConfig;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicLong;
@@ -40,7 +40,7 @@ public final class LedgerValidatorImpl implements LedgerValidator {
     }
 
     @Override
-    public void validate(@NonNull final MerkleState state) throws IllegalStateException {
+    public void validate(@NonNull final State state) throws IllegalStateException {
         final var config = configProvider.getConfiguration().getConfigData(LedgerConfig.class);
         final var expectedTotalTinyBar = config.totalTinyBarFloat();
         final var tokenStates = state.getReadableStates(TokenService.NAME);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
@@ -35,7 +35,7 @@ import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.merkle.disk.OnDiskKey;
 import com.swirlds.state.merkle.disk.OnDiskValue;
 import com.swirlds.virtualmap.VirtualMap;
@@ -91,19 +91,19 @@ public class MerkleStateLifecyclesImpl implements MerkleStateLifecycles {
     }
 
     @Override
-    public void onPreHandle(@NonNull final Event event, @NonNull final MerkleState state) {
+    public void onPreHandle(@NonNull final Event event, @NonNull final State state) {
         hedera.onPreHandle(event, state);
     }
 
     @Override
     public void onHandleConsensusRound(
-            @NonNull final Round round, @NonNull final PlatformState platformState, @NonNull final MerkleState state) {
+            @NonNull final Round round, @NonNull final PlatformState platformState, @NonNull final State state) {
         hedera.onHandleConsensusRound(round, platformState, state);
     }
 
     @Override
     public void onStateInitialized(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final Platform platform,
             @NonNull final PlatformState platformState,
             @NonNull final InitTrigger trigger,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/PreHandleListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/PreHandleListener.java
@@ -17,11 +17,11 @@
 package com.hedera.node.app.state;
 
 import com.swirlds.platform.system.events.Event;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /** Listener invoked whenever an event is ready for pre-handle */
 @FunctionalInterface
 public interface PreHandleListener {
-    void onPreHandle(@NonNull Event event, @NonNull MerkleState state);
+    void onPreHandle(@NonNull Event event, @NonNull State state);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WorkingStateAccessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WorkingStateAccessor.java
@@ -40,7 +40,7 @@ public class WorkingStateAccessor {
      * @return the working {@link State}.
      */
     @Nullable
-    public State getMerkleState() {
+    public State getState() {
         return state;
     }
 
@@ -48,7 +48,7 @@ public class WorkingStateAccessor {
      * Sets the working {@link State}.
      * @param state the working {@link State}.
      */
-    public void setMerkleState(State state) {
+    public void setState(State state) {
         requireNonNull(state);
         this.state = state;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WorkingStateAccessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WorkingStateAccessor.java
@@ -18,17 +18,17 @@ package com.hedera.node.app.state;
 
 import static java.util.Objects.requireNonNull;
 
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * A singleton class that provides access to the working {@link MerkleState}.
+ * A singleton class that provides access to the working {@link State}.
  */
 @Singleton
 public class WorkingStateAccessor {
-    private MerkleState merkleState = null;
+    private State state = null;
 
     @Inject
     public WorkingStateAccessor() {
@@ -36,20 +36,20 @@ public class WorkingStateAccessor {
     }
 
     /**
-     * Returns the working {@link MerkleState}.
-     * @return the working {@link MerkleState}.
+     * Returns the working {@link State}.
+     * @return the working {@link State}.
      */
     @Nullable
-    public MerkleState getMerkleState() {
-        return merkleState;
+    public State getMerkleState() {
+        return state;
     }
 
     /**
-     * Sets the working {@link MerkleState}.
-     * @param merkleState the working {@link MerkleState}.
+     * Sets the working {@link State}.
+     * @param state the working {@link State}.
      */
-    public void setMerkleState(MerkleState merkleState) {
-        requireNonNull(merkleState);
-        this.merkleState = merkleState;
+    public void setMerkleState(State state) {
+        requireNonNull(state);
+        this.state = state;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedState.java
@@ -18,7 +18,7 @@ package com.hedera.node.app.state;
 
 import static java.util.Objects.requireNonNull;
 
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -26,26 +26,26 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A {@link MerkleState} that wraps another {@link MerkleState} and provides a {@link #commit()} method that
+ * A {@link State} that wraps another {@link State} and provides a {@link #commit()} method that
  * commits all modifications to the underlying state.
  */
-public class WrappedMerkleState implements MerkleState {
+public class WrappedState implements State {
 
-    private final MerkleState delegate;
+    private final State delegate;
     private final Map<String, WrappedWritableStates> writableStatesMap = new HashMap<>();
 
     /**
-     * Constructs a {@link WrappedMerkleState} that wraps the given {@link MerkleState}.
+     * Constructs a {@link WrappedState} that wraps the given {@link State}.
      *
-     * @param delegate the {@link MerkleState} to wrap
+     * @param delegate the {@link State} to wrap
      * @throws NullPointerException if {@code delegate} is {@code null}
      */
-    public WrappedMerkleState(@NonNull final MerkleState delegate) {
+    public WrappedState(@NonNull final State delegate) {
         this.delegate = requireNonNull(delegate, "delegate must not be null");
     }
 
     /**
-     * Returns {@code true} if the state of this {@link WrappedMerkleState} has been modified.
+     * Returns {@code true} if the state of this {@link WrappedState} has been modified.
      *
      * @return {@code true}, if the state has been modified; otherwise {@code false}
      */
@@ -65,7 +65,7 @@ public class WrappedMerkleState implements MerkleState {
      * for the same service name. This means that any modifications to the {@link WritableStates} will be reflected
      * in the {@link ReadableStates} instances returned from this method.
      * <p>
-     * Unlike other {@link MerkleState} implementations, the returned {@link ReadableStates} of this implementation
+     * Unlike other {@link State} implementations, the returned {@link ReadableStates} of this implementation
      * must only be used in the handle workflow.
      */
     @Override
@@ -88,7 +88,7 @@ public class WrappedMerkleState implements MerkleState {
     }
 
     /**
-     * Writes all modifications to the underlying {@link MerkleState}.
+     * Writes all modifications to the underlying {@link State}.
      */
     public void commit() {
         for (final var writableStates : writableStatesMap.values()) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/ReconnectListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/ReconnectListener.java
@@ -28,7 +28,7 @@ import com.hedera.node.config.data.NetworkAdminConfig;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.platform.listeners.ReconnectCompleteListener;
 import com.swirlds.platform.listeners.ReconnectCompleteNotification;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
@@ -42,14 +42,14 @@ import org.apache.logging.log4j.Logger;
 public class ReconnectListener implements ReconnectCompleteListener {
     private static final Logger log = LogManager.getLogger(ReconnectListener.class);
 
-    private final Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor;
+    private final Supplier<AutoCloseableWrapper<State>> stateAccessor;
     private final Executor executor;
     private final ConfigProvider configProvider;
     private final PlatformStateAccessor platformStateAccessor;
 
     @Inject
     public ReconnectListener(
-            @NonNull final Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor,
+            @NonNull final Supplier<AutoCloseableWrapper<State>> stateAccessor,
             @NonNull @Named("FreezeService") final Executor executor,
             @NonNull final ConfigProvider configProvider,
             @NonNull final PlatformStateAccessor platformStateAccessor) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/WriteStateToDiskListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/WriteStateToDiskListener.java
@@ -29,7 +29,7 @@ import com.hedera.node.config.data.NetworkAdminConfig;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteNotification;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
@@ -48,13 +48,13 @@ import org.apache.logging.log4j.Logger;
 public class WriteStateToDiskListener implements StateWriteToDiskCompleteListener {
     private static final Logger log = LogManager.getLogger(WriteStateToDiskListener.class);
 
-    private final Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor;
+    private final Supplier<AutoCloseableWrapper<State>> stateAccessor;
     private final Executor executor;
     private final ConfigProvider configProvider;
 
     @Inject
     public WriteStateToDiskListener(
-            @NonNull final Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor,
+            @NonNull final Supplier<AutoCloseableWrapper<State>> stateAccessor,
             @NonNull @Named("FreezeService") final Executor executor,
             @NonNull final ConfigProvider configProvider) {
         requireNonNull(stateAccessor);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -200,7 +200,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
         if (isSoOrdered(currentVersion, previousVersion)) {
             throw new IllegalArgumentException("The currentVersion must be at least the previousVersion");
         }
-        if (!(state instanceof MerkleStateRoot merkleStateRoot)) {
+        if (!(state instanceof MerkleStateRoot stateRoot)) {
             throw new IllegalArgumentException("The state must be an instance of " + MerkleStateRoot.class.getName());
         }
         if (schemas.isEmpty()) {
@@ -227,7 +227,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             // available at this moment in time. This is done to make sure that even after we
             // add new states into the tree, it doesn't increase the number of states that can
             // be seen by the schema migration code
-            final var readableStates = merkleStateRoot.getReadableStates(serviceName);
+            final var readableStates = stateRoot.getReadableStates(serviceName);
             final var previousStates = new FilteredReadableStates(readableStates, readableStates.stateKeys());
             // Similarly, we distinguish between the writable states before and after
             // applying the schema's state definitions. This is done to ensure that we
@@ -237,11 +237,11 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             final WritableStates writableStates;
             final WritableStates newStates;
             if (applications.contains(STATE_DEFINITIONS)) {
-                final var redefinedWritableStates = applyStateDefinitions(schema, config, metrics, merkleStateRoot);
+                final var redefinedWritableStates = applyStateDefinitions(schema, config, metrics, stateRoot);
                 writableStates = redefinedWritableStates.beforeStates();
                 newStates = redefinedWritableStates.afterStates();
             } else {
-                newStates = writableStates = merkleStateRoot.getWritableStates(serviceName);
+                newStates = writableStates = stateRoot.getWritableStates(serviceName);
             }
             final var migrationContext = new MigrationContextImpl(
                     previousStates, newStates, config, networkInfo, entityIdStore, previousVersion, sharedValues);
@@ -256,7 +256,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                 mws.commit();
             }
             // And finally we can remove any states we need to remove
-            schema.statesToRemove().forEach(stateKey -> merkleStateRoot.removeServiceState(serviceName, stateKey));
+            schema.statesToRemove().forEach(stateKey -> stateRoot.removeServiceState(serviceName, stateKey));
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -38,7 +38,7 @@ import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.MerkleDbTableConfig;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.state.MerkleStateRoot;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.merkle.StateMetadata;
 import com.swirlds.state.merkle.StateUtils;
 import com.swirlds.state.merkle.disk.OnDiskKey;
@@ -170,7 +170,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      * to perform any necessary logic on restart. Most services have nothing to do, but some may need
      * to read files from disk, and could potentially change their state as a result.
      *
-     * @param merkleState the state for this registry to use.
+     * @param state the state for this registry to use.
      * @param previousVersion The version of state loaded from disk. Possibly null.
      * @param currentVersion The current version. Never null. Must be newer than {@code
      * previousVersion}.
@@ -178,12 +178,12 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      * @param networkInfo The network information to use at the time of migration
      * @param sharedValues A map of shared values for cross-service migration patterns
      * @throws IllegalArgumentException if the {@code currentVersion} is not at least the
-     * {@code previousVersion} or if the {@code merkleState} is not an instance of {@link MerkleStateRoot}
+     * {@code previousVersion} or if the {@code state} is not an instance of {@link MerkleStateRoot}
      */
     // too many parameters, commented out code
     @SuppressWarnings({"java:S107", "java:S125"})
     public void migrate(
-            @NonNull final MerkleState merkleState,
+            @NonNull final State state,
             @Nullable final SemanticVersion previousVersion,
             @NonNull final SemanticVersion currentVersion,
             @NonNull final Configuration config,
@@ -191,7 +191,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             @NonNull final Metrics metrics,
             @Nullable final WritableEntityIdStore entityIdStore,
             @NonNull final Map<String, Object> sharedValues) {
-        requireNonNull(merkleState);
+        requireNonNull(state);
         requireNonNull(currentVersion);
         requireNonNull(config);
         requireNonNull(networkInfo);
@@ -200,7 +200,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
         if (isSoOrdered(currentVersion, previousVersion)) {
             throw new IllegalArgumentException("The currentVersion must be at least the previousVersion");
         }
-        if (!(merkleState instanceof MerkleStateRoot state)) {
+        if (!(state instanceof MerkleStateRoot merkleStateRoot)) {
             throw new IllegalArgumentException("The state must be an instance of " + MerkleStateRoot.class.getName());
         }
         if (schemas.isEmpty()) {
@@ -227,7 +227,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             // available at this moment in time. This is done to make sure that even after we
             // add new states into the tree, it doesn't increase the number of states that can
             // be seen by the schema migration code
-            final var readableStates = state.getReadableStates(serviceName);
+            final var readableStates = merkleStateRoot.getReadableStates(serviceName);
             final var previousStates = new FilteredReadableStates(readableStates, readableStates.stateKeys());
             // Similarly, we distinguish between the writable states before and after
             // applying the schema's state definitions. This is done to ensure that we
@@ -237,11 +237,11 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             final WritableStates writableStates;
             final WritableStates newStates;
             if (applications.contains(STATE_DEFINITIONS)) {
-                final var redefinedWritableStates = applyStateDefinitions(schema, config, metrics, state);
+                final var redefinedWritableStates = applyStateDefinitions(schema, config, metrics, merkleStateRoot);
                 writableStates = redefinedWritableStates.beforeStates();
                 newStates = redefinedWritableStates.afterStates();
             } else {
-                newStates = writableStates = state.getWritableStates(serviceName);
+                newStates = writableStates = merkleStateRoot.getWritableStates(serviceName);
             }
             final var migrationContext = new MigrationContextImpl(
                     previousStates, newStates, config, networkInfo, entityIdStore, previousVersion, sharedValues);
@@ -256,7 +256,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                 mws.commit();
             }
             // And finally we can remove any states we need to remove
-            schema.statesToRemove().forEach(stateKey -> state.removeServiceState(serviceName, stateKey));
+            schema.statesToRemove().forEach(stateKey -> merkleStateRoot.removeServiceState(serviceName, stateKey));
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -353,7 +353,7 @@ public class RecordCacheImpl implements HederaRecordCache {
     private WritableStates getWritableState() {
         final var merkleState = workingStateAccessor.getMerkleState();
         if (merkleState == null) {
-            throw new RuntimeException("MerkleState is null. This can only happen very early during bootstrapping");
+            throw new RuntimeException("State is null. This can only happen very early during bootstrapping");
         }
         return merkleState.getWritableStates(NAME);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -351,16 +351,16 @@ public class RecordCacheImpl implements HederaRecordCache {
 
     /** Utility method that get the writable queue from the working state */
     private WritableStates getWritableState() {
-        final var merkleState = workingStateAccessor.getMerkleState();
-        if (merkleState == null) {
+        final var state = workingStateAccessor.getState();
+        if (state == null) {
             throw new RuntimeException("State is null. This can only happen very early during bootstrapping");
         }
-        return merkleState.getWritableStates(NAME);
+        return state.getWritableStates(NAME);
     }
 
     /** Utility method that get the readable queue from the working state */
     private ReadableQueueState<TransactionRecordEntry> getReadableQueue() {
-        final var states = requireNonNull(workingStateAccessor.getMerkleState()).getReadableStates(NAME);
+        final var states = requireNonNull(workingStateAccessor.getState()).getReadableStates(NAME);
         return states.getQueue(TXN_RECORD_QUEUE);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/StateDumper.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/StateDumper.java
@@ -85,7 +85,7 @@ import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.state.recordcache.RecordCacheService;
 import com.hedera.node.app.throttle.CongestionThrottleService;
 import com.swirlds.platform.state.MerkleStateRoot;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.merkle.StateMetadata;
 import com.swirlds.state.merkle.disk.OnDiskKey;
 import com.swirlds.state.merkle.disk.OnDiskValue;
@@ -120,14 +120,14 @@ public class StateDumper {
     private static final String SEMANTIC_CONGESTION = "congestion.txt";
 
     public static void dumpModChildrenFrom(
-            @NonNull final MerkleState merkleState,
+            @NonNull final State state,
             @NonNull final DumpCheckpoint checkpoint,
             @NonNull final Set<MerkleStateChild> childrenToDump) {
-        if (!(merkleState instanceof MerkleStateRoot state)) {
+        if (!(state instanceof MerkleStateRoot merkleState)) {
             throw new IllegalArgumentException("Expected a " + MerkleStateRoot.class.getSimpleName());
         }
-        final SingletonNode<BlockInfo> blockInfoNode =
-                requireNonNull(state.getChild(state.findNodeIndex(BlockRecordService.NAME, BLOCK_INFO_STATE_KEY)));
+        final SingletonNode<BlockInfo> blockInfoNode = requireNonNull(
+                merkleState.getChild(merkleState.findNodeIndex(BlockRecordService.NAME, BLOCK_INFO_STATE_KEY)));
         final var blockInfo = blockInfoNode.getValue();
         final var dumpLoc = getExtantDumpLoc(
                 "mod",
@@ -137,57 +137,59 @@ public class StateDumper {
 
         if (childrenToDump.contains(MerkleStateChild.NFTS)) {
             final VirtualMap<OnDiskKey<NftID>, OnDiskValue<Nft>> uniqueTokens =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, NFTS_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, NFTS_KEY)));
             dumpModUniqueTokens(Paths.get(dumpLoc, SEMANTIC_UNIQUE_TOKENS), uniqueTokens, checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.TOKEN_RELS)) {
             final VirtualMap<OnDiskKey<EntityIDPair>, OnDiskValue<TokenRelation>> tokenRelations =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, TOKEN_RELS_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, TOKEN_RELS_KEY)));
             dumpModTokenRelations(Paths.get(dumpLoc, SEMANTIC_TOKEN_RELATIONS), tokenRelations, checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.FILES)) {
             final VirtualMap<OnDiskKey<FileID>, OnDiskValue<com.hedera.hapi.node.state.file.File>> files =
-                    requireNonNull(state.getChild(state.findNodeIndex(FileService.NAME, V0490FileSchema.BLOBS_KEY)));
+                    requireNonNull(merkleState.getChild(
+                            merkleState.findNodeIndex(FileService.NAME, V0490FileSchema.BLOBS_KEY)));
             dumpModFiles(Paths.get(dumpLoc, SEMANTIC_FILES), files, checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.ACCOUNTS)) {
             final VirtualMap<OnDiskKey<AccountID>, OnDiskValue<Account>> accounts =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, ACCOUNTS_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, ACCOUNTS_KEY)));
             dumpModAccounts(Paths.get(dumpLoc, SEMANTIC_ACCOUNTS), accounts, checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.BYTECODE)) {
             final VirtualMap<OnDiskKey<AccountID>, OnDiskValue<Account>> accounts =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, ACCOUNTS_KEY)));
-            final VirtualMap<OnDiskKey<ContractID>, OnDiskValue<Bytecode>> byteCodes = requireNonNull(
-                    state.getChild(state.findNodeIndex(ContractService.NAME, V0490ContractSchema.BYTECODE_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, ACCOUNTS_KEY)));
+            final VirtualMap<OnDiskKey<ContractID>, OnDiskValue<Bytecode>> byteCodes =
+                    requireNonNull(merkleState.getChild(
+                            merkleState.findNodeIndex(ContractService.NAME, V0490ContractSchema.BYTECODE_KEY)));
             dumpModContractBytecodes(
                     Paths.get(dumpLoc, SEMANTIC_CONTRACT_BYTECODES),
                     byteCodes,
                     accounts,
                     (StateMetadata<AccountID, Account>)
-                            state.getServices().get(TokenService.NAME).get(ACCOUNTS_KEY),
+                            merkleState.getServices().get(TokenService.NAME).get(ACCOUNTS_KEY),
                     checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.TOPICS)) {
-            final VirtualMap<OnDiskKey<TopicID>, OnDiskValue<Topic>> topics = requireNonNull(
-                    state.getChild(state.findNodeIndex(ConsensusService.NAME, ConsensusServiceImpl.TOPICS_KEY)));
+            final VirtualMap<OnDiskKey<TopicID>, OnDiskValue<Topic>> topics = requireNonNull(merkleState.getChild(
+                    merkleState.findNodeIndex(ConsensusService.NAME, ConsensusServiceImpl.TOPICS_KEY)));
             dumpModTopics(Paths.get(dumpLoc, SEMANTIC_TOPICS), topics, checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.SCHEDULED_TRANSACTIONS)) {
-            final VirtualMap<OnDiskKey<ScheduleID>, OnDiskValue<Schedule>> scheduledTransactionsByKey =
-                    requireNonNull(state.getChild(state.findNodeIndex(ScheduleService.NAME, SCHEDULES_BY_ID_KEY)));
+            final VirtualMap<OnDiskKey<ScheduleID>, OnDiskValue<Schedule>> scheduledTransactionsByKey = requireNonNull(
+                    merkleState.getChild(merkleState.findNodeIndex(ScheduleService.NAME, SCHEDULES_BY_ID_KEY)));
             final VirtualMap<OnDiskKey<ProtoBytes>, OnDiskValue<ScheduleList>> scheduledTransactionsByEquality =
-                    requireNonNull(
-                            state.getChild(state.findNodeIndex(ScheduleService.NAME, SCHEDULES_BY_EQUALITY_KEY)));
+                    requireNonNull(merkleState.getChild(
+                            merkleState.findNodeIndex(ScheduleService.NAME, SCHEDULES_BY_EQUALITY_KEY)));
             final VirtualMap<OnDiskKey<ProtoLong>, OnDiskValue<ScheduleList>> scheduledTransactionsByExpiry =
-                    requireNonNull(
-                            state.getChild(state.findNodeIndex(ScheduleService.NAME, SCHEDULES_BY_EXPIRY_SEC_KEY)));
+                    requireNonNull(merkleState.getChild(
+                            merkleState.findNodeIndex(ScheduleService.NAME, SCHEDULES_BY_EXPIRY_SEC_KEY)));
             dumpModScheduledTransactions(
                     Paths.get(dumpLoc, SEMANTIC_SCHEDULED_TRANSACTIONS),
                     scheduledTransactionsByKey,
@@ -197,17 +199,17 @@ public class StateDumper {
 
         if (childrenToDump.contains(MerkleStateChild.TOKENS)) {
             final VirtualMap<OnDiskKey<TokenID>, OnDiskValue<Token>> tokenTypes =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, TOKENS_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, TOKENS_KEY)));
             dumpModTokenType(Paths.get(dumpLoc, SEMANTIC_TOKEN_TYPE), tokenTypes, checkpoint);
         }
 
         if (childrenToDump.contains(MerkleStateChild.BLOCK_METADATA)) {
             final SingletonNode<RunningHashes> runningHashesSingleton = requireNonNull(
-                    state.getChild(state.findNodeIndex(BlockRecordService.NAME, RUNNING_HASHES_STATE_KEY)));
-            final SingletonNode<BlockInfo> blocksStateSingleton =
-                    requireNonNull(state.getChild(state.findNodeIndex(BlockRecordService.NAME, BLOCK_INFO_STATE_KEY)));
-            final SingletonNode<EntityNumber> entityIdSingleton =
-                    requireNonNull(state.getChild(state.findNodeIndex(EntityIdService.NAME, ENTITY_ID_STATE_KEY)));
+                    merkleState.getChild(merkleState.findNodeIndex(BlockRecordService.NAME, RUNNING_HASHES_STATE_KEY)));
+            final SingletonNode<BlockInfo> blocksStateSingleton = requireNonNull(
+                    merkleState.getChild(merkleState.findNodeIndex(BlockRecordService.NAME, BLOCK_INFO_STATE_KEY)));
+            final SingletonNode<EntityNumber> entityIdSingleton = requireNonNull(
+                    merkleState.getChild(merkleState.findNodeIndex(EntityIdService.NAME, ENTITY_ID_STATE_KEY)));
             dumpModBlockInfo(
                     Paths.get(dumpLoc, SEMANTIC_BLOCK),
                     runningHashesSingleton.getValue(),
@@ -217,30 +219,30 @@ public class StateDumper {
         }
 
         if (childrenToDump.contains(MerkleStateChild.STAKING_INFOS)) {
-            final VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>> stakingInfoMap =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY)));
+            final VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>> stakingInfoMap = requireNonNull(
+                    merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY)));
             dumpModStakingInfo(Paths.get(dumpLoc, SEMANTIC_STAKING_INFO), stakingInfoMap);
         }
 
         if (childrenToDump.contains(MerkleStateChild.STAKING_NETWORK_METADATA)) {
-            final SingletonNode<NetworkStakingRewards> stakingRewards =
-                    requireNonNull(state.getChild(state.findNodeIndex(TokenService.NAME, STAKING_NETWORK_REWARDS_KEY)));
+            final SingletonNode<NetworkStakingRewards> stakingRewards = requireNonNull(
+                    merkleState.getChild(merkleState.findNodeIndex(TokenService.NAME, STAKING_NETWORK_REWARDS_KEY)));
             dumpModStakingRewards(Paths.get(dumpLoc, SEMANTIC_STAKING_REWARDS), stakingRewards.getValue());
         }
 
         if (childrenToDump.contains(MerkleStateChild.TRANSACTION_RECORD_QUEUE)) {
-            final QueueNode<TransactionRecordEntry> queue =
-                    requireNonNull(state.getChild(state.findNodeIndex(RecordCacheService.NAME, TXN_RECORD_QUEUE)));
+            final QueueNode<TransactionRecordEntry> queue = requireNonNull(
+                    merkleState.getChild(merkleState.findNodeIndex(RecordCacheService.NAME, TXN_RECORD_QUEUE)));
             dumpModTxnRecordQueue(Paths.get(dumpLoc, SEMANTIC_TXN_RECORD_QUEUE), queue);
         }
 
         if (childrenToDump.contains(MerkleStateChild.THROTTLE_METADATA)) {
             final SingletonNode<CongestionLevelStarts> congestionLevelStartsSingletonNode =
-                    requireNonNull(state.getChild(
-                            state.findNodeIndex(CongestionThrottleService.NAME, CONGESTION_LEVEL_STARTS_STATE_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(
+                            CongestionThrottleService.NAME, CONGESTION_LEVEL_STARTS_STATE_KEY)));
             final SingletonNode<ThrottleUsageSnapshots> throttleUsageSnapshotsSingletonNode =
-                    requireNonNull(state.getChild(
-                            state.findNodeIndex(CongestionThrottleService.NAME, THROTTLE_USAGE_SNAPSHOTS_STATE_KEY)));
+                    requireNonNull(merkleState.getChild(merkleState.findNodeIndex(
+                            CongestionThrottleService.NAME, THROTTLE_USAGE_SNAPSHOTS_STATE_KEY)));
             dumpModCongestion(
                     Paths.get(dumpLoc, SEMANTIC_CONGESTION),
                     congestionLevelStartsSingletonNode.getValue(),

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ReadableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ReadableStoreFactory.java
@@ -55,7 +55,7 @@ import com.hedera.node.app.service.token.impl.ReadableNftStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableStakingInfoStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenRelationStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
@@ -67,7 +67,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Factory for all readable stores. It creates new readable stores based on the {@link MerkleState}.
+ * Factory for all readable stores. It creates new readable stores based on the {@link State}.
  *
  * <p>The initial implementation creates all known stores hard-coded. In a future version, this will be replaced by a
  * dynamic approach.
@@ -111,15 +111,15 @@ public class ReadableStoreFactory {
         return Collections.unmodifiableMap(newMap);
     }
 
-    private final MerkleState state;
+    private final State state;
 
     /**
      * Constructor of {@code ReadableStoreFactory}
      *
-     * @param state the {@link MerkleState} to use
+     * @param state the {@link State} to use
      */
     @Inject
-    public ReadableStoreFactory(@NonNull final MerkleState state) {
+    public ReadableStoreFactory(@NonNull final State state) {
         this.state = requireNonNull(state, "The supplied argument 'state' cannot be null!");
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/WritableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/WritableStoreFactory.java
@@ -44,7 +44,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
@@ -52,7 +52,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Factory for all writable stores. It creates new writable stores based on the {@link MerkleState}.
+ * Factory for all writable stores. It creates new writable stores based on the {@link State}.
  *
  * <p>The initial implementation creates all known stores hard-coded. In a future version, this will be replaced by a
  * dynamic approach.
@@ -115,7 +115,7 @@ public class WritableStoreFactory {
     /**
      * Constructor of {@code WritableStoreFactory}
      *
-     * @param state the {@link MerkleState} to use
+     * @param state the {@link State} to use
      * @param serviceName the name of the service to create stores for
      * @param configuration the configuration to use for the created stores
      * @param storeMetricsService Service that provides utilization metrics.
@@ -123,7 +123,7 @@ public class WritableStoreFactory {
      * @throws IllegalArgumentException if the service name is unknown
      */
     public WritableStoreFactory(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final String serviceName,
             @NonNull final Configuration configuration,
             @NonNull final StoreMetricsService storeMetricsService) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManager.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.throttle;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.state.throttles.ThrottleUsageSnapshot;
 import com.hedera.node.app.workflows.TransactionInfo;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
@@ -38,9 +38,7 @@ public interface NetworkUtilizationManager {
      * @param state - the state of the node.
      */
     void trackTxn(
-            @NonNull final TransactionInfo txnInfo,
-            @NonNull final Instant consensusTime,
-            @NonNull final MerkleState state);
+            @NonNull final TransactionInfo txnInfo, @NonNull final Instant consensusTime, @NonNull final State state);
 
     /**
      * Updates the throttle usage and congestion pricing for cases where the transaction is not valid, but we want to track the fee payments related to it.
@@ -48,7 +46,7 @@ public interface NetworkUtilizationManager {
      * @param consensusNow - the consensus time of the transaction.
      * @param state - the state of the node.
      */
-    void trackFeePayments(@NonNull final Instant consensusNow, @NonNull final MerkleState state);
+    void trackFeePayments(@NonNull final Instant consensusNow, @NonNull final State state);
 
     /**
      * Indicates whether the last transaction was throttled by gas.
@@ -75,9 +73,7 @@ public interface NetworkUtilizationManager {
      * @return whether the transaction should be throttled
      */
     boolean shouldThrottle(
-            @NonNull final TransactionInfo txnInfo,
-            @NonNull final MerkleState state,
-            @NonNull final Instant consensusTime);
+            @NonNull final TransactionInfo txnInfo, @NonNull final State state, @NonNull final Instant consensusTime);
 
     /**
      * Verifies if the throttle in this operation context has enough capacity to handle the given number of the

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManagerImpl.java
@@ -31,7 +31,7 @@ import com.hedera.node.app.hapi.utils.throttles.DeterministicThrottle;
 import com.hedera.node.app.throttle.annotations.BackendThrottle;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
@@ -57,15 +57,13 @@ public class NetworkUtilizationManagerImpl implements NetworkUtilizationManager 
 
     @Override
     public void trackTxn(
-            @NonNull final TransactionInfo txnInfo,
-            @NonNull final Instant consensusTime,
-            @NonNull final MerkleState state) {
+            @NonNull final TransactionInfo txnInfo, @NonNull final Instant consensusTime, @NonNull final State state) {
         backendThrottle.shouldThrottle(txnInfo, consensusTime, state);
         congestionMultipliers.updateMultiplier(consensusTime);
     }
 
     @Override
-    public void trackFeePayments(@NonNull final Instant consensusNow, @NonNull final MerkleState state) {
+    public void trackFeePayments(@NonNull final Instant consensusNow, @NonNull final State state) {
         // Used to update network utilization after charging fees for an invalid transaction
         final var chargingFeesCryptoTransfer = new TransactionInfo(
                 Transaction.DEFAULT,
@@ -90,9 +88,7 @@ public class NetworkUtilizationManagerImpl implements NetworkUtilizationManager 
 
     @Override
     public boolean shouldThrottle(
-            @NonNull final TransactionInfo txnInfo,
-            @NonNull final MerkleState state,
-            @NonNull final Instant consensusTime) {
+            @NonNull final TransactionInfo txnInfo, @NonNull final State state, @NonNull final Instant consensusTime) {
         return backendThrottle.shouldThrottle(txnInfo, consensusTime, state);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulator.java
@@ -23,7 +23,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.node.app.throttle.annotations.IngestThrottle;
 import com.hedera.node.app.workflows.TransactionInfo;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
@@ -61,7 +61,7 @@ public class SynchronizedThrottleAccumulator {
      * @param state the current state of the node
      * @return whether the transaction should be throttled
      */
-    public synchronized boolean shouldThrottle(@NonNull TransactionInfo txnInfo, MerkleState state) {
+    public synchronized boolean shouldThrottle(@NonNull TransactionInfo txnInfo, State state) {
         setDecisionTime(instantSource.instant());
         return frontendThrottle.shouldThrottle(txnInfo, lastDecisionTime, state);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -74,7 +74,7 @@ import com.hedera.node.config.data.SchedulingConfig;
 import com.hedera.node.config.data.TokensConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigInteger;
@@ -154,7 +154,7 @@ public class ThrottleAccumulator {
      * @return whether the transaction should be throttled
      */
     public boolean shouldThrottle(
-            @NonNull final TransactionInfo txnInfo, @NonNull final Instant now, @NonNull final MerkleState state) {
+            @NonNull final TransactionInfo txnInfo, @NonNull final Instant now, @NonNull final State state) {
         resetLastAllowedUse();
         lastTxnWasGasThrottled = false;
         if (shouldThrottleTxn(false, txnInfo, now, state)) {
@@ -337,7 +337,7 @@ public class ThrottleAccumulator {
             final boolean isScheduled,
             @NonNull final TransactionInfo txnInfo,
             @NonNull final Instant now,
-            @NonNull final MerkleState state) {
+            @NonNull final State state) {
         final var function = txnInfo.functionality();
         final var configuration = configProvider.getConfiguration();
 
@@ -399,10 +399,7 @@ public class ThrottleAccumulator {
     }
 
     private boolean shouldThrottleScheduleCreate(
-            final ThrottleReqsManager manager,
-            final TransactionInfo txnInfo,
-            final Instant now,
-            final MerkleState state) {
+            final ThrottleReqsManager manager, final TransactionInfo txnInfo, final Instant now, final State state) {
         final var txnBody = txnInfo.txBody();
         final var scheduleCreate = txnBody.scheduleCreateOrThrow();
         final var scheduled = scheduleCreate.scheduledTransactionBodyOrThrow();
@@ -477,7 +474,7 @@ public class ThrottleAccumulator {
     }
 
     private boolean shouldThrottleScheduleSign(
-            ThrottleReqsManager manager, TransactionInfo txnInfo, Instant now, MerkleState state) {
+            ThrottleReqsManager manager, TransactionInfo txnInfo, Instant now, State state) {
         final var txnBody = txnInfo.txBody();
         if (!manager.allReqsMetAt(now)) {
             return true;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleServiceManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleServiceManager.java
@@ -37,7 +37,7 @@ import com.hedera.node.app.throttle.annotations.BackendThrottle;
 import com.hedera.node.app.throttle.annotations.IngestThrottle;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableSingletonState;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.WritableSingletonState;
@@ -86,7 +86,7 @@ public class ThrottleServiceManager {
      * @param state the state to use
      * @param throttleDefinitions the serialized throttle definitions
      */
-    public void init(@NonNull final MerkleState state, @NonNull final Bytes throttleDefinitions) {
+    public void init(@NonNull final State state, @NonNull final Bytes throttleDefinitions) {
         requireNonNull(state);
         // Apply configuration for gas throttles
         applyGasConfig();
@@ -106,7 +106,7 @@ public class ThrottleServiceManager {
      *
      * @param state the state to save to
      */
-    public void saveThrottleSnapshotsAndCongestionLevelStartsTo(@NonNull final MerkleState state) {
+    public void saveThrottleSnapshotsAndCongestionLevelStartsTo(@NonNull final State state) {
         requireNonNull(state);
         final var serviceStates = state.getWritableStates(CongestionThrottleService.NAME);
         saveThrottleSnapshotsTo(serviceStates);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/FileUtilities.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/FileUtilities.java
@@ -26,7 +26,7 @@ import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class FileUtilities {
@@ -36,7 +36,7 @@ public class FileUtilities {
     }
 
     @NonNull
-    public static Bytes getFileContent(@NonNull final MerkleState state, @NonNull final FileID fileID) {
+    public static Bytes getFileContent(@NonNull final State state, @NonNull final FileID fileID) {
         final var states = state.getReadableStates(FileService.NAME);
         final var filesMap = states.<FileID, File>get(BLOBS_KEY);
         final var file = filesMap.get(fileID);
@@ -65,7 +65,7 @@ public class FileUtilities {
      * @param observer the observer to notify
      */
     public static void observePropertiesAndPermissions(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final Configuration config,
             @NonNull final SpecialFilesObserver observer) {
         requireNonNull(state);
@@ -80,7 +80,7 @@ public class FileUtilities {
     }
 
     private static void observePropertiesAndPermissions(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final FileID propertiesId,
             @NonNull final FileID permissionsId,
             @NonNull final SpecialFilesObserver observer) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -69,7 +69,7 @@ import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.transaction.ConsensusTransaction;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.info.NetworkInfo;
 import com.swirlds.state.spi.info.NodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -165,12 +165,12 @@ public class HandleWorkflow {
     /**
      * Handles the next {@link Round}
      *
-     * @param state the writable {@link MerkleState} that this round will work on
+     * @param state the writable {@link State} that this round will work on
      * @param platformState the {@link PlatformState} that this round will work on
      * @param round the next {@link Round} that needs to be processed
      */
     public void handleRound(
-            @NonNull final MerkleState state, @NonNull final PlatformState platformState, @NonNull final Round round) {
+            @NonNull final State state, @NonNull final PlatformState platformState, @NonNull final Round round) {
         // We only close the round with the block record manager after user transactions
         final var userTransactionsHandled = new AtomicBoolean(false);
         logStartRound(round);
@@ -229,14 +229,14 @@ public class HandleWorkflow {
      * executing the workflow for the transaction. This produces a stream of records that are then passed to the
      * {@link BlockRecordManager} to be externalized.
      *
-     * @param state the writable {@link MerkleState} that this transaction will work on
+     * @param state the writable {@link State} that this transaction will work on
      * @param platformState the {@link PlatformState} that this transaction will work on
      * @param event the {@link ConsensusEvent} that this transaction belongs to
      * @param creator the {@link NodeInfo} of the creator of the transaction
      * @param txn the {@link ConsensusTransaction} to be handled
      */
     private void handlePlatformTransaction(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final PlatformState platformState,
             @NonNull final ConsensusEvent event,
             @NonNull final NodeInfo creator,
@@ -492,7 +492,7 @@ public class HandleWorkflow {
      * @return the new user transaction
      */
     private UserTxn newUserTxn(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final PlatformState platformState,
             @NonNull final ConsensusEvent event,
             @NonNull final NodeInfo creator,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
@@ -59,7 +59,7 @@ public interface HandleWorkflowModule {
     @Provides
     static Supplier<AutoCloseableWrapper<State>> provideStateSupplier(
             @NonNull final WorkingStateAccessor workingStateAccessor) {
-        return () -> new AutoCloseableWrapper<>(workingStateAccessor.getMerkleState(), NO_OP);
+        return () -> new AutoCloseableWrapper<>(workingStateAccessor.getState(), NO_OP);
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
@@ -29,7 +29,7 @@ import com.hedera.node.app.service.util.impl.handlers.UtilHandlers;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.app.workflows.dispatcher.TransactionHandlers;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -57,7 +57,7 @@ public interface HandleWorkflowModule {
     Runnable NO_OP = () -> {};
 
     @Provides
-    static Supplier<AutoCloseableWrapper<MerkleState>> provideStateSupplier(
+    static Supplier<AutoCloseableWrapper<State>> provideStateSupplier(
             @NonNull final WorkingStateAccessor workingStateAccessor) {
         return () -> new AutoCloseableWrapper<>(workingStateAccessor.getMerkleState(), NO_OP);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/cache/CacheWarmer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/cache/CacheWarmer.java
@@ -36,7 +36,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.transaction.Transaction;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.concurrent.Executor;
@@ -76,7 +76,7 @@ public class CacheWarmer {
      * @param state the current state
      * @param round the current round
      */
-    public void warm(@NonNull final MerkleState state, @NonNull final Round round) {
+    public void warm(@NonNull final State state, @NonNull final Round round) {
         executor.execute(() -> {
             final ReadableStoreFactory storeFactory = new ReadableStoreFactory(state);
             final ReadableAccountStore accountStore = storeFactory.getStore(ReadableAccountStore.class);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/Savepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/Savepoint.java
@@ -20,7 +20,7 @@ import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
 import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
 import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.ReversingBehavior;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -33,7 +33,7 @@ public interface Savepoint extends BuilderSink {
      *
      * @return the state
      */
-    MerkleState state();
+    State state();
 
     /**
      * Rolls back all changes made in this savepoint, making any necessary changes to the stream item builders

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
@@ -30,11 +30,11 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
 import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.state.WrappedMerkleState;
+import com.hedera.node.app.state.WrappedState;
 import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
 import com.hedera.node.app.workflows.handle.stack.BuilderSink;
 import com.hedera.node.app.workflows.handle.stack.Savepoint;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.EnumSet;
 import java.util.List;
@@ -51,7 +51,7 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
             EnumSet.of(OK, SUCCESS, FEE_SCHEDULE_FILE_PART_UPLOADED, SUCCESS_BUT_MISSING_EXPECTED_OPERATION);
 
     protected final BuilderSink parentSink;
-    protected final WrappedMerkleState state;
+    protected final WrappedState state;
     private Status status = Status.PENDING;
 
     /**
@@ -62,7 +62,7 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
      * @param maxFollowing the maximum number of following builders
      */
     protected AbstractSavepoint(
-            @NonNull final WrappedMerkleState state,
+            @NonNull final WrappedState state,
             @NonNull final BuilderSink parentSink,
             final int maxPreceding,
             final int maxFollowing) {
@@ -78,14 +78,14 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
      * @param maxTotal the maximum number of total builders
      */
     protected AbstractSavepoint(
-            @NonNull final WrappedMerkleState state, @NonNull final BuilderSink parentSink, final int maxTotal) {
+            @NonNull final WrappedState state, @NonNull final BuilderSink parentSink, final int maxTotal) {
         super(maxTotal);
         this.state = requireNonNull(state);
         this.parentSink = requireNonNull(parentSink);
     }
 
     @Override
-    public MerkleState state() {
+    public State state() {
         return state;
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/FirstChildSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/FirstChildSavepoint.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.workflows.handle.stack.savepoints;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.PRECEDING;
 
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.state.WrappedMerkleState;
+import com.hedera.node.app.state.WrappedState;
 import com.hedera.node.app.workflows.handle.stack.BuilderSink;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -39,7 +39,7 @@ public class FirstChildSavepoint extends AbstractSavepoint {
      * @param txnCategory the transaction category
      */
     public FirstChildSavepoint(
-            @NonNull final WrappedMerkleState state,
+            @NonNull final WrappedState state,
             @NonNull final BuilderSink parentSink,
             @NonNull final HandleContext.TransactionCategory txnCategory) {
         super(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/FirstRootSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/FirstRootSavepoint.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.workflows.handle.stack.savepoints;
 
-import com.hedera.node.app.state.WrappedMerkleState;
+import com.hedera.node.app.state.WrappedState;
 import com.hedera.node.app.workflows.handle.stack.BuilderSink;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * parent sink although the capacity is limited in both directions.
  */
 public class FirstRootSavepoint extends AbstractSavepoint {
-    public FirstRootSavepoint(@NonNull WrappedMerkleState state, BuilderSink parentSink) {
+    public FirstRootSavepoint(@NonNull WrappedState state, BuilderSink parentSink) {
         super(state, parentSink, parentSink.precedingCapacity(), parentSink.followingCapacity());
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/FollowingSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/FollowingSavepoint.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.workflows.handle.stack.savepoints;
 
-import com.hedera.node.app.state.WrappedMerkleState;
+import com.hedera.node.app.state.WrappedState;
 import com.hedera.node.app.workflows.handle.stack.Savepoint;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -27,7 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class FollowingSavepoint extends AbstractSavepoint {
 
-    public FollowingSavepoint(@NonNull WrappedMerkleState state, @NonNull Savepoint parent) {
+    public FollowingSavepoint(@NonNull WrappedState state, @NonNull Savepoint parent) {
         super(state, parent, parent.followingCapacity());
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/PlatformStateUpdates.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/PlatformStateUpdates.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.node.freeze.FreezeType;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.networkadmin.FreezeService;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableSingletonState;
 import com.swirlds.state.spi.ReadableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -60,7 +60,7 @@ public class PlatformStateUpdates {
      * @param txBody the transaction body
      */
     public void handleTxBody(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final PlatformState platformState,
             @NonNull final TransactionBody txBody) {
         requireNonNull(state, "state must not be null");

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
@@ -35,7 +35,7 @@ import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -81,7 +81,7 @@ public class SystemFileUpdates {
      * @param state the current state (the updated file content needs to be committed to the state)
      * @param txBody the transaction body
      */
-    public ResponseCodeEnum handleTxBody(@NonNull final MerkleState state, @NonNull final TransactionBody txBody) {
+    public ResponseCodeEnum handleTxBody(@NonNull final State state, @NonNull final TransactionBody txBody) {
         requireNonNull(state, "state must not be null");
         requireNonNull(txBody, "txBody must not be null");
 
@@ -131,7 +131,7 @@ public class SystemFileUpdates {
     private void updateConfig(
             @NonNull final Configuration configuration,
             @NonNull final ConfigType configType,
-            @NonNull final MerkleState state) {
+            @NonNull final State state) {
         observePropertiesAndPermissions(state, configuration, (properties, permissions) -> {
             configProvider.update(properties, permissions);
             if (configType == ConfigType.NETWORK_PROPERTIES) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxn.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxn.java
@@ -61,7 +61,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.transaction.ConsensusTransaction;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.info.NetworkInfo;
 import com.swirlds.state.spi.info.NodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -71,7 +71,7 @@ public record UserTxn(
         boolean isGenesisTxn,
         @NonNull HederaFunctionality functionality,
         @NonNull Instant consensusNow,
-        @NonNull MerkleState state,
+        @NonNull State state,
         @NonNull PlatformState platformState,
         @NonNull ConsensusEvent event,
         @NonNull ConsensusTransaction platformTxn,
@@ -86,7 +86,7 @@ public record UserTxn(
 
     public static UserTxn from(
             // @UserTxnScope
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final PlatformState platformState,
             @NonNull final ConsensusEvent event,
             @NonNull final NodeInfo creatorInfo,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -64,7 +64,7 @@ import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LazyCreationConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.InstantSource;
 import java.util.EnumSet;
@@ -155,14 +155,14 @@ public final class IngestChecker {
     /**
      * Runs all the ingest checks on a {@link Transaction}
      *
-     * @param state the {@link MerkleState} to use
+     * @param state the {@link State} to use
      * @param tx the {@link Transaction} to check
      * @param configuration the {@link Configuration} to use
      * @return the {@link TransactionInfo} with the extracted information
      * @throws PreCheckException if a check fails
      */
     public TransactionInfo runAllChecks(
-            @NonNull final MerkleState state, @NonNull final Transaction tx, @NonNull final Configuration configuration)
+            @NonNull final State state, @NonNull final Transaction tx, @NonNull final Configuration configuration)
             throws PreCheckException {
         // During ingest we approximate consensus time with wall clock time
         final var consensusTime = instantSource.instant();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
@@ -28,7 +28,7 @@ import com.hedera.node.config.ConfigProvider;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -42,7 +42,7 @@ public final class IngestWorkflowImpl implements IngestWorkflow {
 
     private static final Logger logger = LogManager.getLogger(IngestWorkflowImpl.class);
 
-    private final Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor;
+    private final Supplier<AutoCloseableWrapper<State>> stateAccessor;
     private final TransactionChecker transactionChecker;
     private final IngestChecker ingestChecker;
     private final SubmissionManager submissionManager;
@@ -60,7 +60,7 @@ public final class IngestWorkflowImpl implements IngestWorkflow {
      */
     @Inject
     public IngestWorkflowImpl(
-            @NonNull final Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor,
+            @NonNull final Supplier<AutoCloseableWrapper<State>> stateAccessor,
             @NonNull final TransactionChecker transactionChecker,
             @NonNull final IngestChecker ingestChecker,
             @NonNull final SubmissionManager submissionManager,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryContextImpl.java
@@ -33,7 +33,7 @@ import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -46,7 +46,7 @@ public class QueryContextImpl implements QueryContext {
     private final Query query;
     private final Configuration configuration;
     private final RecordCache recordCache;
-    private final MerkleState state;
+    private final State state;
     private final ExchangeRateManager exchangeRateManager;
     private final AccountID payer;
     private final FeeCalculator feeCalculator;
@@ -56,7 +56,7 @@ public class QueryContextImpl implements QueryContext {
     /**
      * Constructor of {@code QueryContextImpl}.
      *
-     * @param state         the {@link MerkleState} with the current state
+     * @param state         the {@link State} with the current state
      * @param storeFactory  the {@link ReadableStoreFactory} used to create the stores
      * @param query         the query that is currently being processed
      * @param configuration the current {@link Configuration}
@@ -67,7 +67,7 @@ public class QueryContextImpl implements QueryContext {
      * @throws NullPointerException if {@code query} is {@code null}
      */
     public QueryContextImpl(
-            @NonNull final MerkleState state,
+            @NonNull final State state,
             @NonNull final ReadableStoreFactory storeFactory,
             @NonNull final Query query,
             @NonNull final Configuration configuration,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -63,7 +63,7 @@ import com.hedera.pbj.runtime.UnknownFieldException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -95,7 +95,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                             .build()))
             .build();
 
-    private final Function<ResponseType, AutoCloseableWrapper<MerkleState>> stateAccessor;
+    private final Function<ResponseType, AutoCloseableWrapper<State>> stateAccessor;
     private final SubmissionManager submissionManager;
     private final QueryChecker queryChecker;
     private final IngestChecker ingestChecker;
@@ -131,7 +131,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
      */
     @Inject
     public QueryWorkflowImpl(
-            @NonNull final Function<ResponseType, AutoCloseableWrapper<MerkleState>> stateAccessor,
+            @NonNull final Function<ResponseType, AutoCloseableWrapper<State>> stateAccessor,
             @NonNull final SubmissionManager submissionManager,
             @NonNull final QueryChecker queryChecker,
             @NonNull final IngestChecker ingestChecker,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
@@ -53,7 +53,7 @@ public interface QueryWorkflowInjectionModule {
     @Singleton
     static Function<ResponseType, AutoCloseableWrapper<State>> provideStateAccess(
             @NonNull final WorkingStateAccessor workingStateAccessor) {
-        return responseType -> new AutoCloseableWrapper<>(workingStateAccessor.getMerkleState(), NO_OP);
+        return responseType -> new AutoCloseableWrapper<>(workingStateAccessor.getState(), NO_OP);
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowInjectionModule.java
@@ -29,7 +29,7 @@ import com.hedera.node.app.service.token.impl.handlers.TokenHandlers;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.pbj.runtime.Codec;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -51,7 +51,7 @@ public interface QueryWorkflowInjectionModule {
 
     @Provides
     @Singleton
-    static Function<ResponseType, AutoCloseableWrapper<MerkleState>> provideStateAccess(
+    static Function<ResponseType, AutoCloseableWrapper<State>> provideStateAccess(
             @NonNull final WorkingStateAccessor workingStateAccessor) {
         return responseType -> new AutoCloseableWrapper<>(workingStateAccessor.getMerkleState(), NO_OP);
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -25,7 +25,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.DaggerHederaInjectionComponent;
 import com.hedera.node.app.HederaInjectionComponent;
 import com.hedera.node.app.config.ConfigProviderImpl;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.info.SelfNodeInfoImpl;
 import com.hedera.node.app.service.contract.impl.ContractServiceImpl;
 import com.hedera.node.app.service.file.impl.FileServiceImpl;
@@ -101,7 +101,7 @@ class IngestComponentTest {
                 .metrics(metrics)
                 .build();
 
-        final var state = new FakeMerkleState();
+        final var state = new FakeState();
         state.addService(RecordCacheService.NAME, Map.of("TransactionRecordQueue", new ArrayDeque<String>()));
         app.workingStateAccessor().setMerkleState(state);
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -103,7 +103,7 @@ class IngestComponentTest {
 
         final var state = new FakeState();
         state.addService(RecordCacheService.NAME, Map.of("TransactionRecordQueue", new ArrayDeque<String>()));
-        app.workingStateAccessor().setMerkleState(state);
+        app.workingStateAccessor().setState(state);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.node.base.TimestampSeconds;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.fees.schemas.V0490FeeSchema;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
@@ -67,7 +67,7 @@ class ExchangeRateManagerTest {
     void setup() {
         final ConfigProvider configProvider = () -> new VersionedConfigImpl(HederaTestConfigBuilder.createConfig(), 1);
         subject = new ExchangeRateManager(configProvider);
-        final var state = new FakeMerkleState();
+        final var state = new FakeState();
         final var midnightRates = new AtomicReference<>(validRatesObj);
         state.addService(FeeService.NAME, Map.of(V0490FeeSchema.MIDNIGHT_RATES_STATE_KEY, midnightRates));
         subject.init(state, validRateBytes);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/FeeCalculatorImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/FeeCalculatorImplTest.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.node.base.*;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.fees.congestion.CongestionMultipliers;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.pbj.runtime.OneOf;
@@ -68,14 +68,14 @@ public class FeeCalculatorImplTest {
                 ExchangeRate.DEFAULT,
                 false,
                 congestionMultipliers,
-                new ReadableStoreFactory(new FakeMerkleState()));
+                new ReadableStoreFactory(new FakeState()));
         assertNotNull(calculator);
 
         calculator = new FeeCalculatorImpl(
                 feeData,
                 new ExchangeRate(0, 0, null),
                 congestionMultipliers,
-                new ReadableStoreFactory(new FakeMerkleState()),
+                new ReadableStoreFactory(new FakeState()),
                 HederaFunctionality.CONTRACT_CALL);
         assertNotNull(calculator);
     }
@@ -96,12 +96,12 @@ public class FeeCalculatorImplTest {
                         ExchangeRate.DEFAULT,
                         false,
                         congestionMultipliers,
-                        new ReadableStoreFactory(new FakeMerkleState())));
+                        new ReadableStoreFactory(new FakeState())));
     }
 
     @Test
     void willReturnMultiplier() {
-        var storeFactory = new ReadableStoreFactory(new FakeMerkleState());
+        var storeFactory = new ReadableStoreFactory(new FakeState());
         var calculator = new FeeCalculatorImpl(
                 feeData,
                 new ExchangeRate(0, 0, null),

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/UtilizationScaledThrottleMultiplierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/UtilizationScaledThrottleMultiplierTest.java
@@ -47,7 +47,7 @@ import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.TokenMintTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.consensus.ConsensusService;
 import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
 import com.hedera.node.app.service.contract.ContractService;
@@ -119,7 +119,7 @@ class UtilizationScaledThrottleMultiplierTest {
     @Mock
     private TransactionInfo txnInfo;
 
-    private FakeMerkleState state;
+    private FakeState state;
 
     @BeforeEach
     void setUp() {
@@ -137,7 +137,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(CRYPTO_CREATE);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         TokenService.NAME,
                         Map.of(
@@ -182,7 +182,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(CONTRACT_CREATE);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         ContractService.NAME,
                         Map.of(
@@ -210,7 +210,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(FILE_CREATE);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         FileService.NAME,
                         Map.of(
@@ -244,7 +244,7 @@ class UtilizationScaledThrottleMultiplierTest {
                 TOKEN_MINT);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         TokenService.NAME,
                         Map.of(
@@ -282,7 +282,7 @@ class UtilizationScaledThrottleMultiplierTest {
                 TOKEN_MINT);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        var storeFactory = new ReadableStoreFactory(new FakeMerkleState());
+        var storeFactory = new ReadableStoreFactory(new FakeState());
         long multiplier = utilizationScaledThrottleMultiplier.currentMultiplier(tokenMintTxnInfo, storeFactory);
 
         assertEquals(SOME_MULTIPLIER, multiplier);
@@ -299,7 +299,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(TOKEN_CREATE);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         TokenService.NAME,
                         Map.of(
@@ -325,7 +325,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(TOKEN_ASSOCIATE_TO_ACCOUNT);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         TokenService.NAME,
                         Map.of(
@@ -357,7 +357,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(CONSENSUS_CREATE_TOPIC);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        state = new FakeMerkleState()
+        state = new FakeState()
                 .addService(
                         ConsensusService.NAME,
                         Map.of(
@@ -379,7 +379,7 @@ class UtilizationScaledThrottleMultiplierTest {
         when(txnInfo.functionality()).thenReturn(CRYPTO_TRANSFER);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
-        var storeFactory = new ReadableStoreFactory(new FakeMerkleState());
+        var storeFactory = new ReadableStoreFactory(new FakeState());
         long multiplier = utilizationScaledThrottleMultiplier.currentMultiplier(txnInfo, storeFactory);
 
         assertEquals(SOME_MULTIPLIER, multiplier);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/StateLifecyclesImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/StateLifecyclesImplTest.java
@@ -56,7 +56,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class MerkleStateLifecyclesImplTest extends MerkleTestBase {
+class StateLifecyclesImplTest extends MerkleTestBase {
     private static final int PRETEND_STAKING_INFO_CHILD_INDEX = 7;
 
     @Mock

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -38,8 +38,8 @@ import com.hedera.hapi.node.state.recordcache.TransactionRecordEntry;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.fixtures.AppTestBase;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.SingleTransactionRecord;
@@ -101,7 +101,7 @@ final class RecordCacheImplTest extends AppTestBase {
             @Mock final NetworkInfo networkInfo) {
         dedupeCache = new DeduplicationCacheImpl(props, instantSource);
         final var registry = new FakeSchemaRegistry();
-        final var state = new FakeMerkleState();
+        final var state = new FakeState();
         final var svc = new RecordCacheService();
         svc.registerSchemas(registry);
         registry.migrate(svc.getServiceName(), state, networkInfo);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -105,7 +105,7 @@ final class RecordCacheImplTest extends AppTestBase {
         final var svc = new RecordCacheService();
         svc.registerSchemas(registry);
         registry.migrate(svc.getServiceName(), state, networkInfo);
-        lenient().when(wsa.getMerkleState()).thenReturn(state);
+        lenient().when(wsa.getState()).thenReturn(state);
         lenient().when(props.getConfiguration()).thenReturn(versionedConfig);
         lenient().when(versionedConfig.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);
         lenient().when(hederaConfig.transactionMaxValidDuration()).thenReturn(180L);
@@ -191,7 +191,7 @@ final class RecordCacheImplTest extends AppTestBase {
                     // duplicate  user tx
                     new TransactionRecordEntry(3, payer1, transactionRecord(DUPLICATE_TRANSACTION, txId1, 400)));
 
-            final var state = wsa.getMerkleState();
+            final var state = wsa.getState();
             assertThat(state).isNotNull();
             final var services = state.getWritableStates(RecordCacheService.NAME);
             final WritableQueueState<TransactionRecordEntry> queue =
@@ -261,7 +261,7 @@ final class RecordCacheImplTest extends AppTestBase {
                     transactionID().copyBuilder().accountID(oldPayer).build();
             final var oldEntry = new TransactionRecordEntry(0, oldPayer, transactionRecord(SUCCESS, oldTxId, 100));
 
-            final var state = wsa.getMerkleState();
+            final var state = wsa.getState();
             assertThat(state).isNotNull();
             final var services = state.getWritableStates(RecordCacheService.NAME);
             final WritableQueueState<TransactionRecordEntry> queue =

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/SynchronizedThrottleAccumulatorTest.java
@@ -26,7 +26,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.node.app.workflows.TransactionInfo;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import java.time.InstantSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class SynchronizedThrottleAccumulatorTest {
     @Test
     void verifyShouldThrottleIsCalled() {
         // given
-        final var state = mock(MerkleState.class);
+        final var state = mock(State.class);
 
         // when
         subject.shouldThrottle(transactionInfo, state);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -85,7 +85,7 @@ import com.hedera.node.config.data.SchedulingConfig;
 import com.hedera.node.config.data.TokensConfig;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -166,7 +166,7 @@ class ThrottleAccumulatorTest {
     private EntitiesConfig entitiesConfig;
 
     @Mock
-    private MerkleState state;
+    private State state;
 
     @Mock
     private ReadableStates readableStates;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleServiceManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleServiceManagerTest.java
@@ -37,7 +37,7 @@ import com.hedera.node.app.hapi.utils.throttles.GasLimitDeterministicThrottle;
 import com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableSingletonState;
 import com.swirlds.state.spi.ReadableStates;
@@ -93,7 +93,7 @@ class ThrottleServiceManagerTest {
     private ReadableStates throttleReadableStates;
 
     @Mock
-    private MerkleState merkleState;
+    private State state;
 
     @Mock
     private ReadableKVState<FileID, File> blobs;
@@ -132,7 +132,7 @@ class ThrottleServiceManagerTest {
                 cryptoTransferThrottle,
                 gasThrottle);
 
-        subject.init(merkleState, MOCK_ENCODED_THROTTLE_DEFS);
+        subject.init(state, MOCK_ENCODED_THROTTLE_DEFS);
 
         inOrder.verify(ingestThrottle).applyGasConfig();
         inOrder.verify(backendThrottle).applyGasConfig();
@@ -162,7 +162,7 @@ class ThrottleServiceManagerTest {
                 .willReturn(asNullTerminatedInstants(
                         MOCK_CONGESTION_LEVEL_STARTS.gasLevelStarts().getFirst()));
 
-        subject.saveThrottleSnapshotsAndCongestionLevelStartsTo(merkleState);
+        subject.saveThrottleSnapshotsAndCongestionLevelStartsTo(state);
 
         verify(writableThrottleSnapshots)
                 .put(new ThrottleUsageSnapshots(List.of(MOCK_USAGE_SNAPSHOT), MOCK_USAGE_SNAPSHOT));
@@ -212,7 +212,7 @@ class ThrottleServiceManagerTest {
     }
 
     private void givenReadableThrottleState() {
-        given(merkleState.getReadableStates(CongestionThrottleService.NAME)).willReturn(throttleReadableStates);
+        given(state.getReadableStates(CongestionThrottleService.NAME)).willReturn(throttleReadableStates);
         given(throttleUsageSnapshots.get()).willReturn(MOCK_THROTTLE_USAGE_SNAPSHOTS);
         given(throttleReadableStates.<ThrottleUsageSnapshots>getSingleton(THROTTLE_USAGE_SNAPSHOTS_STATE_KEY))
                 .willReturn(throttleUsageSnapshots);
@@ -223,7 +223,7 @@ class ThrottleServiceManagerTest {
     }
 
     private void givenWritableThrottleState() {
-        given(merkleState.getWritableStates(CongestionThrottleService.NAME)).willReturn(writableStates);
+        given(state.getWritableStates(CongestionThrottleService.NAME)).willReturn(writableStates);
         given(writableStates.<ThrottleUsageSnapshots>getSingleton(THROTTLE_USAGE_SNAPSHOTS_STATE_KEY))
                 .willReturn(writableThrottleSnapshots);
         given(writableStates.<CongestionLevelStarts>getSingleton(CONGESTION_LEVEL_STARTS_STATE_KEY))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
@@ -35,7 +35,7 @@ import com.hedera.node.app.throttle.NetworkUtilizationManagerImpl;
 import com.hedera.node.app.throttle.ThrottleAccumulator;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableSingletonState;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.WritableSingletonState;
@@ -70,7 +70,7 @@ class NetworkUtilizationManagerImplTest {
     private TransactionInfo transactionInfo;
 
     @Mock
-    private MerkleState state;
+    private State state;
 
     @Mock
     private ReadableStates readableStates;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactoryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactoryTest.java
@@ -31,7 +31,7 @@ import com.hedera.node.app.service.token.ReadableStakingInfoStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.store.ReadableStoreFactory;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableStates;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ReadableStoreFactoryTest {
 
     @Mock
-    private MerkleState state;
+    private State state;
 
     @Mock(strictness = Strictness.LENIENT)
     private ReadableStates readableStates;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
@@ -110,7 +110,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.WritableSingletonState;
 import com.swirlds.state.spi.WritableStates;
 import com.swirlds.state.spi.info.NetworkInfo;
@@ -227,7 +227,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
     private DispatchProcessor dispatchProcessor;
 
     @Mock(strictness = LENIENT)
-    private MerkleState baseState;
+    private State baseState;
 
     @Mock
     private WritableStates writableStates;
@@ -532,7 +532,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
                 G_KEY, GRAPE);
 
         @Mock(strictness = LENIENT)
-        private MerkleState baseState;
+        private State baseState;
 
         @Mock(strictness = LENIENT, answer = Answers.RETURNS_SELF)
         private SingleTransactionRecordBuilderImpl childRecordBuilder;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -49,7 +49,7 @@ import com.hedera.node.app.records.schemas.V0490BlockRecordSchema;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.state.PlatformState;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableSingletonStateBase;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.WritableStates;
@@ -437,8 +437,8 @@ final class BlockRecordManagerTest extends AppTestBase {
         Assertions.assertThat(result).isEqualTo(fromTimestamp(EPOCH));
     }
 
-    private static MerkleState simpleBlockInfoState(final BlockInfo blockInfo) {
-        return new MerkleState() {
+    private static State simpleBlockInfoState(final BlockInfo blockInfo) {
+        return new State() {
             @NonNull
             @Override
             public ReadableStates getReadableStates(@NonNull final String serviceName) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -167,7 +167,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                     .commit();
         }
 
-        final var merkleState = app.workingStateAccessor().getMerkleState();
+        final var merkleState = app.workingStateAccessor().getState();
         final var producer = concurrent
                 ? new StreamFileProducerConcurrent(
                         app.networkInfo().selfNodeInfo(),
@@ -178,7 +178,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                         app.networkInfo().selfNodeInfo(), blockRecordFormat, blockRecordWriterFactory);
         Bytes finalRunningHash;
         try (final var blockRecordManager = new BlockRecordManagerImpl(
-                app.configProvider(), app.workingStateAccessor().getMerkleState(), producer)) {
+                app.configProvider(), app.workingStateAccessor().getState(), producer)) {
             if (!startMode.equals("GENESIS")) {
                 blockRecordManager.switchBlocksAt(FORCED_BLOCK_SWITCH_TIME);
             }
@@ -261,12 +261,12 @@ final class BlockRecordManagerTest extends AppTestBase {
                 .commit();
 
         final Random random = new Random(82792874);
-        final var merkleState = app.workingStateAccessor().getMerkleState();
+        final var merkleState = app.workingStateAccessor().getState();
         final var producer = new StreamFileProducerSingleThreaded(
                 app.networkInfo().selfNodeInfo(), blockRecordFormat, blockRecordWriterFactory);
         Bytes finalRunningHash;
         try (final var blockRecordManager = new BlockRecordManagerImpl(
-                app.configProvider(), app.workingStateAccessor().getMerkleState(), producer)) {
+                app.configProvider(), app.workingStateAccessor().getState(), producer)) {
             blockRecordManager.switchBlocksAt(FORCED_BLOCK_SWITCH_TIME);
             // write a blocks & record files
             int transactionCount = 0;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.when;
 
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.test.fixtures.MapWritableKVState;
 import com.swirlds.state.test.fixtures.StateTestBase;
@@ -55,7 +55,7 @@ class SavepointStackImplTest extends StateTestBase {
             G_KEY, GRAPE);
 
     @Mock(strictness = LENIENT)
-    private MerkleState baseState;
+    private State baseState;
 
     @BeforeEach
     void setup() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/PlatformStateUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/PlatformStateUpdatesTest.java
@@ -29,7 +29,7 @@ import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.freeze.FreezeTransactionBody;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.networkadmin.FreezeService;
 import com.hedera.node.app.spi.fixtures.TransactionFactory;
 import com.swirlds.platform.state.PlatformState;
@@ -48,7 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PlatformStateUpdatesTest implements TransactionFactory {
-    private FakeMerkleState state;
+    private FakeState state;
 
     private PlatformStateUpdates subject;
     private AtomicReference<Timestamp> freezeTimeBackingStore;
@@ -66,7 +66,7 @@ class PlatformStateUpdatesTest implements TransactionFactory {
                 .then(invocation -> new WritableSingletonStateBase<>(
                         FREEZE_TIME_KEY, freezeTimeBackingStore::get, freezeTimeBackingStore::set));
 
-        state = new FakeMerkleState().addService(FreezeService.NAME, Map.of(FREEZE_TIME_KEY, freezeTimeBackingStore));
+        state = new FakeState().addService(FreezeService.NAME, Map.of(FREEZE_TIME_KEY, freezeTimeBackingStore));
 
         doAnswer(answer -> when(platformState.getFreezeTime()).thenReturn(answer.getArgument(0)))
                 .when(platformState)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
@@ -35,7 +35,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeManager;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.file.FileService;
 import com.hedera.node.app.spi.fixtures.TransactionFactory;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
@@ -69,7 +69,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
     @Mock(strictness = Strictness.LENIENT)
     private ConfigProviderImpl configProvider;
 
-    private FakeMerkleState state;
+    private FakeState state;
 
     private Map<FileID, File> files;
 
@@ -87,7 +87,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
     @BeforeEach
     void setUp() {
         files = new HashMap<>();
-        state = new FakeMerkleState().addService(FileService.NAME, Map.of(BLOBS_KEY, files));
+        state = new FakeState().addService(FileService.NAME, Map.of(BLOBS_KEY, files));
 
         final var config = new TestConfigBuilder(false)
                 .withConverter(Bytes.class, new BytesConverter())

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -56,7 +56,7 @@ import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.platform.system.status.PlatformStatus;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -94,10 +94,10 @@ class IngestWorkflowImplTest extends AppTestBase {
 
     // The following fields are all mocked dependencies of the workflow.
     @Mock(strictness = LENIENT)
-    MerkleState state;
+    State state;
 
     @Mock(strictness = LENIENT)
-    Supplier<AutoCloseableWrapper<MerkleState>> stateAccessor;
+    Supplier<AutoCloseableWrapper<State>> stateAccessor;
 
     @Mock(strictness = LENIENT)
     TransactionChecker transactionChecker;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.fixtures.AppTestBase;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.signature.AppKeyVerifier;
@@ -126,7 +126,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
 
     @BeforeEach
     void setUp() {
-        final var fakeMerkleState = new FakeMerkleState();
+        final var fakeMerkleState = new FakeState();
         fakeMerkleState.addService(
                 TokenService.NAME,
                 Map.of(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -84,7 +84,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.time.InstantSource;
@@ -104,7 +104,7 @@ class QueryWorkflowImplTest extends AppTestBase {
     private static final long DEFAULT_CONFIG_VERSION = 1L;
 
     @Mock(strictness = LENIENT)
-    private Function<ResponseType, AutoCloseableWrapper<MerkleState>> stateAccessor;
+    private Function<ResponseType, AutoCloseableWrapper<State>> stateAccessor;
 
     @Mock
     private SubmissionManager submissionManager;

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
@@ -375,7 +375,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
                 svc.registerSchemas(reg);
                 reg.migrate(svc.getServiceName(), initialState, networkInfo);
             });
-            workingStateAccessor.setMerkleState(initialState);
+            workingStateAccessor.setState(initialState);
 
             return new App() {
                 @NonNull
@@ -411,7 +411,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
                 @NonNull
                 @Override
                 public StateMutator stateMutator(@NonNull final String serviceName) {
-                    final var fakeMerkleState = requireNonNull(workingStateAccessor.getMerkleState());
+                    final var fakeMerkleState = requireNonNull(workingStateAccessor.getState());
                     final var writableStates = (MapWritableStates) fakeMerkleState.getWritableStates(serviceName);
                     return new StateMutator(writableStates);
                 }

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
@@ -23,9 +23,9 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.node.state.token.Account;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
 import com.hedera.node.app.fixtures.state.FakePlatform;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.info.NetworkInfoImpl;
 import com.hedera.node.app.info.SelfNodeInfoImpl;
 import com.hedera.node.app.service.token.TokenService;
@@ -52,7 +52,7 @@ import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.Service;
 import com.swirlds.state.spi.WritableStates;
@@ -73,8 +73,8 @@ import java.util.concurrent.ScheduledExecutorService;
  * these dependencies out, especially to test a variety of negative test scenarios, it is often better to test using
  * something more approximating a real environment. Such tests are less brittle to changes in the codebase, and also
  * tend to find issues earlier in the development cycle. They may also result in test failures in seemingly unrelated
- * tests. For example, if all tests use {@link MerkleState}, and the implementation of that has a bug, a large number
- * of tests that are only indirectly related to {@link MerkleState} will still fail.
+ * tests. For example, if all tests use {@link State}, and the implementation of that has a bug, a large number
+ * of tests that are only indirectly related to {@link State} will still fail.
  *
  * <p>The real challenge is that many of these dependencies are not easy to set up. In addition, from test to test,
  * you may want *almost* everything setup as normal, but with a small tweak in one place or another.
@@ -102,7 +102,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
     public static final String ALICE_ALIAS = "Alice Alias";
     protected MapWritableKVState<AccountID, Account> accountsState;
     protected MapWritableKVState<ProtoBytes, AccountID> aliasesState;
-    protected MerkleState state;
+    protected State state;
 
     protected void setupStandardStates() {
         accountsState = new MapWritableKVState<>(ACCOUNTS_KEY);
@@ -118,7 +118,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
                 .state(aliasesState)
                 .build();
 
-        state = new MerkleState() {
+        state = new State() {
             @NonNull
             @Override
             public ReadableStates getReadableStates(@NonNull String serviceName) {
@@ -369,7 +369,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
             final var platform = new FakePlatform(realSelfNodeInfo.nodeId(), new AddressBook(addresses));
             final var networkInfo = new NetworkInfoImpl(realSelfNodeInfo, platform, configProvider);
 
-            final var initialState = new FakeMerkleState();
+            final var initialState = new FakeState();
             services.forEach(svc -> {
                 final var reg = new FakeSchemaRegistry();
                 svc.registerSchemas(reg);

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeSchemaRegistry.java
@@ -68,9 +68,7 @@ public class FakeSchemaRegistry implements SchemaRegistry {
 
     @SuppressWarnings("rawtypes")
     public void migrate(
-            @NonNull final String serviceName,
-            @NonNull final FakeMerkleState state,
-            @NonNull final NetworkInfo networkInfo) {
+            @NonNull final String serviceName, @NonNull final FakeState state, @NonNull final NetworkInfo networkInfo) {
         migrate(
                 serviceName,
                 state,
@@ -83,7 +81,7 @@ public class FakeSchemaRegistry implements SchemaRegistry {
 
     public void migrate(
             @NonNull final String serviceName,
-            @NonNull final FakeMerkleState state,
+            @NonNull final FakeState state,
             @Nullable final SemanticVersion previousVersion,
             @NonNull final NetworkInfo networkInfo,
             @NonNull final Configuration config,
@@ -145,7 +143,7 @@ public class FakeSchemaRegistry implements SchemaRegistry {
             @NonNull final String serviceName,
             @NonNull final Schema schema,
             @NonNull final Configuration configuration,
-            @NonNull final FakeMerkleState state) {
+            @NonNull final FakeState state) {
         final Map<String, Object> stateDataSources = new HashMap<>();
         schema.statesToCreate(configuration).forEach(def -> {
             final var stateKey = def.stateKey();

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeState.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeState.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.fixtures.state;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.EmptyReadableStates;
 import com.swirlds.state.spi.EmptyWritableStates;
 import com.swirlds.state.spi.ReadableKVState;
@@ -39,9 +39,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * A useful test double for {@link MerkleState}. Works together with {@link MapReadableStates} and other fixtures.
+ * A useful test double for {@link State}. Works together with {@link MapReadableStates} and other fixtures.
  */
-public class FakeMerkleState implements MerkleState {
+public class FakeState implements State {
     // Key is Service, value is Map of state name to HashMap or List or Object (depending on state type)
     private final Map<String, Map<String, Object>> states = new ConcurrentHashMap<>();
     private final Map<String, ReadableStates> readableStates = new ConcurrentHashMap<>();
@@ -50,7 +50,7 @@ public class FakeMerkleState implements MerkleState {
     /**
      * Adds to the service with the given name the {@link ReadableKVState} {@code states}
      */
-    public FakeMerkleState addService(@NonNull final String serviceName, @NonNull final Map<String, ?> dataSources) {
+    public FakeState addService(@NonNull final String serviceName, @NonNull final Map<String, ?> dataSources) {
         final var serviceStates = this.states.computeIfAbsent(serviceName, k -> new ConcurrentHashMap<>());
         serviceStates.putAll(dataSources);
         // Purge any readable or writable states whose state definitions are now stale,

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/FreezeServiceImplTest.java
@@ -23,8 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.networkadmin.FreezeService;
 import com.hedera.node.app.service.networkadmin.impl.FreezeServiceImpl;
 import com.swirlds.state.spi.Schema;
@@ -80,7 +80,7 @@ class FreezeServiceImplTest {
     void migratesAsExpected() {
         final var subject = new FreezeServiceImpl();
         final var registry = new FakeSchemaRegistry();
-        final var state = new FakeMerkleState();
+        final var state = new FakeState();
 
         subject.registerSchemas(registry);
         registry.migrate(FreezeService.NAME, state, networkInfo);

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -41,8 +41,8 @@ import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -213,7 +213,7 @@ public class NetworkAdminHandlerTestBase {
     }
 
     protected void refreshRecordCache() {
-        final var state = new FakeMerkleState();
+        final var state = new FakeState();
         final var registry = new FakeSchemaRegistry();
         final var svc = new RecordCacheService();
         svc.registerSchemas(registry);

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -218,7 +218,7 @@ public class NetworkAdminHandlerTestBase {
         final var svc = new RecordCacheService();
         svc.registerSchemas(registry);
         registry.migrate(svc.getServiceName(), state, networkInfo);
-        lenient().when(wsa.getMerkleState()).thenReturn(state);
+        lenient().when(wsa.getState()).thenReturn(state);
         lenient().when(props.getConfiguration()).thenReturn(versionedConfig);
         lenient().when(versionedConfig.getConfigData(HederaConfig.class)).thenReturn(hederaConfig);
         lenient().when(hederaConfig.transactionMaxValidDuration()).thenReturn(123456789999L);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -29,8 +29,8 @@ import static java.util.stream.StreamSupport.stream;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.Hedera;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
 import com.hedera.node.app.fixtures.state.FakeServicesRegistry;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.version.HederaSoftwareVersion;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -87,7 +87,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected final PlatformState platformState = new PlatformState();
     protected final Map<AccountID, NodeId> nodeIds;
     protected final Map<NodeId, com.hedera.hapi.node.base.AccountID> accountIds;
-    protected final FakeMerkleState state = new FakeMerkleState();
+    protected final FakeState state = new FakeState();
     protected final AccountID defaultNodeAccountId;
     protected final AddressBook addressBook;
     protected final NodeId defaultNodeId;
@@ -129,7 +129,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     }
 
     @Override
-    public FakeMerkleState state() {
+    public FakeState state() {
         return state;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
@@ -16,7 +16,7 @@
 
 package com.hedera.services.bdd.junit.hedera.embedded;
 
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
@@ -44,7 +44,7 @@ public interface EmbeddedHedera {
      *
      * @return the fake state of the embedded Hedera node
      */
-    FakeMerkleState state();
+    FakeState state();
 
     /**
      * Returns the next in a repeatable sequence of valid start times that the embedded Hedera's

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeServiceMigrator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeServiceMigrator.java
@@ -20,16 +20,16 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.common.EntityNumber;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
 import com.hedera.node.app.fixtures.state.FakeSchemaRegistry;
 import com.hedera.node.app.fixtures.state.FakeServicesRegistry;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.services.ServiceMigrator;
 import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
 import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.info.NetworkInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -44,22 +44,22 @@ public class FakeServiceMigrator implements ServiceMigrator {
 
     @Override
     public void doMigrations(
-            @NonNull final MerkleState merkleState,
+            @NonNull final State state,
             @NonNull final ServicesRegistry servicesRegistry,
             @Nullable final SemanticVersion previousVersion,
             @NonNull final SemanticVersion currentVersion,
             @NonNull final Configuration config,
             @NonNull final NetworkInfo networkInfo,
             @NonNull final Metrics metrics) {
-        requireNonNull(merkleState);
+        requireNonNull(state);
         requireNonNull(servicesRegistry);
         requireNonNull(currentVersion);
         requireNonNull(config);
         requireNonNull(networkInfo);
         requireNonNull(metrics);
 
-        if (!(merkleState instanceof FakeMerkleState state)) {
-            throw new IllegalArgumentException("Can only be used with FakeMerkleState instances");
+        if (!(state instanceof FakeState fakeState)) {
+            throw new IllegalArgumentException("Can only be used with FakeState instances");
         }
         if (!(servicesRegistry instanceof FakeServicesRegistry registry)) {
             throw new IllegalArgumentException("Can only be used with FakeServicesRegistry instances");
@@ -77,7 +77,13 @@ public class FakeServiceMigrator implements ServiceMigrator {
             throw new IllegalArgumentException("Can only be used with FakeSchemaRegistry instances");
         }
         entityIdRegistry.migrate(
-                NAME_OF_ENTITY_ID_SERVICE, state, previousVersion, networkInfo, config, sharedValues, nextEntityNum);
+                NAME_OF_ENTITY_ID_SERVICE,
+                fakeState,
+                previousVersion,
+                networkInfo,
+                config,
+                sharedValues,
+                nextEntityNum);
         registry.registrations().stream()
                 .filter(r -> !Objects.equals(entityIdRegistration, r))
                 .forEach(registration -> {
@@ -86,14 +92,14 @@ public class FakeServiceMigrator implements ServiceMigrator {
                     }
                     schemaRegistry.migrate(
                             registration.serviceName(),
-                            state,
+                            fakeState,
                             previousVersion,
                             networkInfo,
                             config,
                             sharedValues,
                             nextEntityNum);
                 });
-        final var entityIdWritableStates = state.getWritableStates(NAME_OF_ENTITY_ID_SERVICE);
+        final var entityIdWritableStates = fakeState.getWritableStates(NAME_OF_ENTITY_ID_SERVICE);
         if (!(entityIdWritableStates instanceof MapWritableStates mapWritableStates)) {
             throw new IllegalArgumentException("Can only be used with MapWritableStates instances");
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -67,7 +67,7 @@ import com.google.common.base.MoreObjects;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.token.Account;
-import com.hedera.node.app.fixtures.state.FakeMerkleState;
+import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.extensions.NetworkTargetingExtension;
 import com.hedera.services.bdd.junit.hedera.HederaNetwork;
@@ -452,12 +452,12 @@ public class HapiSpec implements Runnable, Executable {
     }
 
     /**
-     * Get the {@link FakeMerkleState} for the embedded network, if this spec is targeting an embedded network.
+     * Get the {@link FakeState} for the embedded network, if this spec is targeting an embedded network.
      *
      * @return the embedded state
      * @throws IllegalStateException if this spec is not targeting an embedded network
      */
-    public @NonNull FakeMerkleState embeddedStateOrThrow() {
+    public @NonNull FakeState embeddedStateOrThrow() {
         if (!(targetNetworkOrThrow() instanceof EmbeddedNetwork network)) {
             throw new IllegalStateException("Cannot access embedded state for non-embedded network");
         }
@@ -489,7 +489,7 @@ public class HapiSpec implements Runnable, Executable {
     }
 
     /**
-     * Commits all pending changes to the embedded {@link FakeMerkleState} if this spec is targeting
+     * Commits all pending changes to the embedded {@link FakeState} if this spec is targeting
      * an embedded network.
      */
     public void commitEmbeddedState() {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
@@ -23,7 +23,7 @@ import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -41,7 +41,7 @@ public interface MerkleStateLifecycles {
      * @param event the event that was added
      * @param state the latest immutable state at the time of the event
      */
-    void onPreHandle(@NonNull Event event, @NonNull MerkleState state);
+    void onPreHandle(@NonNull Event event, @NonNull State state);
 
     /**
      * Called when a round of events have reached consensus, and are ready to be handled
@@ -51,7 +51,7 @@ public interface MerkleStateLifecycles {
      * @param platformState the working state of the platform
      * @param state the working state of the network
      */
-    void onHandleConsensusRound(@NonNull Round round, @NonNull PlatformState platformState, @NonNull MerkleState state);
+    void onHandleConsensusRound(@NonNull Round round, @NonNull PlatformState platformState, @NonNull State state);
 
     /**
      * Called when the platform is initializing the network state.
@@ -63,7 +63,7 @@ public interface MerkleStateLifecycles {
      * @param previousVersion if non-null, the network version that was previously in use
      */
     void onStateInitialized(
-            @NonNull MerkleState state,
+            @NonNull State state,
             @NonNull Platform platform,
             @NonNull PlatformState platformState,
             @NonNull InitTrigger trigger,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -36,7 +36,7 @@ import com.swirlds.platform.system.SwirldState;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.system.state.notifications.NewRecoveredStateListener;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.merkle.StateMetadata;
 import com.swirlds.state.merkle.StateUtils;
 import com.swirlds.state.merkle.disk.OnDiskReadableKVState;
@@ -76,7 +76,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * An implementation of {@link SwirldState} and {@link MerkleState}. The Hashgraph Platform
+ * An implementation of {@link SwirldState} and {@link com.swirlds.state.State}. The Hashgraph Platform
  * communicates with the application through {@link SwirldMain} and {@link
  * SwirldState}. The Hedera application, after startup, only needs the ability to get {@link
  * ReadableStates} and {@link WritableStates} from this object.
@@ -95,7 +95,7 @@ import org.apache.logging.log4j.Logger;
  */
 @ConstructableIgnored
 public class MerkleStateRoot extends PartialNaryMerkleInternal
-        implements MerkleInternal, SwirldState, MerkleState, MerkleRoot {
+        implements MerkleInternal, SwirldState, State, MerkleRoot {
     private static final Logger logger = LogManager.getLogger(MerkleStateRoot.class);
 
     /**
@@ -807,6 +807,6 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
     @NonNull
     @Override
     public String getInfoString(final int hashDepth) {
-        return State.createInfoString(hashDepth, getPlatformState(), getHash(), this);
+        return com.swirlds.platform.state.State.createInfoString(hashDepth, getPlatformState(), getHash(), this);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -76,7 +76,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * An implementation of {@link SwirldState} and {@link com.swirlds.state.State}. The Hashgraph Platform
+ * An implementation of {@link SwirldState} and {@link State}. The Hashgraph Platform
  * communicates with the application through {@link SwirldMain} and {@link
  * SwirldState}. The Hedera application, after startup, only needs the ability to get {@link
  * ReadableStates} and {@link WritableStates} from this object.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
@@ -32,7 +32,7 @@ import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.test.fixtures.state.MerkleTestBase;
 import com.swirlds.platform.test.fixtures.state.TestSchema;
-import com.swirlds.state.MerkleState;
+import com.swirlds.state.State;
 import com.swirlds.state.merkle.StateMetadata;
 import com.swirlds.state.merkle.StateUtils;
 import com.swirlds.state.spi.ReadableKVState;
@@ -70,7 +70,7 @@ class MerkleStateRootTest extends MerkleTestBase {
 
     private final MerkleStateLifecycles lifecycles = new MerkleStateLifecycles() {
         @Override
-        public void onPreHandle(@NonNull Event event, @NonNull MerkleState state) {
+        public void onPreHandle(@NonNull Event event, @NonNull State state) {
             onPreHandleCalled.set(true);
         }
 
@@ -81,13 +81,13 @@ class MerkleStateRootTest extends MerkleTestBase {
 
         @Override
         public void onHandleConsensusRound(
-                @NonNull Round round, @NonNull PlatformState platformState, @NonNull MerkleState state) {
+                @NonNull Round round, @NonNull PlatformState platformState, @NonNull State state) {
             onHandleCalled.set(true);
         }
 
         @Override
         public void onStateInitialized(
-                @NonNull MerkleState state,
+                @NonNull State state,
                 @NonNull Platform platform,
                 @NonNull PlatformState platformState,
                 @NonNull InitTrigger trigger,
@@ -398,7 +398,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Reading an unknown state on ReadableStates should throw IAE")
         void unknownState() {
-            // Given a MerkleState with the fruit and animal and country states
+            // Given a State with the fruit and animal and country states
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
             stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);
@@ -414,7 +414,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Read a virtual map")
         void readVirtualMap() {
-            // Given a MerkleState with the fruit virtual map
+            // Given a State with the fruit virtual map
             setupFruitVirtualMap();
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitVirtualMap);
 
@@ -428,7 +428,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Try to read a state that is MISSING from the merkle tree")
         void readMissingState() {
-            // Given a MerkleState with the fruit merkle map, which somehow has
+            // Given a State with the fruit merkle map, which somehow has
             // lost the merkle node (this should NEVER HAPPEN in real life!)
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.setChild(0, null);
@@ -443,7 +443,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Contains is true for all states in stateKeys and false for unknown ones")
         void contains() {
-            // Given a MerkleState with the fruit and animal and country and steam states
+            // Given a State with the fruit and animal and country and steam states
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
             stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);
@@ -466,7 +466,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Getting the same readable state twice returns the same instance")
         void getReturnsSameInstanceIfCalledTwice() {
-            // Given a MerkleState with the fruit and the ReadableStates for it
+            // Given a State with the fruit and the ReadableStates for it
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             final var states = stateRoot.getReadableStates(FIRST_SERVICE);
 
@@ -481,7 +481,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Getting ReadableStates on a known service returns an object with all the state")
         void knownServiceNameUsingReadableStates() {
-            // Given a MerkleState with the fruit and animal and country states
+            // Given a State with the fruit and animal and country states
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
             stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);
@@ -596,7 +596,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Reading an unknown state on WritableState should throw IAE")
         void unknownState() {
-            // Given a MerkleState with the fruit and animal and country states
+            // Given a State with the fruit and animal and country states
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
             stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);
@@ -612,7 +612,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Try to read a state that is MISSING from the merkle tree")
         void readMissingState() {
-            // Given a MerkleState with the fruit virtual map, which somehow has
+            // Given a State with the fruit virtual map, which somehow has
             // lost the merkle node (this should NEVER HAPPEN in real life!)
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.setChild(0, null);
@@ -627,7 +627,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Read a virtual map")
         void readVirtualMap() {
-            // Given a MerkleState with the fruit virtual map
+            // Given a State with the fruit virtual map
             setupFruitVirtualMap();
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitVirtualMap);
 
@@ -641,7 +641,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Contains is true for all states in stateKeys and false for unknown ones")
         void contains() {
-            // Given a MerkleState with the fruit and animal and country states
+            // Given a State with the fruit and animal and country states
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
             stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);
@@ -664,7 +664,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Getting the same writable state twice returns the same instance")
         void getReturnsSameInstanceIfCalledTwice() {
-            // Given a MerkleState with the fruit and the WritableStates for it
+            // Given a State with the fruit and the WritableStates for it
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             final var states = stateRoot.getWritableStates(FIRST_SERVICE);
 
@@ -679,7 +679,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Getting WritableStates on a known service returns an object with all the state")
         void knownServiceNameUsingWritableStates() {
-            // Given a MerkleState with the fruit and animal and country states
+            // Given a State with the fruit and animal and country states
             stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
             stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
             stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
@@ -27,7 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * structures provided by the hashgraph platform. But most of our code doesn't need to know that
  * detail, and are happy with just the API provided by this interface.
  */
-public interface MerkleState {
+public interface State {
 
     /**
      * Returns a {@link ReadableStates} for the given named service. If such a service doesn't


### PR DESCRIPTION
**Description**:

This is a follow-up PR to @tinker-michaelj comment (https://github.com/hashgraph/hedera-services/pull/14347#pullrequestreview-2197610519). 

`state-api` module is not Merkle-specific and there are test implementations of this API that are not using Merkle tree under the hood. Therefore, `MerkleState` interface has to be renamed to just `State`. 

This PR does exactly that and updates variable names, nothing else. 

**Related issue(s)**:

Relates to #13274 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
