### PR TITLE
fix: use gagues for ReconnectMapMetrics and reset them to zero on new…

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/stats/ReconnectMapMetrics.java
@@ -16,14 +16,14 @@
 
 package com.swirlds.common.merkle.synchronization.stats;
 
-import com.swirlds.metrics.api.Counter;
+import com.swirlds.metrics.api.LongGauge;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * An implementation of ReconnectMapStats that emits all the stats as Counter metrics.
+ * An implementation of ReconnectMapStats that emits all the stats as LongGauge metrics.
  */
 public class ReconnectMapMetrics implements ReconnectMapStats {
 
@@ -35,18 +35,18 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
 
     private final ReconnectMapStats aggregateStats;
 
-    private final Counter transfersFromTeacher;
-    private final Counter transfersFromLearner;
+    private final LongGauge transfersFromTeacher;
+    private final LongGauge transfersFromLearner;
 
-    private final Counter internalHashes;
-    private final Counter internalCleanHashes;
-    private final Counter internalData;
-    private final Counter internalCleanData;
+    private final LongGauge internalHashes;
+    private final LongGauge internalCleanHashes;
+    private final LongGauge internalData;
+    private final LongGauge internalCleanData;
 
-    private final Counter leafHashes;
-    private final Counter leafCleanHashes;
-    private final Counter leafData;
-    private final Counter leafCleanData;
+    private final LongGauge leafHashes;
+    private final LongGauge leafCleanHashes;
+    private final LongGauge leafData;
+    private final LongGauge leafCleanData;
 
     /**
      * Create an instance of ReconnectMapMetrics.
@@ -67,40 +67,69 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
         final String label = originalLabel == null ? null : originalLabel.replace('.', '_');
 
         this.transfersFromTeacher = metrics.getOrCreate(
-                new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("transfersFromTeacher", label))
+                new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("transfersFromTeacher", label))
                         .withDescription("number of transfers from teacher to learner"));
         this.transfersFromLearner = metrics.getOrCreate(
-                new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("transfersFromLearner", label))
+                new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("transfersFromLearner", label))
                         .withDescription("number of transfers from learner to teacher"));
 
         this.internalHashes =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("internalHashes", label))
+                metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("internalHashes", label))
                         .withDescription("number of internal node hashes transferred"));
-        this.internalCleanHashes =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("internalCleanHashes", label))
+        this.internalCleanHashes = metrics.getOrCreate(
+                new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("internalCleanHashes", label))
                         .withDescription("number of clean internal node hashes transferred"));
         this.internalData =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("internalData", label))
+                metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("internalData", label))
                         .withDescription("number of internal node data transferred"));
         this.internalCleanData =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("internalCleanData", label))
+                metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("internalCleanData", label))
                         .withDescription("number of clean internal node data transferred"));
 
         this.leafHashes =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("leafHashes", label))
+                metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("leafHashes", label))
                         .withDescription("number of leaf node hashes transferred"));
         this.leafCleanHashes =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("leafCleanHashes", label))
+                metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("leafCleanHashes", label))
                         .withDescription("number of clean leaf node hashes transferred"));
-        this.leafData = metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("leafData", label))
+        this.leafData = metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("leafData", label))
                 .withDescription("number of leaf node data transferred"));
         this.leafCleanData =
-                metrics.getOrCreate(new Counter.Config(RECONNECT_MAP_CATEGORY, formatName("leafCleanData", label))
+                metrics.getOrCreate(new LongGauge.Config(RECONNECT_MAP_CATEGORY, formatName("leafCleanData", label))
                         .withDescription("number of clean leaf node data transferred"));
+
+        // Reset metric values to zeros on reconnect start
+        resetMetrics();
     }
 
     private static String formatName(final String name, final String label) {
         return (label == null || label.isBlank() ? name : (name + "_" + label + "_")) + "Total";
+    }
+
+    private static void add(final LongGauge metric, final long value) {
+        metric.set(metric.get() + value);
+    }
+
+    /**
+     * Reset metrics specific to this ReconnectMapMetrics instance to zero,
+     * but do NOT reset the aggregateStats, if any. The aggregateStats
+     * have already been reset earlier when the reconnect process
+     * has started as a whole. We're only resetting label-specific metrics here
+     * before we start the reconnect for this specific label.
+     */
+    private void resetMetrics() {
+        transfersFromTeacher.set(0);
+        transfersFromLearner.set(0);
+
+        internalHashes.set(0);
+        internalCleanHashes.set(0);
+        internalData.set(0);
+        internalCleanData.set(0);
+
+        leafHashes.set(0);
+        leafCleanHashes.set(0);
+        leafData.set(0);
+        leafCleanData.set(0);
     }
 
     /**
@@ -108,7 +137,7 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
      */
     @Override
     public void incrementTransfersFromTeacher() {
-        transfersFromTeacher.increment();
+        add(transfersFromTeacher, 1);
         if (aggregateStats != null) {
             aggregateStats.incrementTransfersFromTeacher();
         }
@@ -119,7 +148,7 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
      */
     @Override
     public void incrementTransfersFromLearner() {
-        transfersFromLearner.increment();
+        add(transfersFromLearner, 1);
         if (aggregateStats != null) {
             aggregateStats.incrementTransfersFromLearner();
         }
@@ -130,8 +159,8 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
      */
     @Override
     public void incrementInternalHashes(final int hashNum, final int cleanHashNum) {
-        if (hashNum > 0) internalHashes.add(hashNum);
-        if (cleanHashNum > 0) internalCleanHashes.add(cleanHashNum);
+        if (hashNum > 0) add(internalHashes, hashNum);
+        if (cleanHashNum > 0) add(internalCleanHashes, cleanHashNum);
         if (aggregateStats != null) {
             aggregateStats.incrementInternalHashes(hashNum, cleanHashNum);
         }
@@ -142,8 +171,8 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
      */
     @Override
     public void incrementInternalData(final int dataNum, final int cleanDataNum) {
-        if (dataNum > 0) internalData.add(dataNum);
-        if (cleanDataNum > 0) internalCleanData.add(cleanDataNum);
+        if (dataNum > 0) add(internalData, dataNum);
+        if (cleanDataNum > 0) add(internalCleanData, cleanDataNum);
         if (aggregateStats != null) {
             aggregateStats.incrementInternalData(dataNum, cleanDataNum);
         }
@@ -154,8 +183,8 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
      */
     @Override
     public void incrementLeafHashes(final int hashNum, final int cleanHashNum) {
-        if (hashNum > 0) leafHashes.add(hashNum);
-        if (cleanHashNum > 0) leafCleanHashes.add(cleanHashNum);
+        if (hashNum > 0) add(leafHashes, hashNum);
+        if (cleanHashNum > 0) add(leafCleanHashes, cleanHashNum);
         if (aggregateStats != null) {
             aggregateStats.incrementLeafHashes(hashNum, cleanHashNum);
         }
@@ -166,8 +195,8 @@ public class ReconnectMapMetrics implements ReconnectMapStats {
      */
     @Override
     public void incrementLeafData(final int dataNum, final int cleanDataNum) {
-        if (dataNum > 0) leafData.add(dataNum);
-        if (cleanDataNum > 0) leafCleanData.add(cleanDataNum);
+        if (dataNum > 0) add(leafData, dataNum);
+        if (cleanDataNum > 0) add(leafCleanData, cleanDataNum);
         if (aggregateStats != null) {
             aggregateStats.incrementLeafData(dataNum, cleanDataNum);
         }


### PR DESCRIPTION
… reconnects

**Description**:
We want to measure ReconnectMapMetrics for each reconnect run, and a node can reconnect multiple times while it's running. However, Counters cannot be reset to zero and can only grow. So in this fix I'm replacing Counters with LongGauges and reset them when a new reconnect starts (aka when a new instance of ReconnectMapMetrics is created.)

**Related issue(s)**:

Fixes #14440

**Notes for reviewer**:
Unit tests pass in swirlds-common, swirlds-merkle, and swirlds-virtualmap.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
