### PR TITLE
fix: add `event.migrateEventHashing=false` override to upgrade `@HapiTest`

### DIFF
--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -16,6 +16,7 @@ state.mainClassNameOverride,                   com.hedera.services.ServicesMain
                                           #############################
 
 event.enableEventStreaming,                    false                        # differs from mainnet
+event.migrateEventHashing,                     false                        # temporary until expected 0.54
 
                                           #############################
                                           #          Metrics          #


### PR DESCRIPTION
**Description**:
 - Until changes in event hashing are enabled, an upgrade with `event.migrateEventHashing=true` will expect the PCES events to be in a `v0.52` format and fail otherwise.
 - This PR updates dev configuration _settings.txt_ to set `event.migrateEventHashing=false`.