### PR TITLE
ci: Add registry mirrors to daemon-config on crazy-max/ghaction-setup-docker

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -454,6 +454,7 @@ jobs:
       - name: Setup Docker Buildx Support
         uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
         with:
+          version: v0.15.1
           driver-opts: network=host
 
       - name: Setup Local Docker Registry

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -176,7 +176,7 @@ jobs:
         env:
           HOME: /x
         with:
-          version: v24.0.7
+          version: v25.0.6
           daemon-config: |
             {
               "registry-mirrors": [
@@ -201,7 +201,7 @@ jobs:
       - name: Setup Docker Buildx Support
         uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
         with:
-          version: v0.12.0
+          version: v0.15.1
           driver-opts: network=host
 
       - name: Setup Local Docker Registry

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -177,6 +177,12 @@ jobs:
           HOME: /x
         with:
           version: v24.0.7
+          daemon-config: |
+            {
+              "registry-mirrors": [
+                "https://artifacts.swirldslabs.io/central-docker-external/"
+              ]
+            }
 
       - name: Configure Default Docker Context
         run: |

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -176,7 +176,7 @@ jobs:
         env:
           HOME: /x
         with:
-          version: v25.0.6
+          version: v25.0.5
           daemon-config: |
             {
               "registry-mirrors": [

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -167,6 +167,12 @@ jobs:
           HOME: /x
         with:
           version: v24.0.7
+          daemon-config: |
+            {
+              "registry-mirrors": [
+                "https://artifacts.swirldslabs.io/central-docker-external/"
+              ]
+            }
 
       - name: Configure Default Docker Context
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -378,6 +384,12 @@ jobs:
           HOME: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
         with:
           version: v24.0.7
+          daemon-config: |
+            {
+              "registry-mirrors": [
+                "https://artifacts.swirldslabs.io/central-docker-external/"
+              ]
+            }
 
       - name: Configure Default Docker Context
         env:

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -166,7 +166,7 @@ jobs:
         env:
           HOME: /x
         with:
-          version: v25.0.6
+          version: v25.0.5
           daemon-config: |
             {
               "registry-mirrors": [
@@ -383,7 +383,7 @@ jobs:
         env:
           HOME: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
         with:
-          version: v25.0.6
+          version: v25.0.5
           daemon-config: |
             {
               "registry-mirrors": [

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -166,7 +166,7 @@ jobs:
         env:
           HOME: /x
         with:
-          version: v24.0.7
+          version: v25.0.6
           daemon-config: |
             {
               "registry-mirrors": [
@@ -194,7 +194,7 @@ jobs:
         uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         with:
-          version: v0.12.0
+          version: v0.15.1
           driver-opts: network=host
 
       - name: Setup Local Docker Registry
@@ -383,7 +383,7 @@ jobs:
         env:
           HOME: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
         with:
-          version: v24.0.7
+          version: v25.0.6
           daemon-config: |
             {
               "registry-mirrors": [
@@ -410,7 +410,7 @@ jobs:
       - name: Setup Docker Buildx Support
         uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
         with:
-          version: v0.12.0
+          version: v0.15.1
           driver-opts: network=host
 
       - name: Setup Local Docker Registry


### PR DESCRIPTION
**Description**:

updates crazy-max/gh-action-setup-docekr to include registry mirrors

**Related issue(s)**:

Fixes #14466 