### PR TITLE
chore: include hedera-cryptography in code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,12 @@
 /hedera-node/test-clients/                      @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core
 /hedera-node/**/module-info.java                @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/devops-ci
 
+###############################
+##### Hedera Cryptography #####
+###############################
+/hedera-cryptography/                           @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects @hashgraph/devops-ci
+/hedera-cryptography/hedera-cryptography-tss    @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
+
 #########################
 ##### Platform SDK ######
 #########################

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,6 @@
 ##### Hedera Cryptography #####
 ###############################
 /hedera-cryptography/                           @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects @hashgraph/devops-ci
-/hedera-cryptography/hedera-cryptography-tss    @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
 
 #########################
 ##### Platform SDK ######

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 ###############################
 ##### Hedera Cryptography #####
 ###############################
-/hedera-cryptography/                           @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects @hashgraph/devops-ci
+/hedera-cryptography/                           @hashgraph/platform-cryptography
 
 #########################
 ##### Platform SDK ######


### PR DESCRIPTION
**Related issue(s)**:

Fixes #14403 

Proposal this work is based on:[ platform-sdk/docs/proposals/TSS-Library/TSS-Library.md](https://github.com/hashgraph/hedera-services/blob/develop/platform-sdk/docs/proposals/TSS-Library/TSS-Library.md)

```
              No new projects should be published under the `com.swirlds` namespace prefix or Maven Group ID. This should be a `com.hedera.cryptography` namespace prefix and `com.hedera.cryptography` Maven Group ID.
```
_Originally posted by @nathanklick in https://github.com/hashgraph/hedera-services/pull/14307#pullrequestreview-2191679889_